### PR TITLE
chaining hints

### DIFF
--- a/rust/opendp-ffi/src/core.rs
+++ b/rust/opendp-ffi/src/core.rs
@@ -2,7 +2,7 @@ use std::mem::transmute;
 use std::os::raw::c_char;
 
 use opendp::core;
-use opendp::core::{Domain, Measure, MeasureGlue, Measurement, Metric, MetricGlue, Transformation};
+use opendp::core::{ChainTT, Domain, Measure, MeasureGlue, Measurement, Metric, MetricGlue, Transformation};
 
 use crate::util;
 use crate::util::Type;
@@ -192,7 +192,8 @@ pub extern "C" fn opendp_core__make_chain_tt(transformation1: *mut FfiTransforma
     let input_glue = transformation0.input_glue.clone();
     let x_glue = transformation0.output_glue.clone();
     let output_glue = transformation1.output_glue.clone();
-    let transformation = core::make_chain_tt_glue(&transformation1.value, &transformation0.value, &input_glue.metric_glue, &x_glue.metric_glue, &output_glue.metric_glue);
+    // TODO: Add plumbing for hints from FFI.
+    let transformation = ChainTT::make_chain_tt_glue(&transformation1.value, &transformation0.value, None, &input_glue.metric_glue, &x_glue.metric_glue, &output_glue.metric_glue);
     FfiTransformation::new(input_glue, output_glue, transformation)
 }
 

--- a/rust/opendp-ffi/src/trans.rs
+++ b/rust/opendp-ffi/src/trans.rs
@@ -13,8 +13,9 @@ use crate::core::FfiTransformation;
 use crate::util;
 use crate::util::c_bool;
 use crate::util::TypeArgs;
-use std::ops::{Sub, Mul};
+use std::ops::{Sub, Mul, Div};
 use num::{NumCast};
+use opendp::traits::DPDistanceCast;
 
 // TODO: update dispatch macros to call new trait calling convention
 //       dispatch based on Metric type
