### PR TITLE
Expanded data loaders/unloaders

### DIFF
--- a/python/example/stability_mechanism.py
+++ b/python/example/stability_mechanism.py
@@ -38,7 +38,7 @@ def privatize_vocabulary(word_count, line_count, budget):
 
     vocabulary = set()
     for word in word_count:
-        privatized_count = odp.measurement_invoke(laplace_mechanism, word_count[word])
+        privatized_count = odp.measurement_invoke(laplace_mechanism, word_count[word], type_name="<f64>")
         if privatized_count >= threshold:
             vocabulary.add(word)
 

--- a/python/test/test_opendp.py
+++ b/python/test/test_opendp.py
@@ -8,36 +8,36 @@ def test_init():
 def test_data_object_int():
     odp = opendp.OpenDP()
     val_in = 123
-    obj = odp.py_to_obj(val_in)
-    val_out = odp.obj_to_py(obj)
+    obj = odp.py_to_object(val_in)
+    val_out = odp.object_to_py(obj)
     assert val_out == val_in
 
 def test_data_object_float():
     odp = opendp.OpenDP()
     val_in = 123.123
-    obj = odp.py_to_obj(val_in)
-    val_out = odp.obj_to_py(obj)
+    obj = odp.py_to_object(val_in)
+    val_out = odp.object_to_py(obj)
     assert val_out == val_in
 
 def test_data_object_str():
     odp = opendp.OpenDP()
     val_in = "hello, world"
-    obj = odp.py_to_obj(val_in)
-    val_out = odp.obj_to_py(obj)
+    obj = odp.py_to_object(val_in)
+    val_out = odp.object_to_py(obj)
     assert val_out == val_in
 
 def test_data_object_list():
     odp = opendp.OpenDP()
     val_in = [1, 2, 3]
-    obj = odp.py_to_obj(val_in)
-    val_out = odp.obj_to_py(obj)
+    obj = odp.py_to_object(val_in)
+    val_out = odp.object_to_py(obj)
     assert val_out == val_in
 
 def test_data_object_tuple():
     odp = opendp.OpenDP()
     val_in = (1., 1e-7)
-    obj = odp.py_to_obj(val_in)
-    val_out = odp.obj_to_py(obj)
+    obj = odp.py_to_object(val_in)
+    val_out = odp.object_to_py(obj)
     assert val_out == val_in
 
 def test_identity_int():

--- a/python/test/test_opendp.py
+++ b/python/test/test_opendp.py
@@ -33,6 +33,13 @@ def test_data_object_list():
     val_out = odp.obj_to_py(obj)
     assert val_out == val_in
 
+def test_data_object_tuple():
+    odp = opendp.OpenDP()
+    val_in = (1., 1e-7)
+    obj = odp.py_to_obj(val_in)
+    val_out = odp.obj_to_py(obj)
+    print(val_out)
+test_data_object_tuple()
 def test_identity_int():
     odp = opendp.OpenDP()
     transformation = odp.trans.make_identity(b"<i32>")

--- a/python/test/test_opendp.py
+++ b/python/test/test_opendp.py
@@ -38,8 +38,8 @@ def test_data_object_tuple():
     val_in = (1., 1e-7)
     obj = odp.py_to_obj(val_in)
     val_out = odp.obj_to_py(obj)
-    print(val_out)
-test_data_object_tuple()
+    assert val_out == val_in
+
 def test_identity_int():
     odp = opendp.OpenDP()
     transformation = odp.trans.make_identity(b"<i32>")

--- a/rust/opendp-ffi/src/core.rs
+++ b/rust/opendp-ffi/src/core.rs
@@ -1,7 +1,7 @@
 use std::{fmt, ptr};
-use std::ffi::{CStr, c_void};
+use std::ffi::{c_void, CStr};
 use std::fmt::{Debug, Formatter};
