### PR TITLE
Cast/Unclamp

### DIFF
--- a/python/example/test.py
+++ b/python/example/test.py
@@ -21,7 +21,7 @@ def main():
 
     # Noisy sum, col 1
     select_1 = odp.trans.make_select_column(b"<HammingDistance, i32, i32>", opendp.i32_p(1))
-    clamp_1 = odp.trans.make_clamp(b"<HammingDistance, i32>", opendp.i32_p(0), opendp.i32_p(10))
+    clamp_1 = odp.trans.make_clamp_vec(b"<HammingDistance, i32>", opendp.i32_p(0), opendp.i32_p(10))
     bounded_sum_1 = odp.trans.make_bounded_sum(b"<HammingDistance, L1Sensitivity<i32>, i32>", opendp.i32_p(0), opendp.i32_p(10))
     base_geometric_1 = odp.meas.make_base_simple_geometric(b"<i32, f64>", opendp.f64_p(1.0), opendp.u32_p(0), opendp.u32_p(1000))
     # base_laplace_1 = odp.meas.make_base_laplace(b"<i32>", opendp.f64_p(1.0))

--- a/rust/opendp-ffi/src/core.rs
+++ b/rust/opendp-ffi/src/core.rs
@@ -157,6 +157,7 @@ impl Measure for FfiMeasure {
 pub struct FfiMetric;
 impl Metric for FfiMetric {
     type Distance = ();
+    fn new() -> Self { unreachable!() }
 }
 
 pub struct FfiMeasurement {

--- a/rust/opendp-ffi/src/core.rs
+++ b/rust/opendp-ffi/src/core.rs
@@ -151,6 +151,8 @@ impl Domain for FfiDomain {
 pub struct FfiMeasure;
 impl Measure for FfiMeasure {
     type Distance = ();
+
+    fn new() -> Self { unreachable!() }
 }
 
 #[derive(Clone)]

--- a/rust/opendp-ffi/src/trans.rs
+++ b/rust/opendp-ffi/src/trans.rs
@@ -1,26 +1,28 @@
 use std::fmt::Debug;
+use std::hash::Hash;
 use std::iter::Sum;
+use std::ops::{Div, Mul, Sub};
 use std::os::raw::{c_char, c_uint, c_void};
 use std::str::FromStr;
 
-use opendp::trans::{MakeTransformation0, MakeTransformation1, MakeTransformation2, BoundedSum, BoundedSumStability, MakeTransformation3};
-use opendp::dist::{HammingDistance, SymmetricDistance, L1Sensitivity, L2Sensitivity};
+use num::One;
+
+use opendp::core::{DatasetMetric, Metric, SensitivityMetric};
+use opendp::dist::{HammingDistance, L1Sensitivity, L2Sensitivity, SymmetricDistance};
 use opendp::dom::AllDomain;
+use opendp::traits::{Abs, CastFrom, DistanceCast};
+use opendp::trans::{BoundedSum, BoundedSumStability, MakeTransformation0, MakeTransformation1, MakeTransformation2, MakeTransformation3, manipulation};
 use opendp::trans;
 
 use crate::core::FfiTransformation;
 use crate::util;
-use crate::util::{c_bool};
+use crate::util::c_bool;
 use crate::util::TypeArgs;
-use std::ops::{Sub, Mul, Div};
-use opendp::traits::{DistanceCast, Abs};
-use std::hash::Hash;
-use opendp::core::{DatasetMetric, SensitivityMetric};
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_identity(type_args: *const c_char) -> *mut FfiTransformation {
     fn monomorphize<T: 'static + Clone>() -> *mut FfiTransformation {
-        let transformation = trans::Identity::make(AllDomain::<T>::new(), HammingDistance::new()).unwrap();
+        let transformation = manipulation::Identity::make(AllDomain::<T>::new(), HammingDistance::new()).unwrap();
         FfiTransformation::new_from_types(transformation)
     }
     let type_args = TypeArgs::expect(type_args, 1);
@@ -120,18 +122,79 @@ pub extern "C" fn opendp_trans__make_select_column(type_args: *const c_char, key
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_clamp(type_args: *const c_char, lower: *const c_void, upper: *const c_void) -> *mut FfiTransformation {
-    fn monomorphize<M, T>(lower: *const c_void, upper: *const c_void) -> *mut FfiTransformation where
-        M: 'static + DatasetMetric<Distance=u32> + Clone,
-        T: 'static + Copy + PartialOrd {
+pub extern "C" fn opendp_trans__make_clamp_vec(type_args: *const c_char, lower: *const c_void, upper: *const c_void) -> *mut FfiTransformation {
+    fn monomorphize<M, T>(lower: *const c_void, upper: *const c_void) -> *mut FfiTransformation
+        where M: 'static + Metric<Distance=u32> + Clone,
+              T: 'static + Copy + PartialOrd {
         let lower = util::as_ref(lower as *const T).clone();
         let upper = util::as_ref(upper as *const T).clone();
-        let transformation = trans::Clamp::<M, T>::make(lower, upper).unwrap();
+        let transformation = manipulation::Clamp::<M, Vec<T>, u32>::make(lower, upper).unwrap();
         FfiTransformation::new_from_types(transformation)
     }
     let type_args = TypeArgs::expect(type_args, 2);
     dispatch!(monomorphize, [(type_args.0[0], @dist_dataset), (type_args.0[1], @numbers)], (lower, upper))
 }
+
+
+#[no_mangle]
+pub extern "C" fn opendp_trans__make_clamp_scalar(type_args: *const c_char, lower: *const c_void, upper: *const c_void) -> *mut FfiTransformation {
+    fn monomorphize<T, Q>(type_args: TypeArgs, lower: *const c_void, upper: *const c_void) -> *mut FfiTransformation
+        where T: 'static + Clone + PartialOrd,
+              Q: 'static + One + Mul<Output=Q> + Div<Output=Q> + PartialOrd + DistanceCast {
+        let lower = util::as_ref(lower as *const T).clone();
+        let upper = util::as_ref(upper as *const T).clone();
+
+        fn monomorphize2<M, T, Q>(lower: T, upper: T) -> *mut FfiTransformation
+            where M: 'static + SensitivityMetric<Distance=Q>,
+                  T: 'static + Clone + PartialOrd,
+                  Q: 'static + One + Mul<Output=Q> + Div<Output=Q> + PartialOrd + DistanceCast {
+            let transformation = trans::manipulation::Clamp::<M, T, Q>::make(lower, upper).unwrap();
+            FfiTransformation::new_from_types(transformation)
+        }
+        dispatch!(monomorphize2, [
+            (type_args.0[0], [L1Sensitivity<Q>, L2Sensitivity<Q>]),
+            (type_args.0[2], [T]), (type_args.0[3], [Q])
+        ], (lower, upper))
+    }
+    let type_args = TypeArgs::expect(type_args, 3);
+    dispatch!(monomorphize, [(type_args.0[2], @numbers), (type_args.0[3], @numbers)], (type_args, lower, upper))
+}
+
+
+#[no_mangle]
+pub extern "C" fn opendp_trans__make_cast_vec(type_args: *const c_char) -> *mut FfiTransformation {
+    fn monomorphize<M, TI, TO>() -> *mut FfiTransformation where
+        M: 'static + DatasetMetric<Distance=u32>, TI: 'static + Clone, TO: 'static + CastFrom<TI> + Default {
+        let transformation = trans::manipulation::Cast::<M, M, Vec<TI>, Vec<TO>>::make().unwrap();
+        FfiTransformation::new_from_types(transformation)
+    }
+    let type_args = TypeArgs::expect(type_args, 3);
+    dispatch!(monomorphize, [(type_args.0[0], @dist_dataset), (type_args.0[1], @primitives), (type_args.0[2], @primitives)], ())
+}
+
+// #[no_mangle]
+// pub extern "C" fn opendp_trans__make_cast(type_args: *const c_char) -> *mut FfiTransformation {
+//     fn monomorphize<TI, TO>(type_args: TypeArgs) -> *mut FfiTransformation
+//         where TI: 'static + Clone + DistanceCast,
+//               TO: 'static + CastFrom<TI> + Default + DistanceCast + One + Div<Output=TO> + Mul<Output=TO> + PartialOrd {
+//
+//         fn monomorphize2<MI, MO, TI, TO>() -> *mut FfiTransformation
+//             where MI: 'static + SensitivityMetric<Distance=TI>,
+//                   MO: 'static + SensitivityMetric<Distance=TO>,
+//                   TI: 'static + Clone + DistanceCast,
+//                   TO: 'static + CastFrom<TI> + Default + DistanceCast + One + Div<Output=TO> + Mul<Output=TO> + PartialOrd {
+//             let transformation = trans::manipulation::Cast::<MI, MO, TI, TO>::make().unwrap();
+//             FfiTransformation::new_from_types(transformation)
+//         }
+//         dispatch!(monomorphize2, [
+//             (type_args.0[0], [L1Sensitivity<TI>, L2Sensitivity<TI>]),
+//             (type_args.0[1], [L1Sensitivity<TO>, L2Sensitivity<TO>]),
+//             (type_args.0[2], [TI]), (type_args.0[3], [TO])
+//         ], ())
+//     }
+//     let type_args = TypeArgs::expect(type_args, 4);
+//     dispatch!(monomorphize, [(type_args.0[2], @numbers), (type_args.0[3], @numbers)], (type_args))
+// }
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_bounded_sum(type_args: *const c_char, lower: *const c_void, upper: *const c_void) -> *mut FfiTransformation {
@@ -213,7 +276,9 @@ r#"{
     { "name": "make_split_dataframe", "args": [ ["const char *", "selector"], ["const char *", "separator"], ["unsigned int", "col_count"] ], "ret": "FfiTransformation *" },
     { "name": "make_parse_column", "args": [ ["const char *", "selector"], ["void *", "key"], ["bool", "impute"] ], "ret": "FfiTransformation *" },
     { "name": "make_select_column", "args": [ ["const char *", "selector"], ["void *", "key"] ], "ret": "FfiTransformation *" },
-    { "name": "make_clamp", "args": [ ["const char *", "selector"], ["void *", "lower"], ["void *", "upper"] ], "ret": "FfiTransformation *" },
+    { "name": "make_clamp_vec", "args": [ ["const char *", "selector"], ["void *", "lower"], ["void *", "upper"] ], "ret": "FfiTransformation *" },
+    { "name": "make_clamp_scalar", "args": [ ["const char *", "selector"], ["void *", "lower"], ["void *", "upper"] ], "ret": "FfiTransformation *" },
+    { "name": "make_cast_vec", "args": [ ["const char *", "selector"] ], "ret": "FfiTransformation *" },
     { "name": "make_bounded_sum", "args": [ ["const char *", "selector"], ["void *", "lower"], ["void *", "upper"] ], "ret": "FfiTransformation *" },
     { "name": "make_count", "args": [ ["const char *", "selector"] ], "ret": "FfiTransformation *" }
 ]

--- a/rust/opendp/src/core.rs
+++ b/rust/opendp/src/core.rs
@@ -89,6 +89,7 @@ impl<DI: 'static + Domain, DO1: 'static + Domain, DO2: 'static + Domain> Functio
 /// A representation of the distance between two elements in a set.
 pub trait Metric: Clone {
     type Distance;
+    fn new() -> Self;
 }
 
 /// A representation of the distance between two distributions.
@@ -97,8 +98,8 @@ pub trait Measure: Clone {
 }
 
 /// A indicator trait that is only implemented for dataset distance
-pub trait DatasetMetric: Metric { fn new() -> Self; }
-pub trait SensitivityMetric: Metric { fn new() -> Self; }
+pub trait DatasetMetric: Metric {}
+pub trait SensitivityMetric: Metric {}
 
 
 // HINTS
@@ -167,9 +168,9 @@ impl<MI: Metric, MO: Measure> PrivacyRelation<MI, MO> {
 
         PrivacyRelation::new_all(
             enclose!(c, move |d_in: &MI::Distance, d_out: &MO::Distance|
-                Ok(d_out.clone() >= MO::Distance::cast(d_in.clone())? * c.clone())),
+                Ok(d_out.clone() >= MO::Distance::distance_cast(d_in.clone())? * c.clone())),
             Some(enclose!(c, move |d_out: &MO::Distance|
-                Ok(Box::new(MI::Distance::cast(d_out.clone() / c.clone())?)))))
+                Ok(Box::new(MI::Distance::distance_cast(d_out.clone() / c.clone())?)))))
     }
     pub fn eval(&self, input_distance: &MI::Distance, output_distance: &MO::Distance) -> Fallible<bool> {
         (self.relation)(input_distance, output_distance)
@@ -280,13 +281,13 @@ impl<MI: Metric, MO: Metric> StabilityRelation<MI, MO> {
         StabilityRelation::new_all(
             // relation
             enclose!(c, move |d_in: &MI::Distance, d_out: &MO::Distance|
-                Ok(d_out.clone() >= MO::Distance::cast(d_in.clone())? * c.clone())),
+                Ok(d_out.clone() >= MO::Distance::distance_cast(d_in.clone())? * c.clone())),
             // forward map
             Some(enclose!(c, move |d_in: &MI::Distance|
-                Ok(Box::new(MO::Distance::cast(d_in.clone())? * c.clone())))),
+                Ok(Box::new(MO::Distance::distance_cast(d_in.clone())? * c.clone())))),
             // backward map
             Some(enclose!(c, move |d_out: &MO::Distance|
-                Ok(Box::new(MI::Distance::cast(d_out.clone() / c.clone())?)))))
+                Ok(Box::new(MI::Distance::distance_cast(d_out.clone() / c.clone())?)))))
     }
     pub fn eval(&self, input_distance: &MI::Distance, output_distance: &MO::Distance) -> Fallible<bool> {
         (self.relation)(input_distance, output_distance)

--- a/rust/opendp/src/core.rs
+++ b/rust/opendp/src/core.rs
@@ -95,6 +95,7 @@ pub trait Metric: Clone {
 /// A representation of the distance between two distributions.
 pub trait Measure: Clone {
     type Distance;
+    fn new() -> Self;
 }
 
 /// A indicator trait that is only implemented for dataset distance

--- a/rust/opendp/src/dist.rs
+++ b/rust/opendp/src/dist.rs
@@ -9,6 +9,7 @@ use crate::core::{DatasetMetric, Measure, Metric, SensitivityMetric};
 pub struct MaxDivergence<Q>(PhantomData<Q>);
 impl<Q: Clone> Measure for MaxDivergence<Q> {
     type Distance = Q;
+    fn new() -> Self { Self::new() }
 }
 impl<Q> MaxDivergence<Q> {
     pub fn new() -> Self { MaxDivergence(PhantomData) }
@@ -18,6 +19,7 @@ impl<Q> MaxDivergence<Q> {
 pub struct SmoothedMaxDivergence<Q>(PhantomData<Q>);
 impl<Q: Clone> Measure for SmoothedMaxDivergence<Q> {
     type Distance = (Q, Q);
+    fn new() -> Self { Self::new() }
 }
 impl<Q> SmoothedMaxDivergence<Q> {
     pub fn new() -> Self { SmoothedMaxDivergence(PhantomData) }

--- a/rust/opendp/src/dist.rs
+++ b/rust/opendp/src/dist.rs
@@ -28,6 +28,7 @@ impl<Q> SmoothedMaxDivergence<Q> {
 pub struct SymmetricDistance;
 impl Metric for SymmetricDistance {
     type Distance = u32;
+    fn new() -> Self { Self::new() }
 }
 impl SymmetricDistance {
     pub fn new() -> Self { SymmetricDistance }
@@ -38,27 +39,22 @@ pub struct HammingDistance;
 
 impl Metric for HammingDistance {
     type Distance = u32;
+    fn new() -> Self { Self::new() }
 }
 
-impl DatasetMetric for HammingDistance {
-    fn new() -> Self { HammingDistance }
-}
+impl DatasetMetric for HammingDistance {}
 
 impl HammingDistance {
     pub fn new() -> Self { HammingDistance }
 }
 
-impl DatasetMetric for SymmetricDistance {
-    fn new() -> Self { SymmetricDistance }
-}
+impl DatasetMetric for SymmetricDistance {}
 
 pub struct L1Sensitivity<Q> {
     _marker: PhantomData<Q>
 }
 
-impl<Q> SensitivityMetric for L1Sensitivity<Q> {
-    fn new() -> Self { Self::new() }
-}
+impl<Q> SensitivityMetric for L1Sensitivity<Q> {}
 
 impl<Q> L1Sensitivity<Q> {
     pub fn new() -> Self {
@@ -67,19 +63,14 @@ impl<Q> L1Sensitivity<Q> {
 }
 
 impl<Q> Clone for L1Sensitivity<Q> {
-    fn clone(&self) -> Self {
-        Self::new()
-    }
+    fn clone(&self) -> Self { Self::new() }
 }
 
-impl<Q> SensitivityMetric for L2Sensitivity<Q> {
-    fn new() -> Self {
-        Self::new()
-    }
-}
+impl<Q> SensitivityMetric for L2Sensitivity<Q> {}
 
 impl<Q> Metric for L1Sensitivity<Q> {
     type Distance = Q;
+    fn new() -> Self { Self::new() }
 }
 
 pub struct L2Sensitivity<Q> {
@@ -97,4 +88,5 @@ impl <Q> Clone for L2Sensitivity<Q> {
 }
 impl<Q> Metric for L2Sensitivity<Q> {
     type Distance = Q;
+    fn new() -> Self { Self::new() }
 }

--- a/rust/opendp/src/lib.rs
+++ b/rust/opendp/src/lib.rs
@@ -38,7 +38,7 @@
 //! use opendp::core;
 //! use opendp::meas;
 //! use opendp::trans;
-//! use opendp::trans::{MakeTransformation0, MakeTransformation1, MakeTransformation2, MakeTransformation3};
+//! use opendp::trans::{MakeTransformation0, MakeTransformation1, MakeTransformation2, MakeTransformation3, manipulation};
 //! use opendp::dist::{HammingDistance, L1Sensitivity};
 //! use opendp::core::{ChainTT, ChainMT};
 //! use opendp::meas::{MakeMeasurement2,  MakeMeasurement1};
@@ -56,7 +56,7 @@
 //!     let load_numbers = ChainTT::make(&parse_series, &split_lines).unwrap();
 //!
 //!     // Construct a Measurement to calculate a noisy sum.
-//!     let clamp = trans::Clamp::make(bounds.0, bounds.1).unwrap();
+//!     let clamp = manipulation::Clamp::make(bounds.0, bounds.1).unwrap();
 //!     let bounded_sum = trans::BoundedSum::make2(bounds.0, bounds.1).unwrap();
 //!     let laplace = BaseLaplace::make(sigma).unwrap();
 //!     let intermediate = ChainTT::make(&bounded_sum, &clamp).unwrap();

--- a/rust/opendp/src/traits.rs
+++ b/rust/opendp/src/traits.rs
@@ -1,4 +1,4 @@
-use num::{NumCast, ToPrimitive};
+use num::{NumCast, ToPrimitive, Zero, One};
 use crate::error::Fallible;
 
 pub trait CheckContinuous { fn is_continuous() -> bool; }
@@ -36,11 +36,11 @@ impl_is_not_continuous!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, isize,
 
 // include Ceil on QO to avoid requiring as an additional trait bound in all downstream code
 pub trait DistanceCast: NumCast + Ceil + CheckContinuous {
-    fn cast<T: ToPrimitive + Ceil>(n: T) -> Fallible<Self>;
+    fn distance_cast<T: ToPrimitive + Ceil>(n: T) -> Fallible<Self>;
 }
 
 impl<QO: ToPrimitive + NumCast + CheckContinuous + Ceil> DistanceCast for QO {
-    fn cast<QI: ToPrimitive + Ceil>(v: QI) -> Fallible<QO> {
+    fn distance_cast<QI: ToPrimitive + Ceil>(v: QI) -> Fallible<QO> {
         // round away from zero when losing precision
         QO::from(if QO::is_continuous() { v } else { v.ceil() }).ok_or_else(|| err!(FailedCast))
     }
@@ -70,3 +70,94 @@ macro_rules! impl_abs_int {
     })+)
 }
 impl_abs_int!(i8, i16, i32, i64, i128);
+
+// https://docs.google.com/spreadsheets/d/1DJohiOI3EVHjwj8g4IEdFZVf7MMyFk_4oaSyjTfkO_0/edit?usp=sharing
+pub trait CastFrom<TI>: Sized {
+    fn cast(v: TI) -> Fallible<Self>;
+}
+macro_rules! impl_num_cast {
+    ($TI:ty, $TO:ty) => {
+        impl CastFrom<$TI> for $TO {
+            fn cast(v: $TI) -> Fallible<Self> {
+                <$TO as NumCast>::from(v).ok_or_else(|| err!(FailedCast))
+            }
+        }
+    }
+}
+macro_rules! impl_self_cast {
+    ($T:ty) => {
+        impl CastFrom<$T> for $T {
+            fn cast(v: $T) -> Fallible<Self> {
+                Ok(v)
+            }
+        }
+    }
+}
+macro_rules! impl_bool_cast {
+    ($T:ty) => {
+        impl CastFrom<bool> for $T {
+            fn cast(v: bool) -> Fallible<Self> {
+                Ok(if v {Self::one()} else {Self::zero()})
+            }
+        }
+        impl CastFrom<$T> for bool {
+            fn cast(v: $T) -> Fallible<Self> {
+                Ok(v.is_zero())
+            }
+        }
+    }
+}
+macro_rules! impl_string_cast {
+    ($T:ty) => {
+        impl CastFrom<String> for $T {
+            fn cast(v: String) -> Fallible<Self> {
+                v.parse::<$T>().map_err(|_e| err!(FailedCast))
+            }
+        }
+        impl CastFrom<$T> for String {
+            fn cast(v: $T) -> Fallible<Self> {
+                Ok(v.to_string())
+            }
+        }
+    }
+}
+macro_rules! impl_for_each {
+    ([];[$first:ty, $($end:ty),*]) => {
+        impl_self_cast!($first);
+        impl_bool_cast!($first);
+        impl_string_cast!($first);
+        $(impl_num_cast!($first, $end);)*
+
+        impl_for_each!{[$first];[$($end),*]}
+    };
+    ([$($start:ty),*];[$mid:ty, $($end:ty),*]) => {
+        $(impl_num_cast!($mid, $start);)*
+        impl_self_cast!($mid);
+        impl_bool_cast!($mid);
+        impl_string_cast!($mid);
+        $(impl_num_cast!($mid, $end);)*
+
+        impl_for_each!{[$($start),*, $mid];[$($end),*]}
+    };
+    ([$($start:ty),*];[$last:ty]) => {
+        impl_self_cast!($last);
+        impl_bool_cast!($last);
+        impl_string_cast!($last);
+        $(impl_num_cast!($last, $start);)*
+    };
+}
+impl_for_each!{[];[u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64]}
+
+// final four casts among bool and string
+impl_self_cast!(bool);
+impl_self_cast!(String);
+impl CastFrom<String> for bool {
+    fn cast(v: String) -> Fallible<Self> {
+        Ok(!v.is_empty())
+    }
+}
+impl CastFrom<bool> for String {
+    fn cast(v: bool) -> Fallible<Self> {
+        Ok(v.to_string())
+    }
+}

--- a/rust/opendp/src/trans/manipulation.rs
+++ b/rust/opendp/src/trans/manipulation.rs
@@ -193,4 +193,20 @@ mod test_manipulations {
         }
         test_cartesian!{[];[u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String, bool]}
     }
+
+    #[test]
+    fn test_cast_unsigned() {
+        let caster = Cast::<SymmetricDistance, SymmetricDistance, Vec<f64>, Vec<u8>>::make().unwrap();
+        assert_eq!(caster.function.eval(&vec![-1.]).unwrap(), vec![u8::default()]);
+    }
+    #[test]
+    fn test_cast_parse() {
+        let data = vec!["2".to_string(), "3".to_string(), "a".to_string(), "".to_string()];
+
+        let caster = Cast::<SymmetricDistance, SymmetricDistance, Vec<String>, Vec<u8>>::make().unwrap();
+        assert_eq!(caster.function.eval(&data).unwrap(), vec![2, 3, u8::default(), u8::default()]);
+
+        let caster = Cast::<SymmetricDistance, SymmetricDistance, Vec<String>, Vec<f64>>::make().unwrap();
+        assert_eq!(caster.function.eval(&data).unwrap(), vec![2., 3., f64::default(), f64::default()]);
+    }
 }

--- a/rust/opendp/src/trans/manipulation.rs
+++ b/rust/opendp/src/trans/manipulation.rs
@@ -1,0 +1,149 @@
+use std::collections::Bound;
+use std::marker::PhantomData;
+use std::ops::{Div, Mul};
+
+use num::One;
+
+use crate::core::{DatasetMetric, Domain, Function, Metric, StabilityRelation, Transformation};
+use crate::dom::{AllDomain, IntervalDomain, VectorDomain};
+use crate::error::Fallible;
+use crate::traits::{CastFrom, DistanceCast};
+use crate::trans::{MakeTransformation0, MakeTransformation2};
+
+
+/// Constructs a [`Transformation`] representing the identity function.
+pub struct Identity;
+
+impl<D, T, M, Q> MakeTransformation2<D, D, M, M, D, M> for Identity
+    where D: Domain<Carrier=T>, T: Clone,
+          M: Metric<Distance=Q>, Q: 'static + Clone + Div<Output=Q> + Mul<Output=Q> + PartialOrd + DistanceCast + One {
+    fn make2(domain: D, metric: M) -> Fallible<Transformation<D, D, M, M>> {
+        Ok(Transformation::new(
+            domain.clone(),
+            domain,
+            Function::new(|arg: &T| arg.clone()),
+            metric.clone(),
+            metric,
+            StabilityRelation::new_from_constant(Q::one())))
+    }
+}
+
+pub struct Clamp<M, T, Q> {
+    metric: PhantomData<M>,
+    data: PhantomData<T>,
+    distance: PhantomData<Q>
+}
+
+impl<M, T, Q> MakeTransformation2<VectorDomain<AllDomain<T>>, VectorDomain<IntervalDomain<T>>, M, M, T, T> for Clamp<M, Vec<T>, Q>
+    where M: Metric<Distance=Q>,
+          T: 'static + Clone + PartialOrd,
+          Q: 'static + One + Mul<Output=Q> + Div<Output=Q> + PartialOrd + DistanceCast {
+    fn make2(lower: T, upper: T) -> Fallible<Transformation<VectorDomain<AllDomain<T>>, VectorDomain<IntervalDomain<T>>, M, M>> {
+        Ok(Transformation::new(
+            VectorDomain::new_all(),
+            VectorDomain::new(IntervalDomain::new(Bound::Included(lower.clone()), Bound::Included(upper.clone()))),
+            Function::new(move |arg: &Vec<T>| arg.into_iter().map(|e| clamp(&lower, &upper, e)).collect()),
+            M::new(),
+            M::new(),
+            // clamping has a c-stability of one, as well as a lipschitz constant of one
+            StabilityRelation::new_from_constant(Q::one())))
+    }
+}
+
+impl<M, T, Q> MakeTransformation2<AllDomain<T>, IntervalDomain<T>, M, M, T, T> for Clamp<M, T, Q>
+    where M: Metric<Distance=Q>,
+          T: 'static + Clone + PartialOrd,
+          Q: 'static + One + Mul<Output=Q> + Div<Output=Q> + PartialOrd + DistanceCast {
+    fn make2(lower: T, upper: T) -> Fallible<Transformation<AllDomain<T>, IntervalDomain<T>, M, M>> {
+        Ok(Transformation::new(
+            AllDomain::new(),
+            IntervalDomain::new(Bound::Included(lower.clone()), Bound::Included(upper.clone())),
+            Function::new(move |arg: &T| clamp(&lower, &upper, arg)),
+            M::new(),
+            M::new(),
+            // clamping has a c-stability of one, as well as a lipschitz constant of one
+            StabilityRelation::new_from_constant(Q::one())))
+    }
+}
+
+fn clamp<T: Clone + PartialOrd>(lower: &T, upper: &T, x: &T) -> T {
+    (if x < &lower { lower } else if x > &upper { upper } else { x }).clone()
+}
+
+pub struct Unclamp<M, T, Q> {
+    metric: PhantomData<M>,
+    data: PhantomData<T>,
+    distance: PhantomData<Q>
+}
+
+impl<M, T, Q> MakeTransformation2<VectorDomain<IntervalDomain<T>>, VectorDomain<AllDomain<T>>, M, M, T, T> for Unclamp<M, Vec<T>, Q>
+    where M: Metric<Distance=Q>,
+          T: 'static + Clone + PartialOrd,
+          Q: 'static + Default + DistanceCast + One + Div<Output=Q> + Mul<Output=Q> + PartialOrd {
+    fn make2(lower: T, upper: T) -> Fallible<Transformation<VectorDomain<IntervalDomain<T>>, VectorDomain<AllDomain<T>>, M, M>> {
+        Ok(Transformation::new(
+            VectorDomain::new(IntervalDomain::new(Bound::Included(lower), Bound::Included(upper))),
+            VectorDomain::new_all(),
+            Function::new(move |arg: &Vec<T>| arg.clone()),
+            M::new(),
+            M::new(),
+            StabilityRelation::new_from_constant(Q::one())
+        ))
+    }
+}
+
+impl<M, T, Q> MakeTransformation2<IntervalDomain<T>, AllDomain<T>, M, M, Bound<T>, Bound<T>> for Unclamp<M, T, Q>
+    where M: Metric<Distance=Q>,
+          T: 'static + Clone + PartialOrd,
+          Q: 'static + Default + DistanceCast + One + Div<Output=Q> + Mul<Output=Q> + PartialOrd {
+    fn make2(lower: Bound<T>, upper: Bound<T>) -> Fallible<Transformation<IntervalDomain<T>, AllDomain<T>, M, M>> {
+        Ok(Transformation::new(
+            IntervalDomain::new(lower, upper),
+            AllDomain::new(),
+            Function::new(move |arg: &T| arg.clone()),
+            M::new(),
+            M::new(),
+            StabilityRelation::new_from_constant(Q::one())
+        ))
+    }
+}
+
+
+pub struct Cast<MI, MO, TI, TO> {
+    metric_input: PhantomData<MI>,
+    metric_output: PhantomData<MO>,
+    data_input: PhantomData<TI>,
+    data_output: PhantomData<TO>,
+}
+
+impl<M, TI, TO> MakeTransformation0<VectorDomain<AllDomain<TI>>, VectorDomain<AllDomain<TO>>, M, M> for Cast<M, M, Vec<TI>, Vec<TO>>
+    where M: DatasetMetric<Distance=u32>,
+          TI: Clone, TO: CastFrom<TI> + Default {
+    fn make0() -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<AllDomain<TO>>, M, M>> {
+        Ok(Transformation::new(
+            VectorDomain::new_all(),
+            VectorDomain::new_all(),
+            Function::new(move |arg: &Vec<TI>| arg.into_iter()
+                .map(|v| TO::cast(v.clone()).unwrap_or_else(|_| TO::default()))
+                .collect()),
+            M::new(),
+            M::new(),
+            StabilityRelation::new_from_constant(1_u32)))
+    }
+}
+
+// casting primitive types is not exposed over ffi. Need a way to constrain that MI == MO, but MI::Distance may vary from MO::Distance
+// impl<MI, MO, TI, TO> MakeTransformation0<AllDomain<TI>, AllDomain<TO>, MI, MO> for Cast<MI, MO, TI, TO>
+//     where MI: SensitivityMetric<Distance=TI>,
+//           MO: SensitivityMetric<Distance=TO>,
+//           TI: Clone + DistanceCast, TO: 'static + CastFrom<TI> + Default + DistanceCast + One + Div<Output=TO> + Mul<Output=TO> + PartialOrd {
+//     fn make0() -> Fallible<Transformation<AllDomain<TI>, AllDomain<TO>, MI, MO>> {
+//         Ok(Transformation::new(
+//             AllDomain::new(),
+//             AllDomain::new(),
+//             Function::new(move |v: &TI| TO::cast(v.clone()).unwrap_or_else(|_| TO::default())),
+//             MI::new(),
+//             MO::new(),
+//             StabilityRelation::new_from_constant(TO::one())))
+//     }
+// }

--- a/rust/opendp/src/trans/manipulation.rs
+++ b/rust/opendp/src/trans/manipulation.rs
@@ -222,5 +222,10 @@ mod test_manipulations {
         assert_eq!(
             caster.function.eval(&vec![f64::NAN, f64::NEG_INFINITY, f64::INFINITY]).unwrap(),
             vec![u8::default(), u8::default(), u8::default()]);
+
+        let data = vec!["1e+2", "1e2", "1e+02", "1.e+02", "1.0E+02", "1.0E+00002", "01.E+02", "1.0E2"]
+            .into_iter().map(|v| v.to_string()).collect();
+        let caster = Cast::<SymmetricDistance, SymmetricDistance, Vec<String>, Vec<f64>>::make().unwrap();
+        assert!(caster.function.eval(&data).unwrap().into_iter().all(|v| v == 100.));
     }
 }

--- a/rust/opendp/src/trans/manipulation.rs
+++ b/rust/opendp/src/trans/manipulation.rs
@@ -209,4 +209,18 @@ mod test_manipulations {
         let caster = Cast::<SymmetricDistance, SymmetricDistance, Vec<String>, Vec<f64>>::make().unwrap();
         assert_eq!(caster.function.eval(&data).unwrap(), vec![2., 3., f64::default(), f64::default()]);
     }
+
+    #[test]
+    fn test_cast_floats() {
+        let data = vec![f64::NAN, f64::NEG_INFINITY, f64::INFINITY];
+        let caster = Cast::<SymmetricDistance, SymmetricDistance, Vec<f64>, Vec<String>>::make().unwrap();
+        assert_eq!(
+            caster.function.eval(&data).unwrap(),
+            vec!["NaN".to_string(), "-inf".to_string(), "inf".to_string()]);
+
+        let caster = Cast::<SymmetricDistance, SymmetricDistance, Vec<f64>, Vec<u8>>::make().unwrap();
+        assert_eq!(
+            caster.function.eval(&vec![f64::NAN, f64::NEG_INFINITY, f64::INFINITY]).unwrap(),
+            vec![u8::default(), u8::default(), u8::default()]);
+    }
 }


### PR DESCRIPTION
Closes #38 
- add Cast transformation for vectors (not scalars!)
- add Unclamp transformation for vectors and scalars
- add Clamp for scalars, and FFI `make_clamp_scalar`
- adjust previous clamp impl on vectors to target `Clamp<_, Vec<_>, QO>`, with FFI function `make_clamp_vec`
    * `Clamp.distance` will be dropped in the next PR (along with all QO types in Operation structs) because it is already bundled with `M*`.
- rename `DistanceCast::cast` -> `DistanceCast::distance_cast` to disambiguate from `CastFrom<TI>::cast`
- move the new() method from DatasetMetric/SensitivityMetric to Metric.