@@ -112,10 +113,10 @@ pub extern "C" fn opendp_trans__make_clamp(type_args: *const c_char, lower: *con
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_bounded_sum_l1(type_args: *const c_char, lower: *const c_void, upper: *const c_void) -> *mut FfiTransformation {
     fn monomorphize<T>(lower: *const c_void, upper: *const c_void) -> *mut FfiTransformation where
-        T: 'static + Copy + PartialOrd + Sub<Output=T> + NumCast + Mul<Output=T> + Sum<T> {
+        T: 'static + Copy + PartialOrd + Sub<Output=T> + NumCast + Mul<Output=T> + Div<Output=T> + Sum<T> + DPDistanceCast {
         let lower = util::as_ref(lower as *const T).clone();
         let upper = util::as_ref(upper as *const T).clone();
-        let transformation = trans::BoundedSum::<HammingDistance, L1Sensitivity<f64>, T>::make(lower, upper);
+        let transformation = trans::BoundedSum::<HammingDistance, L1Sensitivity<T>, T>::make(lower, upper);
         FfiTransformation::new_from_types(transformation)
     }
     let type_args = TypeArgs::expect(type_args, 1);
@@ -125,10 +126,10 @@ pub extern "C" fn opendp_trans__make_bounded_sum_l1(type_args: *const c_char, lo
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_bounded_sum_l2(type_args: *const c_char, lower: *const c_void, upper: *const c_void) -> *mut FfiTransformation {
     fn monomorphize<T>(lower: *const c_void, upper: *const c_void) -> *mut FfiTransformation where
-        T: 'static + Copy + PartialOrd + Sub<Output=T> + NumCast + Mul<Output=T> + Sum<T> {
+        T: 'static + Copy + PartialOrd + Sub<Output=T> + NumCast + Mul<Output=T> + Div<Output=T> + Sum<T> + DPDistanceCast {
         let lower = util::as_ref(lower as *const T).clone();
         let upper = util::as_ref(upper as *const T).clone();
-        let transformation = trans::BoundedSum::<HammingDistance, L2Sensitivity<_>, T>::make(lower, upper);
+        let transformation = trans::BoundedSum::<HammingDistance, L2Sensitivity<T>, T>::make(lower, upper);
         FfiTransformation::new_from_types(transformation)
     }
     let type_args = TypeArgs::expect(type_args, 1);

--- a/rust/opendp-ffi/src/trans.rs
+++ b/rust/opendp-ffi/src/trans.rs
@@ -15,7 +15,7 @@ use crate::util::c_bool;
 use crate::util::TypeArgs;
 use std::ops::{Sub, Mul, Div};
 use num::{NumCast};
-use opendp::traits::DPDistanceCast;
+use opendp::traits::DistanceCast;
 
 // TODO: update dispatch macros to call new trait calling convention
 //       dispatch based on Metric type
@@ -113,7 +113,7 @@ pub extern "C" fn opendp_trans__make_clamp(type_args: *const c_char, lower: *con
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_bounded_sum_l1(type_args: *const c_char, lower: *const c_void, upper: *const c_void) -> *mut FfiTransformation {
     fn monomorphize<T>(lower: *const c_void, upper: *const c_void) -> *mut FfiTransformation where
-        T: 'static + Copy + PartialOrd + Sub<Output=T> + NumCast + Mul<Output=T> + Div<Output=T> + Sum<T> + DPDistanceCast {
+        T: 'static + Copy + PartialOrd + Sub<Output=T> + NumCast + Mul<Output=T> + Div<Output=T> + Sum<T> + DistanceCast {
         let lower = util::as_ref(lower as *const T).clone();
         let upper = util::as_ref(upper as *const T).clone();
         let transformation = trans::BoundedSum::<HammingDistance, L1Sensitivity<T>, T>::make(lower, upper);
@@ -126,7 +126,7 @@ pub extern "C" fn opendp_trans__make_bounded_sum_l1(type_args: *const c_char, lo
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_bounded_sum_l2(type_args: *const c_char, lower: *const c_void, upper: *const c_void) -> *mut FfiTransformation {
     fn monomorphize<T>(lower: *const c_void, upper: *const c_void) -> *mut FfiTransformation where
-        T: 'static + Copy + PartialOrd + Sub<Output=T> + NumCast + Mul<Output=T> + Div<Output=T> + Sum<T> + DPDistanceCast {
+        T: 'static + Copy + PartialOrd + Sub<Output=T> + NumCast + Mul<Output=T> + Div<Output=T> + Sum<T> + DistanceCast {
         let lower = util::as_ref(lower as *const T).clone();
         let upper = util::as_ref(upper as *const T).clone();
         let transformation = trans::BoundedSum::<HammingDistance, L2Sensitivity<T>, T>::make(lower, upper);

--- a/rust/opendp-ffi/src/trans.rs
+++ b/rust/opendp-ffi/src/trans.rs
@@ -115,7 +115,7 @@ pub extern "C" fn opendp_trans__make_bounded_sum_l1(type_args: *const c_char, lo
         T: 'static + Copy + PartialOrd + Sub<Output=T> + NumCast + Mul<Output=T> + Sum<T> {
         let lower = util::as_ref(lower as *const T).clone();
         let upper = util::as_ref(upper as *const T).clone();
-        let transformation = trans::BoundedSum::<HammingDistance, L1Sensitivity<_>, T>::make(lower, upper);
+        let transformation = trans::BoundedSum::<HammingDistance, L1Sensitivity<f64>, T>::make(lower, upper);
         FfiTransformation::new_from_types(transformation)
     }
     let type_args = TypeArgs::expect(type_args, 1);

--- a/rust/opendp/src/core.rs
+++ b/rust/opendp/src/core.rs
@@ -183,8 +183,8 @@ impl<MI: Metric, MO: Metric> StabilityRelation<MI, MO> {
         }
     }
     pub fn new_from_constant(c: MO::Distance) -> StabilityRelation<MI, MO> where
-        MI::Distance: Clone + DPDistanceCast<MO::Distance>,
-        MO::Distance: Clone + DPDistanceCast<MI::Distance> + Mul<Output=MO::Distance> + Div<Output=MO::Distance> + PartialOrd + 'static {
+        MI::Distance: Clone + DPDistanceCast,
+        MO::Distance: Clone + DPDistanceCast + Mul<Output=MO::Distance> + Div<Output=MO::Distance> + PartialOrd + 'static {
 
         // TODO: there has to be a cleaner way
         let c_1 = c.clone();
@@ -320,8 +320,8 @@ impl<DI: Domain, DO: Domain, MI: Metric, MO: Metric> Transformation<DI, DO, MI, 
         output_metric: MO,
         stability_constant: MO::Distance,
     ) -> Self where
-        MI::Distance: Clone + DPDistanceCast<MO::Distance>,
-        MO::Distance: Clone + DPDistanceCast<MI::Distance> + Mul<Output=MO::Distance> + Div<Output=MO::Distance> + PartialOrd + 'static {
+        MI::Distance: Clone + DPDistanceCast,
+        MO::Distance: Clone + DPDistanceCast + Mul<Output=MO::Distance> + Div<Output=MO::Distance> + PartialOrd + 'static {
         Transformation {
             input_domain: Box::new(input_domain),
             output_domain: Box::new(output_domain),

--- a/rust/opendp/src/core.rs
+++ b/rust/opendp/src/core.rs
@@ -22,7 +22,7 @@ use std::rc::Rc;
 
 use crate::dom::{BoxDomain, PairDomain};
 use crate::meas::MakeMeasurement2;
-use crate::traits::DPDistanceCast;
+use crate::traits::DistanceCast;
 use crate::trans::MakeTransformation2;
 
 /// A set which constrains the input or output of a [`Function`].
@@ -156,8 +156,8 @@ impl<MI: Metric, MO: Measure> PrivacyRelation<MI, MO> {
         }
     }
     pub fn new_from_constant(c: MO::Distance) -> Self where
-        MI::Distance: Clone + DPDistanceCast,
-        MO::Distance: Clone + DPDistanceCast + Mul<Output=MO::Distance> + Div<Output=MO::Distance> + PartialOrd + 'static {
+        MI::Distance: Clone + DistanceCast,
+        MO::Distance: Clone + DistanceCast + Mul<Output=MO::Distance> + Div<Output=MO::Distance> + PartialOrd + 'static {
 
         PrivacyRelation::new_all(
             enclose!(c, move |d_in: &MI::Distance, d_out: &MO::Distance|
@@ -260,8 +260,8 @@ impl<MI: Metric, MO: Metric> StabilityRelation<MI, MO> {
         }
     }
     pub fn new_from_constant(c: MO::Distance) -> Self where
-        MI::Distance: Clone + DPDistanceCast,
-        MO::Distance: Clone + DPDistanceCast + Mul<Output=MO::Distance> + Div<Output=MO::Distance> + PartialOrd + 'static {
+        MI::Distance: Clone + DistanceCast,
+        MO::Distance: Clone + DistanceCast + Mul<Output=MO::Distance> + Div<Output=MO::Distance> + PartialOrd + 'static {
 
         StabilityRelation::new_all(
             // relation
@@ -405,8 +405,8 @@ impl<DI: Domain, DO: Domain, MI: Metric, MO: Metric> Transformation<DI, DO, MI, 
         output_metric: MO,
         stability_constant: MO::Distance,
     ) -> Self where
-        MI::Distance: Clone + DPDistanceCast,
-        MO::Distance: Clone + DPDistanceCast + Mul<Output=MO::Distance> + Div<Output=MO::Distance> + PartialOrd + 'static {
+        MI::Distance: Clone + DistanceCast,
+        MO::Distance: Clone + DistanceCast + Mul<Output=MO::Distance> + Div<Output=MO::Distance> + PartialOrd + 'static {
         Transformation {
             input_domain: Box::new(input_domain),
             output_domain: Box::new(output_domain),

--- a/rust/opendp/src/lib.rs
+++ b/rust/opendp/src/lib.rs
@@ -119,6 +119,15 @@
 //! [`Measurement`]/[`Transformation`] constructors are allowed to be generic! Typically, this means that the type parameter on the
 //! constructor will determine type of the input or output [`Domain::Carrier`] (or the generic type within, for instance the `i32` of `Vec<i32>`).
 
+macro_rules! enclose {
+    ( $x:ident, $y:expr ) => (enclose!(($x), $y));
+    ( ($( $x:ident ),*), $y:expr ) => {
+        {
+            $(let $x = $x.clone();)*
+            $y
+        }
+    };
+}
 
 pub mod core;
 pub mod data;

--- a/rust/opendp/src/lib.rs
+++ b/rust/opendp/src/lib.rs
@@ -126,3 +126,4 @@ pub mod dist;
 pub mod dom;
 pub mod meas;
 pub mod trans;
+pub mod traits;

--- a/rust/opendp/src/lib.rs
+++ b/rust/opendp/src/lib.rs
@@ -92,7 +92,7 @@
 //!
 //! #### Example Transformation Constructor
 //! ```
-//!# use opendp::core::Transformation;
+//!# use opendp::core::{Transformation, StabilityRelation};
 //!# use opendp::dist::L1Sensitivity;
 //!# use opendp::dom::AllDomain;
 //! pub fn make_i32_identity() -> Transformation<AllDomain<i32>, AllDomain<i32>, L1Sensitivity<i32>, L1Sensitivity<i32>> {
@@ -101,7 +101,7 @@
 //!     let function = |arg: &i32| -> i32 { *arg };
 //!     let input_metric = L1Sensitivity::new();
 //!     let output_metric = L1Sensitivity::new();
-//!     let stability_relation = |d_in: &i32, d_out: &i32| *d_out >= *d_in;
+//!     let stability_relation = StabilityRelation::new_from_constant(1);
 //!     Transformation::new(input_domain, output_domain, function, input_metric, output_metric, stability_relation)
 //! }
 //! ```

--- a/rust/opendp/src/meas/mod.rs
+++ b/rust/opendp/src/meas/mod.rs
@@ -5,7 +5,7 @@
 
 use rand::Rng;
 
-use crate::core::{Measurement, Domain, Measure, Metric};
+use crate::core::{Measurement, Domain, Measure, Metric, PrivacyRelation};
 use crate::dist::{L2Sensitivity, L1Sensitivity, MaxDivergence, SmoothedMaxDivergence};
 use crate::dom::{AllDomain, VectorDomain};
 use num::NumCast;
@@ -69,7 +69,7 @@ impl<T> MakeMeasurement1<AllDomain<T>, AllDomain<T>, L1Sensitivity<f64>, MaxDive
         };
         let input_metric = L1Sensitivity::new();
         let output_measure = MaxDivergence::new();
-        let privacy_relation = move |d_in: &f64, d_out: &f64| *d_out >= *d_in / sigma;
+        let privacy_relation = PrivacyRelation::new_from_constant(1. / sigma);
         Measurement::new(input_domain, output_domain, function, input_metric, output_measure, privacy_relation)
     }
 }
@@ -91,7 +91,7 @@ impl<T> MakeMeasurement1<VectorDomain<AllDomain<T>>, VectorDomain<AllDomain<T>>,
         };
         let input_metric = L1Sensitivity::new();
         let output_measure = MaxDivergence::new();
-        let privacy_relation = move |d_in: &f64, d_out: &f64| *d_out >= *d_in / sigma;
+        let privacy_relation = PrivacyRelation::new_from_constant(1. / sigma);
         Measurement::new(input_domain, output_domain, function, input_metric, output_measure, privacy_relation)
     }
 }