-use std::mem::{transmute, ManuallyDrop};
+use std::mem::{ManuallyDrop, transmute};
 use std::os::raw::c_char;
 
 use opendp::{err, fallible};
@@ -10,8 +10,7 @@ use opendp::core::{ChainMT, ChainTT, Domain, Measure, MeasureGlue, Measurement, 
 use opendp::error::Error;
 
 use crate::util;
-use crate::util::{Type, c_bool};
-
+use crate::util::{c_bool, Type};
 
 #[derive(PartialEq)]
 pub enum FfiOwnership {
@@ -53,6 +52,12 @@ impl Drop for FfiObject {
             unsafe { ManuallyDrop::drop(&mut self.value) };
         }
     }
+}
+
+#[repr(C)]
+pub struct FfiTuple2 {
+    pub _0: *const c_void,
+    pub _1: *const c_void,
 }
 
 #[repr(C)]
@@ -248,7 +253,7 @@ pub extern "C" fn opendp_core__measurement_check(this: *const FfiMeasurement, di
     let distance_out = util::as_ref(distance_out);
     let res = this.value.privacy_relation.eval(&distance_in.value, &distance_out.value);
 
-    FfiResult::new(res.map(|v| util::into_raw(if v {1} else {0})))
+    FfiResult::new(res.map(util::from_bool).map(util::into_raw))
 }
 
 #[no_mangle]

--- a/rust/opendp-ffi/src/core.rs
+++ b/rust/opendp-ffi/src/core.rs
@@ -55,12 +55,6 @@ impl Drop for FfiObject {
 }
 
 #[repr(C)]
