### PR TITLE
laplace/gaussian/geometric floating-point-safe samplers

### DIFF
--- a/python/opendp.py
+++ b/python/opendp.py
@@ -9,6 +9,9 @@ def str_to_c_char_p(s):
 def c_char_p_to_str(s):
     return s.decode("utf-8") if s is not None else None
 
+def u32_p(i):
+    return ctypes.byref(ctypes.c_uint32(i))
+
 def i32_p(i):
     return ctypes.byref(ctypes.c_int32(i))
 

--- a/python/test.py
+++ b/python/test.py
@@ -24,14 +24,15 @@ def main():
     select_1 = odp.trans.make_select_column(b"<HammingDistance, i32, i32>", opendp.i32_p(1))
     clamp_1 = odp.trans.make_clamp(b"<HammingDistance, i32>", opendp.i32_p(0), opendp.i32_p(10))
     bounded_sum_1 = odp.trans.make_bounded_sum(b"<HammingDistance, L1Sensitivity<i32>, i32>", opendp.i32_p(0), opendp.i32_p(10))
-    base_laplace_1 = odp.meas.make_base_laplace(b"<i32>", 1.0)
-    noisy_sum_1 = odp.core.make_chain_mt(base_laplace_1, odp.make_chain_tt_multi(bounded_sum_1, clamp_1, select_1))
+    base_geometric_1 = odp.meas.make_base_simple_geometric(b"<i32>", 1.0, opendp.u32_p(0), opendp.u32_p(1000))
+    # base_laplace_1 = odp.meas.make_base_laplace(b"<i32>", opendp.f64_p(1.0))
+    noisy_sum_1 = odp.core.make_chain_mt(base_geometric_1, odp.make_chain_tt_multi(bounded_sum_1, clamp_1, select_1))
 
     # Count, col 1
     select_2 = odp.trans.make_select_column(b"<HammingDistance, i32, f64>", opendp.i32_p(2))
     count_2 = odp.trans.make_count(b"<HammingDistance, L1Sensitivity<u32>, f64>")
-    base_laplace_2 = odp.meas.make_base_laplace(b"<u32>", 1.0)
-    noisy_count_2 = odp.core.make_chain_mt(base_laplace_2, odp.make_chain_tt_multi(count_2, select_2))
+    base_geometric_2 = odp.meas.make_base_simple_geometric(b"<u32>", 1.0, opendp.u32_p(0), opendp.u32_p(1000))
+    noisy_count_2 = odp.core.make_chain_mt(base_geometric_2, odp.make_chain_tt_multi(count_2, select_2))
 
     # Compose & chain
     composition = odp.core.make_composition(noisy_sum_1, noisy_count_2)

--- a/rust/opendp-ffi/src/data.rs
+++ b/rust/opendp-ffi/src/data.rs
@@ -7,6 +7,27 @@ use crate::core::FfiObject;
 use crate::util;
 
 #[no_mangle]