@@ -113,10 +113,10 @@ impl<T> MakeMeasurement1<AllDomain<T>, AllDomain<T>, L2Sensitivity<f64>, Smoothe
         let input_metric = L2Sensitivity::new();
         let output_measure = SmoothedMaxDivergence::new();
         // https://docs.google.com/spreadsheets/d/132rAzbSDVCKqFZWeE-P8oOl9f23PzkvNwsrDV5LPkw4/edit#gid=0
-        let privacy_relation = move |d_in: &f64, d_out: &(f64, f64)| {
+        let privacy_relation = PrivacyRelation::new(move |d_in: &f64, d_out: &(f64, f64)| {
             let (eps, delta) = d_out.clone();
             eps.min(1.) >= (*d_in / sigma) * (2. * (1.25 / delta).ln()).sqrt()
-        };
+        });
         Measurement::new(input_domain, output_domain, function, input_metric, output_measure, privacy_relation)
     }
 }

--- a/rust/opendp/src/traits.rs
+++ b/rust/opendp/src/traits.rs
@@ -34,11 +34,11 @@ impl_is_continuous!(f32, f64);
 impl_is_not_continuous!(i8, u8, i16, u16, i32, u32, i64, u64, isize, usize);
 
 // include Ceil on QO to avoid requiring as an additional trait bound in all downstream code
