### PR TITLE
BaseLaplace proof (v2)

### DIFF
--- a/rust/opendp-ffi/src/meas.rs
+++ b/rust/opendp-ffi/src/meas.rs
@@ -4,13 +4,13 @@ use crate::core::FfiMeasurement;
 use crate::util;
 use crate::util::TypeArgs;
 use num::NumCast;
-use opendp::meas::{LaplaceMechanism, MakeMeasurement1, GaussianMechanism, VectorLaplaceMechanism};
+use opendp::meas::{BaseLaplace, MakeMeasurement1, BaseGaussian, BaseVectorLaplace};
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_laplace(type_args: *const c_char, sigma: f64) -> *mut FfiMeasurement {
     fn monomorphize<T>(sigma: f64) -> *mut FfiMeasurement where
         T: 'static + Copy + NumCast {
-        let measurement = LaplaceMechanism::<T>::make(sigma).unwrap();
+        let measurement = BaseLaplace::<T>::make(sigma).unwrap();
         FfiMeasurement::new_from_types(measurement)
     }
     let type_args = TypeArgs::expect(type_args, 1);
@@ -21,7 +21,7 @@ pub extern "C" fn opendp_meas__make_base_laplace(type_args: *const c_char, sigma
 pub extern "C" fn opendp_meas__make_base_laplace_vec(type_args: *const c_char, sigma: f64) -> *mut FfiMeasurement {
     fn monomorphize<T>(sigma: f64) -> *mut FfiMeasurement where
         T: 'static + Copy + NumCast {
-        let measurement = VectorLaplaceMechanism::<T>::make(sigma).unwrap();
+        let measurement = BaseVectorLaplace::<T>::make(sigma).unwrap();
         FfiMeasurement::new_from_types(measurement)
     }
     let type_args = TypeArgs::expect(type_args, 1);
@@ -32,7 +32,7 @@ pub extern "C" fn opendp_meas__make_base_laplace_vec(type_args: *const c_char, s
 pub extern "C" fn opendp_meas__make_base_gaussian(type_args: *const c_char, sigma: f64) -> *mut FfiMeasurement {
     fn monomorphize<T>(sigma: f64) -> *mut FfiMeasurement where
         T: 'static + Copy + NumCast {
-        let measurement = GaussianMechanism::<T>::make(sigma).unwrap();
+        let measurement = BaseGaussian::<T>::make(sigma).unwrap();
         FfiMeasurement::new_from_types(measurement)
     }
     let type_args = TypeArgs::expect(type_args, 1);

--- a/rust/opendp/src/lib.rs
+++ b/rust/opendp/src/lib.rs
@@ -41,7 +41,7 @@
 //! use opendp::trans::{MakeTransformation0, MakeTransformation1, MakeTransformation2, MakeTransformation3};
 //! use opendp::dist::{HammingDistance, L1Sensitivity};
 //! use opendp::core::{ChainTT, ChainMT};
-//! use opendp::meas::{MakeMeasurement2, LaplaceMechanism, MakeMeasurement1};
+//! use opendp::meas::{MakeMeasurement2, BaseLaplace, MakeMeasurement1};
 //!
 //! pub fn example() {
 //!     let data = "56\n15\n97\n56\n6\n17\n2\n19\n16\n50".to_owned();
@@ -57,7 +57,7 @@
 //!     // Construct a Measurement to calculate a noisy sum.
 //!     let clamp = trans::Clamp::make(bounds.0, bounds.1).unwrap();
 //!     let bounded_sum = trans::BoundedSum::make2(bounds.0, bounds.1).unwrap();
-//!     let laplace = LaplaceMechanism::make(sigma).unwrap();
+//!     let laplace = BaseLaplace::make(sigma).unwrap();
 //!     let intermediate = ChainTT::make(&bounded_sum, &clamp).unwrap();
 //!     let noisy_sum = ChainMT::make(&laplace, &intermediate).unwrap();
 //!

--- a/rust/opendp/src/meas/mod.rs
+++ b/rust/opendp/src/meas/mod.rs
@@ -49,7 +49,10 @@ pub trait MakeMeasurement4<DI: Domain, DO: Domain, MI: Metric, MO: Measure, P1, 
     fn make4(param1: P1, param2: P2, param3: P3, param4: P4) -> Fallible<crate::core::Measurement<DI, DO, MI, MO>>;
 }
 
-pub struct LaplaceMechanism<T> {
+
+/// Univariate noise addition for the Laplace Mechanism
+/// [Accompanying Proof](https://www.overleaf.com/read/brvrprjhrhwb)
+pub struct BaseLaplace<T> {
     data: PhantomData<T>
 }
 
@@ -60,7 +63,7 @@ fn laplace(sigma: f64) -> f64 {
 }
 
 // laplace for scalar-valued query
-impl<T> MakeMeasurement1<AllDomain<T>, AllDomain<T>, L1Sensitivity<f64>, MaxDivergence, f64> for LaplaceMechanism<T>
+impl<T> MakeMeasurement1<AllDomain<T>, AllDomain<T>, L1Sensitivity<f64>, MaxDivergence, f64> for BaseLaplace<T>
     where T: Copy + NumCast {
     fn make1(sigma: f64) -> Fallible<Measurement<AllDomain<T>, AllDomain<T>, L1Sensitivity<f64>, MaxDivergence>> {
         Ok(Measurement::new(
@@ -75,12 +78,14 @@ impl<T> MakeMeasurement1<AllDomain<T>, AllDomain<T>, L1Sensitivity<f64>, MaxDive
     }
 }
 
-pub struct VectorLaplaceMechanism<T> {
+/// Univariate noise addition for the Laplace Mechanism
+/// [Accompanying Proof](https://www.overleaf.com/read/brvrprjhrhwb)
+pub struct BaseVectorLaplace<T> {
     data: PhantomData<T>
 }
 
 // laplace for vector-valued query
-impl<T> MakeMeasurement1<VectorDomain<AllDomain<T>>, VectorDomain<AllDomain<T>>, L1Sensitivity<f64>, MaxDivergence, f64> for VectorLaplaceMechanism<T>
+impl<T> MakeMeasurement1<VectorDomain<AllDomain<T>>, VectorDomain<AllDomain<T>>, L1Sensitivity<f64>, MaxDivergence, f64> for BaseVectorLaplace<T>
     where T: Copy + NumCast {
     fn make1(sigma: f64) -> Fallible<Measurement<VectorDomain<AllDomain<T>>, VectorDomain<AllDomain<T>>, L1Sensitivity<f64>, MaxDivergence>> {
         Ok(Measurement::new(
@@ -97,12 +102,12 @@ impl<T> MakeMeasurement1<VectorDomain<AllDomain<T>>, VectorDomain<AllDomain<T>>,
     }
 }
 
-pub struct GaussianMechanism<T> {
+pub struct BaseGaussian<T> {
     data: PhantomData<T>
 }
 
 // gaussian for scalar-valued query
-impl<T> MakeMeasurement1<AllDomain<T>, AllDomain<T>, L2Sensitivity<f64>, SmoothedMaxDivergence, f64> for GaussianMechanism<T>
+impl<T> MakeMeasurement1<AllDomain<T>, AllDomain<T>, L2Sensitivity<f64>, SmoothedMaxDivergence, f64> for BaseGaussian<T>
     where T: Copy + NumCast {
     fn make1(sigma: f64) -> Fallible<Measurement<AllDomain<T>, AllDomain<T>, L2Sensitivity<f64>, SmoothedMaxDivergence>> {
         Ok(Measurement::new(
@@ -136,7 +141,7 @@ mod tests {
 
     #[test]
     fn test_make_laplace_mechanism() {
-        let measurement = LaplaceMechanism::<f64>::make(1.0).unwrap();
+        let measurement = BaseLaplace::<f64>::make(1.0).unwrap();
         let arg = 0.0;
         let _ret = measurement.function.eval(&arg);
 
@@ -145,7 +150,7 @@ mod tests {
 
     #[test]
     fn test_make_vector_laplace_mechanism() {
-        let measurement = VectorLaplaceMechanism::<f64>::make(1.0).unwrap();
+        let measurement = BaseVectorLaplace::<f64>::make(1.0).unwrap();
         let arg = vec![1.0, 2.0, 3.0];
         let _ret = measurement.function.eval(&arg);
 
@@ -154,7 +159,7 @@ mod tests {
 
     #[test]
     fn test_make_gaussian_mechanism() {
-        let measurement = GaussianMechanism::<f64>::make(1.0).unwrap();
+        let measurement = BaseGaussian::<f64>::make(1.0).unwrap();
         let arg = 0.0;
         let _ret = measurement.function.eval(&arg);
 
@@ -163,7 +168,7 @@ mod tests {
 
     #[test]
     fn test_error() {
-        let measurement = GaussianMechanism::<f64>::make(1.0).unwrap();
+        let measurement = BaseGaussian::<f64>::make(1.0).unwrap();
         let error = measurement.privacy_relation.eval(&-0.1, &(0.5, 0.00001)).unwrap_err();
         let _backtrace = format!("{:?}", error.backtrace);
     }


### PR DESCRIPTION
This is an example of one way to integrate proofs into the library for issue #56.

I wrote a latex document for the BaseLaplace measurement on overleaf.com, and included a link to it in the documentation for the BaseLaplace struct in the code. Connor Wagaman shared a WIP document for this with me (and I've made use of it in the linked Overleaf), but it's been a while and I wanted to go ahead and get my version of the proof written up so we can get this discussion started. 

Example proof document links to here: https://www.overleaf.com/read/brvrprjhrhwb

In the SmartNoise library, we checked pdfs and latex into the repository itself. We could go that route here as well. If we do a lot of pair editing on overleaf, it can get tedious to keep the two sources synced.