+pub extern "C" fn opendp_data__from_f64(p: f64) -> *mut FfiObject {
+    FfiObject::new(p)
+}
+
+#[no_mangle]
+pub extern "C" fn opendp_data__to_f64(this: *mut FfiObject) -> f64 {
+    let this = util::as_ref(this);
+    *this.as_ref()
+}
+
+#[no_mangle]
+pub extern "C" fn opendp_data__distance_hamming(d: u32) -> *mut FfiObject {
+    FfiObject::new(d)
+}
+
+#[no_mangle]
+pub extern "C" fn opendp_data__distance_smoothed_max_divergence(epsilon: f64, delta: f64) -> *mut FfiObject {
+    FfiObject::new((epsilon, delta))
+}
+
+#[no_mangle]
 pub extern "C" fn opendp_data__from_string(p: *const c_char) -> *mut FfiObject {
     let s = util::to_str(p).to_owned();
     FfiObject::new(s)

--- a/rust/opendp-ffi/src/dispatch.rs
+++ b/rust/opendp-ffi/src/dispatch.rs
@@ -86,6 +86,9 @@ macro_rules! disp_expand {
     ($function:ident, ($rt_type:expr, @floats),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
         disp_expand!($function, ($rt_type, [f32, f64]), $rt_dispatch_types, $type_args, $args)
     };
+    ($function:ident, ($rt_type:expr, @integers),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
+        disp_expand!($function, ($rt_type, [u8, u32, u64, u128, i8, i16, i32, i64, i128]), $rt_dispatch_types, $type_args, $args)
+    };
     ($function:ident, ($rt_type:expr, @dist_dataset),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
         disp_expand!($function, ($rt_type, [HammingDistance, SymmetricDistance]), $rt_dispatch_types, $type_args, $args)
     };

--- a/rust/opendp-ffi/src/dispatch.rs
+++ b/rust/opendp-ffi/src/dispatch.rs
@@ -70,11 +70,18 @@ macro_rules! disp_expand {
     ($function:ident, ($rt_type:expr, @primitives),              $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
         disp_expand!($function, ($rt_type, [u8, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, bool, String]), $rt_dispatch_types, $type_args, $args)
     };
+    // TODO: reimplement Signed to cover u* types
+    ($function:ident, ($rt_type:expr, @signed_numbers),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
+        disp_expand!($function, ($rt_type, [i32, i64, f32, f64]), $rt_dispatch_types, $type_args, $args)
+    };
     ($function:ident, ($rt_type:expr, @numbers),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
         disp_expand!($function, ($rt_type, [u8, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64]), $rt_dispatch_types, $type_args, $args)
     };
     ($function:ident, ($rt_type:expr, @hashable),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
         disp_expand!($function, ($rt_type, [u8, u32, u64, u128, i8, i16, i32, i64, i128, bool, String]), $rt_dispatch_types, $type_args, $args)
+    };
+    ($function:ident, ($rt_type:expr, @dist_dataset),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
+        disp_expand!($function, ($rt_type, [HammingDistance, SymmetricDistance]), $rt_dispatch_types, $type_args, $args)
     };
     ($function:ident, ($rt_type:expr, @dist_dataset),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
         disp_expand!($function, ($rt_type, [HammingDistance, SymmetricDistance]), $rt_dispatch_types, $type_args, $args)

--- a/rust/opendp-ffi/src/dispatch.rs
+++ b/rust/opendp-ffi/src/dispatch.rs
@@ -75,10 +75,10 @@ macro_rules! disp_expand {
         disp_expand!($function, ($rt_type, [i32, i64, f32, f64]), $rt_dispatch_types, $type_args, $args)
     };
     ($function:ident, ($rt_type:expr, @numbers),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
-        disp_expand!($function, ($rt_type, [u8, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64]), $rt_dispatch_types, $type_args, $args)
+        disp_expand!($function, ($rt_type, [u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64]), $rt_dispatch_types, $type_args, $args)
     };
     ($function:ident, ($rt_type:expr, @hashable),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
-        disp_expand!($function, ($rt_type, [u8, u32, u64, u128, i8, i16, i32, i64, i128, bool, String]), $rt_dispatch_types, $type_args, $args)
+        disp_expand!($function, ($rt_type, [u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, bool, String]), $rt_dispatch_types, $type_args, $args)
     };
     ($function:ident, ($rt_type:expr, @dist_dataset),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
         disp_expand!($function, ($rt_type, [HammingDistance, SymmetricDistance]), $rt_dispatch_types, $type_args, $args)
@@ -87,7 +87,7 @@ macro_rules! disp_expand {
         disp_expand!($function, ($rt_type, [f32, f64]), $rt_dispatch_types, $type_args, $args)
     };
     ($function:ident, ($rt_type:expr, @integers),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
-        disp_expand!($function, ($rt_type, [u8, u32, u64, u128, i8, i16, i32, i64, i128]), $rt_dispatch_types, $type_args, $args)
+        disp_expand!($function, ($rt_type, [u8, u16, u32, u64, u128, i8, i16, i32, i64, i128]), $rt_dispatch_types, $type_args, $args)
     };
     ($function:ident, ($rt_type:expr, @dist_dataset),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
         disp_expand!($function, ($rt_type, [HammingDistance, SymmetricDistance]), $rt_dispatch_types, $type_args, $args)

--- a/rust/opendp-ffi/src/dispatch.rs
+++ b/rust/opendp-ffi/src/dispatch.rs
@@ -83,6 +83,9 @@ macro_rules! disp_expand {
     ($function:ident, ($rt_type:expr, @dist_dataset),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
         disp_expand!($function, ($rt_type, [HammingDistance, SymmetricDistance]), $rt_dispatch_types, $type_args, $args)
     };
+    ($function:ident, ($rt_type:expr, @floats),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
+        disp_expand!($function, ($rt_type, [f32, f64]), $rt_dispatch_types, $type_args, $args)
+    };
     ($function:ident, ($rt_type:expr, @dist_dataset),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
         disp_expand!($function, ($rt_type, [HammingDistance, SymmetricDistance]), $rt_dispatch_types, $type_args, $args)
     };

--- a/rust/opendp-ffi/src/meas.rs
+++ b/rust/opendp-ffi/src/meas.rs
@@ -2,7 +2,7 @@ use std::os::raw::{c_char, c_void};
 
 use num::Float;
 
-use opendp::meas::{MakeMeasurement1, SampleGaussian, SampleLaplace};
+use opendp::meas::{MakeMeasurement1, SampleGaussian, SampleLaplace, MakeMeasurement3, SampleGeometric};
 use opendp::meas::gaussian::BaseGaussian;
 use opendp::meas::laplace::{BaseVectorLaplace, BaseLaplace};
 
@@ -10,6 +10,8 @@ use crate::core::FfiMeasurement;
 use crate::util;
 use crate::util::TypeArgs;
 use opendp::traits::DistanceCast;
+use opendp::meas::geometric::BaseSimpleGeometric;
+use std::ops::{Sub, Add};
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_laplace(type_args: *const c_char, scale: *const c_void) -> *mut FfiMeasurement {
@@ -59,14 +61,29 @@ pub extern "C" fn opendp_meas__make_base_gaussian_vec(type_args: *const c_char, 
     dispatch!(monomorphize, [(type_args.0[0], @floats)], (scale))
 }
 
+
+#[no_mangle]
+pub extern "C" fn opendp_meas__make_base_simple_geometric(type_args: *const c_char, scale: f64, min: *const c_void, max: *const c_void) -> *mut FfiMeasurement {
+    fn monomorphize<T>(scale: f64, min: *const c_void, max: *const c_void) -> *mut FfiMeasurement
+        where T: 'static + Clone + SampleGeometric + Sub<Output=T> + Add<Output=T> + DistanceCast {
+        let min = util::as_ref(min as *const T).clone();
+        let max = util::as_ref(max as *const T).clone();
+        let measurement = BaseSimpleGeometric::<T>::make(scale, min, max).unwrap();
+        FfiMeasurement::new_from_types(measurement)
+    }
+    let type_args = TypeArgs::expect(type_args, 1);
+    dispatch!(monomorphize, [(type_args.0[0], @integers)], (scale, min, max))
+}
+
 #[no_mangle]
 pub extern "C" fn opendp_meas__bootstrap() -> *const c_char {
     let spec =
 r#"{
 "functions": [
-    { "name": "make_base_laplace", "args": [ ["const char *", "selector"], ["double", "scale"] ], "ret": "FfiMeasurement *" },
-    { "name": "make_base_laplace_vec", "args": [ ["const char *", "selector"], ["double", "scale"] ], "ret": "FfiMeasurement *" },
-    { "name": "make_base_gaussian", "args": [ ["const char *", "selector"], ["double", "scale"] ], "ret": "FfiMeasurement *" }
+    { "name": "make_base_laplace", "args": [ ["const char *", "selector"], ["void *", "scale"] ], "ret": "FfiMeasurement *" },
+    { "name": "make_base_laplace_vec", "args": [ ["const char *", "selector"], ["void *", "scale"] ], "ret": "FfiMeasurement *" },
+    { "name": "make_base_gaussian", "args": [ ["const char *", "selector"], ["void *", "scale"] ], "ret": "FfiMeasurement *" },
+    { "name": "make_base_simple_geometric", "args": [ ["const char *", "selector"], ["double", "scale"], ["void *", "min"], ["void *", "max"] ], "ret": "FfiMeasurement *" }
 ]
 }"#;
     util::bootstrap(spec)

--- a/rust/opendp-ffi/src/meas.rs
+++ b/rust/opendp-ffi/src/meas.rs
@@ -1,46 +1,62 @@
-use std::os::raw::c_char;
+use std::os::raw::{c_char, c_void};
 
-use num::NumCast;
+use num::Float;
 
-use opendp::meas::{MakeMeasurement1};
-use opendp::meas::gaussian::GaussianMechanism;
-use opendp::meas::laplace::{VectorLaplaceMechanism, LaplaceMechanism};
+use opendp::meas::{MakeMeasurement1, SampleGaussian, SampleLaplace};
+use opendp::meas::gaussian::BaseGaussian;
+use opendp::meas::laplace::{BaseVectorLaplace, BaseLaplace};
 
 use crate::core::FfiMeasurement;
 use crate::util;
 use crate::util::TypeArgs;
+use opendp::traits::DistanceCast;
 
 #[no_mangle]
-pub extern "C" fn opendp_meas__make_base_laplace(type_args: *const c_char, sigma: f64) -> *mut FfiMeasurement {
-    fn monomorphize<T>(sigma: f64) -> *mut FfiMeasurement where
-        T: 'static + Copy + NumCast {
-        let measurement = LaplaceMechanism::<T>::make(sigma).unwrap();
+pub extern "C" fn opendp_meas__make_base_laplace(type_args: *const c_char, scale: *const c_void) -> *mut FfiMeasurement {
+    fn monomorphize<T>(scale: *const c_void) -> *mut FfiMeasurement
+        where T: 'static + Clone + SampleLaplace + Float + DistanceCast {
+        let scale = util::as_ref(scale as *const T).clone();
+        let measurement = BaseLaplace::<T>::make(scale).unwrap();
         FfiMeasurement::new_from_types(measurement)
     }
     let type_args = TypeArgs::expect(type_args, 1);
-    dispatch!(monomorphize, [(type_args.0[0], @numbers)], (sigma))
+    dispatch!(monomorphize, [(type_args.0[0], @floats)], (scale))
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_meas__make_base_laplace_vec(type_args: *const c_char, sigma: f64) -> *mut FfiMeasurement {
-    fn monomorphize<T>(sigma: f64) -> *mut FfiMeasurement where
-        T: 'static + Copy + NumCast {
-        let measurement = VectorLaplaceMechanism::<T>::make(sigma).unwrap();
+pub extern "C" fn opendp_meas__make_base_laplace_vec(type_args: *const c_char, scale: *const c_void) -> *mut FfiMeasurement {
+    fn monomorphize<T>(scale: *const c_void) -> *mut FfiMeasurement
+        where T: 'static + Clone + SampleLaplace + Float + DistanceCast {
+        let scale = util::as_ref(scale as *const T).clone();
+        let measurement = BaseVectorLaplace::<T>::make(scale).unwrap();
         FfiMeasurement::new_from_types(measurement)
     }
     let type_args = TypeArgs::expect(type_args, 1);
-    dispatch!(monomorphize, [(type_args.0[0], @numbers)], (sigma))
+    dispatch!(monomorphize, [(type_args.0[0], @floats)], (scale))
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_meas__make_base_gaussian(type_args: *const c_char, sigma: f64) -> *mut FfiMeasurement {
-    fn monomorphize<T>(sigma: f64) -> *mut FfiMeasurement where
-        T: 'static + Copy + NumCast {
-        let measurement = GaussianMechanism::<T>::make(sigma).unwrap();
+pub extern "C" fn opendp_meas__make_base_gaussian(type_args: *const c_char, scale: *const c_void) -> *mut FfiMeasurement {
+    fn monomorphize<T>(scale: *const c_void) -> *mut FfiMeasurement where
+        T: 'static + Copy + SampleGaussian + Float {
+        let scale = util::as_ref(scale as *const T).clone();
+        let measurement = BaseGaussian::<T>::make(scale).unwrap();
         FfiMeasurement::new_from_types(measurement)
     }
     let type_args = TypeArgs::expect(type_args, 1);
-    dispatch!(monomorphize, [(type_args.0[0], @numbers)], (sigma))
+    dispatch!(monomorphize, [(type_args.0[0], @floats)], (scale))
+}
+
+#[no_mangle]
+pub extern "C" fn opendp_meas__make_base_gaussian_vec(type_args: *const c_char, scale: *const c_void) -> *mut FfiMeasurement {
+    fn monomorphize<T>(scale: *const c_void) -> *mut FfiMeasurement where
+        T: 'static + Copy + SampleGaussian + Float {
+        let scale = util::as_ref(scale as *const T).clone();
+        let measurement = BaseGaussian::<T>::make(scale).unwrap();
+        FfiMeasurement::new_from_types(measurement)
+    }
+    let type_args = TypeArgs::expect(type_args, 1);
+    dispatch!(monomorphize, [(type_args.0[0], @floats)], (scale))
 }
 
 #[no_mangle]
@@ -48,9 +64,9 @@ pub extern "C" fn opendp_meas__bootstrap() -> *const c_char {
     let spec =
 r#"{
 "functions": [
-    { "name": "make_base_laplace", "args": [ ["const char *", "selector"], ["double", "sigma"] ], "ret": "FfiMeasurement *" },
-    { "name": "make_base_laplace_vec", "args": [ ["const char *", "selector"], ["double", "sigma"] ], "ret": "FfiMeasurement *" },
-    { "name": "make_base_gaussian", "args": [ ["const char *", "selector"], ["double", "sigma"] ], "ret": "FfiMeasurement *" }
+    { "name": "make_base_laplace", "args": [ ["const char *", "selector"], ["double", "scale"] ], "ret": "FfiMeasurement *" },
+    { "name": "make_base_laplace_vec", "args": [ ["const char *", "selector"], ["double", "scale"] ], "ret": "FfiMeasurement *" },
+    { "name": "make_base_gaussian", "args": [ ["const char *", "selector"], ["double", "scale"] ], "ret": "FfiMeasurement *" }
 ]
 }"#;
     util::bootstrap(spec)

--- a/rust/opendp-ffi/src/meas.rs
+++ b/rust/opendp-ffi/src/meas.rs
@@ -1,10 +1,14 @@
 use std::os::raw::c_char;
 
+use num::NumCast;
+
+use opendp::meas::{MakeMeasurement1};
+use opendp::meas::gaussian::GaussianMechanism;
+use opendp::meas::laplace::{VectorLaplaceMechanism, LaplaceMechanism};
+
 use crate::core::FfiMeasurement;
 use crate::util;
 use crate::util::TypeArgs;
-use num::NumCast;
-use opendp::meas::{LaplaceMechanism, MakeMeasurement1, GaussianMechanism, VectorLaplaceMechanism};
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_laplace(type_args: *const c_char, sigma: f64) -> *mut FfiMeasurement {

--- a/rust/opendp/Cargo.toml
+++ b/rust/opendp/Cargo.toml
@@ -9,5 +9,29 @@ rand = "0.7.3"
 num = "0.3.1"
 thiserror = "1.0.24"
 backtrace = "0.3"
+ieee754 = "0.2.6"
+statrs = "0.13.0"
+
+[dependencies.openssl]
+version = "0.10.29"
+features = ["vendored"]
+
+[dependencies.rug]
+version = "1.9.0"
+default-features = false
+features = ["integer", "float", "rand"]
+optional = true
+
+[dependencies.gmp-mpfr-sys]
+version = "=1.3.1"
+default-features = false
+features = ["mpfr"]
+optional = true
+
+[features]
+default = ["use-mpfr"]
+# re-export use-system-libs from mpfr
+use-mpfr = ["gmp-mpfr-sys", "rug"]
+use-system-libs = ["use-mpfr", "gmp-mpfr-sys/use-system-libs"]
 
 [lib]

--- a/rust/opendp/src/dist.rs
+++ b/rust/opendp/src/dist.rs
@@ -6,21 +6,21 @@ use crate::core::{DatasetMetric, Measure, Metric, SensitivityMetric};
 
 /// Measures
 #[derive(Clone)]
-pub struct MaxDivergence;
-impl Measure for MaxDivergence {
-    type Distance = f64;
+pub struct MaxDivergence<Q>(PhantomData<Q>);
+impl<Q: Clone> Measure for MaxDivergence<Q> {
+    type Distance = Q;
 }
-impl MaxDivergence {
-    pub fn new() -> Self { MaxDivergence }
+impl<Q> MaxDivergence<Q> {
+    pub fn new() -> Self { MaxDivergence(PhantomData) }
 }
 
 #[derive(Clone)]
-pub struct SmoothedMaxDivergence;
-impl Measure for SmoothedMaxDivergence {
-    type Distance = (f64, f64);
+pub struct SmoothedMaxDivergence<Q>(PhantomData<Q>);
+impl<Q: Clone> Measure for SmoothedMaxDivergence<Q> {
+    type Distance = (Q, Q);
 }
-impl SmoothedMaxDivergence {
-    pub fn new() -> Self { SmoothedMaxDivergence }
+impl<Q> SmoothedMaxDivergence<Q> {
+    pub fn new() -> Self { SmoothedMaxDivergence(PhantomData) }
 }
 
 /// Metrics

--- a/rust/opendp/src/lib.rs
+++ b/rust/opendp/src/lib.rs
@@ -42,7 +42,7 @@
 //! use opendp::dist::{HammingDistance, L1Sensitivity};
 //! use opendp::core::{ChainTT, ChainMT};
 //! use opendp::meas::{MakeMeasurement2,  MakeMeasurement1};
-//! use opendp::meas::laplace::LaplaceMechanism;
+//! use opendp::meas::laplace::BaseLaplace;
 //!
 //! pub fn example() {
 //!     let data = "56\n15\n97\n56\n6\n17\n2\n19\n16\n50".to_owned();
@@ -58,7 +58,7 @@
 //!     // Construct a Measurement to calculate a noisy sum.
 //!     let clamp = trans::Clamp::make(bounds.0, bounds.1).unwrap();
 //!     let bounded_sum = trans::BoundedSum::make2(bounds.0, bounds.1).unwrap();
-//!     let laplace = LaplaceMechanism::make(sigma).unwrap();
+//!     let laplace = BaseLaplace::make(sigma).unwrap();
 //!     let intermediate = ChainTT::make(&bounded_sum, &clamp).unwrap();
 //!     let noisy_sum = ChainMT::make(&laplace, &intermediate).unwrap();
 //!

--- a/rust/opendp/src/lib.rs
+++ b/rust/opendp/src/lib.rs
@@ -41,7 +41,8 @@
 //! use opendp::trans::{MakeTransformation0, MakeTransformation1, MakeTransformation2, MakeTransformation3};
 //! use opendp::dist::{HammingDistance, L1Sensitivity};
 //! use opendp::core::{ChainTT, ChainMT};
-//! use opendp::meas::{MakeMeasurement2, LaplaceMechanism, MakeMeasurement1};
+//! use opendp::meas::{MakeMeasurement2,  MakeMeasurement1};
+//! use opendp::meas::laplace::LaplaceMechanism;
 //!
 //! pub fn example() {
 //!     let data = "56\n15\n97\n56\n6\n17\n2\n19\n16\n50".to_owned();

--- a/rust/opendp/src/meas/gaussian.rs
+++ b/rust/opendp/src/meas/gaussian.rs
@@ -1,0 +1,60 @@
+use std::marker::PhantomData;
+
+use num::NumCast;
+
+use crate::core::{Measurement, Function, PrivacyRelation};
+use crate::dist::{L2Sensitivity, SmoothedMaxDivergence};
+use crate::dom::AllDomain;
+use crate::meas::{MakeMeasurement1, sample_gaussian};
+use crate::error::Fallible;
+
+
+pub struct GaussianMechanism<T> {
+    data: PhantomData<T>
+}
+
+// gaussian for scalar-valued query
+impl<T> MakeMeasurement1<AllDomain<T>, AllDomain<T>, L2Sensitivity<f64>, SmoothedMaxDivergence, f64> for GaussianMechanism<T>
+    where T: Copy + NumCast {
+    fn make1(sigma: f64) -> Fallible<Measurement<AllDomain<T>, AllDomain<T>, L2Sensitivity<f64>, SmoothedMaxDivergence>> {
+        Ok(Measurement::new(
+            AllDomain::new(),
+            AllDomain::new(),
+            Function::new_fallible(move |arg: &T| -> Fallible<T> {
+                <f64 as NumCast>::from(*arg).ok_or_else(|| err!(FailedCast))
+                    .and_then(|v| sample_gaussian(0., sigma, false)
+                        .and_then(|noise|  T::from(v + noise).ok_or_else(|| err!(FailedCast))))
+            }),
+            L2Sensitivity::new(),
+            SmoothedMaxDivergence::new(),
+            PrivacyRelation::new_fallible(move |&d_in: &f64, &(eps, del): &(f64, f64)| {
+                if d_in < 0. {
+                    return fallible!(InvalidDistance, "gaussian mechanism: input sensitivity must be non-negative")
+                }
+                if eps <= 0. {
+                    return fallible!(InvalidDistance, "gaussian mechanism: epsilon must be positive")
+                }
+                if del <= 0. {
+                    return fallible!(InvalidDistance, "gaussian mechanism: delta must be positive")
+                }
+                // TODO: should we error if epsilon > 1., or just waste the budget?
+                Ok(eps.min(1.) >= (d_in / sigma) * (2. * (1.25 / del).ln()).sqrt())
+            })))
+    }
+}
+
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_make_gaussian_mechanism() {
+        let measurement = GaussianMechanism::<f64>::make(1.0);
+        let arg = 0.0;
+        let _ret = measurement.function.eval(&arg);
+
+        assert!(measurement.privacy_relation.eval(&0.1, &(0.5, 0.00001)));
+    }
+}

--- a/rust/opendp/src/meas/gaussian.rs
+++ b/rust/opendp/src/meas/gaussian.rs
@@ -1,44 +1,46 @@
 use std::marker::PhantomData;
 
-use num::NumCast;
+use num::Float;
 
 use crate::core::{Measurement, Function, PrivacyRelation};
 use crate::dist::{L2Sensitivity, SmoothedMaxDivergence};
 use crate::dom::AllDomain;
-use crate::meas::{MakeMeasurement1, sample_gaussian};
+use crate::meas::{MakeMeasurement1, SampleGaussian};
 use crate::error::Fallible;
 
 
-pub struct GaussianMechanism<T> {
+pub struct BaseGaussian<T> {
     data: PhantomData<T>
 }
 
 // gaussian for scalar-valued query
-impl<T> MakeMeasurement1<AllDomain<T>, AllDomain<T>, L2Sensitivity<f64>, SmoothedMaxDivergence, f64> for GaussianMechanism<T>
-    where T: Copy + NumCast {
-    fn make1(sigma: f64) -> Fallible<Measurement<AllDomain<T>, AllDomain<T>, L2Sensitivity<f64>, SmoothedMaxDivergence>> {
+impl<T> MakeMeasurement1<AllDomain<T>, AllDomain<T>, L2Sensitivity<T>, SmoothedMaxDivergence<T>, T> for BaseGaussian<T>
+    where T: 'static + Clone + SampleGaussian + Float {
+    fn make1(scale: T) -> Fallible<Measurement<AllDomain<T>, AllDomain<T>, L2Sensitivity<T>, SmoothedMaxDivergence<T>>> {
+        let _2_ = T::from(2.).ok_or_else(|| err!(FailedCast))?;
+        let _1_25 = T::from(1.25).ok_or_else(|| err!(FailedCast))?;
+
         Ok(Measurement::new(
             AllDomain::new(),
             AllDomain::new(),
             Function::new_fallible(move |arg: &T| -> Fallible<T> {
-                <f64 as NumCast>::from(*arg).ok_or_else(|| err!(FailedCast))
-                    .and_then(|v| sample_gaussian(0., sigma, false)
-                        .and_then(|noise|  T::from(v + noise).ok_or_else(|| err!(FailedCast))))
+                T::sample_gaussian(arg.clone(), scale.clone(), false)
             }),
             L2Sensitivity::new(),
             SmoothedMaxDivergence::new(),
-            PrivacyRelation::new_fallible(move |&d_in: &f64, &(eps, del): &(f64, f64)| {
-                if d_in < 0. {
+            PrivacyRelation::new_fallible(move |&d_in: &T, &(eps, del): &(T, T)| {
+                if d_in.is_sign_negative() {
                     return fallible!(InvalidDistance, "gaussian mechanism: input sensitivity must be non-negative")
                 }
-                if eps <= 0. {
+                if eps.is_sign_negative() || eps.is_zero() {
                     return fallible!(InvalidDistance, "gaussian mechanism: epsilon must be positive")
                 }
-                if del <= 0. {
+                if del.is_sign_negative() || del.is_zero() {
                     return fallible!(InvalidDistance, "gaussian mechanism: delta must be positive")
                 }
+
                 // TODO: should we error if epsilon > 1., or just waste the budget?
-                Ok(eps.min(1.) >= (d_in / sigma) * (2. * (1.25 / del).ln()).sqrt())
+                Ok(eps.min(T::one()) >= (d_in / scale) * (_2_ * (_1_25 / del).ln()).sqrt())
             })))
     }
 }
@@ -51,10 +53,10 @@ mod tests {
 
     #[test]
     fn test_make_gaussian_mechanism() {
-        let measurement = GaussianMechanism::<f64>::make(1.0);
+        let measurement = BaseGaussian::<f64>::make(1.0).unwrap();
         let arg = 0.0;
-        let _ret = measurement.function.eval(&arg);
+        let _ret = measurement.function.eval(&arg).unwrap();
 
-        assert!(measurement.privacy_relation.eval(&0.1, &(0.5, 0.00001)));
+        assert!(measurement.privacy_relation.eval(&0.1, &(0.5, 0.00001)).unwrap());
     }
 }

--- a/rust/opendp/src/meas/geometric.rs
+++ b/rust/opendp/src/meas/geometric.rs
@@ -13,7 +13,7 @@ pub struct BaseSimpleGeometric<T> {
     data: PhantomData<T>
 }
 
-// gaussian for scalar-valued query
+// geometric for scalar-valued query
 impl<T> MakeMeasurement3<AllDomain<T>, AllDomain<T>, L2Sensitivity<T>, MaxDivergence<f64>, f64, T, T> for BaseSimpleGeometric<T>
     where T: 'static + Clone + SampleGeometric + Sub<Output=T> + Add<Output=T> + DistanceCast {
     fn make3(scale: f64, min: T, max: T) -> Fallible<Measurement<AllDomain<T>, AllDomain<T>, L2Sensitivity<T>, MaxDivergence<f64>>> {

--- a/rust/opendp/src/meas/geometric.rs
+++ b/rust/opendp/src/meas/geometric.rs
@@ -1,0 +1,55 @@
+use std::marker::PhantomData;
+use std::ops::{Sub, Add};
+
+
+use crate::core::{Function, Measurement, PrivacyRelation};
+use crate::dist::{L2Sensitivity, MaxDivergence};
+use crate::dom::AllDomain;
+use crate::error::Fallible;
+use crate::meas::{MakeMeasurement3, SampleBernoulli, SampleGeometric, SampleUniform};
+use crate::traits::DistanceCast;
+
+pub struct BaseSimpleGeometric<T> {
+    data: PhantomData<T>
+}
+
+// gaussian for scalar-valued query
+impl<T> MakeMeasurement3<AllDomain<T>, AllDomain<T>, L2Sensitivity<T>, MaxDivergence<f64>, f64, T, T> for BaseSimpleGeometric<T>
+    where T: 'static + Clone + SampleGeometric + Sub<Output=T> + Add<Output=T> + DistanceCast {
+    fn make3(scale: f64, min: T, max: T) -> Fallible<Measurement<AllDomain<T>, AllDomain<T>, L2Sensitivity<T>, MaxDivergence<f64>>> {
+        Ok(Measurement::new(
+            AllDomain::new(),
+            AllDomain::new(),
+            Function::new_fallible(move |arg: &T| -> Fallible<T> {
+                let alpha: f64 = std::f64::consts::E.powf(-1. / scale);
+                let max_trials: T = max - min;
+
+                // return 0 noise with probability (1-alpha) / (1+alpha), otherwise sample from geometric
+                Ok(if f64::sample_standard_uniform(false)? < (1. - alpha) / (1. + alpha) {
+                    arg.clone()
+                } else if bool::sample_standard_bernoulli()? {
+                    arg.clone() + T::sample_geometric(1. - alpha, max_trials, false)?
+                } else {
+                    arg.clone() - T::sample_geometric(1. - alpha, max_trials, false)?
+                })
+            }),
+            L2Sensitivity::new(),
+            MaxDivergence::new(),
+            PrivacyRelation::new_from_constant(scale.recip())))
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_make_geometric_mechanism() {
+        let measurement = BaseSimpleGeometric::<i32>::make(10.0, 200, 210).unwrap();
+        let arg = 205;
+        let _ret = measurement.function.eval(&arg).unwrap();
+
+        assert!(measurement.privacy_relation.eval(&1, &0.5).unwrap());
+    }
+}

--- a/rust/opendp/src/meas/laplace.rs
+++ b/rust/opendp/src/meas/laplace.rs
@@ -1,0 +1,81 @@
+use std::marker::PhantomData;
+
+use num::NumCast;
+
+use crate::core::{Measurement, Function, PrivacyRelation};
+use crate::dist::{L1Sensitivity, MaxDivergence};
+use crate::dom::{AllDomain, VectorDomain};
+use crate::meas::{MakeMeasurement1, sample_laplace};
+use crate::error::Fallible;
+
+pub struct LaplaceMechanism<T> {
+    data: PhantomData<T>
+}
+
+// laplace for scalar-valued query
+impl<T> MakeMeasurement1<AllDomain<T>, AllDomain<T>, L1Sensitivity<f64>, MaxDivergence, f64> for LaplaceMechanism<T>
+    where T: Copy + NumCast {
+    fn make1(sigma: f64) -> Fallible<Measurement<AllDomain<T>, AllDomain<T>, L1Sensitivity<f64>, MaxDivergence>> {
+        Ok(Measurement::new(
+            AllDomain::new(),
+            AllDomain::new(),
+            Function::new_fallible(move |arg: &T| -> Fallible<T> {
+                <f64 as NumCast>::from(*arg).ok_or_else(|| err!(FailedCast))
+                    .and_then(|v| sample_laplace(sigma).and_then(|noise| T::from(v + noise)
+                        .ok_or_else(|| err!(FailedCast))))
+            }),
+            L1Sensitivity::new(),
+            MaxDivergence::new(),
+            PrivacyRelation::new_from_constant(1. / sigma)))
+    }
+}
+
+pub struct VectorLaplaceMechanism<T> {
+    data: PhantomData<T>
+}
+
+// laplace for vector-valued query
+impl<T> MakeMeasurement1<VectorDomain<AllDomain<T>>, VectorDomain<AllDomain<T>>, L1Sensitivity<f64>, MaxDivergence, f64> for VectorLaplaceMechanism<T>
+    where T: Copy + NumCast {
+    fn make1(sigma: f64) -> Fallible<Measurement<VectorDomain<AllDomain<T>>, VectorDomain<AllDomain<T>>, L1Sensitivity<f64>, MaxDivergence>> {
+        Ok(Measurement::new(
+            VectorDomain::new_all(),
+            VectorDomain::new_all(),
+            Function::new_fallible(move |arg: &Vec<T>| -> Fallible<Vec<T>> {
+                arg.iter()
+                    .map(|v| <f64 as NumCast>::from(*v).ok_or_else(|| err!(FailedCast))
+                        .and_then(|v| sample_laplace(sigma)
+                            .and_then(|noise| T::from(v + noise)
+                                .ok_or_else(|| err!(FailedCast)))))
+                    .collect::<Fallible<_>>()
+            }),
+            L1Sensitivity::new(),
+            MaxDivergence::new(),
+            PrivacyRelation::new_from_constant(1. / sigma)))
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_make_laplace_mechanism() {
+        let measurement = LaplaceMechanism::<f64>::make(1.0);
+        let arg = 0.0;
+        let _ret = measurement.function.eval(&arg);
+
+        assert!(measurement.privacy_relation.eval(&1., &1.));
+    }
+
+    #[test]
+    fn test_make_vector_laplace_mechanism() {
+        let measurement = VectorLaplaceMechanism::<f64>::make(1.0);
+        let arg = vec![1.0, 2.0, 3.0];
+        let _ret = measurement.function.eval(&arg);
+
+        assert!(measurement.privacy_relation.eval(&1., &1.));
+    }
+}
+

--- a/rust/opendp/src/meas/mod.rs
+++ b/rust/opendp/src/meas/mod.rs
@@ -17,9 +17,12 @@ use statrs::function::erf;
 
 use crate::core::{Domain, Measure, Metric};
 use crate::error::Fallible;
+use num::{Zero, One};
+use std::ops::{Neg, AddAssign};
 
 pub mod laplace;
 pub mod gaussian;
+pub mod geometric;
 
 // Trait for all constructors, can have different implementations depending on concrete types of Domains and/or Metrics
 pub trait MakeMeasurement<DI: Domain, DO: Domain, MI: Metric, MO: Measure> {
@@ -79,130 +82,156 @@ impl ThreadRandGen for GeneratorOpenSSL {
 
 
 // SAMPLERS
-pub fn sample_standard_bernoulli() -> Fallible<bool> {
-    let mut buffer = [0u8; 1];
-    fill_bytes(&mut buffer)?;
-    Ok(buffer[0] & 1 == 1)
+pub trait SampleBernoulli: Sized {
+    fn sample_standard_bernoulli() -> Fallible<Self>;
+
+    /// Sample a single bit with arbitrary probability of success
+    ///
+    /// Uses only an unbiased source of coin flips.
+    /// The strategy for doing this with 2 flips in expectation is described [here](https://amakelov.wordpress.com/2013/10/10/arbitrarily-biasing-a-coin-in-2-expected-tosses/).
+    ///
+    /// # Arguments
+    /// * `prob`- The desired probability of success (bit = 1).
+    /// * `enforce_constant_time` - Whether or not to enforce the algorithm to run in constant time
+    ///
+    /// # Return
+    /// A bit that is 1 with probability "prob"
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// // returns a bit with Pr(bit = 1) = 0.7
+    /// use opendp::meas::SampleBernoulli;
+    /// let n = bool::sample_bernoulli(0.7, false);
+    /// # n.unwrap();
+    /// ```
+    /// ```should_panic
+    /// // fails because 1.3 not a valid probability
+    /// use opendp::meas::SampleBernoulli;
+    /// let n = bool::sample_bernoulli(1.3, false);
+    /// # n.unwrap();
+    /// ```
+    /// ```should_panic
+    /// // fails because -0.3 is not a valid probability
+    /// use opendp::meas::SampleBernoulli;
+    /// let n = bool::sample_bernoulli(-0.3, false);
+    /// # n.unwrap();
+    /// ```
+    fn sample_bernoulli(prob: f64, enforce_constant_time: bool) -> Fallible<Self>;
+}
+impl SampleBernoulli for bool {
+    fn sample_standard_bernoulli() -> Fallible<Self> {
+        let mut buffer = [0u8; 1];
+        fill_bytes(&mut buffer)?;
+        Ok(buffer[0] & 1 == 1)
+    }
+
+    fn sample_bernoulli(prob: f64, enforce_constant_time: bool) -> Fallible<Self> {
+
+        // ensure that prob is a valid probability
+        if prob < 0.0 || prob > 1.0 {return fallible!(FailedFunction, "probability is not within [0, 1]")}
+
+        // decompose probability into mantissa and exponent integers to quickly identify the value in the first_heads_index
+        let (_sign, exponent, mantissa) = prob.decompose_raw();
+
+        // repeatedly flip fair coin (up to 1023 times) and identify index (0-based) of first heads
+        let first_heads_index = sample_i10_geometric(enforce_constant_time)?;
+
+        // if prob == 1., return after retrieving censored_specific_geom, to protect constant time
+        if exponent == 1023 { return Ok(true) }
+
+        // number of leading zeros in binary representation of prob
+        //    cast is non-saturating because exponent only uses first 11 bits
+        //    exponent is bounded within [0, 1022] by check for valid probability
+        let num_leading_zeros = 1022_i16 - exponent as i16;
+
+        // 0 is the most significant/leftmost implicit bit in the mantissa/fraction/significand
+        // 52 is the least significant/rightmost
+        Ok(match first_heads_index - num_leading_zeros {
+            // index into the leading zeros of the binary representation
+            i if i < 0 => false,
+            // bit index 0 is implicitly set in ieee-754 when the exponent is nonzero
+            i if i == 0 => exponent != 0,
+            // all other digits out-of-bounds are not float-approximated/are-implicitly-zero
+            i if i > 52 => false,
+            // retrieve the bit at `i` slots shifted from the left
+            i => mantissa & (1_u64 << (52 - i as usize)) != 0
+        })
+    }
+}
+pub trait SampleRademacher: Sized {
+    fn sample_standard_rademacher() -> Fallible<Self>;
+    fn sample_rademacher(prob: f64, enforce_constant_time: bool) -> Fallible<Self>;
+}
+impl<T: Neg<Output=T> + One> SampleRademacher for T {
+    fn sample_standard_rademacher() -> Fallible<Self> {
+        Ok(if bool::sample_standard_bernoulli()? {T::one()} else {T::one().neg()})
+    }
+    fn sample_rademacher(prob: f64, enforce_constant_time: bool) -> Fallible<Self> {
+        Ok(if bool::sample_bernoulli(prob, enforce_constant_time)? {T::one()} else {T::one().neg()})
+    }
 }
 
+pub trait SampleUniform: Sized {
 
-/// Sample a single bit with arbitrary probability of success
-///
-/// Uses only an unbiased source of coin flips.
-/// The strategy for doing this with 2 flips in expectation is described [here](https://amakelov.wordpress.com/2013/10/10/arbitrarily-biasing-a-coin-in-2-expected-tosses/).
-///
-/// # Arguments
-/// * `prob`- The desired probability of success (bit = 1).
-/// * `enforce_constant_time` - Whether or not to enforce the algorithm to run in constant time
-///
-/// # Return
-/// A bit that is 1 with probability "prob"
-///
-/// # Examples
-///
-/// ```
-/// // returns a bit with Pr(bit = 1) = 0.7
-/// use opendp::meas::sample_bernoulli;
-/// let n = sample_bernoulli(0.7, false);
-/// # n.unwrap();
-/// ```
-/// ```should_panic
-/// // fails because 1.3 not a valid probability
-/// use opendp::meas::sample_bernoulli;
-/// let n = sample_bernoulli(1.3, false);
-/// # n.unwrap();
-/// ```
-/// ```should_panic
-/// // fails because -0.3 is not a valid probability
-/// use opendp::meas::sample_bernoulli;
-/// let n = sample_bernoulli(-0.3, false);
-/// # n.unwrap();
-/// ```
-pub fn sample_bernoulli(prob: f64, enforce_constant_time: bool) -> Fallible<bool> {
-
-    // ensure that prob is a valid probability
-    if prob < 0.0 || prob > 1.0 {return fallible!(FailedFunction, "probability is not within [0, 1]")}
-
-    // decompose probability into mantissa and exponent integers to quickly identify the value in the first_heads_index
-    let (_sign, exponent, mantissa) = prob.decompose_raw();
-
-    // repeatedly flip fair coin (up to 1023 times) and identify index (0-based) of first heads
-    let first_heads_index = sample_censored_standard_geometric(enforce_constant_time)?;
-
-    // if prob == 1., return after retrieving censored_specific_geom, to protect constant time
-    if exponent == 1023 { return Ok(true) }
-
-    // number of leading zeros in binary representation of prob
-    //    cast is non-saturating because exponent only uses first 11 bits
-    //    exponent is bounded within [0, 1022] by check for valid probability
-    let num_leading_zeros = 1022_i16 - exponent as i16;
-
-    // 0 is the most significant/leftmost implicit bit in the mantissa/fraction/significand
-    // 52 is the least significant/rightmost
-    Ok(match first_heads_index - num_leading_zeros {
-        // index into the leading zeros of the binary representation
-        i if i < 0 => false,
-        // bit index 0 is implicitly set in ieee-754 when the exponent is nonzero
-        i if i == 0 => exponent != 0,
-        // all other digits out-of-bounds are not float-approximated/are-implicitly-zero
-        i if i > 52 => false,
-        // retrieve the bit at `i` slots shifted from the left
-        i => mantissa & (1_u64 << (52 - i as usize)) != 0
-    })
+    /// Returns a random sample from Uniform[0,1).
+    ///
+    /// This algorithm is taken from [Mironov (2012)](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.366.5957&rep=rep1&type=pdf)
+    /// and is important for making some of the guarantees in the paper.
+    ///
+    /// The idea behind the uniform sampling is to first sample a "precision band".
+    /// Each band is a range of floating point numbers with the same level of arithmetic precision
+    /// and is situated between powers of two.
+    /// A band is sampled with probability relative to the unit of least precision using the Geometric distribution.
+    /// That is, the uniform sampler will generate the band [1/2,1) with probability 1/2, [1/4,1/2) with probability 1/4,
+    /// and so on.
+    ///
+    /// Once the precision band has been selected, floating numbers numbers are generated uniformly within the band
+    /// by generating a 52-bit mantissa uniformly at random.
+    ///
+    /// # Arguments
+    ///
+    /// `min`: f64 minimum of uniform distribution (inclusive)
+    /// `max`: f64 maximum of uniform distribution (non-inclusive)
+    ///
+    /// # Return
+    /// Random draw from Unif[min, max).
+    ///
+    /// # Example
+    /// ```
+    /// // valid draw from Unif[0,1)
+    /// use opendp::meas::SampleUniform;
+    /// let unif = f64::sample_standard_uniform(false);
+    /// # unif.unwrap();
+    /// ```
+    fn sample_standard_uniform(enforce_constant_time: bool) -> Fallible<Self>;
 }
+impl SampleUniform for f64 {
+    fn sample_standard_uniform(enforce_constant_time: bool) -> Fallible<Self> {
 
+        // A saturated mantissa with implicit bit is ~2
+        let exponent: i16 = -(1 + sample_i10_geometric(enforce_constant_time)?);
 
-/// Returns random sample from Uniform[0,1).
-///
-/// This algorithm is taken from [Mironov (2012)](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.366.5957&rep=rep1&type=pdf)
-/// and is important for making some of the guarantees in the paper.
-///
-/// The idea behind the uniform sampling is to first sample a "precision band".
-/// Each band is a range of floating point numbers with the same level of arithmetic precision
-/// and is situated between powers of two.
-/// A band is sampled with probability relative to the unit of least precision using the Geometric distribution.
-/// That is, the uniform sampler will generate the band [1/2,1) with probability 1/2, [1/4,1/2) with probability 1/4,
-/// and so on.
-///
-/// Once the precision band has been selected, floating numbers numbers are generated uniformly within the band
-/// by generating a 52-bit mantissa uniformly at random.
-///
-/// # Arguments
-///
-/// `min`: f64 minimum of uniform distribution (inclusive)
-/// `max`: f64 maximum of uniform distribution (non-inclusive)
-///
-/// # Return
-/// Random draw from Unif[min, max).
-///
-/// # Example
-/// ```
-/// // valid draw from Unif[0,1)
-/// use opendp::meas::sample_standard_uniform;
-/// let unif = sample_standard_uniform(false);
-/// # unif.unwrap();
-/// ```
-pub fn sample_standard_uniform(enforce_constant_time: bool) -> Fallible<f64> {
+        let mantissa: u64 = {
+            let mut mantissa_buffer = [0u8; 8];
+            // mantissa bit index zero is implicit
+            fill_bytes(&mut mantissa_buffer[1..])?;
+            // limit the buffer to 52 bits
+            mantissa_buffer[1] %= 16;
 
-    // Generate mantissa
-    let mut mantissa_buffer = [0u8; 8];
-    // mantissa bit index zero is implicit
-    fill_bytes(&mut mantissa_buffer[1..])?;
-    // limit the buffer to 52 bits
-    mantissa_buffer[1] %= 16;
+            // convert mantissa to integer
+            u64::from_be_bytes(mantissa_buffer)
+        };
 
-    // convert mantissa to integer
-    let mantissa_int = u64::from_be_bytes(mantissa_buffer);
-
-    // Generate exponent. A saturated mantissa with implicit bit is ~2
-    let exponent: i16 = -(1 + sample_censored_standard_geometric(enforce_constant_time)?);
-
-    // Generate uniform random number from [0,1)
-    let uniform_rand = f64::recompose(false, exponent, mantissa_int);
-
-    Ok(uniform_rand)
+        // Generate uniform random number from [0,1)
+        Ok(Self::recompose(false, exponent, mantissa))
+    }
 }
-
+impl SampleUniform for f32 {
+    fn sample_standard_uniform(enforce_constant_time: bool) -> Fallible<Self> {
+        f64::sample_standard_uniform(enforce_constant_time).map(|v| v as f32)
+    }
+}
 
 /// Return sample from a censored Geometric distribution with parameter p=0.5 without calling to sample_bit_prob.
 ///
@@ -210,12 +239,11 @@ pub fn sample_standard_uniform(enforce_constant_time: bool) -> Fallible<f64> {
 /// index of the first bit with value 1. If all 1023 bits are 0, then
 /// the algorithm acts as if the last bit was a 1 and returns 1022.
 ///
-/// This is a less general version of the sample_geometric function, designed to be used
-/// only inside of the sample_bit_prob function. The major difference is that this function does not
-/// call sample_bit_prob itself (whereas sample_geometric does), so having this more specialized
+/// This is a less general version of the sample_geometric function.
+/// The major difference is that this function does not
+/// call sample_geometric itself (whereas sample_geometric does), so having this more specialized
 /// version allows us to avoid an infinite dependence loop.
-pub fn sample_censored_standard_geometric(enforce_constant_time: bool) -> Fallible<i16> {
-
+fn sample_i10_geometric(enforce_constant_time: bool) -> Fallible<i16> {
     Ok(if enforce_constant_time {
         let mut buffer = vec![0_u8; 128];
         fill_bytes(&mut buffer)?;
@@ -245,120 +273,173 @@ pub fn sample_censored_standard_geometric(enforce_constant_time: bool) -> Fallib
 }
 
 
-/// Sample from the censored geometric distribution with parameter "prob" and maximum
-/// number of trials "max_trials".
-///
-/// # Arguments
-/// * `prob` - Parameter for the geometric distribution, the probability of success on any given trials.
-/// * `max_trials` - The maximum number of trials allowed.
-/// * `enforce_constant_time` - Whether or not to enforce the algorithm to run in constant time; if true,
-///                             it will always run for "max_trials" trials.
-///
-/// # Return
-/// A draw from the censored geometric distribution.
-///
-/// # Example
-/// ```
-/// use opendp::meas::sample_censored_geometric;
-/// let geom = sample_censored_geometric(0.1, 20, false);
-/// # geom.unwrap();
-/// ```
-pub fn sample_censored_geometric(prob: f64, max_trials: i64, enforce_constant_time: bool) -> Fallible<i64> {
+pub trait SampleGeometric: Sized {
 
-    // ensure that prob is a valid probability
-    if prob < 0.0 || prob > 1.0 {return fallible!(FailedFunction, "probability is not within [0, 1]")}
+    /// Sample from the censored geometric distribution with parameter "prob" and maximum
+    /// number of trials "max_trials".
+    ///
+    /// # Arguments
+    /// * `prob` - Parameter for the geometric distribution, the probability of success on any given trials.
+    /// * `max_trials` - The maximum number of trials allowed.
+    /// * `enforce_constant_time` - Whether or not to enforce the algorithm to run in constant time; if true,
+    ///                             it will always run for "max_trials" trials.
+    ///
+    /// # Return
+    /// A draw from the censored geometric distribution.
+    ///
+    /// # Example
+    /// ```
+    /// use opendp::meas::SampleGeometric;
+    /// let geom = u8::sample_geometric(0.1, 20, false);
+    /// # geom.unwrap();
+    /// ```
+    fn sample_geometric(prob: f64, max_trials: Self, enforce_constant_time: bool) -> Fallible<Self>;
+}
 
-    let mut bit: bool;
-    let mut n_trials: i64 = 0;
-    let mut geom_return: i64 = 0;
+impl<T: Zero + One + PartialOrd + AddAssign + Clone> SampleGeometric for T {
 
-    // generate bits until we find a 1
-    // if enforcing the runtime of the algorithm to be constant, the while loop
-    // continues after the 1 is found and just stores the first location of a 1 bit.
-    while n_trials < max_trials {
-        bit = sample_bernoulli(prob, enforce_constant_time)?;
-        n_trials += 1;
+    fn sample_geometric(prob: f64, max_trials: Self, enforce_constant_time: bool) -> Fallible<Self> {
 
-        // If we haven't seen a 1 yet, set the return to the current number of trials
-        if bit && geom_return == 0 {
-            geom_return = n_trials;
-            if !enforce_constant_time {
-                return Ok(geom_return);
+        // ensure that prob is a valid probability
+        if prob < 0.0 || prob > 1.0 {return fallible!(FailedFunction, "probability is not within [0, 1]")}
+
+        let mut n_trials: Self = T::zero();
+        let mut geom_return: Self = T::zero();
+
+        // generate bits until we find a 1
+        // if enforcing the runtime of the algorithm to be constant, the while loop
+        // continues after the 1 is found and just stores the first location of a 1 bit.
+        while n_trials < max_trials {
+            n_trials += T::one();
+
+            // If we haven't seen a 1 yet, set the return to the current number of trials
+            if bool::sample_bernoulli(prob, enforce_constant_time)? && geom_return.is_zero() {
+                geom_return = n_trials.clone();
+                if !enforce_constant_time {
+                    return Ok(geom_return);
+                }
             }
         }
-    }
 
-    // set geom_return to max if we never saw a bit equaling 1
-    if geom_return == 0 {
-        geom_return = max_trials; // could also set this equal to n_trials - 1.
-    }
+        // set geom_return to max if we never saw a bit equaling 1
+        if geom_return.is_zero() {
+            geom_return = max_trials; // could also set this equal to n_trials - 1.
+        }
 
-    Ok(geom_return)
+        Ok(geom_return)
+    }
 }
 
 
-#[cfg(feature = "use-mpfr")]
-pub fn sample_laplace(sigma: f64) -> Fallible<f64> {
-    macro_rules! to_rug {($v:expr) => {rug::Float::with_val(53, $v)}}
+pub trait SampleLaplace: SampleRademacher + Sized {
+    fn sample_laplace(shift: Self, scale: Self, enforce_constant_time: bool) -> Fallible<Self>;
+}
 
-    let rademacher_sample = if sample_standard_bernoulli()? {1.} else {-1.};
-    let exponential_sample = {
+
+pub trait SampleGaussian: Sized {
+    /// Generates a draw from a Gaussian(loc, scale) distribution using the MPFR library.
+    ///
+    /// If shift = 0 and scale = 1, sampling is done in a way that respects exact rounding.
+    /// Otherwise, the return will be the result of a composition of two operations that
+    /// respect exact rounding (though the result will not necessarily).
+    ///
+    /// # Arguments
+    /// * `shift` - The expectation of the Gaussian distribution.
+    /// * `scale` - The scaling parameter (standard deviation) of the Gaussian distribution.
+    /// * `enforce_constant_time` - Force underlying computations to run in constant time.
+    ///
+    /// # Return
+    /// Draw from Gaussian(loc, scale)
+    ///
+    /// # Example
+    /// ```
+    /// use opendp::meas::SampleGaussian;
+    /// let gaussian = f64::sample_gaussian(0.0, 1.0, false);
+    /// ```
+    fn sample_gaussian(shift: Self, scale: Self, enforce_constant_time: bool) -> Fallible<Self>;
+}
+
+
+pub trait MantissaDigits { const MANTISSA_DIGITS: u32; }
+impl MantissaDigits for f32 { const MANTISSA_DIGITS: u32 = f32::MANTISSA_DIGITS; }
+impl MantissaDigits for f64 { const MANTISSA_DIGITS: u32 = f64::MANTISSA_DIGITS; }
+
+pub trait CastRug: MantissaDigits + Sized {
+    fn from_rug(v: Float) -> Self;
+    fn into_rug(self) -> Float;
+}
+impl CastRug for f64 {
+    fn from_rug(v: Float) -> Self { v.to_f64() }
+    fn into_rug(self) -> Float { rug::Float::with_val(Self::MANTISSA_DIGITS, self) }
+}
+impl CastRug for f32 {
+    fn from_rug(v: Float) -> Self { v.to_f32() }
+    fn into_rug(self) -> Float { rug::Float::with_val(Self::MANTISSA_DIGITS, self) }
+}
+
+#[cfg(feature = "use-mpfr")]
+impl<T: CastRug + SampleRademacher> SampleLaplace for T {
+    fn sample_laplace(shift: Self, scale: Self, enforce_constant_time: bool) -> Fallible<Self> {
+        if enforce_constant_time {
+            return fallible!(FailedFunction, "mpfr samplers do not support constant time execution")
+        }
+
+        let shift = shift.into_rug();
+        let scale = scale.into_rug() * T::sample_standard_rademacher()?.into_rug();
+        let standard_exponential_sample = {
+            let mut rng = GeneratorOpenSSL {};
+            let mut state = ThreadRandState::new_custom(&mut rng);
+            rug::Float::with_val(Self::MANTISSA_DIGITS, rug::Float::random_exp(&mut state))
+        };
+
+        Ok(Self::from_rug(standard_exponential_sample.mul_add(&scale, &shift)))
+    }
+}
+#[cfg(not(feature = "use-mpfr"))]
+impl<T: Float + rand::distributions::uniform::SampleUniform> SampleLaplace for T {
+    fn sample_laplace(shift: Self, scale: Self, _enforce_constant_time: bool) -> Fallible<Self> {
+        let mut rng = rand::thread_rng();
+        let u: T = rng.gen_range(-0.5..0.5);
+        Ok(shift - u.signum() * (1.0 - 2.0 * u.abs()).ln() * scale)
+    }
+}
+
+#[cfg(feature = "use-mpfr")]
+impl<T: CastRug> SampleGaussian for T {
+
+    fn sample_gaussian(shift: Self, scale: Self, enforce_constant_time: bool) -> Fallible<Self> {
+        if enforce_constant_time {
+            return fallible!(FailedFunction, "mpfr samplers do not support constant time execution")
+        }
+
+        // initialize randomness
         let mut rng = GeneratorOpenSSL {};
         let mut state = ThreadRandState::new_custom(&mut rng);
-        let standard_exponential_sample = rug::Float::random_exp(&mut state);
 
-        to_rug!(standard_exponential_sample) / to_rug!(sigma)
-    };
+        // generate Gaussian(0,1) according to mpfr standard
+        let gauss = rug::Float::with_val(Self::MANTISSA_DIGITS, Float::random_normal(&mut state));
 
-    Ok(to_rug!(rademacher_sample * exponential_sample).to_f64())
+        // initialize floats within mpfr/rug
+        let shift = shift.into_rug();
+        let scale = scale.into_rug();
+        Ok(Self::from_rug(gauss.mul_add(&scale, &shift)))
+    }
+}
+
+
+#[cfg(not(feature = "use-mpfr"))]
+impl SampleGaussian for f64 {
+    fn sample_gaussian(shift: Self, scale: Self, enforce_constant_time: bool) -> Fallible<Self> {
+        let uniform_sample = f64::sample_standard_uniform(enforce_constant_time)?;
+        Ok(shift + scale * std::f64::consts::SQRT_2 * erf::erfc_inv(2.0 * uniform_sample))
+    }
 }
 
 #[cfg(not(feature = "use-mpfr"))]
-pub fn sample_laplace(sigma: f64) -> Fallible<f64> {
-    let mut rng = rand::thread_rng();
-    let u: f64 = rng.gen_range(-0.5, 0.5);
-    Ok(u.signum() * (1.0 - 2.0 * u.abs()).ln() * sigma)
+impl SampleGaussian for f32 {
+    fn sample_gaussian(shift: Self, scale: Self, enforce_constant_time: bool) -> Fallible<Self> {
+        let uniform_sample = f32::sample_standard_uniform(enforce_constant_time)?;
+        Ok(shift + scale * std::f32::consts::SQRT_2 * (erf::erfc_inv(2.0 * uniform_sample) as f32))
+    }
 }
 
-
-/// Generates a draw from a Gaussian(loc, scale) distribution using the MPFR library.
-///
-/// If shift = 0 and scale = 1, sampling is done in a way that respects exact rounding.
-/// Otherwise, the return will be the result of a composition of two operations that
-/// respect exact rounding (though the result will not necessarily).
-///
-/// # Arguments
-/// * `shift` - The expectation of the Gaussian distribution.
-/// * `scale` - The scaling parameter (standard deviation) of the Gaussian distribution.
-///
-/// # Return
-/// Draw from Gaussian(loc, scale)
-///
-/// # Example
-/// ```
-/// use opendp::meas::sample_gaussian;
-/// let gaussian = sample_gaussian(0.0, 1.0, false);
-/// ```
-#[cfg(feature = "use-mpfr")]
-pub fn sample_gaussian(shift: f64, scale: f64, enforce_constant_time: bool) -> Fallible<f64> {
-    // mpfr is not compatible with constant-time queries
-    assert!(!enforce_constant_time);
-
-    // initialize 64-bit floats within mpfr/rug
-    let mpfr_shift = Float::with_val(53, shift);
-    let mpfr_scale = Float::with_val(53, scale);
-
-    // initialize randomness
-    let mut rng = GeneratorOpenSSL {};
-    let mut state = ThreadRandState::new_custom(&mut rng);
-
-    // generate Gaussian(0,1) according to mpfr standard, then convert to correct scale
-    let gauss = Float::with_val(64, Float::random_normal(&mut state));
-    Ok(gauss.mul_add(&mpfr_scale, &mpfr_shift).to_f64())
-}
-
-#[cfg(not(feature = "use-mpfr"))]
-pub fn sample_gaussian(shift: f64, scale: f64, enforce_constant_time: bool) -> Fallible<f64> {
-    let uniform_sample = sample_standard_uniform(enforce_constant_time)?;
-    Ok(shift + scale * std::f64::consts::SQRT_2 * erf::erfc_inv(2.0 * uniform_sample))
-}

--- a/rust/opendp/src/meas/mod.rs
+++ b/rust/opendp/src/meas/mod.rs
@@ -3,15 +3,23 @@
 //! The different [`Measurement`] implementations in this module are accessed by calling the appropriate constructor function.
 //! Constructors are named in the form `make_xxx()`, where `xxx` indicates what the resulting `Measurement` does.
 
-use std::marker::PhantomData;
 
-use num::NumCast;
+use std::cmp;
+
+use ieee754::Ieee754;
+use openssl::rand::rand_bytes;
+#[cfg(not(feature="use-mpfr"))]
 use rand::Rng;
+#[cfg(feature="use-mpfr")]
+use rug::{Float, rand::{ThreadRandGen, ThreadRandState}};
+#[cfg(not(feature="use-mpfr"))]
+use statrs::function::erf;
 
-use crate::core::{Domain, Measure, Measurement, Metric, PrivacyRelation, Function};
-use crate::dist::{L1Sensitivity, L2Sensitivity, MaxDivergence, SmoothedMaxDivergence};
-use crate::dom::{AllDomain, VectorDomain};
+use crate::core::{Domain, Measure, Metric};
 use crate::error::Fallible;
+
+pub mod laplace;
+pub mod gaussian;
 
 // Trait for all constructors, can have different implementations depending on concrete types of Domains and/or Metrics
 pub trait MakeMeasurement<DI: Domain, DO: Domain, MI: Metric, MO: Measure> {
@@ -49,122 +57,308 @@ pub trait MakeMeasurement4<DI: Domain, DO: Domain, MI: Metric, MO: Measure, P1, 
     fn make4(param1: P1, param2: P2, param3: P3, param4: P4) -> Fallible<crate::core::Measurement<DI, DO, MI, MO>>;
 }
 
-pub struct LaplaceMechanism<T> {
-    data: PhantomData<T>
+pub fn fill_bytes(mut buffer: &mut [u8]) -> Fallible<()> {
+    if let Err(e) = rand_bytes(&mut buffer) {
+        fallible!(FailedFunction, "OpenSSL error: {:?}", e)
+    } else { Ok(()) }
 }
 
-fn laplace(sigma: f64) -> f64 {
+#[cfg(feature="use-mpfr")]
+struct GeneratorOpenSSL;
+
+#[cfg(feature="use-mpfr")]
+impl ThreadRandGen for GeneratorOpenSSL {
+    fn gen(&mut self) -> u32 {
+        let mut buffer = [0u8; 4];
+        // impossible not to panic here
+        //    cannot ignore errors with .ok(), because the buffer will remain 0
+        fill_bytes(&mut buffer).unwrap();
+        u32::from_ne_bytes(buffer)
+    }
+}
+
+
+// SAMPLERS
+pub fn sample_standard_bernoulli() -> Fallible<bool> {
+    let mut buffer = [0u8; 1];
+    fill_bytes(&mut buffer)?;
+    Ok(buffer[0] & 1 == 1)
+}
+
+
+/// Sample a single bit with arbitrary probability of success
+///
+/// Uses only an unbiased source of coin flips.
+/// The strategy for doing this with 2 flips in expectation is described [here](https://amakelov.wordpress.com/2013/10/10/arbitrarily-biasing-a-coin-in-2-expected-tosses/).
+///
+/// # Arguments
+/// * `prob`- The desired probability of success (bit = 1).
+/// * `enforce_constant_time` - Whether or not to enforce the algorithm to run in constant time
+///
+/// # Return
+/// A bit that is 1 with probability "prob"
+///
+/// # Examples
+///
+/// ```
+/// // returns a bit with Pr(bit = 1) = 0.7
+/// use opendp::meas::sample_bernoulli;
+/// let n = sample_bernoulli(0.7, false);
+/// # n.unwrap();
+/// ```
+/// ```should_panic
+/// // fails because 1.3 not a valid probability
+/// use opendp::meas::sample_bernoulli;
+/// let n = sample_bernoulli(1.3, false);
+/// # n.unwrap();
+/// ```
+/// ```should_panic
+/// // fails because -0.3 is not a valid probability
+/// use opendp::meas::sample_bernoulli;
+/// let n = sample_bernoulli(-0.3, false);
+/// # n.unwrap();
+/// ```
+pub fn sample_bernoulli(prob: f64, enforce_constant_time: bool) -> Fallible<bool> {
+
+    // ensure that prob is a valid probability
+    if prob < 0.0 || prob > 1.0 {return fallible!(FailedFunction, "probability is not within [0, 1]")}
+
+    // decompose probability into mantissa and exponent integers to quickly identify the value in the first_heads_index
+    let (_sign, exponent, mantissa) = prob.decompose_raw();
+
+    // repeatedly flip fair coin (up to 1023 times) and identify index (0-based) of first heads
+    let first_heads_index = sample_censored_standard_geometric(enforce_constant_time)?;
+
+    // if prob == 1., return after retrieving censored_specific_geom, to protect constant time
+    if exponent == 1023 { return Ok(true) }
+
+    // number of leading zeros in binary representation of prob
+    //    cast is non-saturating because exponent only uses first 11 bits
+    //    exponent is bounded within [0, 1022] by check for valid probability
+    let num_leading_zeros = 1022_i16 - exponent as i16;
+
+    // 0 is the most significant/leftmost implicit bit in the mantissa/fraction/significand
+    // 52 is the least significant/rightmost
+    Ok(match first_heads_index - num_leading_zeros {
+        // index into the leading zeros of the binary representation
+        i if i < 0 => false,
+        // bit index 0 is implicitly set in ieee-754 when the exponent is nonzero
+        i if i == 0 => exponent != 0,
+        // all other digits out-of-bounds are not float-approximated/are-implicitly-zero
+        i if i > 52 => false,
+        // retrieve the bit at `i` slots shifted from the left
+        i => mantissa & (1_u64 << (52 - i as usize)) != 0
+    })
+}
+
+
+/// Returns random sample from Uniform[0,1).
+///
+/// This algorithm is taken from [Mironov (2012)](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.366.5957&rep=rep1&type=pdf)
+/// and is important for making some of the guarantees in the paper.
+///
+/// The idea behind the uniform sampling is to first sample a "precision band".
+/// Each band is a range of floating point numbers with the same level of arithmetic precision
+/// and is situated between powers of two.
+/// A band is sampled with probability relative to the unit of least precision using the Geometric distribution.
+/// That is, the uniform sampler will generate the band [1/2,1) with probability 1/2, [1/4,1/2) with probability 1/4,
+/// and so on.
+///
+/// Once the precision band has been selected, floating numbers numbers are generated uniformly within the band
+/// by generating a 52-bit mantissa uniformly at random.
+///
+/// # Arguments
+///
+/// `min`: f64 minimum of uniform distribution (inclusive)
+/// `max`: f64 maximum of uniform distribution (non-inclusive)
+///
+/// # Return
+/// Random draw from Unif[min, max).
+///
+/// # Example
+/// ```
+/// // valid draw from Unif[0,1)
+/// use opendp::meas::sample_standard_uniform;
+/// let unif = sample_standard_uniform(false);
+/// # unif.unwrap();
+/// ```
+pub fn sample_standard_uniform(enforce_constant_time: bool) -> Fallible<f64> {
+
+    // Generate mantissa
+    let mut mantissa_buffer = [0u8; 8];
+    // mantissa bit index zero is implicit
+    fill_bytes(&mut mantissa_buffer[1..])?;
+    // limit the buffer to 52 bits
+    mantissa_buffer[1] %= 16;
+
+    // convert mantissa to integer
+    let mantissa_int = u64::from_be_bytes(mantissa_buffer);
+
+    // Generate exponent. A saturated mantissa with implicit bit is ~2
+    let exponent: i16 = -(1 + sample_censored_standard_geometric(enforce_constant_time)?);
+
+    // Generate uniform random number from [0,1)
+    let uniform_rand = f64::recompose(false, exponent, mantissa_int);
+
+    Ok(uniform_rand)
+}
+
+
+/// Return sample from a censored Geometric distribution with parameter p=0.5 without calling to sample_bit_prob.
+///
+/// The algorithm generates 1023 bits uniformly at random and returns the
+/// index of the first bit with value 1. If all 1023 bits are 0, then
+/// the algorithm acts as if the last bit was a 1 and returns 1022.
+///
+/// This is a less general version of the sample_geometric function, designed to be used
+/// only inside of the sample_bit_prob function. The major difference is that this function does not
+/// call sample_bit_prob itself (whereas sample_geometric does), so having this more specialized
+/// version allows us to avoid an infinite dependence loop.
+pub fn sample_censored_standard_geometric(enforce_constant_time: bool) -> Fallible<i16> {
+
+    Ok(if enforce_constant_time {
+        let mut buffer = vec![0_u8; 128];
+        fill_bytes(&mut buffer)?;
+
+        cmp::min(buffer.into_iter().enumerate()
+                     // ignore samples that contain no events
+                     .filter(|(_, sample)| sample > &0)
+                     // compute the index of the smallest event in the batch
+                     .map(|(i, sample)| 8 * i + sample.leading_zeros() as usize)
+                     // retrieve the smallest index
+                     .min()
+                     // return 1022 if no events occurred (slight dp violation w.p. ~2^-52)
+                     .unwrap_or(1022) as i16, 1022)
+
+    } else {
+        // retrieve up to 128 bytes, each containing 8 trials
+        for i in 0..128 {
+            let mut buffer = vec![0_u8; 1];
+            fill_bytes(&mut buffer)?;
+
+            if buffer[0] > 0 {
+                return Ok(cmp::min(i * 8 + buffer[0].leading_zeros() as i16, 1022))
+            }
+        }
+        1022
+    })
+}
+
+
+/// Sample from the censored geometric distribution with parameter "prob" and maximum
+/// number of trials "max_trials".
+///
+/// # Arguments
+/// * `prob` - Parameter for the geometric distribution, the probability of success on any given trials.
+/// * `max_trials` - The maximum number of trials allowed.
+/// * `enforce_constant_time` - Whether or not to enforce the algorithm to run in constant time; if true,
+///                             it will always run for "max_trials" trials.
+///
+/// # Return
+/// A draw from the censored geometric distribution.
+///
+/// # Example
+/// ```
+/// use opendp::meas::sample_censored_geometric;
+/// let geom = sample_censored_geometric(0.1, 20, false);
+/// # geom.unwrap();
+/// ```
+pub fn sample_censored_geometric(prob: f64, max_trials: i64, enforce_constant_time: bool) -> Fallible<i64> {
+
+    // ensure that prob is a valid probability
+    if prob < 0.0 || prob > 1.0 {return fallible!(FailedFunction, "probability is not within [0, 1]")}
+
+    let mut bit: bool;
+    let mut n_trials: i64 = 0;
+    let mut geom_return: i64 = 0;
+
+    // generate bits until we find a 1
+    // if enforcing the runtime of the algorithm to be constant, the while loop
+    // continues after the 1 is found and just stores the first location of a 1 bit.
+    while n_trials < max_trials {
+        bit = sample_bernoulli(prob, enforce_constant_time)?;
+        n_trials += 1;
+
+        // If we haven't seen a 1 yet, set the return to the current number of trials
+        if bit && geom_return == 0 {
+            geom_return = n_trials;
+            if !enforce_constant_time {
+                return Ok(geom_return);
+            }
+        }
+    }
+
+    // set geom_return to max if we never saw a bit equaling 1
+    if geom_return == 0 {
+        geom_return = max_trials; // could also set this equal to n_trials - 1.
+    }
+
+    Ok(geom_return)
+}
+
+
+#[cfg(feature = "use-mpfr")]
+pub fn sample_laplace(sigma: f64) -> Fallible<f64> {
+    macro_rules! to_rug {($v:expr) => {rug::Float::with_val(53, $v)}}
+
+    let rademacher_sample = if sample_standard_bernoulli()? {1.} else {-1.};
+    let exponential_sample = {
+        let mut rng = GeneratorOpenSSL {};
+        let mut state = ThreadRandState::new_custom(&mut rng);
+        let standard_exponential_sample = rug::Float::random_exp(&mut state);
+
+        to_rug!(standard_exponential_sample) / to_rug!(sigma)
+    };
+
+    Ok(to_rug!(rademacher_sample * exponential_sample).to_f64())
+}
+
+#[cfg(not(feature = "use-mpfr"))]
+pub fn sample_laplace(sigma: f64) -> Fallible<f64> {
     let mut rng = rand::thread_rng();
     let u: f64 = rng.gen_range(-0.5, 0.5);
-    u.signum() * (1.0 - 2.0 * u.abs()).ln() * sigma
-}
-
-// laplace for scalar-valued query
-impl<T> MakeMeasurement1<AllDomain<T>, AllDomain<T>, L1Sensitivity<f64>, MaxDivergence, f64> for LaplaceMechanism<T>
-    where T: Copy + NumCast {
-    fn make1(sigma: f64) -> Fallible<Measurement<AllDomain<T>, AllDomain<T>, L1Sensitivity<f64>, MaxDivergence>> {
-        Ok(Measurement::new(
-            AllDomain::new(),
-            AllDomain::new(),
-            Function::new_fallible(move |arg: &T| -> Fallible<T> {
-                <f64 as NumCast>::from(*arg).and_then(|v| T::from(v + laplace(sigma))).ok_or_else(|| err!(FailedCast))
-            }),
-            L1Sensitivity::new(),
-            MaxDivergence::new(),
-            PrivacyRelation::new_from_constant(1. / sigma)))
-    }
-}
-
-pub struct VectorLaplaceMechanism<T> {
-    data: PhantomData<T>
-}
-
-// laplace for vector-valued query
-impl<T> MakeMeasurement1<VectorDomain<AllDomain<T>>, VectorDomain<AllDomain<T>>, L1Sensitivity<f64>, MaxDivergence, f64> for VectorLaplaceMechanism<T>
-    where T: Copy + NumCast {
-    fn make1(sigma: f64) -> Fallible<Measurement<VectorDomain<AllDomain<T>>, VectorDomain<AllDomain<T>>, L1Sensitivity<f64>, MaxDivergence>> {
-        Ok(Measurement::new(
-            VectorDomain::new_all(),
-            VectorDomain::new_all(),
-            Function::new_fallible(move |arg: &Vec<T>| -> Fallible<Vec<T>> {
-                arg.iter()
-                    .map(|v| <f64 as NumCast>::from(*v).and_then(|v| T::from(v + laplace(sigma))))
-                    .collect::<Option<_>>().ok_or_else(|| err!(FailedCast))
-            }),
-            L1Sensitivity::new(),
-            MaxDivergence::new(),
-            PrivacyRelation::new_from_constant(1. / sigma)))
-    }
-}
-
-pub struct GaussianMechanism<T> {
-    data: PhantomData<T>
-}
-
-// gaussian for scalar-valued query
-impl<T> MakeMeasurement1<AllDomain<T>, AllDomain<T>, L2Sensitivity<f64>, SmoothedMaxDivergence, f64> for GaussianMechanism<T>
-    where T: Copy + NumCast {
-    fn make1(sigma: f64) -> Fallible<Measurement<AllDomain<T>, AllDomain<T>, L2Sensitivity<f64>, SmoothedMaxDivergence>> {
-        Ok(Measurement::new(
-            AllDomain::new(),
-            AllDomain::new(),
-            Function::new_fallible(move |arg: &T| -> Fallible<T> {
-                <f64 as NumCast>::from(*arg).and_then(|v| T::from(v + laplace(sigma))).ok_or_else(|| err!(FailedCast))
-            }),
-            L2Sensitivity::new(),
-            SmoothedMaxDivergence::new(),
-            PrivacyRelation::new_fallible(move |&d_in: &f64, &(eps, del): &(f64, f64)| {
-                if d_in < 0. {
-                    return fallible!(InvalidDistance, "gaussian mechanism: input sensitivity must be non-negative")
-                }
-                if eps <= 0. {
-                    return fallible!(InvalidDistance, "gaussian mechanism: epsilon must be positive")
-                }
-                if del <= 0. {
-                    return fallible!(InvalidDistance, "gaussian mechanism: delta must be positive")
-                }
-                // TODO: should we error if epsilon > 1., or just waste the budget?
-                Ok(eps.min(1.) >= (d_in / sigma) * (2. * (1.25 / del).ln()).sqrt())
-            })))
-    }
+    Ok(u.signum() * (1.0 - 2.0 * u.abs()).ln() * sigma)
 }
 
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+/// Generates a draw from a Gaussian(loc, scale) distribution using the MPFR library.
+///
+/// If shift = 0 and scale = 1, sampling is done in a way that respects exact rounding.
+/// Otherwise, the return will be the result of a composition of two operations that
+/// respect exact rounding (though the result will not necessarily).
+///
+/// # Arguments
+/// * `shift` - The expectation of the Gaussian distribution.
+/// * `scale` - The scaling parameter (standard deviation) of the Gaussian distribution.
+///
+/// # Return
+/// Draw from Gaussian(loc, scale)
+///
+/// # Example
+/// ```
+/// use opendp::meas::sample_gaussian;
+/// let gaussian = sample_gaussian(0.0, 1.0, false);
+/// ```
+#[cfg(feature = "use-mpfr")]
+pub fn sample_gaussian(shift: f64, scale: f64, enforce_constant_time: bool) -> Fallible<f64> {
+    // mpfr is not compatible with constant-time queries
+    assert!(!enforce_constant_time);
 
-    #[test]
-    fn test_make_laplace_mechanism() {
-        let measurement = LaplaceMechanism::<f64>::make(1.0).unwrap();
-        let arg = 0.0;
-        let _ret = measurement.function.eval(&arg);
+    // initialize 64-bit floats within mpfr/rug
+    let mpfr_shift = Float::with_val(53, shift);
+    let mpfr_scale = Float::with_val(53, scale);
 
-        assert!(measurement.privacy_relation.eval(&1., &1.).unwrap());
-    }
+    // initialize randomness
+    let mut rng = GeneratorOpenSSL {};
+    let mut state = ThreadRandState::new_custom(&mut rng);
 
-    #[test]
-    fn test_make_vector_laplace_mechanism() {
-        let measurement = VectorLaplaceMechanism::<f64>::make(1.0).unwrap();
-        let arg = vec![1.0, 2.0, 3.0];
-        let _ret = measurement.function.eval(&arg);
+    // generate Gaussian(0,1) according to mpfr standard, then convert to correct scale
+    let gauss = Float::with_val(64, Float::random_normal(&mut state));
+    Ok(gauss.mul_add(&mpfr_scale, &mpfr_shift).to_f64())
+}
 
-        assert!(measurement.privacy_relation.eval(&1., &1.).unwrap());
-    }
-
-    #[test]
-    fn test_make_gaussian_mechanism() {
-        let measurement = GaussianMechanism::<f64>::make(1.0).unwrap();
-        let arg = 0.0;
-        let _ret = measurement.function.eval(&arg);
-
-        assert!(measurement.privacy_relation.eval(&0.1, &(0.5, 0.00001)).unwrap());
-    }
-
-    #[test]
-    fn test_error() {
-        let measurement = GaussianMechanism::<f64>::make(1.0).unwrap();
-        let error = measurement.privacy_relation.eval(&-0.1, &(0.5, 0.00001)).unwrap_err();
-        let _backtrace = format!("{:?}", error.backtrace);
-    }
+#[cfg(not(feature = "use-mpfr"))]
+pub fn sample_gaussian(shift: f64, scale: f64, enforce_constant_time: bool) -> Fallible<f64> {
+    let uniform_sample = sample_standard_uniform(enforce_constant_time)?;
+    Ok(shift + scale * std::f64::consts::SQRT_2 * erf::erfc_inv(2.0 * uniform_sample))
 }

--- a/rust/opendp/src/traits.rs
+++ b/rust/opendp/src/traits.rs
@@ -32,7 +32,7 @@ macro_rules! impl_is_not_continuous {
     }
 }
 impl_is_continuous!(f32, f64);
-impl_is_not_continuous!(u8, u32, u64, u128, i8, i16, i32, i64, i128, isize, usize);
+impl_is_not_continuous!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, isize, usize);
 
 // include Ceil on QO to avoid requiring as an additional trait bound in all downstream code
 pub trait DistanceCast: NumCast + Ceil + CheckContinuous {


### PR DESCRIPTION
Ported, with modifications throughout, from SmartNoise.

- introduces dependencies on openssl and gmp/mpfr
- adds feature flags to disable gmp/mpfr
- restructure meas submodule
- reference new samplers from laplace, geometric and gaussian mechanisms


New samplers:
- standard bernoulli
- bernoulli
- standard uniform (over float types)
- uniform (over float types)
- rademacher (over signed types)
- censored standard geometric (accumulates tail of probability < ~2^-52 into fully-saturated 1022)
- censored geometric
- laplace (mpfr and non-mpfr) (over float types)
- gaussian (mpfr and non-mpfr) (over float types)