-pub trait DPDistanceCast: NumCast + Ceil + CheckContinuous {
+pub trait DistanceCast: NumCast + Ceil + CheckContinuous {
     fn cast<T: ToPrimitive + Ceil>(n: T) -> Option<Self>;
 }
 
-impl<QO: ToPrimitive + NumCast + CheckContinuous + Ceil> DPDistanceCast for QO {
+impl<QO: ToPrimitive + NumCast + CheckContinuous + Ceil> DistanceCast for QO {
     fn cast<QI: ToPrimitive + Ceil>(v: QI) -> Option<QO> {
         // round away from zero when losing precision
         QO::from(if QO::is_continuous() { v } else { v.ceil() })

--- a/rust/opendp/src/traits.rs
+++ b/rust/opendp/src/traits.rs
@@ -1,0 +1,26 @@
+use std::convert::TryInto;
+
+pub trait DPDistanceCast<T> where Self: Sized {
+    fn cast(x: T) -> Result<Self, &'static str>;
+}
+
+impl<T> DPDistanceCast<T> for T {
+    fn cast(x: T) -> Result<T, &'static str> {
+        Ok(x)
+    }
+}
+
+impl DPDistanceCast<f64> for i8 {
+    fn cast(x: f64) -> Result<i8, &'static str> {
+        if x.is_sign_negative() {
+            return Err("distances cannot be negative")
+        }
+        Ok(x as i8)
+    }
+}
+
+impl DPDistanceCast<i8> for f64 {
+    fn cast(x: i8) -> Result<f64, &'static str> {
+        Ok(x as f64)
+    }
+}

--- a/rust/opendp/src/traits.rs
+++ b/rust/opendp/src/traits.rs
@@ -1,26 +1,46 @@
-use std::convert::TryInto;
+use num::{NumCast, ToPrimitive};
 
-pub trait DPDistanceCast<T> where Self: Sized {
-    fn cast(x: T) -> Result<Self, &'static str>;
-}
-
-impl<T> DPDistanceCast<T> for T {
-    fn cast(x: T) -> Result<T, &'static str> {
-        Ok(x)
+pub trait CheckContinuous { fn is_continuous() -> bool; }
+pub trait Ceil : Copy { fn ceil(self) -> Self; }
+macro_rules! impl_is_continuous {
+    ($($ty:ty),+) => {
+        $(
+            impl Ceil for $ty {
+                #[inline]
+                fn ceil(self) -> $ty { self.ceil() }
+            }
+            impl CheckContinuous for $ty {
+                #[inline]
+                fn is_continuous() -> bool {true}
+            }
+        )+
     }
 }
-
-impl DPDistanceCast<f64> for i8 {
-    fn cast(x: f64) -> Result<i8, &'static str> {
-        if x.is_sign_negative() {
-            return Err("distances cannot be negative")
-        }
-        Ok(x as i8)
+macro_rules! impl_is_not_continuous {
+    ($($ty:ty),+) => {
+        $(
+            impl Ceil for $ty {
+                #[inline]
+                fn ceil(self) -> $ty { self }
+            }
+            impl CheckContinuous for $ty {
+                #[inline]
+                fn is_continuous() -> bool {false}
+            }
+        )+
     }
 }
+impl_is_continuous!(f32, f64);
+impl_is_not_continuous!(i8, u8, i16, u16, i32, u32, i64, u64, isize, usize);
 
-impl DPDistanceCast<i8> for f64 {
-    fn cast(x: i8) -> Result<f64, &'static str> {
-        Ok(x as f64)
+// include Ceil on QO to avoid requiring as an additional trait bound in all downstream code
+pub trait DPDistanceCast: NumCast + Ceil + CheckContinuous {
+    fn cast<T: ToPrimitive + Ceil>(n: T) -> Option<Self>;
+}
+
+impl<QO: ToPrimitive + NumCast + CheckContinuous + Ceil> DPDistanceCast for QO {
+    fn cast<QI: ToPrimitive + Ceil>(v: QI) -> Option<QO> {
+        // round away from zero when losing precision
+        QO::from(if QO::is_continuous() { v } else { v.ceil() })
     }
 }

--- a/rust/opendp/src/trans/dataframe.rs
+++ b/rust/opendp/src/trans/dataframe.rs
@@ -4,7 +4,7 @@ use std::iter::repeat;
 use std::marker::PhantomData;
 use std::str::FromStr;
 
-use crate::core::{DatasetMetric, Metric, Transformation};
+use crate::core::{DatasetMetric, Metric, Transformation, StabilityRelation};
 use crate::data::{Data, Element};
 use crate::dom::{AllDomain, MapDomain, VectorDomain};
 use crate::trans::{MakeTransformation0, MakeTransformation1, MakeTransformation2};
@@ -47,7 +47,7 @@ pub fn create_dataframe_domain() -> MapDomain<AllDomain<Data>> {
 impl<M> MakeTransformation1<VectorDomain<VectorDomain<AllDomain<String>>>, MapDomain<AllDomain<Data>>, M, M, usize> for CreateDataFrame<M>
     where M: Clone + Metric<Distance=u32> + DatasetMetric {
     fn make1(col_count: usize) -> Transformation<VectorDomain<VectorDomain<AllDomain<String>>>, MapDomain<AllDomain<Data>>, M, M> {
-        Transformation::new_constant_stability(
+        Transformation::new(
             VectorDomain::new(VectorDomain::new_all()),
             create_dataframe_domain(),
             // move is necessary because it captures `col_count`
@@ -57,7 +57,7 @@ impl<M> MakeTransformation1<VectorDomain<VectorDomain<AllDomain<String>>>, MapDo
             },
             M::new(),
             M::new(),
-            1_u32)
+            StabilityRelation::new_from_constant(1_u32))
     }
 }
 
@@ -76,7 +76,7 @@ impl<M> MakeTransformation2<AllDomain<String>, MapDomain<AllDomain<Data>>, M, M,
     where M: Clone + Metric<Distance=u32> + DatasetMetric {
     fn make2(separator: Option<&str>, col_count: usize) -> Transformation<AllDomain<String>, MapDomain<AllDomain<Data>>, M, M> {
         let separator = separator.unwrap_or(",").to_owned();
-        Transformation::new_constant_stability(
+        Transformation::new(
             AllDomain::new(),
             create_dataframe_domain(),
             move |arg: &String| -> DataFrame {
@@ -84,7 +84,7 @@ impl<M> MakeTransformation2<AllDomain<String>, MapDomain<AllDomain<Data>>, M, M,
             },
             M::new(),
             M::new(),
-            1_u32)
+            StabilityRelation::new_from_constant(1_u32))
     }
 }
 
@@ -114,7 +114,7 @@ impl<M, T> MakeTransformation2<MapDomain<AllDomain<Data>>, MapDomain<AllDomain<D
           T::Err: Debug {
     fn make2(key: &str, impute: bool) -> Transformation<MapDomain<AllDomain<Data>>, MapDomain<AllDomain<Data>>, M, M> {
         let key = key.to_owned();
-        Transformation::new_constant_stability(
+        Transformation::new(
             create_dataframe_domain(),
             create_dataframe_domain(),
             move |arg: &DataFrame| -> DataFrame {
@@ -122,7 +122,7 @@ impl<M, T> MakeTransformation2<MapDomain<AllDomain<Data>>, MapDomain<AllDomain<D
             },
             M::new(),
             M::new(),
-            1_u32)
+            StabilityRelation::new_from_constant(1_u32))
     }
 }
 
@@ -137,7 +137,7 @@ impl<M, T> MakeTransformation1<MapDomain<AllDomain<Data>>, VectorDomain<AllDomai
           T: 'static + Element + Clone + PartialEq {
     fn make1(key: &str) -> Transformation<MapDomain<AllDomain<Data>>, VectorDomain<AllDomain<T>>, M, M> {
         let key = key.to_owned();
-        Transformation::new_constant_stability(
+        Transformation::new(
             create_dataframe_domain(),
             VectorDomain::new_all(),
             move |arg: &DataFrame| -> Vec<T> {
@@ -147,7 +147,7 @@ impl<M, T> MakeTransformation1<MapDomain<AllDomain<Data>>, VectorDomain<AllDomai
             },
             M::new(),
             M::new(),
-            1_u32)
+            StabilityRelation::new_from_constant(1_u32))
     }
 }
 
@@ -171,7 +171,7 @@ fn split_lines(s: &str) -> Vec<&str> {
 impl<M> MakeTransformation0<AllDomain<String>, VectorDomain<AllDomain<String>>, M, M> for SplitLines<M>
     where M: Clone + Metric<Distance=u32> + DatasetMetric {
     fn make0() -> Transformation<AllDomain<String>, VectorDomain<AllDomain<String>>, M, M> {
-        Transformation::new_constant_stability(
+        Transformation::new(
             AllDomain::<String>::new(),
             VectorDomain::new_all(),
             |arg: &String| -> Vec<String> {
@@ -179,7 +179,7 @@ impl<M> MakeTransformation0<AllDomain<String>, VectorDomain<AllDomain<String>>, 
             },
             M::new(),
             M::new(),
-            1_u32)
+            StabilityRelation::new_from_constant(1_u32))
     }
 }
 
@@ -203,7 +203,7 @@ impl<T, M> MakeTransformation1<VectorDomain<AllDomain<String>>, VectorDomain<All
           T: FromStr + Default,
           T::Err: Debug {
     fn make1(impute: bool) -> Transformation<VectorDomain<AllDomain<String>>, VectorDomain<AllDomain<T>>, M, M> {
-        Transformation::new_constant_stability(
+        Transformation::new(
             VectorDomain::new_all(),
             VectorDomain::new_all(),
             // move is necessary because it captures `impute`
@@ -213,7 +213,7 @@ impl<T, M> MakeTransformation1<VectorDomain<AllDomain<String>>, VectorDomain<All
             },
             M::new(),
             M::new(),
-            1_u32)
+            StabilityRelation::new_from_constant(1_u32))
     }
 }
 
@@ -233,7 +233,7 @@ impl<M> MakeTransformation1<VectorDomain<AllDomain<String>>, VectorDomain<Vector
     where M: Clone + Metric<Distance=u32> + DatasetMetric {
     fn make1(separator: Option<&str>) -> Transformation<VectorDomain<AllDomain<String>>, VectorDomain<VectorDomain<AllDomain<String>>>, M, M> {
         let separator = separator.unwrap_or(",").to_owned();
-        Transformation::new_constant_stability(
+        Transformation::new(
             VectorDomain::new_all(),
             VectorDomain::new(VectorDomain::new_all()),
             // move is necessary because it captures `separator`
@@ -244,7 +244,7 @@ impl<M> MakeTransformation1<VectorDomain<AllDomain<String>>, VectorDomain<Vector
             },
             M::new(),
             M::new(),
-            1_u32)
+            StabilityRelation::new_from_constant(1_u32))
     }
 }
 

--- a/rust/opendp/src/trans/dataframe.rs
+++ b/rust/opendp/src/trans/dataframe.rs
@@ -47,7 +47,7 @@ pub fn create_dataframe_domain() -> MapDomain<AllDomain<Data>> {
 impl<M> MakeTransformation1<VectorDomain<VectorDomain<AllDomain<String>>>, MapDomain<AllDomain<Data>>, M, M, usize> for CreateDataFrame<M>
     where M: Clone + Metric<Distance=u32> + DatasetMetric {
     fn make1(col_count: usize) -> Transformation<VectorDomain<VectorDomain<AllDomain<String>>>, MapDomain<AllDomain<Data>>, M, M> {
-        Transformation::new(
+        Transformation::new_constant_stability(
             VectorDomain::new(VectorDomain::new_all()),
             create_dataframe_domain(),
             // move is necessary because it captures `col_count`
@@ -57,7 +57,7 @@ impl<M> MakeTransformation1<VectorDomain<VectorDomain<AllDomain<String>>>, MapDo
             },
             M::new(),
             M::new(),
-            |d_in: &u32, d_out: &u32| *d_out >= *d_in)
+            1_u32)
     }
 }
 
@@ -76,7 +76,7 @@ impl<M> MakeTransformation2<AllDomain<String>, MapDomain<AllDomain<Data>>, M, M,
     where M: Clone + Metric<Distance=u32> + DatasetMetric {
     fn make2(separator: Option<&str>, col_count: usize) -> Transformation<AllDomain<String>, MapDomain<AllDomain<Data>>, M, M> {
         let separator = separator.unwrap_or(",").to_owned();
-        Transformation::new(
+        Transformation::new_constant_stability(
             AllDomain::new(),
             create_dataframe_domain(),
             move |arg: &String| -> DataFrame {
@@ -84,7 +84,7 @@ impl<M> MakeTransformation2<AllDomain<String>, MapDomain<AllDomain<Data>>, M, M,
             },
             M::new(),
             M::new(),
-            |d_in: &u32, d_out: &u32| *d_out >= *d_in)
+            1_u32)
     }
 }
 
@@ -114,7 +114,7 @@ impl<M, T> MakeTransformation2<MapDomain<AllDomain<Data>>, MapDomain<AllDomain<D
           T::Err: Debug {
     fn make2(key: &str, impute: bool) -> Transformation<MapDomain<AllDomain<Data>>, MapDomain<AllDomain<Data>>, M, M> {
         let key = key.to_owned();
-        Transformation::new(
+        Transformation::new_constant_stability(
             create_dataframe_domain(),
             create_dataframe_domain(),
             move |arg: &DataFrame| -> DataFrame {
@@ -122,7 +122,7 @@ impl<M, T> MakeTransformation2<MapDomain<AllDomain<Data>>, MapDomain<AllDomain<D
             },
             M::new(),
             M::new(),
-            |d_in: &u32, d_out: &u32| *d_out >= *d_in)
+            1_u32)
     }
 }
 
@@ -137,7 +137,7 @@ impl<M, T> MakeTransformation1<MapDomain<AllDomain<Data>>, VectorDomain<AllDomai
           T: 'static + Element + Clone + PartialEq {
     fn make1(key: &str) -> Transformation<MapDomain<AllDomain<Data>>, VectorDomain<AllDomain<T>>, M, M> {
         let key = key.to_owned();
-        Transformation::new(
+        Transformation::new_constant_stability(
             create_dataframe_domain(),
             VectorDomain::new_all(),
             move |arg: &DataFrame| -> Vec<T> {
@@ -147,7 +147,7 @@ impl<M, T> MakeTransformation1<MapDomain<AllDomain<Data>>, VectorDomain<AllDomai
             },
             M::new(),
             M::new(),
-            |d_in: &u32, d_out: &u32| *d_out >= *d_in)
+            1_u32)
     }
 }
 
@@ -171,7 +171,7 @@ fn split_lines(s: &str) -> Vec<&str> {
 impl<M> MakeTransformation0<AllDomain<String>, VectorDomain<AllDomain<String>>, M, M> for SplitLines<M>
     where M: Clone + Metric<Distance=u32> + DatasetMetric {
     fn make0() -> Transformation<AllDomain<String>, VectorDomain<AllDomain<String>>, M, M> {
-        Transformation::new(
+        Transformation::new_constant_stability(
             AllDomain::<String>::new(),
             VectorDomain::new_all(),
             |arg: &String| -> Vec<String> {
@@ -179,7 +179,7 @@ impl<M> MakeTransformation0<AllDomain<String>, VectorDomain<AllDomain<String>>, 
             },
             M::new(),
             M::new(),
-            |d_in: &u32, d_out: &u32| *d_out >= *d_in)
+            1_u32)
     }
 }
 
@@ -203,7 +203,7 @@ impl<T, M> MakeTransformation1<VectorDomain<AllDomain<String>>, VectorDomain<All
           T: FromStr + Default,
           T::Err: Debug {
     fn make1(impute: bool) -> Transformation<VectorDomain<AllDomain<String>>, VectorDomain<AllDomain<T>>, M, M> {
-        Transformation::new(
+        Transformation::new_constant_stability(
             VectorDomain::new_all(),
             VectorDomain::new_all(),
             // move is necessary because it captures `impute`
@@ -213,7 +213,7 @@ impl<T, M> MakeTransformation1<VectorDomain<AllDomain<String>>, VectorDomain<All
             },
             M::new(),
             M::new(),
-            |d_in: &u32, d_out: &u32| *d_out >= *d_in)
+            1_u32)
     }
 }
 
@@ -233,7 +233,7 @@ impl<M> MakeTransformation1<VectorDomain<AllDomain<String>>, VectorDomain<Vector
     where M: Clone + Metric<Distance=u32> + DatasetMetric {
     fn make1(separator: Option<&str>) -> Transformation<VectorDomain<AllDomain<String>>, VectorDomain<VectorDomain<AllDomain<String>>>, M, M> {
         let separator = separator.unwrap_or(",").to_owned();
-        Transformation::new(
+        Transformation::new_constant_stability(
             VectorDomain::new_all(),
             VectorDomain::new(VectorDomain::new_all()),
             // move is necessary because it captures `separator`
@@ -244,7 +244,7 @@ impl<M> MakeTransformation1<VectorDomain<AllDomain<String>>, VectorDomain<Vector
             },
             M::new(),
             M::new(),
-            |d_in: &u32, d_out: &u32| *d_out >= *d_in)
+            1_u32)
     }
 }
 