-pub struct FfiTuple2 {
-    pub _0: *const c_void,
-    pub _1: *const c_void,
-}
-
-#[repr(C)]
 pub struct FfiSlice {
     pub ptr: *const c_void,
     pub len: usize,
@@ -261,7 +255,7 @@ pub extern "C" fn opendp_core__measurement_invoke(this: *const FfiMeasurement, a
     let this = util::as_ref(this);
     let arg = util::as_ref(arg);
     if arg.type_ != this.input_glue.domain_carrier {
-        return FfiResult::new(fallible!(DomainMismatch))
+        return FfiResult::new(fallible!(DomainMismatch, "arg type does not match input domain"))
     }
     let res_type = this.output_glue.domain_carrier.clone();
     let res = this.value.function.eval_ffi(&arg.value);
@@ -279,7 +273,7 @@ pub extern "C" fn opendp_core__transformation_invoke(this: *const FfiTransformat
     let this = util::as_ref(this);
     let arg = util::as_ref(arg);
     if arg.type_ != this.input_glue.domain_carrier {
-        return FfiResult::new(fallible!(DomainMismatch))
+        return FfiResult::new(fallible!(DomainMismatch, "arg type does not match input domain"))
     }
     let res_type = this.output_glue.domain_carrier.clone();
     let res = this.value.function.eval_ffi(&arg.value);
@@ -310,7 +304,7 @@ pub extern "C" fn opendp_core__make_chain_mt(measurement1: *const FfiMeasurement
     } = measurement1;
 
     if output_glue0.domain_type != input_glue1.domain_type {
-        return FfiResult::new(fallible!(DomainMismatch))
+        return FfiResult::new(fallible!(DomainMismatch, "chained domain types do not match"))
     }
 
     let measurement = ChainMT::make_chain_mt_glue(
@@ -342,7 +336,7 @@ pub extern "C" fn opendp_core__make_chain_tt(transformation1: *const FfiTransfor
     } = transformation1;
 
     if output_glue0.domain_type != input_glue1.domain_type {
-        return FfiResult::new(fallible!(DomainMismatch))
+        return FfiResult::new(fallible!(DomainMismatch, "chained domain types do not match"))
     }
 
     let transformation = ChainTT::make_chain_tt_glue(
@@ -362,7 +356,7 @@ pub extern "C" fn opendp_core__make_composition(measurement0: *const FfiMeasurem
     let measurement0 = util::as_ref(measurement0);
     let measurement1 = util::as_ref(measurement1);
     if measurement0.input_glue.domain_type != measurement1.input_glue.domain_type {
-        return FfiResult::new(fallible!(DomainMismatch))
+        return FfiResult::new(fallible!(DomainMismatch, "chained domain types do not match"))
     }
     let input_glue = measurement0.input_glue.clone();
     let output_glue0 = measurement0.output_glue.clone();

--- a/rust/opendp-ffi/src/data.rs
+++ b/rust/opendp-ffi/src/data.rs
@@ -102,7 +102,7 @@ pub extern "C" fn opendp_data__object_as_raw(obj: *const FfiObject) -> FfiResult
     }
     fn tuple_to_raw<T0: 'static + Clone, T1: 'static + Clone>(obj: &FfiObject) -> *mut FfiSlice {
         let tuple: &(T0, T1) = obj.as_ref();
-        let arr = vec![
+        let arr = [
             util::into_raw(tuple.0.clone()) as *const T0 as *const c_void,
             util::into_raw(tuple.1.clone()) as *const T1 as *const c_void
         ];

--- a/rust/opendp-ffi/src/data.rs
+++ b/rust/opendp-ffi/src/data.rs
@@ -34,12 +34,12 @@ pub extern "C" fn opendp_data__object_new(type_args: *const c_char, raw: *const 
     fn raw_to_tuple<T0: Clone + Debug, T1: Clone>(raw: &FfiSlice) -> *const c_void {
         assert_eq!(raw.len, 2);
         let tuple = (
+            // offset the c_void pointer by the size of a c_void pointer
             // cast inner c_void to a pointer to c_void
-            // offset the outer pointer by the size of a c_void pointer
             // dereference twice, place behind a direct reference
             // clone the data behind the direct reference
-            unsafe {&**(raw.ptr as *const *const T0).offset(0)}.clone(),
-            unsafe {&**(raw.ptr as *const *const T1).offset(1)}.clone(),
+            unsafe {&**(raw.ptr.offset(0) as *const *const T0)}.clone(),
+            unsafe {&**(raw.ptr.offset(1) as *const *const T1)}.clone(),
         );
         util::into_raw(tuple) as *const c_void
     }

--- a/rust/opendp-ffi/src/data.rs
+++ b/rust/opendp-ffi/src/data.rs
@@ -7,12 +7,12 @@ use opendp::data::Column;
 
 use crate::core::{FfiObject, FfiOwnership, FfiResult, FfiSlice};
 use crate::util;
-use crate::util::{Type, TypeArgs, TypeContents};
+use crate::util::{Type, TypeArgs, TypeContents, c_bool};
 use std::fmt::Debug;
 use opendp::error::Fallible;
 
 #[no_mangle]
-pub extern "C" fn opendp_data__object_new(type_args: *const c_char, raw: *const FfiSlice) -> FfiResult<*mut FfiObject> {
+pub extern "C" fn opendp_data__slice_as_object(type_args: *const c_char, raw: *const FfiSlice) -> FfiResult<*mut FfiObject> {
     fn raw_to_plain<T: Clone>(raw: &FfiSlice) -> *const c_void {
         assert_eq!(raw.len, 1);
         let plain = util::as_ref(raw.ptr as *const T).clone();
@@ -80,7 +80,7 @@ pub extern "C" fn opendp_data__object_type(this: *mut FfiObject) -> FfiResult<*m
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_data__object_as_raw(obj: *const FfiObject) -> FfiResult<*mut FfiSlice> {
+pub extern "C" fn opendp_data__object_as_slice(obj: *const FfiObject) -> FfiResult<*mut FfiSlice> {
     fn plain_to_raw(obj: &FfiObject) -> *mut FfiSlice {
         let plain: &c_void = obj.as_ref();
         FfiSlice::new(plain as *const c_void as *mut c_void, 1)
@@ -145,6 +145,16 @@ pub extern "C" fn opendp_data__slice_free(this: *mut FfiSlice) {
     util::into_owned(this);
 }
 
+#[no_mangle]
+pub extern "C" fn opendp_data__str_free(this: *mut c_char) {
+    util::into_owned(this);
+}
+
+#[no_mangle]
+pub extern "C" fn opendp_data__bool_free(this: *mut c_bool) {
+    util::into_owned(this);
+}
+
 // TODO: Remove this function once we have composition and/or tuples sorted out.
 #[no_mangle]
 pub extern "C" fn opendp_data__to_string(this: *const FfiObject) -> *const c_char {
@@ -174,11 +184,13 @@ pub extern "C" fn opendp_data__bootstrap() -> *const c_char {
 r#"{
 "functions": [
     { "name": "to_string", "args": [ ["const FfiObject *", "this"] ], "ret": "const char *" },
-    { "name": "object_new", "args": [ ["const char *", "type_args"], ["const void *", "raw"] ], "ret": "FfiResult<const FfiObject *>" },
+    { "name": "slice_as_object", "args": [ ["const char *", "type_args"], ["const void *", "raw"] ], "ret": "FfiResult<const FfiObject *>" },
     { "name": "object_type", "args": [ ["const FfiObject *", "this"] ], "ret": "FfiResult<const char *>" },
-    { "name": "object_as_raw", "args": [ ["const FfiObject *", "this"] ], "ret": "FfiResult<const FfiSlice *>" },
+    { "name": "object_as_slice", "args": [ ["const FfiObject *", "this"] ], "ret": "FfiResult<const FfiSlice *>" },
     { "name": "object_free", "args": [ ["FfiObject *", "this"] ] },
-    { "name": "slice_free", "args": [ ["FfiSlice *", "this"] ] }
+    { "name": "slice_free", "args": [ ["FfiSlice *", "this"] ] },
+    { "name": "str_free", "args": [ ["const char *", "this"] ] },
+    { "name": "bool_free", "args": [ ["bool *", "this"] ] }
 ]
 }"#;
     util::bootstrap(spec)
@@ -196,7 +208,7 @@ mod tests {
         let raw_ptr = util::into_raw(val_in) as *mut c_void;
         let raw_len = 1;
         let raw = FfiSlice::new(raw_ptr, raw_len);
-        let res = opendp_data__object_new(util::into_c_char_p("<i32>".to_owned()), raw);
+        let res = opendp_data__slice_as_object(util::into_c_char_p("<i32>".to_owned()), raw);
         match res {
             FfiResult::Ok(obj) => {
                 let obj = util::as_ref(obj);
@@ -214,7 +226,7 @@ mod tests {
         let raw_ptr = util::into_c_char_p(val_in.clone()) as *mut c_void;
         let raw_len = val_in.len() + 1;
         let raw = FfiSlice::new(raw_ptr, raw_len);
-        let res = opendp_data__object_new(util::into_c_char_p("<String>".to_owned()), raw);
+        let res = opendp_data__slice_as_object(util::into_c_char_p("<String>".to_owned()), raw);
         match res {
             FfiResult::Ok(obj) => {
                 let obj = util::as_ref(obj);
@@ -232,7 +244,7 @@ mod tests {
         let raw_ptr = val_in.as_ptr() as *mut c_void;
         let raw_len = val_in.len();
         let raw = FfiSlice::new(raw_ptr, raw_len);
-        let res = opendp_data__object_new(util::into_c_char_p("<Vec<i32>>".to_owned()), raw);
+        let res = opendp_data__slice_as_object(util::into_c_char_p("<Vec<i32>>".to_owned()), raw);
         match res {
             FfiResult::Ok(obj) => {
                 let obj = util::as_ref(obj);
@@ -248,7 +260,7 @@ mod tests {
     fn test_data_as_raw_number() {
         let val_in = 999;
         let obj = FfiObject::new_from_type(val_in);
-        let res = opendp_data__object_as_raw(obj);
+        let res = opendp_data__object_as_slice(obj);
         match res {
             FfiResult::Ok(obj) => {
                 let raw = util::as_ref(obj);
@@ -266,7 +278,7 @@ mod tests {
     fn test_data_as_raw_string() {
         let val_in = "Hello".to_owned();
         let obj = FfiObject::new_from_type(val_in.clone());
-        let res = opendp_data__object_as_raw(obj);
+        let res = opendp_data__object_as_slice(obj);
         match res {
             FfiResult::Ok(obj) => {
                 let raw = util::as_ref(obj);
@@ -284,7 +296,7 @@ mod tests {
     fn test_data_as_raw_vec() {
         let val_in = vec![1, 2, 3];
         let obj = FfiObject::new_from_type(val_in.clone());
-        let res = opendp_data__object_as_raw(obj);
+        let res = opendp_data__object_as_slice(obj);
         match res {
             FfiResult::Ok(obj) => {
                 let raw = util::as_ref(obj);

--- a/rust/opendp-ffi/src/trans.rs
+++ b/rust/opendp-ffi/src/trans.rs
@@ -33,7 +33,7 @@ pub extern "C" fn opendp_trans__make_identity(type_args: *const c_char) -> *mut 
     }
     let type_args = TypeArgs::expect(type_args, 1);
     match &type_args.0[0].contents {
-        TypeContents::VEC(element_id) => dispatch!(monomorphize_vec, [(Type::of_id(*element_id), @primitives)], ()),
+        TypeContents::VEC(element_id) => dispatch!(monomorphize_vec, [(Type::of_id(*element_id).unwrap(), @primitives)], ()),
         _ => dispatch!(monomorphize_scalar, [(&type_args.0[0], @primitives)], ())
     }
 }

--- a/rust/opendp-ffi/src/util.rs
+++ b/rust/opendp-ffi/src/util.rs
@@ -7,6 +7,8 @@ use std::ffi::CString;
 use std::os::raw::c_char;
 
 use opendp::dist::{L1Sensitivity, L2Sensitivity, HammingDistance, SymmetricDistance};
+use opendp::error::*;
+use opendp::{err};
 
 #[derive(Debug)]
 pub struct TypeError;
@@ -45,8 +47,8 @@ impl Type {
         Self::new(TypeId::of::<T>(), descriptor, TypeContents::PLAIN(descriptor))
     }
 
-    pub fn of_id(id: TypeId) -> Self {
-        TYPE_ID_TO_TYPE.get(&id).unwrap().clone()
+    pub fn of_id(id: TypeId) -> Fallible<Self> {
+        TYPE_ID_TO_TYPE.get(&id).cloned().ok_or_else(|| err!(UnknownType))
     }
 
     // Hacky special entry point for composition.

--- a/rust/opendp/src/error.rs
+++ b/rust/opendp/src/error.rs
@@ -48,6 +48,9 @@ pub enum ErrorVariant {
     #[error("{0}")]
     Raw(Box<dyn std::error::Error>),
 
+    #[error("UnknownType")]
+    UnknownType,
+
     #[error("Failed function execution")]
     FailedFunction,
 

--- a/rust/opendp/src/error.rs
+++ b/rust/opendp/src/error.rs
@@ -51,8 +51,11 @@ pub enum ErrorVariant {
     #[error("Failed function execution")]
     FailedFunction,
 
-    #[error("Failed relation")]
+    #[error("FailedRelation")]
     FailedRelation,
+
+    #[error("RelationDebug")]
+    RelationDebug,
 
     #[error("Unable to cast type")]
     FailedCast,

--- a/rust/opendp/src/meas/stability.rs
+++ b/rust/opendp/src/meas/stability.rs
@@ -67,9 +67,9 @@ impl<MI, TIK, TIC, TOC> MakeMeasurement3<CountDomain<TIK, TIC>, CountDomain<TIK,
             MI::new(),
             SmoothedMaxDivergence::new(),
             PrivacyRelation::new_fallible(move |&d_in: &TOC, &(eps, del): &(TOC, TOC)|{
-                let _eps: f64 = NumCast::from(eps).unwrap();
-                let _del: f64 = NumCast::from(del).unwrap();
-                println!("eps, del: {:?}, {:?}", _eps, _del);
+                // let _eps: f64 = NumCast::from(eps).unwrap();
+                // let _del: f64 = NumCast::from(del).unwrap();
+                // println!("eps, del: {:?}, {:?}", _eps, _del);
                 let ideal_scale = d_in / (eps * _n);
                 let ideal_threshold = (_2 / del).ln() * ideal_scale + _n.recip();
                 // println!("ideal: {:?}, {:?}", ideal_sigma, ideal_threshold);

--- a/rust/opendp/src/meas/stability.rs
+++ b/rust/opendp/src/meas/stability.rs
@@ -67,6 +67,9 @@ impl<MI, TIK, TIC, TOC> MakeMeasurement3<CountDomain<TIK, TIC>, CountDomain<TIK,
             MI::new(),
             SmoothedMaxDivergence::new(),
             PrivacyRelation::new_fallible(move |&d_in: &TOC, &(eps, del): &(TOC, TOC)|{
+                let _eps: f64 = NumCast::from(eps).unwrap();
+                let _del: f64 = NumCast::from(del).unwrap();
+                println!("eps, del: {:?}, {:?}", _eps, _del);
                 let ideal_scale = d_in / (eps * _n);
                 let ideal_threshold = (_2 / del).ln() * ideal_scale + _n.recip();
                 // println!("ideal: {:?}, {:?}", ideal_sigma, ideal_threshold);
@@ -75,19 +78,19 @@ impl<MI, TIK, TIC, TOC> MakeMeasurement3<CountDomain<TIK, TIC>, CountDomain<TIK,
                     return fallible!(FailedRelation, "cause: epsilon <= 0")
                 }
                 if eps >= _n.ln() {
-                    return fallible!(FailedRelation, "cause: epsilon >= n.ln()");
+                    return fallible!(RelationDebug, "cause: epsilon >= n.ln()");
                 }
                 if del.is_sign_negative() || del.is_zero() {
                     return fallible!(FailedRelation, "cause: delta <= 0")
                 }
                 if del >= _n.recip() {
-                    return fallible!(FailedRelation, "cause: del >= n.ln()");
+                    return fallible!(RelationDebug, "cause: del >= n.ln()");
                 }
                 if scale < ideal_scale {
-                    return fallible!(FailedRelation, "cause: scale < d_in / (epsilon * n)")
+                    return fallible!(RelationDebug, "cause: scale < d_in / (epsilon * n)")
                 }
                 if threshold < ideal_threshold {
-                    return fallible!(FailedRelation, "cause: threshold < (2. / delta).ln() * d_in / (epsilon * n) + 1. / n");
+                    return fallible!(RelationDebug, "cause: threshold < (2. / delta).ln() * d_in / (epsilon * n) + 1. / n");
                 }
                 return Ok(true)
             })))


### PR DESCRIPTION
closes #77 

- adds a new error variant "RelationDebug" to pass messages to Python, as well as a measurement_check function
     * the error variant is likely temporary
- refactored python data loader to have more type checking and support more data types
- data loader/unloader for tuples via void* slices
     * modified descriptor parser to keep tuples together in one descriptor, instead of just splitting by comma
- stability relation example works again
- OdpException.cls -> .variant
- OpenDP.py_to_obj now takes an optional type argument for explicit typing
- print out a warning for errors masked by obj_to_py failures
- adds de-allocation methods for strings and bools
- de-allocate relation checks, ffi slices and type strings once parsed into python