### PR TITLE
constructor error handling

### DIFF
--- a/python/example/test.py
+++ b/python/example/test.py
@@ -12,7 +12,7 @@ def main():
 
     ### SUMMARY STATS
     # Parse dataframe
-    col_names = odp.py_to_obj([0, 1, 2])
+    col_names = odp.py_to_object([0, 1, 2])
     split_dataframe = odp.trans.make_split_dataframe(b"<HammingDistance, i32>", b",", col_names)
     parse_column_1 = odp.trans.make_parse_column(b"<HammingDistance, i32, i32>", opendp.i32_p(1), True)
     parse_column_2 = odp.trans.make_parse_column(b"<HammingDistance, i32, f64>", opendp.i32_p(2), True)

--- a/python/example/test.py
+++ b/python/example/test.py
@@ -12,7 +12,8 @@ def main():
 
     ### SUMMARY STATS
     # Parse dataframe
-    split_dataframe = odp.trans.make_split_dataframe(b"<HammingDistance>", b",", 3)
+    col_names = odp.py_to_obj([0, 1, 2])
+    split_dataframe = odp.trans.make_split_dataframe(b"<HammingDistance, i32>", b",", col_names)
     parse_column_1 = odp.trans.make_parse_column(b"<HammingDistance, i32, i32>", opendp.i32_p(1), True)
     parse_column_2 = odp.trans.make_parse_column(b"<HammingDistance, i32, f64>", opendp.i32_p(2), True)
     parse_dataframe = odp.make_chain_tt_multi(parse_column_2, parse_column_1, split_dataframe)

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -76,7 +76,7 @@ class OdpException(Exception):
     def __str__(self):
         response = self.variant
         if self.message:
-            response += f"({self.message})"
+            response += f'("{self.message}")'
         if self.inner_traceback:
             response += "\n" + '\n'.join('\t' + line for line in self.inner_traceback.split('\n'))
         return response

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -244,7 +244,7 @@ class Mod:
     @classmethod
     def get_type(cls, name, allow_generic=False):
         def lookup_type(n):
-            if not n in cls.name_to_type:
+            if n not in cls.name_to_type:
                 raise Exception("Unknown type", n)
             return cls.name_to_type[n]
         if allow_generic:

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -412,9 +412,6 @@ class OpenDP:
     def object_to_py(self, obj):
         type_name_ptr = self.data.object_type(obj)
         type_name = type_name_ptr.value.decode()
-        # result = self.data.str_free(type_name_ptr)
-        # print('result', result)
-        # Mod.error_free(result)
         ffi_slice = self.data.object_as_slice(obj)
         try:
             return _slice_to_py(ffi_slice, type_name)

--- a/python/test/test_errors.py
+++ b/python/test/test_errors.py
@@ -1,0 +1,32 @@
+import opendp
+import pytest
+from opendp import OdpException
+
+odp = opendp.OpenDP()
+
+
+def test_unknown_dispatch():
+    with pytest.raises(OdpException):
+        odp.meas.make_base_laplace(b"<u32>", opendp.f64_p(1.0))
+
+
+def test_invalid_arg_length():
+    with pytest.raises(OdpException):
+        odp.meas.make_base_laplace(b"<u32, f64>", opendp.f64_p(1.0))
+
+
+def test_invalid_data():
+    base_laplace = odp.meas.make_base_laplace(b"<f64>", opendp.f64_p(1.0))
+    with pytest.raises(OdpException):
+        odp.measurement_invoke(base_laplace, 2)
+
+
+def test_invalid_constructor():
+    with pytest.raises(OdpException):
+        odp.meas.make_base_laplace(b"<f64>", opendp.f64_p(-1.0))
+
+
+def test_relation():
+    base_laplace = odp.meas.make_base_gaussian(b"<f64>", opendp.f64_p(1.0))
+    with pytest.raises(OdpException):
+        odp.measurement_check(base_laplace, 2, (-.01, 1e-7))

--- a/rust/opendp-ffi/src/core.rs
+++ b/rust/opendp-ffi/src/core.rs
@@ -257,6 +257,7 @@ impl<DI: 'static + Domain, DO: 'static + Domain, MI: 'static + Metric, MO: 'stat
 }
 
 #[no_mangle]
+#[must_use]
 pub extern "C" fn opendp_core__error_free(this: *mut FfiError) -> bool {
     util::into_owned(this).is_ok()
 }