--- a/rust/opendp/src/trans/mod.rs
+++ b/rust/opendp/src/trans/mod.rs
@@ -14,7 +14,7 @@ use crate::core::{DatasetMetric, Domain, Metric, SensitivityMetric, Transformati
 use crate::dist::{HammingDistance, SymmetricDistance};
 use crate::dom::{AllDomain, IntervalDomain, SizedDomain, VectorDomain};
 pub use crate::trans::dataframe::*;
-use crate::traits::DPDistanceCast;
+use crate::traits::DistanceCast;
 
 pub mod dataframe;
 
@@ -59,7 +59,7 @@ pub struct Identity;
 
 impl<D, T, M, Q> MakeTransformation2<D, D, M, M, D, M> for Identity
     where D: Domain<Carrier=T>, T: Clone,
-          M: Metric<Distance=Q>, Q: 'static + Clone + Div<Output=Q> + Mul<Output=Q> + PartialOrd + DPDistanceCast + One {
+          M: Metric<Distance=Q>, Q: 'static + Clone + Div<Output=Q> + Mul<Output=Q> + PartialOrd + DistanceCast + One {
     fn make2(domain: D, metric: M) -> Transformation<D, D, M, M> {
         Transformation::new_constant_stability(
             domain.clone(), domain,
@@ -104,7 +104,7 @@ pub struct BoundedSum<MI, MO, T> {
 }
 
 impl<MO, T> MakeTransformation2<VectorDomain<IntervalDomain<T>>, AllDomain<T>, HammingDistance, MO, T, T> for BoundedSum<HammingDistance, MO, T>
-    where T: 'static + Copy + PartialOrd + Sub<Output=T> + Mul<Output=T> + Sum<T> + DPDistanceCast,
+    where T: 'static + Copy + PartialOrd + Sub<Output=T> + Mul<Output=T> + Sum<T> + DistanceCast,
           MO: SensitivityMetric<Distance=T>,
           MO::Distance: Clone + Mul<Output=MO::Distance> + Div<Output=MO::Distance> + PartialOrd {
     fn make2(lower: T, upper: T) -> Transformation<VectorDomain<IntervalDomain<T>>, AllDomain<T>, HammingDistance, MO> {
@@ -127,7 +127,7 @@ fn max<T: PartialOrd>(a: T, b: T) -> T {
 }
 
 impl<MO, T> MakeTransformation2<VectorDomain<IntervalDomain<T>>, AllDomain<T>, SymmetricDistance, MO, T, T> for BoundedSum<SymmetricDistance, MO, T>
-    where T: 'static + Copy + PartialOrd + Sub<Output=T> + Mul<Output=T> + Sum<T> + Signed + DPDistanceCast,
+    where T: 'static + Copy + PartialOrd + Sub<Output=T> + Mul<Output=T> + Sum<T> + Signed + DistanceCast,
           MO: SensitivityMetric<Distance=T>,
           MO::Distance: Clone + Mul<MO::Distance, Output=MO::Distance> + Div<MO::Distance, Output=MO::Distance> + PartialOrd, {
     // Question- how to set the associated type for a trait that a concrete type is using
@@ -144,7 +144,7 @@ impl<MO, T> MakeTransformation2<VectorDomain<IntervalDomain<T>>, AllDomain<T>, S
 }
 
 impl<MO, T> MakeTransformation3<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, SymmetricDistance, MO, usize, T, T> for BoundedSum<SymmetricDistance, MO, T>
-    where T: 'static + Copy + PartialOrd + Sub<Output=T> + Mul<Output=T> + Div<Output=T> + Sum<T> + DPDistanceCast,
+    where T: 'static + Copy + PartialOrd + Sub<Output=T> + Mul<Output=T> + Div<Output=T> + Sum<T> + DistanceCast,
           MO: SensitivityMetric<Distance=T>,
           SymmetricDistance: Metric<Distance=u32>  {
     fn make3(length: usize, lower: T, upper: T) -> Transformation<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, SymmetricDistance, MO> {

--- a/rust/opendp/src/trans/mod.rs
+++ b/rust/opendp/src/trans/mod.rs
@@ -102,8 +102,7 @@ pub struct BoundedSum<MI, MO, T> {
 }
 
 impl<MO, T> MakeTransformation2<VectorDomain<IntervalDomain<T>>, AllDomain<T>, HammingDistance, MO, T, T> for BoundedSum<HammingDistance, MO, T>
-    where T: 'static + Copy + PartialOrd + Sub<Output=T> + NumCast + Mul<Output=T> + Sum<T> + DPDistanceCast<u32>,
-          u32: DPDistanceCast<T>,
+    where T: 'static + Copy + PartialOrd + Sub<Output=T> + NumCast + Mul<Output=T> + Sum<T> + DPDistanceCast,
           MO: SensitivityMetric<Distance=T>,
           MO::Distance: Clone + Mul<Output=MO::Distance> + Div<Output=MO::Distance> + PartialOrd {
     fn make2(lower: T, upper: T) -> Transformation<VectorDomain<IntervalDomain<T>>, AllDomain<T>, HammingDistance, MO> {
@@ -126,10 +125,9 @@ fn max<T: PartialOrd>(a: T, b: T) -> T {
 }
 
 impl<MO, T> MakeTransformation2<VectorDomain<IntervalDomain<T>>, AllDomain<T>, SymmetricDistance, MO, T, T> for BoundedSum<SymmetricDistance, MO, T>
-    where T: 'static + Copy + PartialOrd + Sub<Output=T> + NumCast + Mul<Output=T> + Sum<T> + Signed + DPDistanceCast<u32>,
-          u32: DPDistanceCast<T>,
+    where T: 'static + Copy + PartialOrd + Sub<Output=T> + NumCast + Mul<Output=T> + Sum<T> + Signed + DPDistanceCast,
           MO: SensitivityMetric<Distance=T>,
-          MO::Distance: Clone + Mul<MO::Distance, Output=MO::Distance> + Div<MO::Distance, Output=MO::Distance> + From<u32> + From<T> + PartialOrd, {
+          MO::Distance: Clone + Mul<MO::Distance, Output=MO::Distance> + Div<MO::Distance, Output=MO::Distance> + PartialOrd, {
     // Question- how to set the associated type for a trait that a concrete type is using
     fn make2(lower: T, upper: T) -> Transformation<VectorDomain<IntervalDomain<T>>, AllDomain<T>, SymmetricDistance, MO> {
         Transformation::new_constant_stability(

--- a/rust/opendp/src/trans/mod.rs
+++ b/rust/opendp/src/trans/mod.rs
@@ -14,6 +14,7 @@ use crate::core::{DatasetMetric, Domain, Metric, SensitivityMetric, Transformati
 use crate::dist::{HammingDistance, SymmetricDistance};
 use crate::dom::{AllDomain, IntervalDomain, SizedDomain, VectorDomain};
 pub use crate::trans::dataframe::*;
+use crate::traits::DPDistanceCast;
 
 pub mod dataframe;
 
@@ -101,10 +102,10 @@ pub struct BoundedSum<MI, MO, T> {
 }
 
 impl<MO, T> MakeTransformation2<VectorDomain<IntervalDomain<T>>, AllDomain<T>, HammingDistance, MO, T, T> for BoundedSum<HammingDistance, MO, T>
-    where T: 'static + Copy + PartialOrd + Sub<Output=T> + NumCast + Mul<Output=T> + Sum<T>,
+    where T: 'static + Copy + PartialOrd + Sub<Output=T> + NumCast + Mul<Output=T> + Sum<T> + DPDistanceCast<u32>,
+          u32: DPDistanceCast<T>,
           MO: SensitivityMetric<Distance=T>,
-          u32: From<MO::Distance>,
-          MO::Distance: Clone + From<u32> + From<T> + Mul<Output=MO::Distance> + Div<Output=MO::Distance> + PartialOrd {
+          MO::Distance: Clone + Mul<Output=MO::Distance> + Div<Output=MO::Distance> + PartialOrd {
     fn make2(lower: T, upper: T) -> Transformation<VectorDomain<IntervalDomain<T>>, AllDomain<T>, HammingDistance, MO> {
         Transformation::new_constant_stability(
             VectorDomain::new(IntervalDomain::new(Bound::Included(lower.clone()), Bound::Included(upper.clone()))),
@@ -125,9 +126,9 @@ fn max<T: PartialOrd>(a: T, b: T) -> T {
 }
 
 impl<MO, T> MakeTransformation2<VectorDomain<IntervalDomain<T>>, AllDomain<T>, SymmetricDistance, MO, T, T> for BoundedSum<SymmetricDistance, MO, T>
-    where T: 'static + Copy + PartialOrd + Sub<Output=T> + NumCast + Mul<Output=T> + Sum<T> + Signed + From<MO::Distance>,
+    where T: 'static + Copy + PartialOrd + Sub<Output=T> + NumCast + Mul<Output=T> + Sum<T> + Signed + DPDistanceCast<u32>,
+          u32: DPDistanceCast<T>,
           MO: SensitivityMetric<Distance=T>,
-          u32: From<MO::Distance>,
           MO::Distance: Clone + Mul<MO::Distance, Output=MO::Distance> + Div<MO::Distance, Output=MO::Distance> + From<u32> + From<T> + PartialOrd, {
     // Question- how to set the associated type for a trait that a concrete type is using
     fn make2(lower: T, upper: T) -> Transformation<VectorDomain<IntervalDomain<T>>, AllDomain<T>, SymmetricDistance, MO> {


### PR DESCRIPTION
Linked to #30 

Still need to implement passing hints over FFI.
Suffers from #33.

Stability and privacy relations are oftentimes specified in terms of a constant.  
In these cases, it is possible to bundle a forward and backward map with the stability relation, to construct hints automatically. 