--- a/rust/opendp-ffi/src/core.rs
+++ b/rust/opendp-ffi/src/core.rs
@@ -257,8 +257,8 @@ impl<DI: 'static + Domain, DO: 'static + Domain, MI: 'static + Metric, MO: 'stat
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_core__error_free(this: *mut FfiError) {
-    util::into_owned(this).expect("Attempted to free a null pointer to an error.");
+pub extern "C" fn opendp_core__error_free(this: *mut FfiError) -> bool {
+    util::into_owned(this).is_ok()
 }
 
 #[no_mangle]
@@ -284,8 +284,8 @@ pub extern "C" fn opendp_core__measurement_invoke(this: *const FfiMeasurement, a
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_core__measurement_free(this: *mut FfiMeasurement) {
-    util::into_owned(this).expect("Attempted to free a null pointer to a measurement.");
+pub extern "C" fn opendp_core__measurement_free(this: *mut FfiMeasurement) -> FfiResult<*mut ()>{
+    util::into_owned(this).map(|_| ()).into()
 }
 
 #[no_mangle]
@@ -301,8 +301,8 @@ pub extern "C" fn opendp_core__transformation_invoke(this: *const FfiTransformat
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_core__transformation_free(this: *mut FfiTransformation) {
-    util::into_owned(this).expect("Attempted to free a null pointer to a transformation.");
+pub extern "C" fn opendp_core__transformation_free(this: *mut FfiTransformation) -> FfiResult<*mut ()> {
+    util::into_owned(this).map(|_| ()).into()
 }
 
 #[no_mangle]
@@ -413,12 +413,12 @@ pub extern "C" fn opendp_core__bootstrap() -> *const c_char {
     let spec =
 r#"{
 "functions": [
-    { "name": "error_free", "args": [ ["const FfiError *", "this"] ] },
+    { "name": "error_free", "args": [ ["const FfiError *", "this"] ], "res": "bool" },
     { "name": "measurement_check", "args": [ ["const FfiMeasurement *", "this"], ["const FfiObject *", "d_in"], ["const FfiObject *", "d_out"] ], "ret": "FfiResult<bool *>" },
     { "name": "measurement_invoke", "args": [ ["const FfiMeasurement *", "this"], ["const FfiObject *", "arg"] ], "ret": "FfiResult<FfiObject *>" },
-    { "name": "measurement_free", "args": [ ["FfiMeasurement *", "this"] ] },
+    { "name": "measurement_free", "args": [ ["FfiMeasurement *", "this"] ], "ret": "FfiResult<void *>" },
     { "name": "transformation_invoke", "args": [ ["const FfiTransformation *", "this"], ["const FfiObject *", "arg"] ], "ret": "FfiResult<FfiObject *>" },
-    { "name": "transformation_free", "args": [ ["FfiTransformation *", "this"] ] },
+    { "name": "transformation_free", "args": [ ["FfiTransformation *", "this"] ], "ret": "FfiResult<void *>" },
     { "name": "make_chain_mt", "args": [ ["const FfiMeasurement *", "measurement"], ["const FfiTransformation *", "transformation"] ], "ret": "FfiResult<FfiMeasurement *>" },
     { "name": "make_chain_tt", "args": [ ["const FfiTransformation *", "transformation1"], ["const FfiTransformation *", "transformation0"] ], "ret": "FfiResult<FfiTransformation *>" },
     { "name": "make_composition", "args": [ ["const FfiMeasurement *", "transformation0"], ["const FfiMeasurement *", "transformation1"] ], "ret": "FfiResult<FfiMeasurement *>" }

--- a/rust/opendp-ffi/src/core.rs
+++ b/rust/opendp-ffi/src/core.rs
@@ -189,7 +189,7 @@ impl<D: 'static + Domain, M: 'static + Measure> FfiMeasureGlue<D, M> {
 pub struct FfiDomain;
 impl Domain for FfiDomain {
     type Carrier = ();
-    fn member(&self, _val: &Self::Carrier) -> bool { unimplemented!() }
+    fn member(&self, _val: &Self::Carrier) -> bool { unreachable!() }
 }
 
 #[derive(Clone)]

--- a/rust/opendp-ffi/src/core.rs
+++ b/rust/opendp-ffi/src/core.rs
@@ -93,8 +93,7 @@ impl From<Error> for FfiError {
 
 impl Drop for FfiError {
     fn drop(&mut self) {
-        // variants do not contain null bytes
-        let _variant = util::into_string(self.variant).unwrap_assert();
+        let _variant = util::into_string(self.variant).unwrap_assert("variants do not contain null bytes");
         let _message = unsafe { self.message.as_mut() }.map(|p| util::into_string(p).unwrap());
         let _backtrace = util::into_string(self.backtrace).unwrap();
     }

--- a/rust/opendp-ffi/src/core.rs
+++ b/rust/opendp-ffi/src/core.rs
@@ -82,7 +82,8 @@ impl FfiError {
 }
 
 impl From<Error> for FfiError {
-    fn from(error: Error) -> Self {
+    fn from(mut error: Error) -> Self {
+        error.backtrace.resolve();
         Self {
             variant: try_!(util::into_c_char_p(format!("{:?}", error.variant))),
             message: try_!(error.message.map_or(Ok(ptr::null::<c_char>() as *mut c_char), util::into_c_char_p)),

--- a/rust/opendp-ffi/src/data.rs
+++ b/rust/opendp-ffi/src/data.rs
@@ -279,7 +279,6 @@ mod tests {
     #[test]
     fn test_data_as_raw_number() {
         let val_in = 999;
-        let obj = FfiObject::new_raw_from_type(val_in);
         match opendp_data__object_as_slice(obj) {
             FfiResult::Ok(obj) => {
                 let raw = util::as_ref(obj).unwrap_test();

--- a/rust/opendp-ffi/src/data.rs
+++ b/rust/opendp-ffi/src/data.rs
@@ -279,6 +279,7 @@ mod tests {
     #[test]
     fn test_data_as_raw_number() {
         let val_in = 999;
+        let obj = FfiObject::new_raw_from_type(val_in);
         match opendp_data__object_as_slice(obj) {
             FfiResult::Ok(obj) => {
                 let raw = util::as_ref(obj).unwrap_test();

--- a/rust/opendp-ffi/src/data.rs
+++ b/rust/opendp-ffi/src/data.rs
@@ -55,18 +55,18 @@ pub extern "C" fn opendp_data__slice_as_object(type_args: *const c_char, raw: *c
             raw_to_string(raw)
         },
         TypeContents::SLICE(element_id) => {
-            let element = try_!(Type::of_id(element_id));
+            let element = try_!(Type::of_id(&element_id));
             dispatch!(raw_to_slice, [(element, @primitives)], (raw))
         },
         TypeContents::VEC(element_id) => {
-            let element = try_!(Type::of_id(element_id));
+            let element = try_!(Type::of_id(&element_id));
             dispatch!(raw_to_vec, [(element, @primitives)], (raw))
         },
         TypeContents::TUPLE(ref element_ids) => {
             if element_ids.len() != 2 {
                 return fallible!(FFI, "Only tuples of length 2 are supported").into();
             }
-            if let Ok(types) = element_ids.iter().cloned().map(Type::of_id).collect::<Fallible<Vec<_>>>() {
+            if let Ok(types) = element_ids.iter().map(Type::of_id).collect::<Fallible<Vec<_>>>() {
                 // primitively typed tuples
                 dispatch!(raw_to_tuple, [(types[0], @primitives), (types[1], @primitives)], (raw))
             } else {
@@ -118,7 +118,7 @@ pub extern "C" fn opendp_data__object_as_slice(obj: *const FfiObject) -> FfiResu
         ]) as *mut c_void, 2))
     }
     let obj = try_as_ref!(obj);
-    match obj.type_.contents {
+    match &obj.type_.contents {
         TypeContents::PLAIN("String") => {
             string_to_raw(obj)
         },
@@ -130,11 +130,11 @@ pub extern "C" fn opendp_data__object_as_slice(obj: *const FfiObject) -> FfiResu
             let element = try_!(Type::of_id(element_id));
             dispatch!(vec_to_raw, [(element, @primitives)], (obj))
         },
-        TypeContents::TUPLE(ref element_ids) => {
+        TypeContents::TUPLE(element_ids) => {
             if element_ids.len() != 2 {
                 return fallible!(FFI, "Only tuples of length 2 are supported").into();
             }
-            if let Ok(types) = element_ids.iter().cloned().map(Type::of_id).collect::<Fallible<Vec<_>>>() {
+            if let Ok(types) = element_ids.iter().map(Type::of_id).collect::<Fallible<Vec<_>>>() {
                 // primitively typed tuples
                 dispatch!(tuple_to_raw, [(types[0], @primitives), (types[1], @primitives)], (obj))
             } else {

--- a/rust/opendp-ffi/src/data.rs
+++ b/rust/opendp-ffi/src/data.rs
@@ -9,7 +9,7 @@ use crate::core::{FfiObject, FfiOwnership, FfiResult, FfiSlice};
 use crate::util;
 use crate::util::{Type, TypeArgs, TypeContents, c_bool};
 use std::fmt::Debug;
-use opendp::error::Fallible;
+use opendp::error::{Fallible, ExplainUnwrap};
 use opendp::{fallible, err};
 
 #[no_mangle]
@@ -169,13 +169,13 @@ pub extern "C" fn opendp_data__bool_free(this: *mut c_bool) {
 
 // TODO: Remove this function once we have composition and/or tuples sorted out.
 #[no_mangle]
-pub extern "C" fn opendp_data__to_string(this: *const FfiObject) -> *const c_char {
-    fn monomorphize<T: 'static + std::fmt::Debug>(this: &FfiObject) -> *const c_char {
+pub extern "C" fn opendp_data__to_string(this: *const FfiObject) -> *mut c_char {
+    fn monomorphize<T: 'static + std::fmt::Debug>(this: &FfiObject) -> Fallible<*mut c_char> {
         let this = this.as_ref::<T>();
         // FIXME: Figure out how to implement general to_string().
         let string = format!("{:?}", this);
         // FIXME: Leaks string.
-        util::into_c_char_p(string).unwrap()
+        util::into_c_char_p(string)
     }
     let this = util::as_ref(this).unwrap();
     let type_arg = &this.type_;
@@ -187,7 +187,7 @@ pub extern "C" fn opendp_data__to_string(this: *const FfiObject) -> *const c_cha
         (Box<i32>, Box<f64>),
         (Box<i32>, Box<u32>),
         (Box<(Box<f64>, Box<f64>)>, Box<f64>)
-    ])], (this))
+    ])], (this)).unwrap_assert()
 }
 
 #[no_mangle]

--- a/rust/opendp-ffi/src/data.rs
+++ b/rust/opendp-ffi/src/data.rs
@@ -9,7 +9,7 @@ use crate::core::{FfiObject, FfiOwnership, FfiResult, FfiSlice};
 use crate::util;
 use crate::util::{Type, TypeArgs, TypeContents, c_bool};
 use std::fmt::Debug;
-use opendp::error::{Fallible, ExplainUnwrap};
+use opendp::error::Fallible;
 use opendp::{fallible, err};
 
 #[no_mangle]
@@ -187,7 +187,7 @@ pub extern "C" fn opendp_data__to_string(this: *const FfiObject) -> *mut c_char 
         (Box<i32>, Box<f64>),
         (Box<i32>, Box<u32>),
         (Box<(Box<f64>, Box<f64>)>, Box<f64>)
-    ])], (this)).unwrap_assert()
+    ])], (this)).expect(&format!("to_string given unknown type argument: {:?}", type_arg))
 }
 
 #[no_mangle]

--- a/rust/opendp-ffi/src/data.rs
+++ b/rust/opendp-ffi/src/data.rs
@@ -229,7 +229,7 @@ mod tests {
                 let obj = util::as_ref(obj).unwrap_test();
                 let val_out: &i32 = obj.as_ref();
                 assert_eq!(&val_in, val_out);
-                if let Err(_) = opendp_data__object_free(obj as *const FfiObject as *mut FfiObject) {
+                if let FfiResult::Err(_) = opendp_data__object_free(obj as *const FfiObject as *mut FfiObject) {
                     panic!("Got Err!")
                 }
             },
@@ -249,7 +249,7 @@ mod tests {
                 let obj = util::as_ref(obj).unwrap_test();
                 let val_out: &String = obj.as_ref();
                 assert_eq!(&val_in, val_out);
-                if let Err(_) = opendp_data__object_free(obj as *const FfiObject as *mut FfiObject) {
+                if let FfiResult::Err(_) = opendp_data__object_free(obj as *const FfiObject as *mut FfiObject) {
                     panic!("Got Err!")
                 }
             },
@@ -268,7 +268,7 @@ mod tests {
                 let obj = util::as_ref(obj).unwrap_test();
                 let val_out: &Vec<i32> = obj.as_ref();
                 assert_eq!(&val_in, val_out);
-                if let Err(_) = opendp_data__object_free(obj as *const FfiObject as *mut FfiObject) {
+                if let FfiResult::Err(_) = opendp_data__object_free(obj as *const FfiObject as *mut FfiObject) {
                     panic!("Got Err!")
                 }
             },
@@ -280,18 +280,19 @@ mod tests {
     fn test_data_as_raw_number() {
         let val_in = 999;
         let obj = FfiObject::new_raw_from_type(val_in);
-        let res = opendp_data__object_as_slice(obj);
         match opendp_data__object_as_slice(obj) {
             FfiResult::Ok(obj) => {
                 let raw = util::as_ref(obj).unwrap_test();
                 assert_eq!(raw.len, 1);
                 let val_out = util::as_ref(raw.ptr as *const i32).unwrap_test();
                 assert_eq!(&val_in, val_out);
-                opendp_data__slice_free(raw as *const FfiSlice as *mut FfiSlice)
+                if let FfiResult::Err(_) = opendp_data__slice_free(raw as *const FfiSlice as *mut FfiSlice) {
+                    panic!("Got Err!")
+                }
             },
             FfiResult::Err(_) => panic!("Got Err!"),
         }
-        if let Err(_) = opendp_data__object_free(obj) {
+        if let FfiResult::Err(_) = opendp_data__object_free(obj) {
             panic!("Got Err!")
         }
     }
@@ -306,11 +307,13 @@ mod tests {
                 assert_eq!(raw.len, val_in.len() + 1);
                 let val_out = util::to_str(raw.ptr as *const c_char).unwrap_test().to_owned();
                 assert_eq!(val_in, val_out);
-                opendp_data__slice_free(raw as *const FfiSlice as *mut FfiSlice)
+                if let FfiResult::Err(_) = opendp_data__slice_free(raw as *const FfiSlice as *mut FfiSlice) {
+                    panic!("Got Err!")
+                }
             },
             FfiResult::Err(_) => panic!("Got Err!"),
         }
-        if let Err(_) = opendp_data__object_free(obj) {
+        if let FfiResult::Err(_) = opendp_data__object_free(obj) {
             panic!("Got Err!")
         }
     }
@@ -325,11 +328,13 @@ mod tests {
                 assert_eq!(raw.len, val_in.len());
                 let val_out = unsafe { Vec::from_raw_parts(raw.ptr as *mut i32, raw.len, raw.len) };
                 assert_eq!(val_in, val_out);
-                opendp_data__slice_free(raw as *const FfiSlice as *mut FfiSlice)
+                if let FfiResult::Err(_) = opendp_data__slice_free(raw as *const FfiSlice as *mut FfiSlice) {
+                    panic!("Got Err!")
+                }
             },
             FfiResult::Err(_) => panic!("Got Err!"),
         }
-        if let Err(_) = opendp_data__object_free(obj) {
+        if let FfiResult::Err(_) = opendp_data__object_free(obj) {
             panic!("Got Err!")
         }
     }

--- a/rust/opendp-ffi/src/dispatch.rs
+++ b/rust/opendp-ffi/src/dispatch.rs
@@ -92,7 +92,7 @@ macro_rules! disp_expand {
     ($function:ident, ($rt_type:expr, [$($dispatch_type:ty),+]), $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
         match $rt_type.id {
             $(x if x == std::any::TypeId::of::<$dispatch_type>() => disp_1!($function, $rt_dispatch_types, $type_args, $dispatch_type, $args)),+,
-            _ => panic!("No match for concrete type {:?}/{}", $rt_type.id, $rt_type.descriptor)
+            _ => opendp::err!(FFI, "No match for concrete type {:?}/{}", $rt_type.id, $rt_type.descriptor).into()
         }
     };
 }

--- a/rust/opendp-ffi/src/dispatch.rs
+++ b/rust/opendp-ffi/src/dispatch.rs
@@ -80,9 +80,6 @@ macro_rules! disp_expand {
     ($function:ident, ($rt_type:expr, @hashable),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
         disp_expand!($function, ($rt_type, [u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, bool, String]), $rt_dispatch_types, $type_args, $args)
     };
-    ($function:ident, ($rt_type:expr, @dist_dataset),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
-        disp_expand!($function, ($rt_type, [HammingDistance, SymmetricDistance]), $rt_dispatch_types, $type_args, $args)
-    };
     ($function:ident, ($rt_type:expr, @floats),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
         disp_expand!($function, ($rt_type, [f32, f64]), $rt_dispatch_types, $type_args, $args)
     };

--- a/rust/opendp-ffi/src/lib.rs
+++ b/rust/opendp-ffi/src/lib.rs
@@ -89,6 +89,7 @@ extern crate lazy_static;
 
 // internal module for err! macro resolution
 mod error { pub use opendp::error::{Error, ErrorVariant}; }
+// replacement for ? operator, for FfiResults
 macro_rules! try_ {
     ($value:expr) => {
         match $value {
@@ -97,6 +98,9 @@ macro_rules! try_ {
         }
     }
 }
+// attempt to convert a raw pointer to a reference
+//      as_ref      ok_or_else       try_!
+// *mut T -> Option<&T> -> Fallible<&T> -> &T
 macro_rules! try_as_ref {
     ($value:expr) => {
         try_!(util::as_ref($value).ok_or_else(|| opendp::err!(FFI, concat!("null pointer: ", stringify!($value)))));

--- a/rust/opendp-ffi/src/lib.rs
+++ b/rust/opendp-ffi/src/lib.rs
@@ -97,6 +97,11 @@ macro_rules! try_ {
         }
     }
 }
+macro_rules! try_as_ref {
+    ($value:expr) => {
+        try_!(util::as_ref($value).ok_or_else(|| opendp::err!(FFI, concat!("null pointer: ", stringify!($value)))));
+    }
+}
 
 #[macro_use]
 mod dispatch;

--- a/rust/opendp-ffi/src/lib.rs
+++ b/rust/opendp-ffi/src/lib.rs
@@ -89,6 +89,14 @@ extern crate lazy_static;
 
 // internal module for err! macro resolution
 mod error { pub use opendp::error::{Error, ErrorVariant}; }
+macro_rules! try_ {
+    ($value:expr) => {
+        match $value {
+            Ok(x) => x,
+            Err(e) => return e.into(),
+        }
+    }
+}
 
 #[macro_use]
 mod dispatch;

--- a/rust/opendp-ffi/src/meas.rs
+++ b/rust/opendp-ffi/src/meas.rs
@@ -6,7 +6,7 @@ use opendp::meas::{MakeMeasurement1, MakeMeasurement3};
 use opendp::meas::gaussian::BaseGaussian;
 use opendp::meas::laplace::{BaseVectorLaplace, BaseLaplace};
 
-use crate::core::FfiMeasurement;
+use crate::core::{FfiMeasurement, FfiResult};
 use crate::util;
 use crate::util::TypeArgs;
 use opendp::traits::DistanceCast;
@@ -19,82 +19,76 @@ use opendp::dist::{L2Sensitivity, L1Sensitivity};
 use opendp::core::SensitivityMetric;
 
 #[no_mangle]
-pub extern "C" fn opendp_meas__make_base_laplace(type_args: *const c_char, scale: *const c_void) -> *mut FfiMeasurement {
-    fn monomorphize<T>(scale: *const c_void) -> *mut FfiMeasurement
+pub extern "C" fn opendp_meas__make_base_laplace(type_args: *const c_char, scale: *const c_void) -> FfiResult<*mut FfiMeasurement> {
+    fn monomorphize<T>(scale: *const c_void) -> FfiResult<*mut FfiMeasurement>
         where T: 'static + Clone + SampleLaplace + Float + DistanceCast {
         let scale = util::as_ref(scale as *const T).clone();
-        let measurement = BaseLaplace::<T>::make(scale).unwrap();
-        FfiMeasurement::new_from_types(measurement)
+        BaseLaplace::<T>::make(scale).into()
     }
-    let type_args = TypeArgs::expect(type_args, 1);
+    let type_args = try_!(TypeArgs::parse(type_args, 1));
     dispatch!(monomorphize, [(type_args.0[0], @floats)], (scale))
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_meas__make_base_laplace_vec(type_args: *const c_char, scale: *const c_void) -> *mut FfiMeasurement {
-    fn monomorphize<T>(scale: *const c_void) -> *mut FfiMeasurement
+pub extern "C" fn opendp_meas__make_base_laplace_vec(type_args: *const c_char, scale: *const c_void) -> FfiResult<*mut FfiMeasurement> {
+    fn monomorphize<T>(scale: *const c_void) -> FfiResult<*mut FfiMeasurement>
         where T: 'static + Clone + SampleLaplace + Float + DistanceCast {
         let scale = util::as_ref(scale as *const T).clone();
-        let measurement = BaseVectorLaplace::<T>::make(scale).unwrap();
-        FfiMeasurement::new_from_types(measurement)
+        BaseVectorLaplace::<T>::make(scale).into()
     }
-    let type_args = TypeArgs::expect(type_args, 1);
+    let type_args = try_!(TypeArgs::parse(type_args, 1));
     dispatch!(monomorphize, [(type_args.0[0], @floats)], (scale))
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_meas__make_base_gaussian(type_args: *const c_char, scale: *const c_void) -> *mut FfiMeasurement {
-    fn monomorphize<T>(scale: *const c_void) -> *mut FfiMeasurement where
+pub extern "C" fn opendp_meas__make_base_gaussian(type_args: *const c_char, scale: *const c_void) -> FfiResult<*mut FfiMeasurement> {
+    fn monomorphize<T>(scale: *const c_void) -> FfiResult<*mut FfiMeasurement> where
         T: 'static + Copy + SampleGaussian + Float {
         let scale = util::as_ref(scale as *const T).clone();
-        let measurement = BaseGaussian::<T>::make(scale).unwrap();
-        FfiMeasurement::new_from_types(measurement)
+        BaseGaussian::<T>::make(scale).into()
     }
-    let type_args = TypeArgs::expect(type_args, 1);
+    let type_args = try_!(TypeArgs::parse(type_args, 1));
     dispatch!(monomorphize, [(type_args.0[0], @floats)], (scale))
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_meas__make_base_gaussian_vec(type_args: *const c_char, scale: *const c_void) -> *mut FfiMeasurement {
-    fn monomorphize<T>(scale: *const c_void) -> *mut FfiMeasurement where
+pub extern "C" fn opendp_meas__make_base_gaussian_vec(type_args: *const c_char, scale: *const c_void) -> FfiResult<*mut FfiMeasurement> {
+    fn monomorphize<T>(scale: *const c_void) -> FfiResult<*mut FfiMeasurement> where
         T: 'static + Copy + SampleGaussian + Float {
         let scale = util::as_ref(scale as *const T).clone();
-        let measurement = BaseGaussian::<T>::make(scale).unwrap();
-        FfiMeasurement::new_from_types(measurement)
+        BaseGaussian::<T>::make(scale).into()
     }
-    let type_args = TypeArgs::expect(type_args, 1);
+    let type_args = try_!(TypeArgs::parse(type_args, 1));
     dispatch!(monomorphize, [(type_args.0[0], @floats)], (scale))
 }
 
 
 #[no_mangle]
-pub extern "C" fn opendp_meas__make_base_simple_geometric(type_args: *const c_char, scale: *const c_void, min: *const c_void, max: *const c_void) -> *mut FfiMeasurement {
-    fn monomorphize<T, QO>(scale: *const c_void, min: *const c_void, max: *const c_void) -> *mut FfiMeasurement
+pub extern "C" fn opendp_meas__make_base_simple_geometric(type_args: *const c_char, scale: *const c_void, min: *const c_void, max: *const c_void) -> FfiResult<*mut FfiMeasurement> {
+    fn monomorphize<T, QO>(scale: *const c_void, min: *const c_void, max: *const c_void) -> FfiResult<*mut FfiMeasurement>
         where T: 'static + Clone + SampleGeometric + Sub<Output=T> + Add<Output=T> + DistanceCast,
               QO: 'static + Float + DistanceCast, f64: From<QO> {
         let scale = util::as_ref(scale as *const QO).clone();
         let min = util::as_ref(min as *const T).clone();
         let max = util::as_ref(max as *const T).clone();
-        let measurement = BaseSimpleGeometric::<T, QO>::make(scale, min, max).unwrap();
-        FfiMeasurement::new_from_types(measurement)
+        BaseSimpleGeometric::<T, QO>::make(scale, min, max).into()
     }
-    let type_args = TypeArgs::expect(type_args, 2);
+    let type_args = try_!(TypeArgs::parse(type_args, 2));
     dispatch!(monomorphize, [(type_args.0[0], @integers), (type_args.0[1], @floats)], (scale, min, max))
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_meas__make_base_stability(type_args: *const c_char, n: usize, scale: *const c_void, threshold: *const c_void) -> *mut FfiMeasurement {
-    fn monomorphize<TIC, TOC>(type_args: TypeArgs, n: usize, scale: *const c_void, threshold: *const c_void) -> *mut FfiMeasurement
+pub extern "C" fn opendp_meas__make_base_stability(type_args: *const c_char, n: usize, scale: *const c_void, threshold: *const c_void) -> FfiResult<*mut FfiMeasurement> {
+    fn monomorphize<TIC, TOC>(type_args: TypeArgs, n: usize, scale: *const c_void, threshold: *const c_void) -> FfiResult<*mut FfiMeasurement>
         where TIC: 'static + Integer + Zero + One + AddAssign + Clone + NumCast,
               TOC: 'static + PartialOrd + Clone + NumCast + Float + CastRug {
 
-        fn monomorphize2<MI, TIK, TIC, TOC>(n: usize, scale: TOC, threshold: TOC) -> *mut FfiMeasurement
+        fn monomorphize2<MI, TIK, TIC, TOC>(n: usize, scale: TOC, threshold: TOC) -> FfiResult<*mut FfiMeasurement>
             where MI: 'static + SensitivityMetric<Distance=TOC> + BaseStabilityNoise<TOC>,
                   TIK: 'static + Eq + Hash + Clone,
                   TIC: 'static + Integer + Zero + One + AddAssign + Clone + NumCast,
                   TOC: 'static + Clone + NumCast + PartialOrd + Float + CastRug {
-            let measurement = BaseStability::<MI, TIK, TIC, TOC>::make(n, scale, threshold).unwrap();
-            FfiMeasurement::new_from_types(measurement)
+            BaseStability::<MI, TIK, TIC, TOC>::make(n, scale, threshold).into()
         }
         let scale = util::as_ref(scale as *const TOC).clone();
         let threshold = util::as_ref(threshold as *const TOC).clone();
@@ -105,7 +99,7 @@ pub extern "C" fn opendp_meas__make_base_stability(type_args: *const c_char, n: 
             (type_args.0[3], [TOC])
         ], (n, scale, threshold))
     }
-    let type_args = TypeArgs::expect(type_args, 4);
+    let type_args = try_!(TypeArgs::parse(type_args, 4));
     dispatch!(monomorphize, [
         (type_args.0[2], @integers),
         (type_args.0[3], @floats)
@@ -117,11 +111,11 @@ pub extern "C" fn opendp_meas__bootstrap() -> *const c_char {
     let spec =
 r#"{
 "functions": [
-    { "name": "make_base_laplace", "args": [ ["const char *", "selector"], ["void *", "scale"] ], "ret": "FfiMeasurement *" },
-    { "name": "make_base_laplace_vec", "args": [ ["const char *", "selector"], ["void *", "scale"] ], "ret": "FfiMeasurement *" },
-    { "name": "make_base_gaussian", "args": [ ["const char *", "selector"], ["void *", "scale"] ], "ret": "FfiMeasurement *" },
-    { "name": "make_base_simple_geometric", "args": [ ["const char *", "selector"], ["void *", "scale"], ["void *", "min"], ["void *", "max"] ], "ret": "FfiMeasurement *" },
-    { "name": "make_base_stability", "args": [ ["const char *", "selector"], ["unsigned int", "n"], ["void *", "scale"], ["void *", "threshold"] ], "ret": "FfiMeasurement *" }
+    { "name": "make_base_laplace", "args": [ ["const char *", "selector"], ["void *", "scale"] ], "ret": "FfiResult<FfiMeasurement *>" },
+    { "name": "make_base_laplace_vec", "args": [ ["const char *", "selector"], ["void *", "scale"] ], "ret": "FfiResult<FfiMeasurement *>" },
+    { "name": "make_base_gaussian", "args": [ ["const char *", "selector"], ["void *", "scale"] ], "ret": "FfiResult<FfiMeasurement *>" },
+    { "name": "make_base_simple_geometric", "args": [ ["const char *", "selector"], ["void *", "scale"], ["void *", "min"], ["void *", "max"] ], "ret": "FfiResult<FfiMeasurement *>" },
+    { "name": "make_base_stability", "args": [ ["const char *", "selector"], ["unsigned int", "n"], ["void *", "scale"], ["void *", "threshold"] ], "ret": "FfiResult<FfiMeasurement *>" }
 ]
 }"#;
     util::bootstrap(spec)

--- a/rust/opendp-ffi/src/meas.rs
+++ b/rust/opendp-ffi/src/meas.rs
@@ -17,6 +17,7 @@ use opendp::meas::stability::{BaseStability, BaseStabilityNoise};
 use std::hash::Hash;
 use opendp::dist::{L2Sensitivity, L1Sensitivity};
 use opendp::core::SensitivityMetric;
+use opendp::err;
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_laplace(type_args: *const c_char, scale: *const c_void) -> FfiResult<*mut FfiMeasurement> {

--- a/rust/opendp-ffi/src/meas.rs
+++ b/rust/opendp-ffi/src/meas.rs
@@ -22,7 +22,7 @@ use opendp::core::SensitivityMetric;
 pub extern "C" fn opendp_meas__make_base_laplace(type_args: *const c_char, scale: *const c_void) -> FfiResult<*mut FfiMeasurement> {
     fn monomorphize<T>(scale: *const c_void) -> FfiResult<*mut FfiMeasurement>
         where T: 'static + Clone + SampleLaplace + Float + DistanceCast {
-        let scale = util::as_ref(scale as *const T).clone();
+        let scale = try_as_ref!(scale as *const T).clone();
         BaseLaplace::<T>::make(scale).into()
     }
     let type_args = try_!(TypeArgs::parse(type_args, 1));
@@ -33,7 +33,7 @@ pub extern "C" fn opendp_meas__make_base_laplace(type_args: *const c_char, scale
 pub extern "C" fn opendp_meas__make_base_laplace_vec(type_args: *const c_char, scale: *const c_void) -> FfiResult<*mut FfiMeasurement> {
     fn monomorphize<T>(scale: *const c_void) -> FfiResult<*mut FfiMeasurement>
         where T: 'static + Clone + SampleLaplace + Float + DistanceCast {
-        let scale = util::as_ref(scale as *const T).clone();
+        let scale = try_as_ref!(scale as *const T).clone();
         BaseVectorLaplace::<T>::make(scale).into()
     }
     let type_args = try_!(TypeArgs::parse(type_args, 1));
@@ -44,7 +44,7 @@ pub extern "C" fn opendp_meas__make_base_laplace_vec(type_args: *const c_char, s
 pub extern "C" fn opendp_meas__make_base_gaussian(type_args: *const c_char, scale: *const c_void) -> FfiResult<*mut FfiMeasurement> {
     fn monomorphize<T>(scale: *const c_void) -> FfiResult<*mut FfiMeasurement> where
         T: 'static + Copy + SampleGaussian + Float {
-        let scale = util::as_ref(scale as *const T).clone();
+        let scale = try_as_ref!(scale as *const T).clone();
         BaseGaussian::<T>::make(scale).into()
     }
     let type_args = try_!(TypeArgs::parse(type_args, 1));
@@ -55,7 +55,7 @@ pub extern "C" fn opendp_meas__make_base_gaussian(type_args: *const c_char, scal
 pub extern "C" fn opendp_meas__make_base_gaussian_vec(type_args: *const c_char, scale: *const c_void) -> FfiResult<*mut FfiMeasurement> {
     fn monomorphize<T>(scale: *const c_void) -> FfiResult<*mut FfiMeasurement> where
         T: 'static + Copy + SampleGaussian + Float {
-        let scale = util::as_ref(scale as *const T).clone();
+        let scale = try_as_ref!(scale as *const T).clone();
         BaseGaussian::<T>::make(scale).into()
     }
     let type_args = try_!(TypeArgs::parse(type_args, 1));
@@ -68,9 +68,9 @@ pub extern "C" fn opendp_meas__make_base_simple_geometric(type_args: *const c_ch
     fn monomorphize<T, QO>(scale: *const c_void, min: *const c_void, max: *const c_void) -> FfiResult<*mut FfiMeasurement>
         where T: 'static + Clone + SampleGeometric + Sub<Output=T> + Add<Output=T> + DistanceCast,
               QO: 'static + Float + DistanceCast, f64: From<QO> {
-        let scale = util::as_ref(scale as *const QO).clone();
-        let min = util::as_ref(min as *const T).clone();
-        let max = util::as_ref(max as *const T).clone();
+        let scale = try_as_ref!(scale as *const QO).clone();
+        let min = try_as_ref!(min as *const T).clone();
+        let max = try_as_ref!(max as *const T).clone();
         BaseSimpleGeometric::<T, QO>::make(scale, min, max).into()
     }
     let type_args = try_!(TypeArgs::parse(type_args, 2));
@@ -90,8 +90,8 @@ pub extern "C" fn opendp_meas__make_base_stability(type_args: *const c_char, n: 
                   TOC: 'static + Clone + NumCast + PartialOrd + Float + CastRug {
             BaseStability::<MI, TIK, TIC, TOC>::make(n, scale, threshold).into()
         }
-        let scale = util::as_ref(scale as *const TOC).clone();
-        let threshold = util::as_ref(threshold as *const TOC).clone();
+        let scale = try_as_ref!(scale as *const TOC).clone();
+        let threshold = try_as_ref!(threshold as *const TOC).clone();
         dispatch!(monomorphize2, [
             (type_args.0[0], [L1Sensitivity<TOC>, L2Sensitivity<TOC>]),
             (type_args.0[1], @hashable),

--- a/rust/opendp-ffi/src/trans.rs
+++ b/rust/opendp-ffi/src/trans.rs
@@ -75,11 +75,11 @@ pub extern "C" fn opendp_trans__make_create_dataframe(type_args: *const c_char, 
     fn monomorphize<M, K>(col_names: *const FfiObject) -> FfiResult<*mut FfiTransformation>
         where M: 'static + DatasetMetric<Distance=u32> + Clone,
               K: 'static + Eq + Hash + Debug + Clone {
-        let col_names = try_as_ref!(col_names as *const Vec<K>).clone();
+        let col_names = try_as_ref!(col_names).as_ref::<Vec<K>>().clone();
         trans::CreateDataFrame::<M, K>::make(col_names).into()
     }
     let type_args = try_!(TypeArgs::parse(type_args, 2));
-    dispatch!(monomorphize, [(type_args.0[0], @dist_dataset), (type_args.0[0], @hashable)], (col_names))
+    dispatch!(monomorphize, [(type_args.0[0], @dist_dataset), (type_args.0[1], @hashable)], (col_names))
 }
 
 #[no_mangle]
@@ -87,12 +87,12 @@ pub extern "C" fn opendp_trans__make_split_dataframe(type_args: *const c_char, s
     fn monomorphize<M, K>(separator: Option<&str>, col_names: *const FfiObject) -> FfiResult<*mut FfiTransformation>
         where M: 'static + DatasetMetric<Distance=u32> + Clone,
               K: 'static + Eq + Hash + Debug + Clone {
-        let col_names = try_as_ref!(col_names as *const Vec<K>).clone();
+        let col_names = try_as_ref!(col_names).as_ref::<Vec<K>>().clone();
         trans::SplitDataFrame::<M, K>::make(separator, col_names).into()
     }
     let type_args = try_!(TypeArgs::parse(type_args, 2));
     let separator = try_!(util::to_option_str(separator));
-    dispatch!(monomorphize, [(type_args.0[0], @dist_dataset), (type_args.0[0], @hashable)], (separator, col_names))
+    dispatch!(monomorphize, [(type_args.0[0], @dist_dataset), (type_args.0[1], @hashable)], (separator, col_names))
 }
 
 #[no_mangle]

--- a/rust/opendp-ffi/src/trans.rs
+++ b/rust/opendp-ffi/src/trans.rs
@@ -32,7 +32,7 @@ pub extern "C" fn opendp_trans__make_identity(type_args: *const c_char) -> FfiRe
     }
     let type_args = try_!(TypeArgs::parse(type_args, 1));
     match &type_args.0[0].contents {
-        TypeContents::VEC(element_id) => dispatch!(monomorphize_vec, [(try_!(Type::of_id(*element_id)), @primitives)], ()),
+        TypeContents::VEC(element_id) => dispatch!(monomorphize_vec, [(try_!(Type::of_id(element_id)), @primitives)], ()),
         _ => dispatch!(monomorphize_scalar, [(&type_args.0[0], @primitives)], ())
     }
 }

--- a/rust/opendp-ffi/src/trans.rs
+++ b/rust/opendp-ffi/src/trans.rs
@@ -15,23 +15,21 @@ use opendp::trans::{count, MakeTransformation0, MakeTransformation1, MakeTransfo
 use opendp::trans;
 use opendp::trans::sum::{BoundedSum, BoundedSumConstant};
 
-use crate::core::{FfiTransformation, FfiObject};
+use crate::core::{FfiTransformation, FfiObject, FfiResult};
 use crate::util;
 use crate::util::{c_bool, Type, TypeArgs, TypeContents};
 use opendp::trans::count::{CountByCategoriesConstant, CountByCategories, CountBy, CountByConstant};
 use num::traits::FloatConst;
 
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_identity(type_args: *const c_char) -> *mut FfiTransformation {
-    fn monomorphize_scalar<T: 'static + Clone>() -> *mut FfiTransformation {
-        let transformation = manipulation::Identity::make(AllDomain::<T>::new(), HammingDistance::new()).unwrap();
-        FfiTransformation::new_from_types(transformation)
+pub extern "C" fn opendp_trans__make_identity(type_args: *const c_char) -> FfiResult<*mut FfiTransformation> {
+    fn monomorphize_scalar<T: 'static + Clone>() -> FfiResult<*mut FfiTransformation> {
+        manipulation::Identity::make(AllDomain::<T>::new(), HammingDistance::new()).into()
     }
-    fn monomorphize_vec<T: 'static + Clone>() -> *mut FfiTransformation {
-        let transformation = manipulation::Identity::make(VectorDomain::new(AllDomain::<T>::new()), HammingDistance::new()).unwrap();
-        FfiTransformation::new_from_types(transformation)
+    fn monomorphize_vec<T: 'static + Clone>() -> FfiResult<*mut FfiTransformation> {
+        manipulation::Identity::make(VectorDomain::new(AllDomain::<T>::new()), HammingDistance::new()).into()
     }
-    let type_args = TypeArgs::expect(type_args, 1);
+    let type_args = try_!(TypeArgs::parse(type_args, 1));
     match &type_args.0[0].contents {
         TypeContents::VEC(element_id) => dispatch!(monomorphize_vec, [(Type::of_id(*element_id).unwrap(), @primitives)], ()),
         _ => dispatch!(monomorphize_scalar, [(&type_args.0[0], @primitives)], ())
@@ -39,161 +37,153 @@ pub extern "C" fn opendp_trans__make_identity(type_args: *const c_char) -> *mut 
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_split_lines(type_args: *const c_char) -> *mut FfiTransformation {
-    fn monomorphize<M>() -> *mut FfiTransformation
+pub extern "C" fn opendp_trans__make_split_lines(type_args: *const c_char) -> FfiResult<*mut FfiTransformation> {
+    fn monomorphize<M>() -> FfiResult<*mut FfiTransformation>
         where M: 'static + DatasetMetric<Distance=u32> + Clone {
-        let transformation = trans::SplitLines::<M>::make().unwrap();
-        FfiTransformation::new_from_types(transformation)
+        trans::SplitLines::<M>::make().into()
     }
-    let type_args = TypeArgs::expect(type_args, 1);
+    let type_args = try_!(TypeArgs::parse(type_args, 1));
     dispatch!(monomorphize, [(type_args.0[0], @dist_dataset)], ())
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_parse_series(type_args: *const c_char, impute: c_bool) -> *mut FfiTransformation {
-    fn monomorphize<M, T>(impute: bool) -> *mut FfiTransformation
+pub extern "C" fn opendp_trans__make_parse_series(type_args: *const c_char, impute: c_bool) -> FfiResult<*mut FfiTransformation> {
+    fn monomorphize<M, T>(impute: bool) -> FfiResult<*mut FfiTransformation>
         where M: 'static + DatasetMetric<Distance=u32> + Clone,
               T: 'static + FromStr + Default,
               T::Err: Debug {
-        let transformation = trans::ParseSeries::<T, M>::make(impute).unwrap();
-        FfiTransformation::new_from_types(transformation)
+        trans::ParseSeries::<T, M>::make(impute).into()
     }
-    let type_args = TypeArgs::expect(type_args, 1);
+    let type_args = try_!(TypeArgs::parse(type_args, 1));
     let impute = util::to_bool(impute);
     dispatch!(monomorphize, [(type_args.0[0], @dist_dataset), (type_args.0[1], @primitives)], (impute))
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_split_records(type_args: *const c_char, separator: *const c_char) -> *mut FfiTransformation {
-    fn monomorphize<M>(separator: Option<&str>) -> *mut FfiTransformation
+pub extern "C" fn opendp_trans__make_split_records(type_args: *const c_char, separator: *const c_char) -> FfiResult<*mut FfiTransformation> {
+    fn monomorphize<M>(separator: Option<&str>) -> FfiResult<*mut FfiTransformation>
         where M: 'static + DatasetMetric<Distance=u32> + Clone {
-        let transformation = trans::SplitRecords::<M>::make(separator).unwrap();
-        FfiTransformation::new_from_types(transformation)
+        trans::SplitRecords::<M>::make(separator).into()
     }
-    let type_args = TypeArgs::expect(type_args, 1);
+    let type_args = try_!(TypeArgs::parse(type_args, 1));
     let separator = util::to_option_str(separator);
     dispatch!(monomorphize, [(type_args.0[0], @dist_dataset)], (separator))
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_create_dataframe(type_args: *const c_char, col_count: c_uint) -> *mut FfiTransformation {
-    fn monomorphize<M>(col_names: Vec<i32>) -> *mut FfiTransformation
-        where M: 'static + DatasetMetric<Distance=u32> + Clone {
-        let transformation = trans::CreateDataFrame::<M>::make(col_names).unwrap();
-        FfiTransformation::new_from_types(transformation)
+pub extern "C" fn opendp_trans__make_create_dataframe(type_args: *const c_char, col_names: *const FfiObject) -> FfiResult<*mut FfiTransformation> {
+    fn monomorphize<M, K>(col_names: *const FfiObject) -> FfiResult<*mut FfiTransformation>
+        where M: 'static + DatasetMetric<Distance=u32> + Clone,
+              K: 'static + Eq + Hash + Debug + Clone {
+        let col_names = util::as_ref(col_names as *const Vec<K>).clone();
+        trans::CreateDataFrame::<M, K>::make(col_names).into()
     }
-    let type_args = TypeArgs::expect(type_args, 1);
-    let col_names = (0..col_count as usize as i32).collect(); // TODO: pass Vec<T> over FFI
-    dispatch!(monomorphize, [(type_args.0[0], @dist_dataset)], (col_names))
+    let type_args = try_!(TypeArgs::parse(type_args, 1));
+    dispatch!(monomorphize, [(type_args.0[0], @dist_dataset), (type_args.0[0], @hashable)], (col_names))
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_split_dataframe(type_args: *const c_char, separator: *const c_char, col_count: c_uint) -> *mut FfiTransformation {
-    fn monomorphize<M>(separator: Option<&str>, col_names: Vec<i32>) -> *mut FfiTransformation
-        where M: 'static + DatasetMetric<Distance=u32> + Clone {
-        let transformation = trans::SplitDataFrame::<M>::make(separator, col_names).unwrap();
-        FfiTransformation::new_from_types(transformation)
+pub extern "C" fn opendp_trans__make_split_dataframe(type_args: *const c_char, separator: *const c_char, col_names: *const FfiObject) -> FfiResult<*mut FfiTransformation> {
+    fn monomorphize<M, K>(separator: Option<&str>, col_names: *const FfiObject) -> FfiResult<*mut FfiTransformation>
+        where M: 'static + DatasetMetric<Distance=u32> + Clone,
+              K: 'static + Eq + Hash + Debug + Clone {
+        let col_names = util::as_ref(col_names as *const Vec<K>).clone();
+        trans::SplitDataFrame::<M>::make(separator, col_names).into()
     }
-    let type_args = TypeArgs::expect(type_args, 1);
+    let type_args = try_!(TypeArgs::parse(type_args, 1));
     let separator = util::to_option_str(separator);
-    let col_names = (0..col_count as usize as i32).collect(); // TODO: pass Vec<T> over FFI
-    dispatch!(monomorphize, [(type_args.0[0], @dist_dataset)], (separator, col_names))
+    dispatch!(monomorphize, [(type_args.0[0], @dist_dataset), (type_args.0[0], @hashable)], (separator, col_names))
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_parse_column(type_args: *const c_char, key: *const c_void, impute: c_bool) -> *mut FfiTransformation {
-    fn monomorphize<M, K, T>(key: *const c_void, impute: bool) -> *mut FfiTransformation where
+pub extern "C" fn opendp_trans__make_parse_column(type_args: *const c_char, key: *const c_void, impute: c_bool) -> FfiResult<*mut FfiTransformation> {
+    fn monomorphize<M, K, T>(key: *const c_void, impute: bool) -> FfiResult<*mut FfiTransformation> where
         M: 'static + DatasetMetric<Distance=u32> + Clone,
         K: 'static + Hash + Eq + Debug + Clone,
         T: 'static + Debug + Clone + PartialEq + FromStr + Default,
         T::Err: Debug {
         let key = util::as_ref(key as *const K).clone();
-        let transformation = trans::ParseColumn::<M, T>::make(key, impute).unwrap();
-        FfiTransformation::new_from_types(transformation)
+        trans::ParseColumn::<M, T>::make(key, impute).into()
     }
-    let type_args = TypeArgs::expect(type_args, 3);
+    let type_args = try_!(TypeArgs::parse(type_args, 3));
     let impute = util::to_bool(impute);
     dispatch!(monomorphize, [(type_args.0[0], @dist_dataset), (type_args.0[1], @hashable), (type_args.0[2], @primitives)], (key, impute))
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_select_column(type_args: *const c_char, key: *const c_void) -> *mut FfiTransformation {
-    fn monomorphize<M, K, T>(key: *const c_void) -> *mut FfiTransformation where
+pub extern "C" fn opendp_trans__make_select_column(type_args: *const c_char, key: *const c_void) -> FfiResult<*mut FfiTransformation> {
+    fn monomorphize<M, K, T>(key: *const c_void) -> FfiResult<*mut FfiTransformation> where
         M: 'static + DatasetMetric<Distance=u32> + Clone,
         K: 'static + Hash + Eq + Debug + Clone,
         T: 'static + Debug + Clone + PartialEq {
         let key = util::as_ref(key as *const K).clone();
-        let transformation = trans::SelectColumn::<M, T>::make(key).unwrap();
-        FfiTransformation::new_from_types(transformation)
+        trans::SelectColumn::<M, T>::make(key).into()
     }
-    let type_args = TypeArgs::expect(type_args, 3);
+    let type_args = try_!(TypeArgs::parse(type_args, 3));
     dispatch!(monomorphize, [(type_args.0[0], @dist_dataset), (type_args.0[1], @hashable), (type_args.0[2], @primitives)], (key))
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_clamp_vec(type_args: *const c_char, lower: *const c_void, upper: *const c_void) -> *mut FfiTransformation {
-    fn monomorphize<M, T>(lower: *const c_void, upper: *const c_void) -> *mut FfiTransformation
+pub extern "C" fn opendp_trans__make_clamp_vec(type_args: *const c_char, lower: *const c_void, upper: *const c_void) -> FfiResult<*mut FfiTransformation> {
+    fn monomorphize<M, T>(lower: *const c_void, upper: *const c_void) -> FfiResult<*mut FfiTransformation>
         where M: 'static + Metric<Distance=u32> + Clone,
               T: 'static + Copy + PartialOrd {
         let lower = util::as_ref(lower as *const T).clone();
         let upper = util::as_ref(upper as *const T).clone();
-        let transformation = manipulation::Clamp::<M, Vec<T>>::make(lower, upper).unwrap();
-        FfiTransformation::new_from_types(transformation)
+        manipulation::Clamp::<M, Vec<T>>::make(lower, upper).into()
     }
-    let type_args = TypeArgs::expect(type_args, 2);
+    let type_args = try_!(TypeArgs::parse(type_args, 2));
     dispatch!(monomorphize, [(type_args.0[0], @dist_dataset), (type_args.0[1], @numbers)], (lower, upper))
 }
 
 
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_clamp_scalar(type_args: *const c_char, lower: *const c_void, upper: *const c_void) -> *mut FfiTransformation {
-    fn monomorphize<T, Q>(type_args: TypeArgs, lower: *const c_void, upper: *const c_void) -> *mut FfiTransformation
+pub extern "C" fn opendp_trans__make_clamp_scalar(type_args: *const c_char, lower: *const c_void, upper: *const c_void) -> FfiResult<*mut FfiTransformation> {
+    fn monomorphize<T, Q>(type_args: TypeArgs, lower: *const c_void, upper: *const c_void) -> FfiResult<*mut FfiTransformation>
         where T: 'static + Clone + PartialOrd,
               Q: 'static + One + Mul<Output=Q> + Div<Output=Q> + PartialOrd + DistanceCast {
         let lower = util::as_ref(lower as *const T).clone();
         let upper = util::as_ref(upper as *const T).clone();
 
-        fn monomorphize2<M, T, Q>(lower: T, upper: T) -> *mut FfiTransformation
+        fn monomorphize2<M, T, Q>(lower: T, upper: T) -> FfiResult<*mut FfiTransformation>
             where M: 'static + SensitivityMetric<Distance=Q>,
                   T: 'static + Clone + PartialOrd,
                   Q: 'static + One + Mul<Output=Q> + Div<Output=Q> + PartialOrd + DistanceCast {
-            let transformation = trans::manipulation::Clamp::<M, T>::make(lower, upper).unwrap();
-            FfiTransformation::new_from_types(transformation)
+            trans::manipulation::Clamp::<M, T>::make(lower, upper).into()
         }
         dispatch!(monomorphize2, [
             (type_args.0[0], [L1Sensitivity<Q>, L2Sensitivity<Q>]),
             (type_args.0[2], [T]), (type_args.0[3], [Q])
         ], (lower, upper))
     }
-    let type_args = TypeArgs::expect(type_args, 3);
+    let type_args = try_!(TypeArgs::parse(type_args, 3));
     dispatch!(monomorphize, [(type_args.0[2], @numbers), (type_args.0[3], @numbers)], (type_args, lower, upper))
 }
 
 
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_cast_vec(type_args: *const c_char) -> *mut FfiTransformation {
-    fn monomorphize<M, TI, TO>() -> *mut FfiTransformation where
+pub extern "C" fn opendp_trans__make_cast_vec(type_args: *const c_char) -> FfiResult<*mut FfiTransformation> {
+    fn monomorphize<M, TI, TO>() -> FfiResult<*mut FfiTransformation> where
         M: 'static + DatasetMetric<Distance=u32>, TI: 'static + Clone, TO: 'static + CastFrom<TI> + Default {
-        let transformation = trans::manipulation::Cast::<M, Vec<TI>, Vec<TO>>::make().unwrap();
-        FfiTransformation::new_from_types(transformation)
+        trans::manipulation::Cast::<M, Vec<TI>, Vec<TO>>::make().into()
     }
-    let type_args = TypeArgs::expect(type_args, 3);
+    let type_args = try_!(TypeArgs::parse(type_args, 3));
     dispatch!(monomorphize, [(type_args.0[0], @dist_dataset), (type_args.0[1], @primitives), (type_args.0[2], @primitives)], ())
 }
 
 // #[no_mangle]
-// pub extern "C" fn opendp_trans__make_cast(type_args: *const c_char) -> *mut FfiTransformation {
-//     fn monomorphize<TI, TO>(type_args: TypeArgs) -> *mut FfiTransformation
+// pub extern "C" fn opendp_trans__make_cast(type_args: *const c_char) -> FfiResult<*mut FfiTransformation> {
+//     fn monomorphize<TI, TO>(type_args: TypeArgs) -> FfiResult<*mut FfiTransformation>
 //         where TI: 'static + Clone + DistanceCast,
 //               TO: 'static + CastFrom<TI> + Default + DistanceCast + One + Div<Output=TO> + Mul<Output=TO> + PartialOrd {
 //
-//         fn monomorphize2<MI, MO, TI, TO>() -> *mut FfiTransformation
+//         fn monomorphize2<MI, MO, TI, TO>() -> FfiResult<*mut FfiTransformation>
 //             where MI: 'static + SensitivityMetric<Distance=TI>,
 //                   MO: 'static + SensitivityMetric<Distance=TO>,
 //                   TI: 'static + Clone + DistanceCast,
 //                   TO: 'static + CastFrom<TI> + Default + DistanceCast + One + Div<Output=TO> + Mul<Output=TO> + PartialOrd {
-//             let transformation = trans::manipulation::Cast::<MI, MO, TI, TO>::make().unwrap();
-//             FfiTransformation::new_from_types(transformation)
+//             let transformation = trans::manipulation::Cast::<MI, MO, TI, TO>::make();
+//             FfiResult::new(transformation.map(FfiTransformation::new_from_types))
 //         }
 //         dispatch!(monomorphize2, [
 //             (type_args.0[0], [L1Sensitivity<TI>, L2Sensitivity<TI>]),
@@ -206,17 +196,15 @@ pub extern "C" fn opendp_trans__make_cast_vec(type_args: *const c_char) -> *mut 
 // }
 
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_bounded_sum(type_args: *const c_char, lower: *const c_void, upper: *const c_void) -> *mut FfiTransformation {
-    fn monomorphize<T>(type_args: TypeArgs, lower: *const c_void, upper: *const c_void) -> *mut FfiTransformation
-        where T: 'static + Copy + PartialOrd + Sub<Output=T> + Mul<Output=T> + Div<Output=T> + Sum<T> + DistanceCast + Abs {
-
-        fn monomorphize2<MI, MO, T>(lower: T, upper: T) -> *mut FfiTransformation
+pub extern "C" fn opendp_trans__make_bounded_sum(type_args: *const c_char, lower: *const c_void, upper: *const c_void) -> FfiResult<*mut FfiTransformation> {
+    fn monomorphize<T>(type_args: TypeArgs, lower: *const c_void, upper: *const c_void) -> FfiResult<*mut FfiTransformation>
+        where T: 'static + Clone + PartialOrd + Sub<Output=T> + Mul<Output=T> + Div<Output=T> + Sum<T> + Abs + DistanceCast {
+        fn monomorphize2<MI, MO, T>(lower: T, upper: T) -> FfiResult<*mut FfiTransformation>
             where MI: 'static + DatasetMetric<Distance=u32>,
                   MO: 'static + SensitivityMetric<Distance=T>,
-                  T: 'static + Clone + PartialOrd + Sub<Output=T> + Mul<Output=T> + Div<Output=T> + Sum<T> + DistanceCast,
-                  BoundedSum<MI, MO, T>: BoundedSumConstant<MI, MO, T> {
-            let transformation = sum::BoundedSum::<MI, MO, T>::make(lower, upper).unwrap();
-            FfiTransformation::new_from_types(transformation)
+                  T: 'static + Clone + PartialOrd + Sub<Output=T> + Mul<Output=T> + Div<Output=T> + Sum<T> + Abs + DistanceCast,
+                  BoundedSum<MI, MO>: BoundedSumConstant<MI, MO> {
+            sum::BoundedSum::<MI, MO>::make(lower, upper).into()
         }
         let lower = util::as_ref(lower as *const T).clone();
         let upper = util::as_ref(upper as *const T).clone();
@@ -226,21 +214,20 @@ pub extern "C" fn opendp_trans__make_bounded_sum(type_args: *const c_char, lower
             (type_args.0[2], [T])
         ], (lower, upper))
     }
-    let type_args = TypeArgs::expect(type_args, 3);
+    let type_args = try_!(TypeArgs::parse(type_args, 3));
     dispatch!(monomorphize, [(type_args.0[2], @numbers)], (type_args, lower, upper))
 }
 
 
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_bounded_sum_n(type_args: *const c_char, lower: *const c_void, upper: *const c_void, n: c_uint) -> *mut FfiTransformation {
-    fn monomorphize<T>(type_args: TypeArgs, lower: *const c_void, upper: *const c_void, n: usize) -> *mut FfiTransformation
+pub extern "C" fn opendp_trans__make_bounded_sum_n(type_args: *const c_char, lower: *const c_void, upper: *const c_void, n: c_uint) -> FfiResult<*mut FfiTransformation> {
+    fn monomorphize<T>(type_args: TypeArgs, lower: *const c_void, upper: *const c_void, n: usize) -> FfiResult<*mut FfiTransformation>
         where T: 'static + Copy + PartialOrd + Sub<Output=T> + Mul<Output=T> + Div<Output=T> + Sum<T> + DistanceCast + Abs {
 
-        fn monomorphize2<MO, T>(lower: T, upper: T, n: usize) -> *mut FfiTransformation
+        fn monomorphize2<MO, T>(lower: T, upper: T, n: usize) -> FfiResult<*mut FfiTransformation>
             where MO: 'static + SensitivityMetric<Distance=T>,
                   T: 'static + Clone + PartialOrd + Sub<Output=T> + Mul<Output=T> + Div<Output=T> + Sum<T> + DistanceCast {
-            let transformation = sum::BoundedSum::<SymmetricDistance, MO, T>::make3(lower, upper, n).unwrap();
-            FfiTransformation::new_from_types(transformation)
+            sum::BoundedSum::<SymmetricDistance, MO>::make3(lower, upper, n).into()
         }
         let lower = util::as_ref(lower as *const T).clone();
         let upper = util::as_ref(upper as *const T).clone();
@@ -250,21 +237,20 @@ pub extern "C" fn opendp_trans__make_bounded_sum_n(type_args: *const c_char, low
         ], (lower, upper, n))
     }
     let n = n as usize;
-    let type_args = TypeArgs::expect(type_args, 2);
+    let type_args = try_!(TypeArgs::parse(type_args, 2));
     dispatch!(monomorphize, [(type_args.0[1], @numbers)], (type_args, lower, upper, n))
 }
 
 
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_count(type_args: *const c_char) -> *mut FfiTransformation {
+pub extern "C" fn opendp_trans__make_count(type_args: *const c_char) -> FfiResult<*mut FfiTransformation> {
 
-    fn monomorphize<MI, MO, T: 'static>() -> *mut FfiTransformation
+    fn monomorphize<MI, MO, T: 'static>() -> FfiResult<*mut FfiTransformation>
         where MI: 'static + DatasetMetric<Distance=u32> + Clone,
               MO: 'static + SensitivityMetric<Distance=u32> + Clone {
-        let transformation = count::Count::<MI, MO, T>::make().unwrap();
-        FfiTransformation::new_from_types(transformation)
+        count::Count::<MI, MO, T>::make().into()
     }
-    let type_args = TypeArgs::expect(type_args, 3);
+    let type_args = try_!(TypeArgs::parse(type_args, 3));
     dispatch!(monomorphize, [
         (type_args.0[0], [SymmetricDistance, HammingDistance]),
         (type_args.0[1], [L1Sensitivity<u32>, L2Sensitivity<u32>]),
@@ -274,11 +260,11 @@ pub extern "C" fn opendp_trans__make_count(type_args: *const c_char) -> *mut Ffi
 
 
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_count_by_categories(type_args: *const c_char, categories: *const FfiObject) -> *mut FfiTransformation {
-    fn monomorphize<QO>(type_args: TypeArgs, categories: *const FfiObject) -> *mut FfiTransformation
+pub extern "C" fn opendp_trans__make_count_by_categories(type_args: *const c_char, categories: *const FfiObject) -> FfiResult<*mut FfiTransformation> {
+    fn monomorphize<QO>(type_args: TypeArgs, categories: *const FfiObject) -> FfiResult<*mut FfiTransformation>
         where QO: 'static + Clone + DistanceCast + Mul<Output=QO> + Div<Output=QO> + PartialOrd + FloatConst + One + NumCast {
 
-        fn monomorphize2<MI, MO, TI, TO, QO>(categories: *const FfiObject) -> *mut FfiTransformation
+        fn monomorphize2<MI, MO, TI, TO, QO>(categories: *const FfiObject) -> FfiResult<*mut FfiTransformation>
             where MI: 'static + DatasetMetric<Distance=u32>,
                   MO: 'static + SensitivityMetric<Distance=QO>,
                   TI: 'static + Eq + Hash + Clone,
@@ -286,8 +272,7 @@ pub extern "C" fn opendp_trans__make_count_by_categories(type_args: *const c_cha
                   QO: 'static + Clone + DistanceCast + Mul<Output=QO> + Div<Output=QO> + PartialOrd + FloatConst + One + NumCast,
                   CountByCategories<MI, MO, TI, TO>: CountByCategoriesConstant<MI, MO> {
             let categories = util::as_ref(categories as *const Vec<TI>).clone();
-            let transformation = count::CountByCategories::<MI, MO, TI, TO>::make(categories).unwrap();
-            FfiTransformation::new_from_types(transformation)
+            count::CountByCategories::<MI, MO, TI, TO>::make(categories).into()
         }
         dispatch!(monomorphize2, [
             (type_args.0[0], [HammingDistance, SymmetricDistance]),
@@ -297,24 +282,23 @@ pub extern "C" fn opendp_trans__make_count_by_categories(type_args: *const c_cha
             (type_args.0[4], [QO])
         ], (categories))
     }
-    let type_args = TypeArgs::expect(type_args, 5);
+    let type_args = try_!(TypeArgs::parse(type_args, 5));
     dispatch!(monomorphize, [(type_args.0[4], @floats)], (type_args, categories))
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_count_by(type_args: *const c_char, n: c_uint) -> *mut FfiTransformation {
-    fn monomorphize<QO>(type_args: TypeArgs, n: usize) -> *mut FfiTransformation
+pub extern "C" fn opendp_trans__make_count_by(type_args: *const c_char, n: c_uint) -> FfiResult<*mut FfiTransformation> {
+    fn monomorphize<QO>(type_args: TypeArgs, n: usize) -> FfiResult<*mut FfiTransformation>
         where QO: 'static + Clone + DistanceCast + Mul<Output=QO> + Div<Output=QO> + PartialOrd + FloatConst + One + NumCast {
 
-        fn monomorphize2<MI, MO, TI, TO, QO>(n: usize) -> *mut FfiTransformation
+        fn monomorphize2<MI, MO, TI, TO, QO>(n: usize) -> FfiResult<*mut FfiTransformation>
             where MI: 'static + DatasetMetric<Distance=u32>,
                   MO: 'static + SensitivityMetric<Distance=QO>,
                   TI: 'static + Eq + Hash + Clone,
                   TO: 'static + Integer + Zero + One + AddAssign,
                   QO: 'static + Clone + DistanceCast + Mul<Output=QO> + Div<Output=QO> + PartialOrd + FloatConst + One + NumCast,
                   CountBy<MI, MO, TI, TO>: CountByConstant<MI, MO> {
-            let transformation = count::CountBy::<MI, MO, TI, TO>::make(n).unwrap();
-                FfiTransformation::new_from_types(transformation)
+            count::CountBy::<MI, MO, TI, TO>::make(n).into()
         }
         dispatch!(monomorphize2, [
             (type_args.0[0], [HammingDistance, SymmetricDistance]),
@@ -326,7 +310,7 @@ pub extern "C" fn opendp_trans__make_count_by(type_args: *const c_char, n: c_uin
     }
     // TODO: drop type_args.0[4] by parsing inner type from type_args.0[1], once data loading PR is merged
     let n = n as usize;
-    let type_args = TypeArgs::expect(type_args, 5);
+    let type_args = try_!(TypeArgs::parse(type_args, 5));
     dispatch!(monomorphize, [(type_args.0[4], @floats)], (type_args, n))
 }
 
@@ -335,22 +319,22 @@ pub extern "C" fn opendp_trans__bootstrap() -> *const c_char {
     let spec =
 r#"{
 "functions": [
-    { "name": "make_identity", "ret": "FfiTransformation *" },
-    { "name": "make_split_lines", "args": [ ["const char *", "selector"] ], "ret": "FfiTransformation *" },
-    { "name": "make_parse_series", "args": [ ["const char *", "selector"], ["bool", "impute"] ], "ret": "FfiTransformation *" },
-    { "name": "make_split_records", "args": [ ["const char *", "selector"], ["const char *", "separator"] ], "ret": "FfiTransformation *" },
-    { "name": "make_create_dataframe", "args": [ ["const char *", "selector"], ["unsigned int", "col_count"] ], "ret": "FfiTransformation *" },
-    { "name": "make_split_dataframe", "args": [ ["const char *", "selector"], ["const char *", "separator"], ["unsigned int", "col_count"] ], "ret": "FfiTransformation *" },
-    { "name": "make_parse_column", "args": [ ["const char *", "selector"], ["void *", "key"], ["bool", "impute"] ], "ret": "FfiTransformation *" },
-    { "name": "make_select_column", "args": [ ["const char *", "selector"], ["void *", "key"] ], "ret": "FfiTransformation *" },
-    { "name": "make_clamp_vec", "args": [ ["const char *", "selector"], ["void *", "lower"], ["void *", "upper"] ], "ret": "FfiTransformation *" },
-    { "name": "make_clamp_scalar", "args": [ ["const char *", "selector"], ["void *", "lower"], ["void *", "upper"] ], "ret": "FfiTransformation *" },
-    { "name": "make_cast_vec", "args": [ ["const char *", "selector"] ], "ret": "FfiTransformation *" },
-    { "name": "make_bounded_sum", "args": [ ["const char *", "selector"], ["void *", "lower"], ["void *", "upper"] ], "ret": "FfiTransformation *" },
-    { "name": "make_bounded_sum_n", "args": [ ["const char *", "selector"], ["void *", "lower"], ["void *", "upper"], ["unsigned int", "n"] ], "ret": "FfiTransformation *" },
-    { "name": "make_count", "args": [ ["const char *", "selector"] ], "ret": "FfiTransformation *" },
-    { "name": "make_count_by", "args": [ ["const char *", "selector"], ["unsigned int", "n"] ], "ret": "FfiTransformation *" },
-    { "name": "make_count_by_categories", "args": [ ["const char *", "selector"], ["FfiObject *", "categories"] ], "ret": "FfiTransformation *" }
+    { "name": "make_identity", "ret": "FfiResult<FfiTransformation *>" },
+    { "name": "make_split_lines", "args": [ ["const char *", "selector"] ], "ret": "FfiResult<FfiTransformation *>" },
+    { "name": "make_parse_series", "args": [ ["const char *", "selector"], ["bool", "impute"] ], "ret": "FfiResult<FfiTransformation *>" },
+    { "name": "make_split_records", "args": [ ["const char *", "selector"], ["const char *", "separator"] ], "ret": "FfiResult<FfiTransformation *>" },
+    { "name": "make_create_dataframe", "args": [ ["const char *", "selector"], ["unsigned int", "col_count"] ], "ret": "FfiResult<FfiTransformation *>" },
+    { "name": "make_split_dataframe", "args": [ ["const char *", "selector"], ["const char *", "separator"], ["unsigned int", "col_count"] ], "ret": "FfiResult<FfiTransformation *>" },
+    { "name": "make_parse_column", "args": [ ["const char *", "selector"], ["void *", "key"], ["bool", "impute"] ], "ret": "FfiResult<FfiTransformation *>" },
+    { "name": "make_select_column", "args": [ ["const char *", "selector"], ["void *", "key"] ], "ret": "FfiResult<FfiTransformation *>" },
+    { "name": "make_clamp_vec", "args": [ ["const char *", "selector"], ["void *", "lower"], ["void *", "upper"] ], "ret": "FfiResult<FfiTransformation *>" },
+    { "name": "make_clamp_scalar", "args": [ ["const char *", "selector"], ["void *", "lower"], ["void *", "upper"] ], "ret": "FfiResult<FfiTransformation *>" },
+    { "name": "make_cast_vec", "args": [ ["const char *", "selector"] ], "ret": "FfiResult<FfiTransformation *>" },
+    { "name": "make_bounded_sum", "args": [ ["const char *", "selector"], ["void *", "lower"], ["void *", "upper"] ], "ret": "FfiResult<FfiTransformation *>" },
+    { "name": "make_bounded_sum_n", "args": [ ["const char *", "selector"], ["void *", "lower"], ["void *", "upper"], ["unsigned int", "n"] ], "ret": "FfiResult<FfiTransformation *>" },
+    { "name": "make_count", "args": [ ["const char *", "selector"] ], "ret": "FfiResult<FfiTransformation *>" },
+    { "name": "make_count_by", "args": [ ["const char *", "selector"], ["unsigned int", "n"] ], "ret": "FfiResult<FfiTransformation *>" },
+    { "name": "make_count_by_categories", "args": [ ["const char *", "selector"], ["FfiObject *", "categories"] ], "ret": "FfiResult<FfiTransformation *>" }
 ]
 }"#;
     util::bootstrap(spec)

--- a/rust/opendp-ffi/src/trans.rs
+++ b/rust/opendp-ffi/src/trans.rs
@@ -20,6 +20,7 @@ use crate::util;
 use crate::util::{c_bool, Type, TypeArgs, TypeContents};
 use opendp::trans::count::{CountByCategoriesConstant, CountByCategories, CountBy, CountByConstant};
 use num::traits::FloatConst;
+use opendp::err;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_identity(type_args: *const c_char) -> FfiResult<*mut FfiTransformation> {

--- a/rust/opendp-ffi/src/util.rs
+++ b/rust/opendp-ffi/src/util.rs
@@ -274,8 +274,7 @@ pub fn to_option_str<'a>(p: *const c_char) -> Fallible<Option<&'a str>> {
 
 pub fn bootstrap(spec: &str) -> *const c_char {
     // FIXME: Leaks string.
-    // unwrap is ok because our json strings won't contain null bytes
-    into_c_char_p(spec.to_owned()).unwrap_assert()
+    into_c_char_p(spec.to_owned()).unwrap_assert("unwrap is ok because our json strings won't contain null bytes")
 }
 
 #[allow(non_camel_case_types)]

--- a/rust/opendp-ffi/src/util.rs
+++ b/rust/opendp-ffi/src/util.rs
@@ -67,7 +67,7 @@ impl Type {
                 (type1, [bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String, (Box<f64>, Box<f64>)])
             ],
             (type0, type1)
-        ).unwrap_assert()
+        ).unwrap()
     }
 }
 

--- a/rust/opendp-ffi/src/util.rs
+++ b/rust/opendp-ffi/src/util.rs
@@ -45,8 +45,8 @@ impl Type {
         Self::new(TypeId::of::<T>(), descriptor, TypeContents::PLAIN(descriptor))
     }
 
-    pub fn of_id(id: TypeId) -> Fallible<Self> {
-        TYPE_ID_TO_TYPE.get(&id).cloned().ok_or_else(|| err!(TypeParse))
+    pub fn of_id(id: &TypeId) -> Fallible<Self> {
+        TYPE_ID_TO_TYPE.get(id).cloned().ok_or_else(|| err!(TypeParse))
     }
 
     // Hacky special entry point for composition.

--- a/rust/opendp-ffi/src/util.rs
+++ b/rust/opendp-ffi/src/util.rs
@@ -51,13 +51,13 @@ impl Type {
 
     // Hacky special entry point for composition.
     pub fn new_box_pair(type0: &Type, type1: &Type) -> Self {
-        fn monomorphize<T0: 'static, T1: 'static>(type0: &Type, type1: &Type) -> Type {
+        fn monomorphize<T0: 'static, T1: 'static>(type0: &Type, type1: &Type) -> Fallible<Type> {
             let id = TypeId::of::<(Box<T0>, Box<T1>)>();
             let descriptor = format!("(Box<{}>, Box<{}>)", type0.descriptor, type1.descriptor);
             // Hacky way to get &'static str from String.
             let descriptor = Box::leak(descriptor.into_boxed_str());
             let contents = TypeContents::TUPLE(vec![TypeId::of::<Box<T0>>(), TypeId::of::<Box<T1>>()]);
-            Type::new(id, descriptor, contents)
+            Ok(Type::new(id, descriptor, contents))
         }
         dispatch!(
             monomorphize,
@@ -67,7 +67,7 @@ impl Type {
                 (type1, [bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String, (Box<f64>, Box<f64>)])
             ],
             (type0, type1)
-        )
+        ).unwrap_assert()
     }
 }
 

--- a/rust/opendp-ffi/src/util.rs
+++ b/rust/opendp-ffi/src/util.rs
@@ -227,8 +227,9 @@ pub fn into_box<T, U>(o: T) -> Box<U> {
     unsafe { Box::from_raw(p) }
 }
 
-pub fn into_owned<T>(p: *mut T) -> Option<T> {
+pub fn into_owned<T>(p: *mut T) -> Fallible<T> {
     (!p.is_null()).then(|| *unsafe { Box::<T>::from_raw(p) })
+        .ok_or_else(|| err!(FFI, "attempted to free a null pointer"))
 }
 
 pub fn as_ref<'a, T>(p: *const T) -> Option<&'a T> {

--- a/rust/opendp/src/core.rs
+++ b/rust/opendp/src/core.rs
@@ -178,6 +178,17 @@ impl<MI: Metric, MO: Measure> PrivacyRelation<MI, MO> {
     }
 }
 
+fn chain_option_maps<QI, QX, QO>(
+    map1: &Option<Rc<dyn Fn(&QX) -> Fallible<Box<QO>>>>,
+    map0: &Option<Rc<dyn Fn(&QI) -> Fallible<Box<QX>>>>
+) -> Option<impl Fn(&QI) -> Fallible<Box<QO>>> {
+    if let (Some(map0), Some(map1)) = (map0, map1) {
+        Some(enclose!((map0, map1), move |d_in: &QI| map1(&*map0(d_in)?)))
+    } else {
+        None
+    }
+}
+
 impl<MI: 'static + Metric, MO: 'static + Measure> PrivacyRelation<MI, MO> {
     pub fn make_chain<MX: 'static + Metric>(
         relation1: &PrivacyRelation<MX, MO>,
@@ -206,21 +217,11 @@ impl<MI: 'static + Metric, MO: 'static + Measure> PrivacyRelation<MI, MO> {
             Self::make_chain_hint(relation1, relation0, &hint)
         } else {
             // TODO: Implement binary search for hints.
-            panic!("Binary search for hints not implemented, must have maps or supply explicit hint.")
+            unimplemented!("Binary search for hints not implemented, must have maps or supply explicit hint.")
         }
     }
 
     fn make_chain_hint<MX: 'static + Metric>(relation1: &PrivacyRelation<MX, MO>, relation0: &StabilityRelation<MI, MX>, hint: &HintMt<MI, MO, MX>) -> Self {
-        fn chain_option_maps<QI, QX, QO>(
-            map1: &Option<Rc<dyn Fn(&QX) -> Fallible<Box<QO>>>>,
-            map0: &Option<Rc<dyn Fn(&QI) -> Fallible<Box<QX>>>>
-        ) -> Option<impl Fn(&QI) -> Fallible<Box<QO>>> {
-            if let (Some(map0), Some(map1)) = (map0, map1) {
-                Some(enclose!((map1, map0), move |d_in: &QI| map1(&*map0(d_in)?)))
-            } else {
-                None
-            }
-        }
         let PrivacyRelation {
             relation: relation1,
             backward_map: backward_map1
@@ -318,21 +319,11 @@ impl<MI: 'static + Metric, MO: 'static + Metric> StabilityRelation<MI, MO> {
             Self::make_chain_hint(relation1, relation0, &hint)
         } else {
             // TODO: Implement binary search for hints.
-            panic!("Binary search for hints not implemented, must have maps or supply explicit hint.")
+            unimplemented!("Binary search for hints not implemented, must have maps or supply explicit hint.")
         }
     }
 
     fn make_chain_hint<MX: 'static + Metric>(relation1: &StabilityRelation<MX, MO>, relation0: &StabilityRelation<MI, MX>, hint: &HintTt<MI, MO, MX>) -> Self {
-        fn chain_option_maps<QI, QX, QO>(
-            map1: &Option<Rc<dyn Fn(&QX) -> Fallible<Box<QO>>>>,
-            map0: &Option<Rc<dyn Fn(&QI) -> Fallible<Box<QX>>>>
-        ) -> Option<impl Fn(&QI) -> Fallible<Box<QO>>> {
-            if let (Some(map0), Some(map1)) = (map0, map1) {
-                Some(enclose!((map0, map1), move |d_in: &QI| map1(&*map0(d_in)?)))
-            } else {
-                None
-            }
-        }
 
         let StabilityRelation {
             relation: relation0,

--- a/rust/opendp/src/core.rs
+++ b/rust/opendp/src/core.rs
@@ -467,7 +467,7 @@ impl<D: 'static + Domain, M: 'static + Metric> MetricGlue<D, M> {
 pub struct ChainMT;
 
 impl ChainMT {
-    pub fn make_chain_mt_glue<DI, DX, DO, MI, MX, MO>(
+    pub fn make_glue<DI, DX, DO, MI, MX, MO>(
         measurement1: &Measurement<DX, DO, MX, MO>,
         transformation0: &Transformation<DI, DX, MI, MX>,
         hint: Option<&HintMt<MI, MO, MX>>,
@@ -506,7 +506,7 @@ impl<DI, DX, DO, MI, MX, MO> MakeMeasurement2<DI, DO, MI, MO, &Measurement<DX, D
           MX: 'static + Metric,
           MO: 'static + Measure {
     fn make2(measurement1: &Measurement<DX, DO, MX, MO>, transformation0: &Transformation<DI, DX, MI, MX>) -> Fallible<Measurement<DI, DO, MI, MO>> {
-        Self::make_chain_mt_glue(
+        Self::make_glue(
             measurement1, transformation0, None,
             &MetricGlue::<DI, MI>::new(),
             &MetricGlue::<DX, MX>::new(),
@@ -517,7 +517,7 @@ impl<DI, DX, DO, MI, MX, MO> MakeMeasurement2<DI, DO, MI, MO, &Measurement<DX, D
 pub struct ChainTT;
 
 impl ChainTT {
-    pub fn make_chain_tt_glue<DI, DX, DO, MI, MX, MO>(
+    pub fn make_glue<DI, DX, DO, MI, MX, MO>(
         transformation1: &Transformation<DX, DO, MX, MO>,
         transformation0: &Transformation<DI, DX, MI, MX>,
         hint: Option<&HintTt<MI, MO, MX>>,
@@ -556,7 +556,7 @@ impl<DI, DX, DO, MI, MX, MO> MakeTransformation2<DI, DO, MI, MO, &Transformation
           MX: 'static + Metric,
           MO: 'static + Metric {
     fn make2(transformation1: &Transformation<DX, DO, MX, MO>, transformation0: &Transformation<DI, DX, MI, MX>) -> Fallible<Transformation<DI, DO, MI, MO>> {
-        Self::make_chain_tt_glue(
+        Self::make_glue(
             transformation1, transformation0, None,
             &MetricGlue::<DI, MI>::new(),
             &MetricGlue::<DX, MX>::new(),
@@ -573,7 +573,7 @@ impl<DI, DO0, DO1, MI, MO> MakeMeasurement2<DI, PairDomain<BoxDomain<DO0>, BoxDo
           MI: 'static + Metric,
           MO: 'static + Measure {
     fn make2(measurement0: &Measurement<DI, DO0, MI, MO>, measurement1: &Measurement<DI, DO1, MI, MO>) -> Fallible<Measurement<DI, PairDomain<BoxDomain<DO0>, BoxDomain<DO1>>, MI, MO>> {
-        make_composition_glue(
+        Self::make_glue(
             measurement0, measurement1,
             &MetricGlue::<DI, MI>::new(),
             &MeasureGlue::<DO0, MO>::new(),
@@ -581,34 +581,36 @@ impl<DI, DO0, DO1, MI, MO> MakeMeasurement2<DI, PairDomain<BoxDomain<DO0>, BoxDo
     }
 }
 
-pub fn make_composition_glue<DI, DO0, DO1, MI, MO>(
-    measurement0: &Measurement<DI, DO0, MI, MO>,
-    measurement1: &Measurement<DI, DO1, MI, MO>,
-    input_glue: &MetricGlue<DI, MI>,
-    output_glue0: &MeasureGlue<DO0, MO>,
-    output_glue1: &MeasureGlue<DO1, MO>
-) -> Fallible<Measurement<DI, PairDomain<BoxDomain<DO0>, BoxDomain<DO1>>, MI, MO>>
-    where DI: 'static + Domain,
-          DO0: 'static + Domain,
-          DO1: 'static + Domain,
-          MI: 'static + Metric,
-          MO: 'static + Measure {
-    if (input_glue.domain_eq)(&measurement0.input_domain, &measurement1.input_domain) {
-        Ok(Measurement {
-            input_domain: (input_glue.domain_clone)(&measurement0.input_domain),
-            output_domain: Box::new(PairDomain::new(
-                BoxDomain::new((output_glue0.domain_clone)(&measurement0.output_domain)),
-                BoxDomain::new((output_glue1.domain_clone)(&measurement1.output_domain)))),
-            function: Function::make_composition(&measurement0.function, &measurement1.function),
-            // TODO: Figure out input_metric for composition.
-            input_metric: (input_glue.metric_clone)(&measurement0.input_metric),
-            // TODO: Figure out output_measure for composition.
-            output_measure: (output_glue0.measure_clone)(&measurement0.output_measure),
-            // TODO: PrivacyRelation for make_composition
-            privacy_relation: PrivacyRelation::new(|_i, _o| false)
-        })
-    } else {
-        fallible!(DomainMismatch)
+impl Composition {
+    pub fn make_glue<DI, DO0, DO1, MI, MO>(
+        measurement0: &Measurement<DI, DO0, MI, MO>,
+        measurement1: &Measurement<DI, DO1, MI, MO>,
+        input_glue: &MetricGlue<DI, MI>,
+        output_glue0: &MeasureGlue<DO0, MO>,
+        output_glue1: &MeasureGlue<DO1, MO>
+    ) -> Fallible<Measurement<DI, PairDomain<BoxDomain<DO0>, BoxDomain<DO1>>, MI, MO>>
+        where DI: 'static + Domain,
+              DO0: 'static + Domain,
+              DO1: 'static + Domain,
+              MI: 'static + Metric,
+              MO: 'static + Measure {
+        if (input_glue.domain_eq)(&measurement0.input_domain, &measurement1.input_domain) {
+            Ok(Measurement {
+                input_domain: (input_glue.domain_clone)(&measurement0.input_domain),
+                output_domain: Box::new(PairDomain::new(
+                    BoxDomain::new((output_glue0.domain_clone)(&measurement0.output_domain)),
+                    BoxDomain::new((output_glue1.domain_clone)(&measurement1.output_domain)))),
+                function: Function::make_composition(&measurement0.function, &measurement1.function),
+                // TODO: Figure out input_metric for composition.
+                input_metric: (input_glue.metric_clone)(&measurement0.input_metric),
+                // TODO: Figure out output_measure for composition.
+                output_measure: (output_glue0.measure_clone)(&measurement0.output_measure),
+                // TODO: PrivacyRelation for make_composition
+                privacy_relation: PrivacyRelation::new(|_i, _o| false)
+            })
+        } else {
+            fallible!(DomainMismatch)
+        }
     }
 }
 
@@ -631,7 +633,7 @@ mod tests {
         let stability_relation = StabilityRelation::new_from_constant(1);
         let identity = Transformation::new(input_domain, output_domain, function, input_metric, output_metric, stability_relation);
         let arg = 99;
-        let ret = identity.function.eval(&arg).unwrap_assert();
+        let ret = identity.function.eval(&arg).unwrap_test();
         assert_eq!(ret, 99);
     }
 
@@ -651,9 +653,9 @@ mod tests {
         let output_measure1 = MaxDivergence::new();
         let privacy_relation1 = PrivacyRelation::new(|_d_in: &i32, _d_out: &f64| true);
         let measurement1 = Measurement::new(input_domain1, output_domain1, function1, input_metric1, output_measure1, privacy_relation1);
-        let chain = ChainMT::make(&measurement1, &transformation0).unwrap_assert();
+        let chain = ChainMT::make(&measurement1, &transformation0).unwrap_test();
         let arg = 99_u8;
-        let ret = chain.function.eval(&arg).unwrap_assert();
+        let ret = chain.function.eval(&arg).unwrap_test();
         assert_eq!(ret, 101.0);
     }
 
@@ -673,9 +675,9 @@ mod tests {
         let output_metric1 = L1Sensitivity::<i32>::new();
         let stability_relation1 = StabilityRelation::new_from_constant(1);
         let transformation1 = Transformation::new(input_domain1, output_domain1, function1, input_metric1, output_metric1, stability_relation1);
-        let chain = ChainTT::make(&transformation1, &transformation0).unwrap_assert();
+        let chain = ChainTT::make(&transformation1, &transformation0).unwrap_test();
         let arg = 99_u8;
-        let ret = chain.function.eval(&arg).unwrap_assert();
+        let ret = chain.function.eval(&arg).unwrap_test();
         assert_eq!(ret, 101.0);
     }
 
@@ -695,9 +697,9 @@ mod tests {
         let output_measure1 = MaxDivergence::new();
         let privacy_relation1 = PrivacyRelation::new(|_d_in: &i32, _d_out: &f64| true);
         let measurement1 = Measurement::new(input_domain1, output_domain1, function1, input_metric1, output_measure1, privacy_relation1);
-        let composition = Composition::make(&measurement0, &measurement1).unwrap_assert();
+        let composition = Composition::make(&measurement0, &measurement1).unwrap_test();
         let arg = 99;
-        let ret = composition.function.eval(&arg).unwrap_assert();
+        let ret = composition.function.eval(&arg).unwrap_test();
         assert_eq!(ret, (Box::new(100_f32), Box::new(98_f64)));
     }
 }

--- a/rust/opendp/src/core.rs
+++ b/rust/opendp/src/core.rs
@@ -23,7 +23,7 @@
 use std::ops::{Div, Mul};
 use std::rc::Rc;
 
-use crate::error::Fallible;
+use crate::error::*;
 use crate::dom::{BoxDomain, PairDomain};
 use crate::meas::MakeMeasurement2;
 use crate::traits::DistanceCast;
@@ -631,7 +631,7 @@ mod tests {
         let stability_relation = StabilityRelation::new_from_constant(1);
         let identity = Transformation::new(input_domain, output_domain, function, input_metric, output_metric, stability_relation);
         let arg = 99;
-        let ret = identity.function.eval(&arg).unwrap();
+        let ret = identity.function.eval(&arg).unwrap_assert();
         assert_eq!(ret, 99);
     }
 
@@ -651,9 +651,9 @@ mod tests {
         let output_measure1 = MaxDivergence::new();
         let privacy_relation1 = PrivacyRelation::new(|_d_in: &i32, _d_out: &f64| true);
         let measurement1 = Measurement::new(input_domain1, output_domain1, function1, input_metric1, output_measure1, privacy_relation1);
-        let chain = ChainMT::make(&measurement1, &transformation0).unwrap();
+        let chain = ChainMT::make(&measurement1, &transformation0).unwrap_assert();
         let arg = 99_u8;
-        let ret = chain.function.eval(&arg).unwrap();
+        let ret = chain.function.eval(&arg).unwrap_assert();
         assert_eq!(ret, 101.0);
     }
 
@@ -673,9 +673,9 @@ mod tests {
         let output_metric1 = L1Sensitivity::<i32>::new();
         let stability_relation1 = StabilityRelation::new_from_constant(1);
         let transformation1 = Transformation::new(input_domain1, output_domain1, function1, input_metric1, output_metric1, stability_relation1);
-        let chain = ChainTT::make(&transformation1, &transformation0).unwrap();
+        let chain = ChainTT::make(&transformation1, &transformation0).unwrap_assert();
         let arg = 99_u8;
-        let ret = chain.function.eval(&arg).unwrap();
+        let ret = chain.function.eval(&arg).unwrap_assert();
         assert_eq!(ret, 101.0);
     }
 
@@ -695,9 +695,9 @@ mod tests {
         let output_measure1 = MaxDivergence::new();
         let privacy_relation1 = PrivacyRelation::new(|_d_in: &i32, _d_out: &f64| true);
         let measurement1 = Measurement::new(input_domain1, output_domain1, function1, input_metric1, output_measure1, privacy_relation1);
-        let composition = Composition::make(&measurement0, &measurement1).unwrap();
+        let composition = Composition::make(&measurement0, &measurement1).unwrap_assert();
         let arg = 99;
-        let ret = composition.function.eval(&arg).unwrap();
+        let ret = composition.function.eval(&arg).unwrap_assert();
         assert_eq!(ret, (Box::new(100_f32), Box::new(98_f64)));
     }
 }

--- a/rust/opendp/src/data.rs
+++ b/rust/opendp/src/data.rs
@@ -2,7 +2,7 @@
 
 use std::any::Any;
 use std::fmt::Debug;
-use crate::error::Fallible;
+use crate::error::*;
 
 pub trait IsVec: Debug {
     // Not sure if we need into_any() (which consumes the Form), keeping it for now.
@@ -32,7 +32,7 @@ impl<T> From<Vec<T>> for Column
 pub struct Column(Box<dyn IsVec>);
 
 impl Column {
-    pub fn new<T: 'static + Debug>(form: Vec<T>) -> Column where Vec<T>: IsVec {
+    pub fn new<T: 'static + Debug>(form: Vec<T>) -> Self where Vec<T>: IsVec {
         Column(Box::new(form))
     }
     pub fn as_form<T: 'static + IsVec>(&self) -> Fallible<&T> {
@@ -80,7 +80,7 @@ mod tests {
 
     fn test_round_trip<T: 'static + IsVec + PartialEq>(form: T) {
         let data = Column(form.box_clone());
-        assert_eq!(&form, data.as_form().unwrap());
-        assert_eq!(form, data.into_form().unwrap())
+        assert_eq!(&form, data.as_form().unwrap_assert());
+        assert_eq!(form, data.into_form().unwrap_assert())
     }
 }

--- a/rust/opendp/src/data.rs
+++ b/rust/opendp/src/data.rs
@@ -80,7 +80,7 @@ mod tests {
 
     fn test_round_trip<T: 'static + IsVec + PartialEq>(form: T) {
         let data = Column(form.box_clone());
-        assert_eq!(&form, data.as_form().unwrap_assert());
-        assert_eq!(form, data.into_form().unwrap_assert())
+        assert_eq!(&form, data.as_form().unwrap_test());
+        assert_eq!(form, data.into_form().unwrap_test())
     }
 }

--- a/rust/opendp/src/error.rs
+++ b/rust/opendp/src/error.rs
@@ -38,13 +38,13 @@ pub struct Error {
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
 pub enum ErrorVariant {
-    #[error("{0}")]
-    Raw(Box<dyn std::error::Error>),
+    #[error("FFI")]
+    FFI,
 
     #[error("TypeParse")]
     TypeParse,
 
-    #[error("Failed function execution")]
+    #[error("FailedFunction")]
     FailedFunction,
 
     #[error("FailedRelation")]
@@ -53,22 +53,22 @@ pub enum ErrorVariant {
     #[error("RelationDebug")]
     RelationDebug,
 
-    #[error("Unable to cast type")]
+    #[error("FailedCast")]
     FailedCast,
 
-    #[error("Domain mismatch")]
+    #[error("DomainMismatch")]
     DomainMismatch,
 
-    #[error("Failed to make transformation")]
+    #[error("MakeTransformation")]
     MakeTransformation,
 
-    #[error("Failed to make measurement")]
+    #[error("MakeMeasurement")]
     MakeMeasurement,
 
-    #[error("Invalid distance")]
+    #[error("InvalidDistance")]
     InvalidDistance,
 
-    #[error("Not implemented")]
+    #[error("NotImplemented")]
     NotImplemented,
 }
 
@@ -86,23 +86,31 @@ impl From<ErrorVariant> for Error {
 
 pub type Fallible<T> = Result<T, Error>;
 
-/// A trait for calling unwrap. Differs from unwrap in that the developer has made the assertion that failure should be unreachable
-/// This is ok to use in two scenarios:
-/// - Tests
-/// - Code with unreachable None or Err variants
-pub trait UnwrapAssert {
+/// A trait for calling unwrap with an explanation. Makes calls to unwrap() discoverable.
+/// - unwrap_test: panics are acceptable in tests
+/// - unwrap_assert: situations with unreachable None or Err variants
+pub trait ExplainUnwrap {
     type Inner;
+    /// use in tests
     fn unwrap_assert(self) -> Self::Inner;
+    /// use if the alternate variant is structurally unreachable
+    fn unwrap_test(self) -> Self::Inner;
 }
-impl<T> UnwrapAssert for Option<T> {
+impl<T> ExplainUnwrap for Option<T> {
     type Inner = T;
     fn unwrap_assert(self) -> T {
         self.unwrap()
     }
+    fn unwrap_test(self) -> T {
+        self.unwrap()
+    }
 }
-impl<T> UnwrapAssert for Fallible<T> {
+impl<T> ExplainUnwrap for Fallible<T> {
     type Inner = T;
     fn unwrap_assert(self) -> T {
+        self.unwrap()
+    }
+    fn unwrap_test(self) -> T {
         self.unwrap()
     }
 }

--- a/rust/opendp/src/error.rs
+++ b/rust/opendp/src/error.rs
@@ -2,12 +2,13 @@ use std::fmt;
 
 use backtrace::Backtrace as _Backtrace;
 
-
+// create an instance of opendp::Fallible
 #[macro_export]
 macro_rules! fallible {
     ($variant:ident) => (Err(err!($variant)));
     ($variant:ident, $($inner:expr),+) => (Err(err!($variant, $($inner),+)));
 }
+// create an instance of opendp::Error
 // "error" is shadowed, and breaks intellij macro resolution
 #[macro_export]
 macro_rules! err {

--- a/rust/opendp/src/error.rs
+++ b/rust/opendp/src/error.rs
@@ -84,6 +84,12 @@ impl From<ErrorVariant> for Error {
     }
 }
 
+impl<T> From<Error> for Result<T, Error> {
+    fn from(e: Error) -> Self {
+        Err(e)
+    }
+}
+
 pub type Fallible<T> = Result<T, Error>;
 
 /// A trait for calling unwrap with an explanation. Makes calls to unwrap() discoverable.

--- a/rust/opendp/src/error.rs
+++ b/rust/opendp/src/error.rs
@@ -16,13 +16,13 @@ macro_rules! err {
     ($variant:ident) => (crate::error::Error {
         variant: crate::error::ErrorVariant::$variant,
         message: None,
-        backtrace: backtrace::Backtrace::new()
+        backtrace: backtrace::Backtrace::new_unresolved()
     });
     // error with explicit message
     ($variant:ident, $message:expr) => (crate::error::Error {
         variant: crate::error::ErrorVariant::$variant,
         message: Some($message.to_string()), // ToString is impl'ed for String
-        backtrace: backtrace::Backtrace::new()
+        backtrace: backtrace::Backtrace::new_unresolved()
     });
     // args to format into message
     ($variant:ident, $template:expr, $($args:expr),+) =>

--- a/rust/opendp/src/error.rs
+++ b/rust/opendp/src/error.rs
@@ -99,13 +99,13 @@ pub type Fallible<T> = Result<T, Error>;
 pub trait ExplainUnwrap {
     type Inner;
     /// use in tests
-    fn unwrap_assert(self) -> Self::Inner;
+    fn unwrap_assert(self, explanation: &'static str) -> Self::Inner;
     /// use if the alternate variant is structurally unreachable
     fn unwrap_test(self) -> Self::Inner;
 }
 impl<T> ExplainUnwrap for Option<T> {
     type Inner = T;
-    fn unwrap_assert(self) -> T {
+    fn unwrap_assert(self, _explanation: &'static str) -> T {
         self.unwrap()
     }
     fn unwrap_test(self) -> T {
@@ -114,7 +114,7 @@ impl<T> ExplainUnwrap for Option<T> {
 }
 impl<T> ExplainUnwrap for Fallible<T> {
     type Inner = T;
-    fn unwrap_assert(self) -> T {
+    fn unwrap_assert(self, _explanation: &'static str) -> T {
         self.unwrap()
     }
     fn unwrap_test(self) -> T {

--- a/rust/opendp/src/error.rs
+++ b/rust/opendp/src/error.rs
@@ -94,13 +94,11 @@ impl<T> From<Error> for Result<T, Error> {
 pub type Fallible<T> = Result<T, Error>;
 
 /// A trait for calling unwrap with an explanation. Makes calls to unwrap() discoverable.
-/// - unwrap_test: panics are acceptable in tests
-/// - unwrap_assert: situations with unreachable None or Err variants
 pub trait ExplainUnwrap {
     type Inner;
-    /// use in tests
+    /// use if the None or Err variant is structurally unreachable
     fn unwrap_assert(self, explanation: &'static str) -> Self::Inner;
-    /// use if the alternate variant is structurally unreachable
+    /// use in tests, where panics are acceptable
     fn unwrap_test(self) -> Self::Inner;
 }
 impl<T> ExplainUnwrap for Option<T> {

--- a/rust/opendp/src/lib.rs
+++ b/rust/opendp/src/lib.rs
@@ -124,6 +124,7 @@
 //! [`Measurement`]/[`Transformation`] constructors are allowed to be generic! Typically, this means that the type parameter on the
 //! constructor will determine type of the input or output [`Domain::Carrier`] (or the generic type within, for instance the `i32` of `Vec<i32>`).
 
+// create clones of variables that are free to be consumed by a closure
 macro_rules! enclose {
     ( $x:ident, $y:expr ) => (enclose!(($x), $y));
     ( ($( $x:ident ),*), $y:expr ) => {

--- a/rust/opendp/src/lib.rs
+++ b/rust/opendp/src/lib.rs
@@ -43,30 +43,33 @@
 //! use opendp::core::{ChainTT, ChainMT};
 //! use opendp::meas::{MakeMeasurement2,  MakeMeasurement1};
 //! use opendp::meas::laplace::BaseLaplace;
+//! use opendp::error::*;
 //!
-//! pub fn example() {
+//! pub fn example() -> Fallible<()> {
 //!     let data = "56\n15\n97\n56\n6\n17\n2\n19\n16\n50".to_owned();
 //!     let bounds = (0.0, 100.0);
 //!     let epsilon = 1.0;
 //!     let sigma = (bounds.1 - bounds.0) / epsilon;
 //!
 //!     // Construct a Transformation to load the numbers.
-//!     let split_lines = trans::SplitLines::<HammingDistance>::make().unwrap();
-//!     let parse_series = trans::ParseSeries::<f64, HammingDistance>::make(true).unwrap();
-//!     let load_numbers = ChainTT::make(&parse_series, &split_lines).unwrap();
+//!     let split_lines = trans::SplitLines::<HammingDistance>::make()?;
+//!     let parse_series = trans::ParseSeries::<f64, HammingDistance>::make(true)?;
+//!     let load_numbers = ChainTT::make(&parse_series, &split_lines)?;
 //!
 //!     // Construct a Measurement to calculate a noisy sum.
-//!     let clamp = manipulation::Clamp::make(bounds.0, bounds.1).unwrap();
-//!     let bounded_sum = sum::BoundedSum::make2(bounds.0, bounds.1).unwrap();
-//!     let laplace = BaseLaplace::make(sigma).unwrap();
-//!     let intermediate = ChainTT::make(&bounded_sum, &clamp).unwrap();
-//!     let noisy_sum = ChainMT::make(&laplace, &intermediate).unwrap();
+//!     let clamp = manipulation::Clamp::make(bounds.0, bounds.1)?;
+//!     let bounded_sum = sum::BoundedSum::make2(bounds.0, bounds.1)?;
+//!     let laplace = BaseLaplace::make(sigma)?;
+//!     let intermediate = ChainTT::make(&bounded_sum, &clamp)?;
+//!     let noisy_sum = ChainMT::make(&laplace, &intermediate)?;
 //!
 //!     // Put it all together.
-//!     let pipeline = ChainMT::make(&noisy_sum, &load_numbers).unwrap();
-//!     let result = pipeline.function.eval(&data).unwrap();
+//!     let pipeline = ChainMT::make(&noisy_sum, &load_numbers)?;
+//!     let result = pipeline.function.eval(&data)?;
 //!     println!("result = {}", result);
-//!  }
+//!     Ok(())
+//! }
+//! example().unwrap_assert();
 //! ```
 //!
 //! # Contributor Guide
@@ -105,6 +108,7 @@
 //!     let stability_relation = StabilityRelation::new_from_constant(1);
 //!     Transformation::new(input_domain, output_domain, function, input_metric, output_metric, stability_relation)
 //! }
+//! make_i32_identity();
 //! ```
 //!
 //! #### Input and Output Types

--- a/rust/opendp/src/lib.rs
+++ b/rust/opendp/src/lib.rs
@@ -69,7 +69,7 @@
 //!     println!("result = {}", result);
 //!     Ok(())
 //! }
-//! example().unwrap_assert();
+//! example().unwrap_test();
 //! ```
 //!
 //! # Contributor Guide

--- a/rust/opendp/src/meas/gaussian.rs
+++ b/rust/opendp/src/meas/gaussian.rs
@@ -57,10 +57,10 @@ mod tests {
 
     #[test]
     fn test_make_gaussian_mechanism() {
-        let measurement = BaseGaussian::<f64>::make(1.0).unwrap_assert();
+        let measurement = BaseGaussian::<f64>::make(1.0).unwrap_test();
         let arg = 0.0;
-        let _ret = measurement.function.eval(&arg).unwrap_assert();
+        let _ret = measurement.function.eval(&arg).unwrap_test();
 
-        assert!(measurement.privacy_relation.eval(&0.1, &(0.5, 0.00001)).unwrap_assert());
+        assert!(measurement.privacy_relation.eval(&0.1, &(0.5, 0.00001)).unwrap_test());
     }
 }

--- a/rust/opendp/src/meas/gaussian.rs
+++ b/rust/opendp/src/meas/gaussian.rs
@@ -21,6 +21,9 @@ const ADDITIVE_GAUSS_CONST: f64 = 0.4373061836;
 impl<T> MakeMeasurement1<AllDomain<T>, AllDomain<T>, L2Sensitivity<T>, SmoothedMaxDivergence<T>, T> for BaseGaussian<T>
     where T: 'static + Clone + SampleGaussian + Float {
     fn make1(scale: T) -> Fallible<Measurement<AllDomain<T>, AllDomain<T>, L2Sensitivity<T>, SmoothedMaxDivergence<T>>> {
+        if scale.is_sign_negative() {
+            return fallible!(MakeMeasurement, "scale must not be negative")
+        }
         let _2_ = T::from(2.).ok_or_else(|| err!(FailedCast))?;
         let additive_gauss_const = T::from(ADDITIVE_GAUSS_CONST).ok_or_else(|| err!(FailedCast))?;
 

--- a/rust/opendp/src/meas/gaussian.rs
+++ b/rust/opendp/src/meas/gaussian.rs
@@ -5,7 +5,7 @@ use num::Float;
 use crate::core::{Function, Measurement, PrivacyRelation};
 use crate::dist::{L2Sensitivity, SmoothedMaxDivergence};
 use crate::dom::AllDomain;
-use crate::error::Fallible;
+use crate::error::*;
 use crate::meas::MakeMeasurement1;
 use crate::samplers::SampleGaussian;
 
@@ -57,10 +57,10 @@ mod tests {
 
     #[test]
     fn test_make_gaussian_mechanism() {
-        let measurement = BaseGaussian::<f64>::make(1.0).unwrap();
+        let measurement = BaseGaussian::<f64>::make(1.0).unwrap_assert();
         let arg = 0.0;
-        let _ret = measurement.function.eval(&arg).unwrap();
+        let _ret = measurement.function.eval(&arg).unwrap_assert();
 
-        assert!(measurement.privacy_relation.eval(&0.1, &(0.5, 0.00001)).unwrap());
+        assert!(measurement.privacy_relation.eval(&0.1, &(0.5, 0.00001)).unwrap_assert());
     }
 }

--- a/rust/opendp/src/meas/geometric.rs
+++ b/rust/opendp/src/meas/geometric.rs
@@ -21,6 +21,9 @@ impl<T, QO> MakeMeasurement3<AllDomain<T>, AllDomain<T>, L1Sensitivity<T>, MaxDi
     where T: 'static + Clone + SampleGeometric + Sub<Output=T> + Add<Output=T> + DistanceCast,
           QO: 'static + Float + DistanceCast, f64: From<QO> {
     fn make3(scale: QO, min: T, max: T) -> Fallible<Measurement<AllDomain<T>, AllDomain<T>, L1Sensitivity<T>, MaxDivergence<QO>>> {
+        if scale.is_sign_negative() {
+            return fallible!(MakeMeasurement, "scale must not be negative")
+        }
         Ok(Measurement::new(
             AllDomain::new(),
             AllDomain::new(),

--- a/rust/opendp/src/meas/geometric.rs
+++ b/rust/opendp/src/meas/geometric.rs
@@ -51,10 +51,10 @@ mod tests {
 
     #[test]
     fn test_make_geometric_mechanism() {
-        let measurement = BaseSimpleGeometric::<i32, f64>::make(10.0, 200, 210).unwrap_assert();
+        let measurement = BaseSimpleGeometric::<i32, f64>::make(10.0, 200, 210).unwrap_test();
         let arg = 205;
-        let _ret = measurement.function.eval(&arg).unwrap_assert();
+        let _ret = measurement.function.eval(&arg).unwrap_test();
 
-        assert!(measurement.privacy_relation.eval(&1, &0.5).unwrap_assert());
+        assert!(measurement.privacy_relation.eval(&1, &0.5).unwrap_test());
     }
 }

--- a/rust/opendp/src/meas/geometric.rs
+++ b/rust/opendp/src/meas/geometric.rs
@@ -5,7 +5,7 @@ use std::ops::{Sub, Add};
 use crate::core::{Function, Measurement, PrivacyRelation};
 use crate::dist::{MaxDivergence, L1Sensitivity};
 use crate::dom::AllDomain;
-use crate::error::Fallible;
+use crate::error::*;
 use crate::samplers::{SampleBernoulli, SampleGeometric, SampleUniform};
 use crate::meas::MakeMeasurement3;
 use crate::traits::DistanceCast;
@@ -51,10 +51,10 @@ mod tests {
 
     #[test]
     fn test_make_geometric_mechanism() {
-        let measurement = BaseSimpleGeometric::<i32, f64>::make(10.0, 200, 210).unwrap();
+        let measurement = BaseSimpleGeometric::<i32, f64>::make(10.0, 200, 210).unwrap_assert();
         let arg = 205;
-        let _ret = measurement.function.eval(&arg).unwrap();
+        let _ret = measurement.function.eval(&arg).unwrap_assert();
 
-        assert!(measurement.privacy_relation.eval(&1, &0.5).unwrap());
+        assert!(measurement.privacy_relation.eval(&1, &0.5).unwrap_assert());
     }
 }

--- a/rust/opendp/src/meas/laplace.rs
+++ b/rust/opendp/src/meas/laplace.rs
@@ -7,7 +7,7 @@ use crate::dist::{L1Sensitivity, MaxDivergence};
 use crate::dom::{AllDomain, VectorDomain};
 use crate::samplers::{SampleLaplace};
 use crate::meas::{MakeMeasurement1};
-use crate::error::Fallible;
+use crate::error::*;
 use crate::traits::DistanceCast;
 
 pub struct BaseLaplace<T> {
@@ -59,20 +59,20 @@ mod tests {
 
     #[test]
     fn test_make_laplace_mechanism() {
-        let measurement = BaseLaplace::<f64>::make(1.0).unwrap();
+        let measurement = BaseLaplace::<f64>::make(1.0).unwrap_assert();
         let arg = 0.0;
-        let _ret = measurement.function.eval(&arg).unwrap();
+        let _ret = measurement.function.eval(&arg).unwrap_assert();
 
-        assert!(measurement.privacy_relation.eval(&1., &1.).unwrap());
+        assert!(measurement.privacy_relation.eval(&1., &1.).unwrap_assert());
     }
 
     #[test]
     fn test_make_vector_laplace_mechanism() {
-        let measurement = BaseVectorLaplace::<f64>::make(1.0).unwrap();
+        let measurement = BaseVectorLaplace::<f64>::make(1.0).unwrap_assert();
         let arg = vec![1.0, 2.0, 3.0];
-        let _ret = measurement.function.eval(&arg).unwrap();
+        let _ret = measurement.function.eval(&arg).unwrap_assert();
 
-        assert!(measurement.privacy_relation.eval(&1., &1.).unwrap());
+        assert!(measurement.privacy_relation.eval(&1., &1.).unwrap_assert());
     }
 }
 

--- a/rust/opendp/src/meas/laplace.rs
+++ b/rust/opendp/src/meas/laplace.rs
@@ -18,6 +18,9 @@ pub struct BaseLaplace<T> {
 impl<T> MakeMeasurement1<AllDomain<T>, AllDomain<T>, L1Sensitivity<T>, MaxDivergence<T>, T> for BaseLaplace<T>
     where T: 'static + Clone + SampleLaplace + Float + DistanceCast {
     fn make1(scale: T) -> Fallible<Measurement<AllDomain<T>, AllDomain<T>, L1Sensitivity<T>, MaxDivergence<T>>> {
+        if scale.is_sign_negative() {
+            return fallible!(MakeMeasurement, "scale must not be negative")
+        }
         Ok(Measurement::new(
             AllDomain::new(),
             AllDomain::new(),
@@ -38,6 +41,9 @@ pub struct BaseVectorLaplace<T> {
 impl<T> MakeMeasurement1<VectorDomain<AllDomain<T>>, VectorDomain<AllDomain<T>>, L1Sensitivity<T>, MaxDivergence<T>, T> for BaseVectorLaplace<T>
     where T: 'static + Clone + SampleLaplace + Float + DistanceCast {
     fn make1(scale: T) -> Fallible<Measurement<VectorDomain<AllDomain<T>>, VectorDomain<AllDomain<T>>, L1Sensitivity<T>, MaxDivergence<T>>> {
+        if scale.is_sign_negative() {
+            return fallible!(MakeMeasurement, "scale must not be negative")
+        }
         Ok(Measurement::new(
             VectorDomain::new_all(),
             VectorDomain::new_all(),

--- a/rust/opendp/src/meas/laplace.rs
+++ b/rust/opendp/src/meas/laplace.rs
@@ -59,20 +59,20 @@ mod tests {
 
     #[test]
     fn test_make_laplace_mechanism() {
-        let measurement = BaseLaplace::<f64>::make(1.0).unwrap_assert();
+        let measurement = BaseLaplace::<f64>::make(1.0).unwrap_test();
         let arg = 0.0;
-        let _ret = measurement.function.eval(&arg).unwrap_assert();
+        let _ret = measurement.function.eval(&arg).unwrap_test();
 
-        assert!(measurement.privacy_relation.eval(&1., &1.).unwrap_assert());
+        assert!(measurement.privacy_relation.eval(&1., &1.).unwrap_test());
     }
 
     #[test]
     fn test_make_vector_laplace_mechanism() {
-        let measurement = BaseVectorLaplace::<f64>::make(1.0).unwrap_assert();
+        let measurement = BaseVectorLaplace::<f64>::make(1.0).unwrap_test();
         let arg = vec![1.0, 2.0, 3.0];
-        let _ret = measurement.function.eval(&arg).unwrap_assert();
+        let _ret = measurement.function.eval(&arg).unwrap_test();
 
-        assert!(measurement.privacy_relation.eval(&1., &1.).unwrap_assert());
+        assert!(measurement.privacy_relation.eval(&1., &1.).unwrap_test());
     }
 }
 

--- a/rust/opendp/src/meas/stability.rs
+++ b/rust/opendp/src/meas/stability.rs
@@ -67,8 +67,8 @@ impl<MI, TIK, TIC, TOC> MakeMeasurement3<CountDomain<TIK, TIC>, CountDomain<TIK,
             MI::new(),
             SmoothedMaxDivergence::new(),
             PrivacyRelation::new_fallible(move |&d_in: &TOC, &(eps, del): &(TOC, TOC)|{
-                // let _eps: f64 = NumCast::from(eps).unwrap();
-                // let _del: f64 = NumCast::from(del).unwrap();
+                // let _eps: f64 = NumCast::from(eps).unwrap_test();
+                // let _del: f64 = NumCast::from(del).unwrap_test();
                 // println!("eps, del: {:?}, {:?}", _eps, _del);
                 let ideal_scale = d_in / (eps * _n);
                 let ideal_threshold = (_2 / del).ln() * ideal_scale + _n.recip();
@@ -103,14 +103,15 @@ mod test_stability {
     use super::*;
 
     #[test]
-    fn test_base_stability() {
+    fn test_base_stability() -> Fallible<()> {
         let mut arg = HashMap::new();
         arg.insert(true, 6);
         arg.insert(false, 4);
-        let measurement = BaseStability::<L2Sensitivity<f64>, bool, i8, f64>::make(10, 0.5, 1.).unwrap();
-        let ret = measurement.function.eval(&arg).unwrap();
+        let measurement = BaseStability::<L2Sensitivity<f64>, bool, i8, f64>::make(10, 0.5, 1.)?;
+        let ret = measurement.function.eval(&arg)?;
         println!("stability eval: {:?}", ret);
 
-        assert!(measurement.privacy_relation.eval(&1., &(2.3, 1e-5)).unwrap());
+        assert!(measurement.privacy_relation.eval(&1., &(2.3, 1e-5))?);
+        Ok(())
     }
 }

--- a/rust/opendp/src/meas/stability.rs
+++ b/rust/opendp/src/meas/stability.rs
@@ -45,6 +45,13 @@ impl<MI, TIK, TIC, TOC> MakeMeasurement3<CountDomain<TIK, TIC>, CountDomain<TIK,
           TIC: Integer + Clone + NumCast,
           TOC: 'static + Float + Clone + PartialOrd + SampleLaplace + NumCast {
     fn make3(n: usize, scale: TOC, threshold: TOC) -> Fallible<Measurement<CountDomain<TIK, TIC>, CountDomain<TIK, TOC>, MI, SmoothedMaxDivergence<TOC>>> {
+        if scale.is_sign_negative() {
+            return fallible!(MakeMeasurement, "scale must not be negative")
+        }
+        if threshold.is_sign_negative() {
+            return fallible!(MakeMeasurement, "threshold must not be negative")
+        }
+
         let _n: TOC = TOC::from(n).ok_or_else(|| err!(FailedCast))?;
         let _2: TOC = TOC::from(2).ok_or_else(|| err!(FailedCast))?;
 

--- a/rust/opendp/src/samplers.rs
+++ b/rust/opendp/src/samplers.rs
@@ -58,22 +58,22 @@ pub trait SampleBernoulli: Sized {
     /// // returns a bit with Pr(bit = 1) = 0.7
     /// use opendp::samplers::SampleBernoulli;
     /// let n = bool::sample_bernoulli(0.7, false);
-    /// # use opendp::error::UnwrapAssert;
-    /// # n.unwrap_assert();
+    /// # use opendp::error::ExplainUnwrap;
+    /// # n.unwrap_test();
     /// ```
     /// ```should_panic
     /// // fails because 1.3 not a valid probability
     /// use opendp::samplers::SampleBernoulli;
     /// let n = bool::sample_bernoulli(1.3, false);
-    /// # use opendp::error::UnwrapAssert;
-    /// # n.unwrap_assert();
+    /// # use opendp::error::ExplainUnwrap;
+    /// # n.unwrap_test();
     /// ```
     /// ```should_panic
     /// // fails because -0.3 is not a valid probability
     /// use opendp::samplers::SampleBernoulli;
     /// let n = bool::sample_bernoulli(-0.3, false);
-    /// # use opendp::error::UnwrapAssert;
-    /// # n.unwrap_assert();
+    /// # use opendp::error::ExplainUnwrap;
+    /// # n.unwrap_test();
     /// ```
     fn sample_bernoulli(prob: f64, enforce_constant_time: bool) -> Fallible<Self>;
 }
@@ -163,8 +163,8 @@ pub trait SampleUniform: Sized {
     /// // valid draw from Unif[0,1)
     /// use opendp::samplers::SampleUniform;
     /// let unif = f64::sample_standard_uniform(false);
-    /// # use opendp::error::UnwrapAssert;
-    /// # unif.unwrap_assert();
+    /// # use opendp::error::ExplainUnwrap;
+    /// # unif.unwrap_test();
     /// ```
     fn sample_standard_uniform(enforce_constant_time: bool) -> Fallible<Self>;
 }
@@ -255,8 +255,8 @@ pub trait SampleGeometric: Sized {
     /// ```
     /// use opendp::samplers::SampleGeometric;
     /// let geom = u8::sample_geometric(0.1, 20, false);
-    /// # use opendp::error::UnwrapAssert;
-    /// # geom.unwrap_assert();
+    /// # use opendp::error::ExplainUnwrap;
+    /// # geom.unwrap_test();
     /// ```
     fn sample_geometric(prob: f64, max_trials: Self, enforce_constant_time: bool) -> Fallible<Self>;
 }

--- a/rust/opendp/src/samplers.rs
+++ b/rust/opendp/src/samplers.rs
@@ -58,19 +58,22 @@ pub trait SampleBernoulli: Sized {
     /// // returns a bit with Pr(bit = 1) = 0.7
     /// use opendp::samplers::SampleBernoulli;
     /// let n = bool::sample_bernoulli(0.7, false);
-    /// # n.unwrap();
+    /// # use opendp::error::UnwrapAssert;
+    /// # n.unwrap_assert();
     /// ```
     /// ```should_panic
     /// // fails because 1.3 not a valid probability
     /// use opendp::samplers::SampleBernoulli;
     /// let n = bool::sample_bernoulli(1.3, false);
-    /// # n.unwrap();
+    /// # use opendp::error::UnwrapAssert;
+    /// # n.unwrap_assert();
     /// ```
     /// ```should_panic
     /// // fails because -0.3 is not a valid probability
     /// use opendp::samplers::SampleBernoulli;
     /// let n = bool::sample_bernoulli(-0.3, false);
-    /// # n.unwrap();
+    /// # use opendp::error::UnwrapAssert;
+    /// # n.unwrap_assert();
     /// ```
     fn sample_bernoulli(prob: f64, enforce_constant_time: bool) -> Fallible<Self>;
 }
@@ -160,7 +163,8 @@ pub trait SampleUniform: Sized {
     /// // valid draw from Unif[0,1)
     /// use opendp::samplers::SampleUniform;
     /// let unif = f64::sample_standard_uniform(false);
-    /// # unif.unwrap();
+    /// # use opendp::error::UnwrapAssert;
+    /// # unif.unwrap_assert();
     /// ```
     fn sample_standard_uniform(enforce_constant_time: bool) -> Fallible<Self>;
 }
@@ -251,7 +255,8 @@ pub trait SampleGeometric: Sized {
     /// ```
     /// use opendp::samplers::SampleGeometric;
     /// let geom = u8::sample_geometric(0.1, 20, false);
-    /// # geom.unwrap();
+    /// # use opendp::error::UnwrapAssert;
+    /// # geom.unwrap_assert();
     /// ```
     fn sample_geometric(prob: f64, max_trials: Self, enforce_constant_time: bool) -> Fallible<Self>;
 }

--- a/rust/opendp/src/trans/count.rs
+++ b/rust/opendp/src/trans/count.rs
@@ -11,7 +11,7 @@ use num::traits::FloatConst;
 use crate::core::{DatasetMetric, Function, SensitivityMetric, StabilityRelation, Transformation};
 use crate::dist::{HammingDistance, L1Sensitivity, L2Sensitivity, SymmetricDistance};
 use crate::dom::{AllDomain, MapDomain, SizedDomain, VectorDomain};
-use crate::error::Fallible;
+use crate::error::*;
 use crate::traits::DistanceCast;
 use crate::trans::{MakeTransformation0, MakeTransformation1};
 
@@ -90,8 +90,7 @@ impl<MI, MO, TI, TO, QO> MakeTransformation1<VectorDomain<AllDomain<TI>>, SizedD
 
                 categories.iter().map(|cat| counts.remove(cat))
                     .chain(vec![Some(null_count)])
-                    // this is a "safe" unwrap
-                    .collect::<Option<_>>().unwrap()
+                    .collect::<Option<_>>().unwrap_assert()
             }),
             MI::new(),
             MO::new(),
@@ -111,7 +110,6 @@ pub struct CountBy<MI, MO, TI, TO> {
 pub trait CountByConstant<MI: DatasetMetric, MO: SensitivityMetric> {
     fn get_stability_constant() -> Fallible<MO::Distance>;
 }
-
 
 impl<TI, TO, QO: NumCast> CountByConstant<HammingDistance, L1Sensitivity<QO>> for CountBy<HammingDistance, L1Sensitivity<QO>, TI, TO> {
     fn get_stability_constant() -> Fallible<QO> {
@@ -164,18 +162,18 @@ mod tests {
 
     #[test]
     fn test_make_count_l1() {
-        let transformation = Count::<SymmetricDistance, L1Sensitivity<_>, i32>::make().unwrap();
+        let transformation = Count::<SymmetricDistance, L1Sensitivity<_>, i32>::make().unwrap_assert();
         let arg = vec![1, 2, 3, 4, 5];
-        let ret = transformation.function.eval(&arg).unwrap();
+        let ret = transformation.function.eval(&arg).unwrap_assert();
         let expected = 5;
         assert_eq!(ret, expected);
     }
 
     #[test]
     fn test_make_count_l2() {
-        let transformation = Count::<SymmetricDistance, L2Sensitivity<_>, i32>::make().unwrap();
+        let transformation = Count::<SymmetricDistance, L2Sensitivity<_>, i32>::make().unwrap_assert();
         let arg = vec![1, 2, 3, 4, 5];
-        let ret = transformation.function.eval(&arg).unwrap();
+        let ret = transformation.function.eval(&arg).unwrap_assert();
         let expected = 5;
         assert_eq!(ret, expected);
     }

--- a/rust/opendp/src/trans/count.rs
+++ b/rust/opendp/src/trans/count.rs
@@ -1,11 +1,11 @@
-use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
+use std::collections::hash_map::Entry;
 use std::convert::TryFrom;
 use std::hash::Hash;
 use std::marker::PhantomData;
 use std::ops::{AddAssign, Div, Mul};
 
-use num::{Integer, One, Zero, NumCast};
+use num::{Integer, NumCast, One, Zero};
 use num::traits::FloatConst;
 
 use crate::core::{DatasetMetric, Function, SensitivityMetric, StabilityRelation, Transformation};
@@ -92,10 +92,10 @@ impl<MI, MO, TI, TO, QO> MakeTransformation1<VectorDomain<AllDomain<TI>>, SizedD
                         Entry::Vacant(_v) => &mut null_count
                     } += TO::one());
 
-                categories.iter().map(|cat| counts.remove(cat))
-                    .chain(vec![Some(null_count)])
-                    // we always know that .remove will be some, because categories are distinct and every category is in the map
-                    .collect::<Option<_>>().unwrap_assert()
+                categories.iter().map(|cat| counts.remove(cat)
+                    .unwrap_assert("categories are distinct and every category is in the map"))
+                    .chain(vec![null_count])
+                    .collect()
             }),
             MI::new(),
             MO::new(),

--- a/rust/opendp/src/trans/dataframe.rs
+++ b/rust/opendp/src/trans/dataframe.rs
@@ -260,32 +260,32 @@ impl<M> MakeTransformation1<VectorDomain<AllDomain<String>>, VectorDomain<Vector
 mod tests {
     use crate::core::ChainTT;
     use crate::dist::HammingDistance;
-    use crate::error::UnwrapAssert;
+    use crate::error::ExplainUnwrap;
 
     use super::*;
 
     #[test]
     fn test_make_split_lines() {
-        let transformation = SplitLines::<HammingDistance>::make().unwrap_assert();
+        let transformation = SplitLines::<HammingDistance>::make().unwrap_test();
         let arg = "ant\nbat\ncat\n".to_owned();
-        let ret = transformation.function.eval(&arg).unwrap_assert();
+        let ret = transformation.function.eval(&arg).unwrap_test();
         assert_eq!(ret, vec!["ant".to_owned(), "bat".to_owned(), "cat".to_owned()]);
     }
 
     #[test]
     fn test_make_parse_series() {
-        let transformation = ParseSeries::<i32, HammingDistance>::make(true).unwrap_assert();
+        let transformation = ParseSeries::<i32, HammingDistance>::make(true).unwrap_test();
         let arg = vec!["1".to_owned(), "2".to_owned(), "3".to_owned(), "foo".to_owned()];
-        let ret = transformation.function.eval(&arg).unwrap_assert();
+        let ret = transformation.function.eval(&arg).unwrap_test();
         let expected = vec![1, 2, 3, 0];
         assert_eq!(ret, expected);
     }
 
     #[test]
     fn test_make_split_records() {
-        let transformation = SplitRecords::<HammingDistance>::make(None).unwrap_assert();
+        let transformation = SplitRecords::<HammingDistance>::make(None).unwrap_test();
         let arg = vec!["ant, foo".to_owned(), "bat, bar".to_owned(), "cat, baz".to_owned()];
-        let ret = transformation.function.eval(&arg).unwrap_assert();
+        let ret = transformation.function.eval(&arg).unwrap_test();
         assert_eq!(ret, vec![
             vec!["ant".to_owned(), "foo".to_owned()],
             vec!["bat".to_owned(), "bar".to_owned()],
@@ -295,13 +295,13 @@ mod tests {
 
     #[test]
     fn test_make_create_dataframe() {
-        let transformation = CreateDataFrame::<HammingDistance, u32>::make(vec![0, 1]).unwrap_assert();
+        let transformation = CreateDataFrame::<HammingDistance, u32>::make(vec![0, 1]).unwrap_test();
         let arg = vec![
             vec!["ant".to_owned(), "foo".to_owned()],
             vec!["bat".to_owned(), "bar".to_owned()],
             vec!["cat".to_owned(), "baz".to_owned()],
         ];
-        let ret = transformation.function.eval(&arg).unwrap_assert();
+        let ret = transformation.function.eval(&arg).unwrap_test();
         let expected: DataFrame<u32> = vec![
             (0, Column::new(vec!["ant".to_owned(), "bat".to_owned(), "cat".to_owned()])),
             (1, Column::new(vec!["foo".to_owned(), "bar".to_owned(), "baz".to_owned()])),
@@ -311,9 +311,9 @@ mod tests {
 
     #[test]
     fn test_make_split_dataframe() {
-        let transformation = SplitDataFrame::<HammingDistance, String>::make(None, vec!["0".to_string(), "1".to_string()]).unwrap_assert();
+        let transformation = SplitDataFrame::<HammingDistance, String>::make(None, vec!["0".to_string(), "1".to_string()]).unwrap_test();
         let arg = "ant, foo\nbat, bar\ncat, baz".to_owned();
-        let ret = transformation.function.eval(&arg).unwrap_assert();
+        let ret = transformation.function.eval(&arg).unwrap_test();
         let expected: DataFrame<String> = vec![
             ("0".to_owned(), Column::new(vec!["ant".to_owned(), "bat".to_owned(), "cat".to_owned()])),
             ("1".to_owned(), Column::new(vec!["foo".to_owned(), "bar".to_owned(), "baz".to_owned()])),
@@ -323,12 +323,12 @@ mod tests {
 
     #[test]
     fn test_make_parse_column() {
-        let transformation = ParseColumn::<HammingDistance, i32>::make(1, true).unwrap_assert();
+        let transformation = ParseColumn::<HammingDistance, i32>::make(1, true).unwrap_test();
         let arg: DataFrame<usize> = vec![
             (0, Column::new(vec!["ant".to_owned(), "bat".to_owned(), "cat".to_owned()])),
             (1, Column::new(vec!["1".to_owned(), "2".to_owned(), "".to_owned()])),
         ].into_iter().collect();
-        let ret = transformation.function.eval(&arg).unwrap_assert();
+        let ret = transformation.function.eval(&arg).unwrap_test();
         let expected: DataFrame<usize> = vec![
             (0, Column::new(vec!["ant".to_owned(), "bat".to_owned(), "cat".to_owned()])),
             (1, Column::new(vec![1, 2, 0])),
@@ -338,15 +338,15 @@ mod tests {
 
     #[test]
     fn test_make_parse_columns() {
-        let transformation0 = ParseColumn::<HammingDistance, i32>::make("1".to_string(), true).unwrap_assert();
-        let transformation1 = ParseColumn::<HammingDistance, f64>::make("2".to_string(), true).unwrap_assert();
-        let transformation = ChainTT::make(&transformation1, &transformation0).unwrap_assert();
+        let transformation0 = ParseColumn::<HammingDistance, i32>::make("1".to_string(), true).unwrap_test();
+        let transformation1 = ParseColumn::<HammingDistance, f64>::make("2".to_string(), true).unwrap_test();
+        let transformation = ChainTT::make(&transformation1, &transformation0).unwrap_test();
         let arg: DataFrame<String> = vec![
             ("0".to_owned(), Column::new(vec!["ant".to_owned(), "bat".to_owned(), "cat".to_owned()])),
             ("1".to_owned(), Column::new(vec!["1".to_owned(), "2".to_owned(), "3".to_owned()])),
             ("2".to_owned(), Column::new(vec!["1.1".to_owned(), "2.2".to_owned(), "3.3".to_owned()])),
         ].into_iter().collect();
-        let ret = transformation.function.eval(&arg).unwrap_assert();
+        let ret = transformation.function.eval(&arg).unwrap_test();
         let expected: DataFrame<String> = vec![
             ("0".to_owned(), Column::new(vec!["ant".to_owned(), "bat".to_owned(), "cat".to_owned()])),
             ("1".to_owned(), Column::new(vec![1, 2, 3])),
@@ -357,12 +357,12 @@ mod tests {
 
     #[test]
     fn test_make_select_column() {
-        let transformation = SelectColumn::<HammingDistance, String>::make("1".to_owned()).unwrap_assert();
+        let transformation = SelectColumn::<HammingDistance, String>::make("1".to_owned()).unwrap_test();
         let arg: DataFrame<String> = vec![
             ("0".to_owned(), Column::new(vec!["ant".to_owned(), "bat".to_owned(), "cat".to_owned()])),
             ("1".to_owned(), Column::new(vec!["foo".to_owned(), "bar".to_owned(), "baz".to_owned()])),
         ].into_iter().collect();
-        let ret = transformation.function.eval(&arg).unwrap_assert();
+        let ret = transformation.function.eval(&arg).unwrap_test();
         let expected = vec!["foo".to_owned(), "bar".to_owned(), "baz".to_owned()];
         assert_eq!(ret, expected);
     }

--- a/rust/opendp/src/trans/manipulation.rs
+++ b/rust/opendp/src/trans/manipulation.rs
@@ -156,19 +156,19 @@ mod test_manipulations {
 
     #[test]
     fn test_unclamp() {
-        let clamp = Clamp::<SymmetricDistance, Vec<u8>>::make2(2, 3).unwrap();
-        let unclamp = Unclamp::<SymmetricDistance, Vec<u8>>::make2(2, 3).unwrap();
-        ChainTT::make(&clamp, &unclamp).unwrap();
+        let clamp = Clamp::<SymmetricDistance, Vec<u8>>::make2(2, 3).unwrap_test();
+        let unclamp = Unclamp::<SymmetricDistance, Vec<u8>>::make2(2, 3).unwrap_test();
+        ChainTT::make(&clamp, &unclamp).unwrap_test();
     }
 
     #[test]
     fn test_cast() {
         macro_rules! test_pair {
             ($from:ty, $to:ty) => {
-                let caster = Cast::<SymmetricDistance, Vec<$from>, Vec<$to>>::make().unwrap();
-                caster.function.eval(&vec!(<$from>::default())).unwrap();
-                let caster = Cast::<HammingDistance, Vec<$from>, Vec<$to>>::make().unwrap();
-                caster.function.eval(&vec!(<$from>::default())).unwrap();
+                let caster = Cast::<SymmetricDistance, Vec<$from>, Vec<$to>>::make().unwrap_test();
+                caster.function.eval(&vec!(<$from>::default())).unwrap_test();
+                let caster = Cast::<HammingDistance, Vec<$from>, Vec<$to>>::make().unwrap_test();
+                caster.function.eval(&vec!(<$from>::default())).unwrap_test();
             }
         }
         macro_rules! test_cartesian {
@@ -194,54 +194,57 @@ mod test_manipulations {
     }
 
     #[test]
-    fn test_cast_unsigned() {
-        let caster = Cast::<SymmetricDistance, Vec<f64>, Vec<u8>>::make().unwrap();
-        assert_eq!(caster.function.eval(&vec![-1.]).unwrap(), vec![u8::default()]);
+    fn test_cast_unsigned() -> Fallible<()> {
+        let caster = Cast::<SymmetricDistance, Vec<f64>, Vec<u8>>::make()?;
+        assert_eq!(caster.function.eval(&vec![-1.])?, vec![u8::default()]);
+        Ok(())
     }
     #[test]
-    fn test_cast_parse() {
+    fn test_cast_parse() -> Fallible<()> {
         let data = vec!["2".to_string(), "3".to_string(), "a".to_string(), "".to_string()];
 
-        let caster = Cast::<SymmetricDistance, Vec<String>, Vec<u8>>::make().unwrap();
-        assert_eq!(caster.function.eval(&data).unwrap(), vec![2, 3, u8::default(), u8::default()]);
+        let caster = Cast::<SymmetricDistance, Vec<String>, Vec<u8>>::make()?;
+        assert_eq!(caster.function.eval(&data)?, vec![2, 3, u8::default(), u8::default()]);
 
-        let caster = Cast::<SymmetricDistance, Vec<String>, Vec<f64>>::make().unwrap();
-        assert_eq!(caster.function.eval(&data).unwrap(), vec![2., 3., f64::default(), f64::default()]);
+        let caster = Cast::<SymmetricDistance, Vec<String>, Vec<f64>>::make()?;
+        assert_eq!(caster.function.eval(&data)?, vec![2., 3., f64::default(), f64::default()]);
+        Ok(())
     }
 
     #[test]
-    fn test_cast_floats() {
+    fn test_cast_floats() -> Fallible<()> {
         let data = vec![f64::NAN, f64::NEG_INFINITY, f64::INFINITY];
-        let caster = Cast::<SymmetricDistance, Vec<f64>, Vec<String>>::make().unwrap();
+        let caster = Cast::<SymmetricDistance, Vec<f64>, Vec<String>>::make()?;
         assert_eq!(
-            caster.function.eval(&data).unwrap(),
+            caster.function.eval(&data)?,
             vec!["NaN".to_string(), "-inf".to_string(), "inf".to_string()]);
 
-        let caster = Cast::<SymmetricDistance, Vec<f64>, Vec<u8>>::make().unwrap();
+        let caster = Cast::<SymmetricDistance, Vec<f64>, Vec<u8>>::make()?;
         assert_eq!(
-            caster.function.eval(&vec![f64::NAN, f64::NEG_INFINITY, f64::INFINITY]).unwrap(),
+            caster.function.eval(&vec![f64::NAN, f64::NEG_INFINITY, f64::INFINITY])?,
             vec![u8::default(), u8::default(), u8::default()]);
 
         let data = vec!["1e+2", "1e2", "1e+02", "1.e+02", "1.0E+02", "1.0E+00002", "01.E+02", "1.0E2"]
             .into_iter().map(|v| v.to_string()).collect();
-        let caster = Cast::<SymmetricDistance, Vec<String>, Vec<f64>>::make().unwrap();
-        assert!(caster.function.eval(&data).unwrap().into_iter().all(|v| v == 100.));
+        let caster = Cast::<SymmetricDistance, Vec<String>, Vec<f64>>::make()?;
+        assert!(caster.function.eval(&data)?.into_iter().all(|v| v == 100.));
+        Ok(())
     }
 
     #[test]
     fn test_identity() {
-        let identity = Identity::make(AllDomain::new(), HammingDistance).unwrap_assert();
+        let identity = Identity::make(AllDomain::new(), HammingDistance).unwrap_test();
         let arg = 99;
-        let ret = identity.function.eval(&arg).unwrap_assert();
+        let ret = identity.function.eval(&arg).unwrap_test();
         assert_eq!(ret, 99);
     }
 
 
     #[test]
     fn test_make_clamp() {
-        let transformation = Clamp::<HammingDistance, Vec<i32>>::make(0, 10).unwrap_assert();
+        let transformation = Clamp::<HammingDistance, Vec<i32>>::make(0, 10).unwrap_test();
         let arg = vec![-10, -5, 0, 5, 10, 20];
-        let ret = transformation.function.eval(&arg).unwrap_assert();
+        let ret = transformation.function.eval(&arg).unwrap_test();
         let expected = vec![0, 0, 0, 5, 10, 10];
         assert_eq!(ret, expected);
     }

--- a/rust/opendp/src/trans/manipulation.rs
+++ b/rust/opendp/src/trans/manipulation.rs
@@ -6,7 +6,7 @@ use num::One;
 
 use crate::core::{DatasetMetric, Domain, Function, Metric, StabilityRelation, Transformation};
 use crate::dom::{AllDomain, IntervalDomain, VectorDomain};
-use crate::error::Fallible;
+use crate::error::*;
 use crate::traits::{CastFrom, DistanceCast};
 use crate::trans::{MakeTransformation0, MakeTransformation2};
 
@@ -230,18 +230,18 @@ mod test_manipulations {
 
     #[test]
     fn test_identity() {
-        let identity = Identity::make(AllDomain::new(), HammingDistance).unwrap();
+        let identity = Identity::make(AllDomain::new(), HammingDistance).unwrap_assert();
         let arg = 99;
-        let ret = identity.function.eval(&arg).unwrap();
+        let ret = identity.function.eval(&arg).unwrap_assert();
         assert_eq!(ret, 99);
     }
 
 
     #[test]
     fn test_make_clamp() {
-        let transformation = Clamp::<HammingDistance, Vec<i32>>::make(0, 10).unwrap();
+        let transformation = Clamp::<HammingDistance, Vec<i32>>::make(0, 10).unwrap_assert();
         let arg = vec![-10, -5, 0, 5, 10, 20];
-        let ret = transformation.function.eval(&arg).unwrap();
+        let ret = transformation.function.eval(&arg).unwrap_assert();
         let expected = vec![0, 0, 0, 5, 10, 10];
         assert_eq!(ret, expected);
     }

--- a/rust/opendp/src/trans/mod.rs
+++ b/rust/opendp/src/trans/mod.rs
@@ -4,7 +4,7 @@
 //! Constructors are named in the form `make_xxx()`, where `xxx` indicates what the resulting `Transformation` does.
 
 use crate::core::{Domain, Metric};
-use crate::error::Fallible;
+use crate::error::*;
 pub use crate::trans::dataframe::*;
 
 pub mod dataframe;

--- a/rust/opendp/src/trans/sum.rs
+++ b/rust/opendp/src/trans/sum.rs
@@ -7,47 +7,43 @@ use std::ops::{Div, Mul, Sub};
 use crate::core::{DatasetMetric, Function, Metric, SensitivityMetric, StabilityRelation, Transformation};
 use crate::dist::{HammingDistance, SymmetricDistance};
 use crate::dom::{AllDomain, IntervalDomain, SizedDomain, VectorDomain};
-use crate::error::Fallible;
+use crate::error::*;
 use crate::traits::{Abs, DistanceCast};
 use crate::trans::{MakeTransformation2, MakeTransformation3};
 
-pub struct BoundedSum<MI, MO, T> {
+pub struct BoundedSum<MI, MO> {
     input_metric: PhantomData<MI>,
-    output_metric: PhantomData<MO>,
-    data: PhantomData<T>,
+    output_metric: PhantomData<MO>
 }
 
 fn max<T: PartialOrd>(a: T, b: T) -> Option<T> {
     a.partial_cmp(&b).map(|o| if let Ordering::Less = o {b} else {a})
 }
 
-pub trait BoundedSumConstant<MI: Metric, MO: Metric, T> {
-    fn get_stability(lower: MO::Distance, upper: MO::Distance) -> Fallible<StabilityRelation<MI, MO>>;
+pub trait BoundedSumConstant<MI: Metric, MO: Metric> {
+    fn get_stability_constant(lower: MO::Distance, upper: MO::Distance) -> Fallible<MO::Distance>;
 }
 
-impl<MO, T> BoundedSumConstant<HammingDistance, MO, T> for BoundedSum<HammingDistance, MO, T>
-    where MO: Metric<Distance=T>,
-          T: 'static + Clone + PartialOrd + Sub<Output=T> + Mul<Output=T> + Div<Output=T> + Sum<T> + DistanceCast {
-    fn get_stability(lower: T, upper: T) -> Fallible<StabilityRelation<HammingDistance, MO>> {
-        Ok(StabilityRelation::new_from_constant(upper - lower))
+impl<MO: Metric<Distance=T>, T> BoundedSumConstant<HammingDistance, MO> for BoundedSum<HammingDistance, MO>
+    where T: 'static + Sub<Output=T> {
+    fn get_stability_constant(lower: T, upper: T) -> Fallible<T> {
+        Ok(upper - lower)
     }
 }
 
-impl<MO, T> BoundedSumConstant<SymmetricDistance, MO, T> for BoundedSum<SymmetricDistance, MO, T>
-    where MO: Metric<Distance=T>,
-          T: 'static + Clone + PartialOrd + Sub<Output=T> + Mul<Output=T> + Div<Output=T> + Sum<T> + DistanceCast + Abs {
-    fn get_stability(lower: T, upper: T) -> Fallible<StabilityRelation<SymmetricDistance, MO>> {
+impl<MO: Metric<Distance=T>, T> BoundedSumConstant<SymmetricDistance, MO> for BoundedSum<SymmetricDistance, MO>
+    where T: 'static + PartialOrd + Abs {
+    fn get_stability_constant(lower: T, upper: T) -> Fallible<T> {
         max(lower.abs(), upper.abs())
             .ok_or_else(|| err!(InvalidDistance, "lower and upper must be comparable"))
-            .map(StabilityRelation::new_from_constant)
     }
 }
 
-impl<MI, MO, T> MakeTransformation2<VectorDomain<IntervalDomain<T>>, AllDomain<T>, MI, MO, T, T> for BoundedSum<MI, MO, T>
+impl<MI, MO, T> MakeTransformation2<VectorDomain<IntervalDomain<T>>, AllDomain<T>, MI, MO, T, T> for BoundedSum<MI, MO>
     where MI: DatasetMetric<Distance=u32>,
           MO: SensitivityMetric<Distance=T>,
           T: 'static + Clone + PartialOrd + Sub<Output=T> + Mul<Output=T> + Div<Output=T> + Sum<T> + DistanceCast,
-          Self: BoundedSumConstant<MI, MO, T> {
+          Self: BoundedSumConstant<MI, MO> {
     fn make2(lower: T, upper: T) -> Fallible<Transformation<VectorDomain<IntervalDomain<T>>, AllDomain<T>, MI, MO>> {
         if lower > upper { return fallible!(MakeTransformation, "lower bound may not be greater than upper bound") }
 
@@ -57,14 +53,13 @@ impl<MI, MO, T> MakeTransformation2<VectorDomain<IntervalDomain<T>>, AllDomain<T
             Function::new(|arg: &Vec<T>| arg.iter().cloned().sum()),
             MI::new(),
             MO::new(),
-            Self::get_stability(lower, upper)?))
+            StabilityRelation::new_from_constant(Self::get_stability_constant(lower, upper)?)))
     }
 }
 
-impl<MO, T> MakeTransformation3<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, SymmetricDistance, MO, T, T, usize> for BoundedSum<SymmetricDistance, MO, T>
+impl<MO, T> MakeTransformation3<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, SymmetricDistance, MO, T, T, usize> for BoundedSum<SymmetricDistance, MO>
     where MO: SensitivityMetric<Distance=T>,
-          T: 'static + Copy + PartialOrd + Sub<Output=T> + Mul<Output=T> + Div<Output=T> + Sum<T> + DistanceCast,
-          SymmetricDistance: Metric<Distance=u32> {
+          T: 'static + Copy + PartialOrd + Sub<Output=T> + Mul<Output=T> + Div<Output=T> + Sum<T> + DistanceCast {
     fn make3(lower: T, upper: T, length: usize) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, SymmetricDistance, MO>> {
         if lower > upper { return fallible!(MakeTransformation, "lower bound may not be greater than upper bound") }
 
@@ -88,18 +83,18 @@ mod tests {
 
     #[test]
     fn test_make_bounded_sum_l1() {
-        let transformation = BoundedSum::<HammingDistance, L1Sensitivity<_>, i32>::make(0, 10).unwrap();
+        let transformation = BoundedSum::<HammingDistance, L1Sensitivity<i32>>::make(0, 10).unwrap_assert();
         let arg = vec![1, 2, 3, 4, 5];
-        let ret = transformation.function.eval(&arg).unwrap();
+        let ret = transformation.function.eval(&arg).unwrap_assert();
         let expected = 15;
         assert_eq!(ret, expected);
     }
 
     #[test]
     fn test_make_bounded_sum_l2() {
-        let transformation = BoundedSum::<HammingDistance, L2Sensitivity<_>, i32>::make(0, 10).unwrap();
+        let transformation = BoundedSum::<HammingDistance, L2Sensitivity<i32>>::make(0, 10).unwrap_assert();
         let arg = vec![1, 2, 3, 4, 5];
-        let ret = transformation.function.eval(&arg).unwrap();
+        let ret = transformation.function.eval(&arg).unwrap_assert();
         let expected = 15;
         assert_eq!(ret, expected);
     }

--- a/rust/opendp/src/trans/sum.rs
+++ b/rust/opendp/src/trans/sum.rs
@@ -83,18 +83,18 @@ mod tests {
 
     #[test]
     fn test_make_bounded_sum_l1() {
-        let transformation = BoundedSum::<HammingDistance, L1Sensitivity<i32>>::make(0, 10).unwrap_assert();
+        let transformation = BoundedSum::<HammingDistance, L1Sensitivity<i32>>::make(0, 10).unwrap_test();
         let arg = vec![1, 2, 3, 4, 5];
-        let ret = transformation.function.eval(&arg).unwrap_assert();
+        let ret = transformation.function.eval(&arg).unwrap_test();
         let expected = 15;
         assert_eq!(ret, expected);
     }
 
     #[test]
     fn test_make_bounded_sum_l2() {
-        let transformation = BoundedSum::<HammingDistance, L2Sensitivity<i32>>::make(0, 10).unwrap_assert();
+        let transformation = BoundedSum::<HammingDistance, L2Sensitivity<i32>>::make(0, 10).unwrap_test();
         let arg = vec![1, 2, 3, 4, 5];
-        let ret = transformation.function.eval(&arg).unwrap_assert();
+        let ret = transformation.function.eval(&arg).unwrap_test();
         let expected = 15;
         assert_eq!(ret, expected);
     }


### PR DESCRIPTION
Closes #67 

- add From impls for common error handling paths. Example:
    * in opendp-ffi/src/trans.rs, `count::Count::<MI, MO, T>::make().into()` builds an `FfiResult<*mut FfiTransformation>`
- Add `ExplainUnwrap` trait for `.unwrap_assert()` and `.unwrap_test()`, to make it easier to identify leftover `.unwrap()`s
    * By convention, replace unwrap with unwrap_test in tests
    * By convention, replace unwrap with unwrap_assert in library code where panics should be unreachable
- Replace `assert_eq!`, `assert!`, `unwrap`, `expect` with error handling throughout the library
    * there are still some cases that can cause panics- these should now be easy to identify
- Add `try_!` macro to substitute for ? when the return is FfiResult. This is based on the deprecated std try! macro.
- Add `try_as_ref!` for dereferencing raw pointers with error handling.
- Updated the composition internals to look like the chainers.
- The monomorphize function in the dispatch macro must now return an FfiResult or Result. 
- Added an FFI variant to the ErrorVariant enum.
- TypeArgs::expect -> TypeArgs::parse; remove the TypeError struct
- More verbose errors for parsing strings
- Check that categories are distinct in CountByCategories, to prevent a double-remove panic and unbounded stability