### PR TITLE
Interactive Measurements (and type-erased component types)

### DIFF
--- a/rust/opendp-ffi/src/core.rs
+++ b/rust/opendp-ffi/src/core.rs
@@ -193,7 +193,7 @@ impl Domain for FfiDomain {
     fn member(&self, _val: &Self::Carrier) -> bool { unreachable!() }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct FfiMeasure;
 impl Default for FfiMeasure {
     fn default() -> Self { FfiMeasure }
@@ -202,7 +202,7 @@ impl Measure for FfiMeasure {
     type Distance = ();
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct FfiMetric;
 impl Default for FfiMetric {
     fn default() -> Self { FfiMetric }

--- a/rust/opendp/src/any.rs
+++ b/rust/opendp/src/any.rs
@@ -274,14 +274,6 @@ impl Metric for AnyMetric {
 }
 
 impl<DI: Domain, DO: Domain> Function<DI, DO> where DI::Carrier: 'static, DO::Carrier: 'static {
-    pub fn as_any_out(&self) -> Function<DI, AnyDomain> {
-        let function = self.function.clone();
-        let function = move |arg: &DI::Carrier| -> Fallible<Box<dyn Any>> {
-            let res = function(arg);
-            res.map(|o| Box::new(*o) as Box<dyn Any>)
-        };
-        Function::new_fallible(function)
-    }
     pub fn as_any(&self) -> Function<AnyDomain, AnyDomain> {
         let function = self.function.clone();
         let function = move |arg: &Box<dyn Any>| -> Fallible<Box<dyn Any>> {
@@ -344,16 +336,6 @@ impl<DI: 'static + Domain, DO: 'static + Domain, MI: 'static + Metric, MO: 'stat
           DO::Carrier: 'static,
           MI::Distance: 'static + Clone + PartialOrd,
           MO::Distance: 'static + Clone + PartialOrd {
-    pub fn into_any_out(self) -> Measurement<DI, AnyDomain, MI, MO> {
-        Measurement::new(
-            *self.input_domain,
-            AnyDomain::new(*self.output_domain),
-            self.function.as_any_out(),
-            *self.input_metric,
-            *self.output_measure,
-            self.privacy_relation,
-        )
-    }
     pub fn into_any(self) -> Measurement<AnyDomain, AnyDomain, AnyMetric, AnyMeasure> {
         Measurement::new(
             AnyDomain::new(*self.input_domain),
@@ -371,16 +353,6 @@ impl<DI: 'static + Domain, DO: 'static + Domain, MI: 'static + Metric, MO: 'stat
           DO::Carrier: 'static,
           MI::Distance: 'static + Clone + PartialOrd,
           MO::Distance: 'static + Clone + PartialOrd {
-    pub fn into_any_out(self) -> Transformation<DI, AnyDomain, MI, MO> {
-        Transformation::new(
-            *self.input_domain,
-            AnyDomain::new(*self.output_domain),
-            self.function.as_any_out(),
-            *self.input_metric,
-            *self.output_metric,
-            self.stability_relation,
-        )
-    }
     pub fn into_any(self) -> Transformation<AnyDomain, AnyDomain, AnyMetric, AnyMetric> {
         Transformation::new(
             AnyDomain::new(*self.input_domain),

--- a/rust/opendp/src/any.rs
+++ b/rust/opendp/src/any.rs
@@ -1,0 +1,421 @@
+use std::any::Any;
+use std::cmp::Ordering;
+use std::rc::Rc;
+
+use crate::core::{Domain, Function, Measure, Measurement, Metric, PrivacyRelation, StabilityRelation, Transformation};
+use crate::error::*;
+use crate::traits::{FallibleSub, MeasureDistance, MetricDistance};
+
+pub trait Downcast {
+    fn downcast<T: 'static>(self) -> Fallible<T>;
+    fn downcast_ref<T: 'static>(&self) -> Fallible<&T>;
+}
+
+pub struct AnyBox {
+    value: Box<dyn Any>,
+    eq_glue: Rc<dyn Fn(&Self, &Self) -> bool>,
+}
+
+impl AnyBox {
+    pub fn new<T: 'static + PartialEq>(value: T) -> Self {
+        let eq_ = |self_: &Self, other: &Self| {
+            // This downcast of self will always succeed, so equality check is all that's necessary.
+            self_.value.downcast_ref::<T>() == other.value.downcast_ref::<T>()
+        };
+        Self {
+            value: Box::new(value),
+            eq_glue: Rc::new(eq_),
+        }
+    }
+}
+
+impl PartialEq for AnyBox {
+    fn eq(&self, other: &Self) -> bool {
+        (self.eq_glue)(self, other)
+    }
+}
+
+impl Downcast for AnyBox {
+    fn downcast<T: 'static>(self) -> Fallible<T> {
+        self.value.downcast().map_or_else(|_| fallible!(FailedCast), |v| *v)
+    }
+    fn downcast_ref<T: 'static>(&self) -> Fallible<&T> {
+        self.value.downcast_ref().ok_or_else(|| err!(FailedCast))
+    }
+}
+
+pub struct CloneableAnyBox {
+    value: Box<dyn Any>,
+    eq_glue: Rc<dyn Fn(&Self, &Self) -> bool>,
+    clone_glue: Rc<dyn Fn(&Self) -> Self>,
+}
+
+impl CloneableAnyBox {
+    pub fn new<T: 'static + PartialEq + Clone>(value: T) -> Self {
+        let eq_ = |self_: &Self, other: &Self| {
+            // This downcast of self will always succeed, so equality check is all that's necessary.
+            self_.value.downcast_ref::<T>() == other.value.downcast_ref::<T>()
+        };
+        let clone_ = |self_: &Self| {
+            Self {
+                value: Box::new(self_.value.downcast_ref::<T>().unwrap().clone()),
+                eq_glue: self_.eq_glue.clone(),
+                clone_glue: self_.clone_glue.clone(),
+            }
+        };
+        Self {
+            value: Box::new(value),
+            eq_glue: Rc::new(eq_),
+            clone_glue: Rc::new(clone_),
+        }
+    }
+}
+
+impl PartialEq for CloneableAnyBox {
+    fn eq(&self, other: &Self) -> bool {
+        (self.eq_glue)(self, other)
+    }
+}
+
+impl Clone for CloneableAnyBox {
+    fn clone(&self) -> Self {
+        (self.clone_glue)(self)
+    }
+}
+
+impl Downcast for CloneableAnyBox {
+    fn downcast<T: 'static>(self) -> Fallible<T> {
+        self.value.downcast().map_or_else(|_| fallible!(FailedCast), |v| *v)
+    }
+    fn downcast_ref<T: 'static>(&self) -> Fallible<&T> {
+        self.value.downcast_ref().ok_or_else(|| err!(FailedCast))
+    }
+}
+
+
+#[derive(Clone)]
+pub struct AnyDomain {
+    pub domain: CloneableAnyBox,
+    pub member_glue: Rc<dyn Fn(&Self, &dyn Any) -> bool>,
+}
+
+impl AnyDomain {
+    pub fn new<D: 'static + Domain>(domain: D) -> Self {
+        Self {
+            domain: CloneableAnyBox::new(domain),
+            member_glue: Rc::new(|self_: &Self, val: &dyn Any| {
+                let self_ = self_.downcast_ref::<D>().unwrap_assert("downcast of AnyDomain to constructed type will always work");
+                let val = val.downcast_ref::<D::Carrier>();
+                // FIXME: Return a Fallible here for bad downcast (https://github.com/opendp/opendp/issues/87)
+                val.map_or(false, |v| self_.member(v))
+            }),
+        }
+    }
+}
+
+impl PartialEq for AnyDomain {
+    fn eq(&self, other: &Self) -> bool {
+        self.domain == other.domain
+    }
+}
+
+impl Domain for AnyDomain {
+    type Carrier = Box<dyn Any>;
+    fn member(&self, val: &Self::Carrier) -> bool {
+        (self.member_glue)(self, val)
+    }
+}
+
+impl Downcast for AnyDomain {
+    fn downcast<T: 'static>(self) -> Fallible<T> {
+        self.domain.downcast()
+    }
+    fn downcast_ref<T: 'static>(&self) -> Fallible<&T> {
+        self.domain.downcast_ref()
+    }
+}
+
+// TODO: If/when we remove the clone of the budget from make_adaptive_composition(), then remove Clone from AnyXXXDistance.
+#[derive(Clone)]
+pub struct AnyMeasureDistance {
+    pub distance: CloneableAnyBox,
+    pub partial_cmp_glue: Rc<dyn Fn(&Self, &Self) -> Option<Ordering>>,
+    pub sub_glue: Rc<dyn Fn(Self, &Self) -> Fallible<Self>>,
+}
+
+impl AnyMeasureDistance {
+    pub fn new<Q: 'static + Clone + MeasureDistance>(distance: Q) -> Self {
+        Self {
+            distance: CloneableAnyBox::new(distance),
+            partial_cmp_glue: Rc::new(|self_: &Self, other: &Self| -> Option<Ordering> {
+                let self_ = self_.downcast_ref::<Q>().unwrap_assert("downcast of AnyMeasureDistance to constructed type will always work");
+                let other = other.downcast_ref::<Q>();
+                // FIXME: Do we want to have a FalliblePartialCmp for this?
+                other.map_or(None, |o| self_.partial_cmp(o))
+            }),
+            sub_glue: Rc::new(|self_: Self, rhs: &Self| -> Fallible<Self> {
+                let distance = self_.downcast::<Q>()?;
+                let rhs = rhs.downcast_ref::<Q>()?;
+                let res = distance.sub(rhs);
+                res.map(Self::new)
+            }),
+        }
+    }
+}
+
+impl PartialEq for AnyMeasureDistance {
+    fn eq(&self, other: &Self) -> bool {
+        self.distance == other.distance
+    }
+}
+
+impl PartialOrd for AnyMeasureDistance {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        (self.partial_cmp_glue)(self, other)
+    }
+}
+
+impl FallibleSub<&Self> for AnyMeasureDistance {
+    type Output = Self;
+    fn sub(self, rhs: &Self) -> Fallible<Self::Output> {
+        // We have to clone sub_glue, because self is moved into the call.
+        self.sub_glue.clone()(self, rhs)
+    }
+}
+
+impl Downcast for AnyMeasureDistance {
+    fn downcast<T: 'static>(self) -> Fallible<T> {
+        self.distance.downcast()
+    }
+
+    fn downcast_ref<T: 'static>(&self) -> Fallible<&T> {
+        self.distance.downcast_ref()
+    }
+}
+
+// TODO: If/when we remove the clone of the budget from make_adaptive_composition(), then remove Clone from AnyXXXDistance.
+#[derive(Clone)]
+pub struct AnyMetricDistance {
+    pub distance: CloneableAnyBox,
+    pub partial_cmp_glue: Rc<dyn Fn(&Self, &Self) -> Option<Ordering>>,
+}
+
+impl AnyMetricDistance {
+    pub fn new<Q: 'static + Clone + MetricDistance>(distance: Q) -> Self {
+        Self {
+            distance: CloneableAnyBox::new(distance),
+            partial_cmp_glue: Rc::new(|self_: &Self, other: &Self| -> Option<Ordering> {
+                let self_ = self_.downcast_ref::<Q>().unwrap_assert("downcast of AnyMeasureDistance to constructed type will always work");
+                let other = other.downcast_ref::<Q>();
+                // FIXME: Do we want to have a FalliblePartialCmp for this?
+                other.map_or(None, |o| self_.partial_cmp(o))
+            }),
+        }
+    }
+}
+
+impl PartialEq for AnyMetricDistance {
+    fn eq(&self, other: &Self) -> bool {
+        self.distance == other.distance
+    }
+}
+
+impl PartialOrd for AnyMetricDistance {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        (self.partial_cmp_glue)(self, other)
+    }
+}
+
+impl Downcast for AnyMetricDistance {
+    fn downcast<T: 'static>(self) -> Fallible<T> {
+        self.distance.downcast()
+    }
+    fn downcast_ref<T: 'static>(&self) -> Fallible<&T> {
+        self.distance.downcast_ref()
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct AnyMeasure {
+    pub measure: CloneableAnyBox,
+}
+
+impl AnyMeasure {
+    pub fn new<M: 'static + Measure>(measure: M) -> Self {
+        Self { measure: CloneableAnyBox::new(measure) }
+    }
+}
+
+impl Default for AnyMeasure {
+    fn default() -> Self { unimplemented!("called AnyMeasure::default()") }
+}
+
+impl Measure for AnyMeasure {
+    type Distance = AnyMeasureDistance;
+}
+
+#[derive(Clone, PartialEq)]
+pub struct AnyMetric {
+    pub metric: CloneableAnyBox,
+}
+
+impl AnyMetric {
+    pub fn new<M: 'static + Metric>(metric: M) -> Self {
+        Self { metric: CloneableAnyBox::new(metric) }
+    }
+}
+
+impl Default for AnyMetric {
+    fn default() -> Self { unimplemented!("called AnyMetric::default()") }
+}
+
+impl Metric for AnyMetric {
+    type Distance = AnyMetricDistance;
+}
+
+impl<DI: Domain, DO: Domain> Function<DI, DO> where DI::Carrier: 'static, DO::Carrier: 'static {
+    pub fn as_any_out(&self) -> Function<DI, AnyDomain> {
+        let function = self.function.clone();
+        let function = move |arg: &DI::Carrier| -> Fallible<Box<dyn Any>> {
+            let res = function(arg);
+            res.map(|o| Box::new(*o) as Box<dyn Any>)
+        };
+        Function::new_fallible(function)
+    }
+    pub fn as_any(&self) -> Function<AnyDomain, AnyDomain> {
+        let function = self.function.clone();
+        let function = move |arg: &Box<dyn Any>| -> Fallible<Box<dyn Any>> {
+            let arg = arg.downcast_ref().ok_or_else(|| err!(FailedCast))?;
+            let res = function(arg);
+            res.map(|o| Box::new(*o) as Box<dyn Any>)
+        };
+        Function::new_fallible(function)
+    }
+}
+
+fn make_any_relation<QI: 'static, QO: 'static, AQI: Downcast, AQO: Downcast>(relation: &Rc<dyn Fn(&QI, &QO) -> Fallible<bool>>) -> impl Fn(&AQI, &AQO) -> Fallible<bool> + 'static {
+    let relation = relation.clone();
+    move |d_in: &AQI, d_out: &AQO| {
+        let d_in = d_in.downcast_ref()?;
+        let d_out = d_out.downcast_ref()?;
+        relation(d_in, d_out)
+    }
+}
+
+fn make_any_map<QI, QO, AQI>(map: &Option<Rc<dyn Fn(&QI) -> Fallible<Box<QO>>>>) -> Option<impl Fn(&AQI) -> Fallible<Box<AnyMetricDistance>>>
+    where QI: 'static + PartialOrd,
+          QO: 'static + PartialOrd + Clone,
+          AQI: Downcast {
+    map.as_ref().map(|map| {
+        let map = map.clone();
+        move |d_in: &AQI| -> Fallible<Box<AnyMetricDistance>> {
+            let d_in = d_in.downcast_ref()?;
+            let d_out = map(d_in);
+            d_out.map(|d| AnyMetricDistance::new(*d)).map(Box::new)
+        }
+    })
+}
+
+impl<MI: Metric, MO: Measure> PrivacyRelation<MI, MO>
+    where MI::Distance: 'static + Clone + PartialOrd,
+          MO::Distance: 'static + Clone + PartialOrd {
+    pub fn as_any(&self) -> PrivacyRelation<AnyMetric, AnyMeasure> {
+        PrivacyRelation::new_all(
+            make_any_relation(&self.relation),
+            make_any_map(&self.backward_map),
+        )
+    }
+}
+
+impl<MI: Metric, MO: Metric> StabilityRelation<MI, MO>
+    where MI::Distance: 'static + Clone + PartialOrd,
+          MO::Distance: 'static + Clone + PartialOrd {
+    pub fn as_any(&self) -> StabilityRelation<AnyMetric, AnyMetric> {
+        StabilityRelation::new_all(
+            make_any_relation(&self.relation),
+            make_any_map(&self.forward_map),
+            make_any_map(&self.backward_map),
+        )
+    }
+}
+
+impl<DI: 'static + Domain, DO: 'static + Domain, MI: 'static + Metric, MO: 'static + Measure> Measurement<DI, DO, MI, MO>
+    where DI::Carrier: 'static,
+          DO::Carrier: 'static,
+          MI::Distance: 'static + Clone + PartialOrd,
+          MO::Distance: 'static + Clone + PartialOrd {
+    pub fn into_any_out(self) -> Measurement<DI, AnyDomain, MI, MO> {
+        Measurement::new(
+            *self.input_domain,
+            AnyDomain::new(*self.output_domain),
+            self.function.as_any_out(),
+            *self.input_metric,
+            *self.output_measure,
+            self.privacy_relation,
+        )
+    }
+    pub fn into_any(self) -> Measurement<AnyDomain, AnyDomain, AnyMetric, AnyMeasure> {
+        Measurement::new(
+            AnyDomain::new(*self.input_domain),
+            AnyDomain::new(*self.output_domain),
+            self.function.as_any(),
+            AnyMetric::new(*self.input_metric),
+            AnyMeasure::new(*self.output_measure),
+            self.privacy_relation.as_any(),
+        )
+    }
+}
+
+impl<DI: 'static + Domain, DO: 'static + Domain, MI: 'static + Metric, MO: 'static + Metric> Transformation<DI, DO, MI, MO>
+    where DI::Carrier: 'static,
+          DO::Carrier: 'static,
+          MI::Distance: 'static + Clone + PartialOrd,
+          MO::Distance: 'static + Clone + PartialOrd {
+    pub fn into_any_out(self) -> Transformation<DI, AnyDomain, MI, MO> {
+        Transformation::new(
+            *self.input_domain,
+            AnyDomain::new(*self.output_domain),
+            self.function.as_any_out(),
+            *self.input_metric,
+            *self.output_metric,
+            self.stability_relation,
+        )
+    }
+    pub fn into_any(self) -> Transformation<AnyDomain, AnyDomain, AnyMetric, AnyMetric> {
+        Transformation::new(
+            AnyDomain::new(*self.input_domain),
+            AnyDomain::new(*self.output_domain),
+            self.function.as_any(),
+            AnyMetric::new(*self.input_metric),
+            AnyMetric::new(*self.output_metric),
+            self.stability_relation.as_any(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::dist::{HammingDistance, L2Sensitivity};
+    use crate::error::*;
+    use crate::meas;
+    use crate::trans;
+
+    use super::*;
+
+    #[test]
+    fn test_any_chain() -> Fallible<()> {
+        let t1 = trans::make_split_dataframe::<HammingDistance, _>(None, vec!["a".to_owned(), "b".to_owned()])?;
+        let t2 = trans::make_parse_column::<HammingDistance, _, f64>("a".to_owned(), true)?.into_any();
+        let t3 = trans::make_select_column::<HammingDistance, _, f64>("a".to_owned())?.into_any();
+        let t4 = trans::make_clamp_vec::<HammingDistance, _>(0.0, 10.0)?.into_any();
+        let t5 = trans::make_bounded_sum::<HammingDistance, L2Sensitivity<_>>(0.0, 10.0)?.into_any();
+        let m1 = meas::make_base_gaussian(0.0)?.into_any();
+        let chain = (t1.into_any() >> t2 >> t3 >> t4 >> t5 >> m1)?;
+        let arg = Box::new("1.0, 10.0\n2.0, 20.0\n3.0, 30.0\n".to_owned()) as Box<dyn Any>;
+        let res = chain.function.eval(&arg);
+        let res = *res?.downcast::<f64>().unwrap_test();
+        assert_eq!(res, 6.0);
+
+        Ok(())
+    }
+}

--- a/rust/opendp/src/core.rs
+++ b/rust/opendp/src/core.rs
@@ -84,12 +84,12 @@ impl<DI: 'static + Domain, DO1: 'static + Domain, DO2: 'static + Domain> Functio
 }
 
 /// A representation of the distance between two elements in a set.
-pub trait Metric: Default + Clone {
+pub trait Metric: Default + Clone + PartialEq {
     type Distance;
 }
 
 /// A representation of the distance between two distributions.
-pub trait Measure: Default + Clone {
+pub trait Measure: Default + Clone + PartialEq {
     type Distance;
 }
 
@@ -149,7 +149,7 @@ impl<MI: Metric, MO: Measure> PrivacyRelation<MI, MO> {
             backward_map: None
         }
     }
-    fn new_all(
+    pub fn new_all(
         relation: impl Fn(&MI::Distance, &MO::Distance) -> Fallible<bool> + 'static,
         backward_map: Option<impl Fn(&MO::Distance) -> Fallible<Box<MI::Distance>> + 'static>
     ) -> Self {
@@ -260,7 +260,7 @@ impl<MI: Metric, MO: Metric> StabilityRelation<MI, MO> {
     pub fn new_fallible(relation: impl Fn(&MI::Distance, &MO::Distance) -> Fallible<bool> + 'static) -> Self {
         StabilityRelation { relation: Rc::new(relation), forward_map: None, backward_map: None }
     }
-    fn new_all(
+    pub fn new_all(
         relation: impl Fn(&MI::Distance, &MO::Distance) -> Fallible<bool> + 'static,
         forward_map: Option<impl Fn(&MI::Distance) -> Fallible<Box<MO::Distance>> + 'static>,
         backward_map: Option<impl Fn(&MO::Distance) -> Fallible<Box<MI::Distance>> + 'static>

--- a/rust/opendp/src/dist.rs
+++ b/rust/opendp/src/dist.rs
@@ -7,8 +7,12 @@ use crate::core::{DatasetMetric, Measure, Metric, SensitivityMetric};
 /// Measures
 #[derive(Clone)]
 pub struct MaxDivergence<Q>(PhantomData<Q>);
-impl<Q> Default for  MaxDivergence<Q> {
+impl<Q> Default for MaxDivergence<Q> {
     fn default() -> Self { MaxDivergence(PhantomData) }
+}
+
+impl<Q> PartialEq for MaxDivergence<Q> {
+    fn eq(&self, _other: &Self) -> bool { true }
 }
 
 impl<Q: Clone> Measure for MaxDivergence<Q> {
@@ -20,6 +24,10 @@ pub struct SmoothedMaxDivergence<Q>(PhantomData<Q>);
 
 impl<Q> Default for SmoothedMaxDivergence<Q> {
     fn default() -> Self { SmoothedMaxDivergence(PhantomData) }
+}
+
+impl<Q> PartialEq for SmoothedMaxDivergence<Q> {
+    fn eq(&self, _other: &Self) -> bool { true }
 }
 
 impl<Q: Clone> Measure for SmoothedMaxDivergence<Q> {
@@ -34,6 +42,10 @@ impl Default for SymmetricDistance {
     fn default() -> Self { SymmetricDistance }
 }
 
+impl PartialEq for SymmetricDistance {
+    fn eq(&self, _other: &Self) -> bool { true }
+}
+
 impl Metric for SymmetricDistance {
     type Distance = u32;
 }
@@ -45,6 +57,10 @@ pub struct HammingDistance;
 
 impl Default for HammingDistance {
     fn default() -> Self { HammingDistance }
+}
+
+impl PartialEq for HammingDistance {
+    fn eq(&self, _other: &Self) -> bool { true }
 }
 
 impl Metric for HammingDistance {
@@ -63,6 +79,10 @@ impl<Q> Clone for L1Sensitivity<Q> {
     fn clone(&self) -> Self { Self::default() }
 }
 
+impl<Q> PartialEq for L1Sensitivity<Q> {
+    fn eq(&self, _other: &Self) -> bool { true }
+}
+
 impl<Q> Metric for L1Sensitivity<Q> {
     type Distance = Q;
 }
@@ -77,6 +97,10 @@ impl<Q> Default for L2Sensitivity<Q> {
 
 impl<Q> Clone for L2Sensitivity<Q> {
     fn clone(&self) -> Self { Self::default() }
+}
+
+impl<Q> PartialEq for L2Sensitivity<Q> {
+    fn eq(&self, _other: &Self) -> bool { true }
 }
 
 impl<Q> Metric for L2Sensitivity<Q> {

--- a/rust/opendp/src/error.rs
+++ b/rust/opendp/src/error.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::fmt::Debug;
 
 use backtrace::Backtrace as _Backtrace;
 
@@ -110,7 +111,7 @@ impl<T> ExplainUnwrap for Option<T> {
         self.unwrap()
     }
 }
-impl<T> ExplainUnwrap for Fallible<T> {
+impl<T, E: Debug> ExplainUnwrap for Result<T, E> {
     type Inner = T;
     fn unwrap_assert(self, _explanation: &'static str) -> T {
         self.unwrap()

--- a/rust/opendp/src/interactive.rs
+++ b/rust/opendp/src/interactive.rs
@@ -1,0 +1,212 @@
+use std::any::Any;
+use std::rc::Rc;
+
+use crate::core::{Domain, Function, Measure, Measurement, Metric, PrivacyRelation};
+use crate::dom::AllDomain;
+use crate::error::*;
+use crate::traits::{FallibleSub, MeasureDistance, MetricDistance};
+
+/// A structure tracking the state of an interactive measurement queryable.
+/// It's generic over state (S), query (Q), answer (A), so it can be used for any
+/// interactive measurement expressible as a transition function.
+pub struct Queryable<S, Q, A> {
+    /// The state of the Queryable. It is wrapped in an option so that ownership can be moved out
+    /// temporarily, during transitions.
+    state: Option<S>,
+    /// The transition function of the Queryable. Takes the current state and a query, returns
+    /// the new state and the answer.
+    transition: Rc<dyn Fn(S, &Q) -> Fallible<(S, A)>>,
+}
+
+impl<S, Q, A> Queryable<S, Q, A> {
+    /// Constructs a Queryable with initial state and transition function.
+    pub fn new(initial: S, transition: impl Fn(S, &Q) -> Fallible<(S, A)> + 'static) -> Self {
+        Queryable {
+            state: Some(initial),
+            transition: Rc::new(transition),
+        }
+    }
+
+    /// Evaluates the given query.
+    pub fn eval(&mut self, query: &Q) -> Fallible<A> {
+        // Take temporary ownership of the state from this struct.
+        let state = self.state.take().unwrap_assert("Queryable state is only accessed in this method, always replaced.");
+        // Obtain then new state and answer.
+        let new_state_answer = (self.transition)(state, query)?;
+        // Restore ownership of the state into this struct.
+        self.state.replace(new_state_answer.0);
+        Ok(new_state_answer.1)
+    }
+}
+
+impl<S, Q> Queryable<S, Q, Box<dyn Any>> {
+    pub fn eval_downcast<A: 'static>(&mut self, query: &Q) -> Fallible<A> {
+        self.eval(query)?.downcast().map_err(|_| err!(FailedCast)).map(|b| *b)
+    }
+}
+
+type AcState<DI, MI, MO> = (<DI as Domain>::Carrier, <MI as Metric>::Distance, <MO as Measure>::Distance);
+type AcQuery<DI, DO, MI, MO> = (Measurement<DI, DO, MI, MO>, <MO as Measure>::Distance);
+type AcQueryable<DI, DO, MI, MO> = Queryable<AcState<DI, MI, MO>, AcQuery<DI, DO, MI, MO>, <DO as Domain>::Carrier>;
+type AcMeasurement<DI, DO, MI, MO> = Measurement<DI, AllDomain<AcQueryable<DI, DO, MI, MO>>, MI, MO>;
+
+fn ac_transition<DI: Domain, DO: Domain, MI: Metric, MO: Measure>(
+    (arg, d_in_budget, d_out_budget): AcState<DI, MI, MO>,
+    (measurement, d_out_query): &AcQuery<DI, DO, MI, MO>,
+) -> Fallible<(AcState<DI, MI, MO>, DO::Carrier)>
+    where MO::Distance: MeasureDistance {
+    measurement.privacy_relation.eval(&d_in_budget, d_out_query)?;
+    if d_out_query > &d_out_budget {
+        return fallible!(FailedRelation, "not enough budget")
+    }
+    let new_d_out_budget = d_out_budget.sub(d_out_query)?;
+    // we want the res to be fallible, so that failing eval does not consume the queryable
+    let res = measurement.function.eval(&arg)?;
+    Ok(((arg, d_in_budget, new_d_out_budget), res))
+}
+
+pub fn make_adaptive_composition<DI: Domain, DO: Domain, MI: Metric, MO: Measure>(
+    input_domain: DI,
+    input_metric: MI,
+    output_measure: MO,
+    d_in_budget: MI::Distance,
+    d_out_budget: MO::Distance,
+) -> AcMeasurement<DI, DO, MI, MO>
+    where DI::Carrier: Clone,
+          MI::Distance: 'static + MetricDistance + Clone,
+          MO::Distance: 'static + MeasureDistance + Clone {
+    AcMeasurement::new(
+        input_domain,
+        AllDomain::new(),
+        Function::new(enclose!((d_in_budget, d_out_budget), move |arg: &DI::Carrier| -> AcQueryable<DI, DO, MI, MO> {
+            AcQueryable::new(
+                // TODO: Remove these clones and have the Queryable use refs. (Also remove Clone trait bounds.)
+                (arg.clone(), d_in_budget.clone(), d_out_budget.clone()),
+                |s, q| ac_transition(s, q))
+        })),
+        input_metric,
+        output_measure,
+        PrivacyRelation::new(move |d_in, d_out| d_in <= &d_in_budget && d_out <= &d_out_budget),
+    )
+}
+
+
+#[cfg(test)]
+mod tests {
+    use crate::dist::{HammingDistance, L1Sensitivity, MaxDivergence};
+    use crate::dom::VectorDomain;
+    use crate::error::*;
+    use crate::meas::*;
+    use crate::trans::*;
+
+    use super::*;
+
+    fn make_dummy_meas<TO: From<i32>>() -> Measurement<AllDomain<i32>, AllDomain<TO>, L1Sensitivity<f64>, MaxDivergence<f64>> {
+        Measurement::new(
+            AllDomain::new(),
+            AllDomain::new(),
+            Function::new(|a: &i32| TO::from(a.clone())),
+            L1Sensitivity::<f64>::default(),
+            MaxDivergence::<f64>::default(),
+            PrivacyRelation::new(|d_in, d_out| d_out <= d_in),
+        )
+    }
+
+    #[test]
+    fn test_adaptive_comp_simple() -> Fallible<()> {
+        let meas1 = make_dummy_meas::<i32>();
+        let meas2 = make_dummy_meas::<i32>();
+
+        let data = 999;
+        let d_in_budget = 1.0;
+        let d_out_budget = 1.0;
+        let adaptive = make_adaptive_composition(*meas1.input_domain.clone(), *meas1.input_metric.clone(), *meas1.output_measure.clone(), d_in_budget, d_out_budget);
+        let mut queryable = adaptive.function.eval(&data)?;
+        let res1 = queryable.eval(&(meas1, d_out_budget / 2.0))?;
+        assert_eq!(res1, 999);
+        let res2 = queryable.eval(&(meas2, d_out_budget / 2.0))?;
+        assert_eq!(res2, 999);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_adaptive_comp_heterogeneous() -> Fallible<()> {
+        let meas1 = make_dummy_meas::<i32>().into_any_out();
+        let meas2 = make_dummy_meas::<i64>().into_any_out();
+
+        let data = 999;
+        let d_in_budget = 1.0;
+        let d_out_budget = 1.0;
+        let adaptive = make_adaptive_composition(*meas1.input_domain.clone(), *meas1.input_metric.clone(), *meas1.output_measure.clone(), d_in_budget, d_out_budget);
+        let mut queryable = adaptive.function.eval(&data)?;
+        let res1: i32 = queryable.eval_downcast(&(meas1, d_out_budget / 2.0))?;
+        assert_eq!(res1, 999_i32);
+        let res2: i64 = queryable.eval_downcast(&(meas2, d_out_budget / 2.0))?;
+        assert_eq!(res2, 999_i64);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_adaptive_comp_budget() -> Fallible<()> {
+        let meas1 = make_dummy_meas::<i32>();
+        let meas2 = make_dummy_meas::<i32>();
+
+        let data = 999;
+        let d_in_budget = 1.0;
+        let d_out_budget = 1.0;
+        let adaptive = make_adaptive_composition(*meas1.input_domain.clone(), *meas1.input_metric.clone(), *meas1.output_measure.clone(), d_in_budget, d_out_budget);
+        let mut queryable = adaptive.function.eval(&data)?;
+        let res1 = queryable.eval(&(meas1, d_out_budget / 2.0))?;
+        assert_eq!(res1, 999);
+        let res2 = queryable.eval(&(meas2, d_out_budget));
+        // TODO: Would be handy to have a way of comparing Errors for this assertion.
+        assert!(res2.is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_adaptive_comp_chain() -> Fallible<()> {
+        // Definitions
+        let input_domain = VectorDomain::new(AllDomain::new());
+        // Output domain is implied (AnyDomain).
+        let input_metric = HammingDistance::default();
+        let output_measure = MaxDivergence::default();
+
+        // Build queryable
+        let d_in = 1;
+        let d_out_budget = 1.0;
+        let adaptive = make_adaptive_composition(input_domain, input_metric, output_measure, d_in, d_out_budget);
+        let data = vec![0.6, 2.8, 6.0, 9.4, 8.9, 7.7, 5.9, 3.4, 8.0, 2.4, 4.4, 7.1, 6.0, 3.2, 7.1];
+        let mut queryable = adaptive.function.eval(&data)?;
+        // NO FURTHER ACCESS TO DATA AFTER THIS POINT.
+
+        // Set parameters for queries
+        let count_bounds = (0, 20);
+        let val_bounds = (0.0, 10.0);
+        let d_out_query = 0.5 * d_out_budget;
+
+        // Noisy count
+        let measurement1 = (
+            make_count()? >>
+                make_base_geometric(1.0 / d_out_query, count_bounds.0, count_bounds.1)?
+        )?.into_any_out();
+        let query1 = (measurement1, d_out_query);
+        let result1: u32 = queryable.eval_downcast(&query1)?;
+        println!("result = {}", result1);
+
+        // Noisy sum
+        let measurement2 = (
+            make_clamp_vec(val_bounds.0, val_bounds.1)? >>
+                make_bounded_sum(val_bounds.0, val_bounds.1)? >>
+                make_base_laplace(1.0 / d_out_query)?
+        )?.into_any_out();
+        let query2 = (measurement2, d_out_query);
+        let result2: f64 = queryable.eval_downcast(&query2)?;
+        println!("result = {}", result2);
+
+        Ok(())
+    }
+}

--- a/rust/opendp/src/lib.rs
+++ b/rust/opendp/src/lib.rs
@@ -144,12 +144,14 @@ macro_rules! num_cast {
 #[macro_use]
 pub mod error;
 
+pub mod any;
+pub mod chain;
 pub mod core;
 pub mod data;
 pub mod dist;
 pub mod dom;
+pub mod interactive;
 pub mod meas;
-pub mod trans;
-pub mod traits;
 pub mod samplers;
-pub mod chain;
+pub mod traits;
+pub mod trans;

--- a/rust/opendp/src/lib.rs
+++ b/rust/opendp/src/lib.rs
@@ -152,6 +152,7 @@ pub mod dist;
 pub mod dom;
 pub mod interactive;
 pub mod meas;
+pub mod poly;
 pub mod samplers;
 pub mod traits;
 pub mod trans;

--- a/rust/opendp/src/poly.rs
+++ b/rust/opendp/src/poly.rs
@@ -1,0 +1,117 @@
+use std::any::Any;
+
+use crate::core::{Domain, Function, Measure, Measurement, Metric, Transformation};
+use crate::error::*;
+
+/// A polymorphic Domain. This admits any value of any type (represented as a Box<dyn Any>).
+#[derive(PartialEq, Clone)]
+pub struct PolyDomain {}
+
+impl PolyDomain {
+    pub fn new() -> Self { PolyDomain {} }
+}
+
+impl Domain for PolyDomain {
+    type Carrier = Box<dyn Any>;
+    fn member(&self, _val: &Self::Carrier) -> bool { true }
+}
+
+impl<DI, DO> Function<DI, DO>
+    where DI: 'static + Domain,
+          DI::Carrier: 'static,
+          DO: 'static + Domain,
+          DO::Carrier: 'static {
+    /// Converts this Function into one with polymorphic output.
+    pub fn into_poly(self) -> Function<DI, PolyDomain> {
+        let function = move |arg: &DI::Carrier| -> Fallible<Box<dyn Any>> {
+            let res = (self.function)(arg);
+            res.map(|o| Box::new(*o) as Box<dyn Any>)
+        };
+        Function::new_fallible(function)
+    }
+}
+
+impl<DI: Domain> Function<DI, PolyDomain> {
+    pub fn eval_poly<T: 'static>(&self, arg: &DI::Carrier) -> Fallible<T> {
+        self.eval(arg)?.downcast().map_err(|_| err!(FailedCast)).map(|res| *res)
+    }
+}
+
+impl<DI, DO, MI, MO> Measurement<DI, DO, MI, MO>
+    where DI: 'static + Domain,
+          DI::Carrier: 'static,
+          DO: 'static + Domain,
+          DO::Carrier: 'static,
+          MI: 'static + Metric,
+          MO: 'static + Measure {
+    /// Converts this Measurement into one with polymorphic output. This is useful for composition
+    /// of heterogeneous Measurements.
+    pub fn into_poly(self) -> Measurement<DI, PolyDomain, MI, MO> {
+        Measurement::new(
+            *self.input_domain,
+            PolyDomain::new(),
+            self.function.into_poly(),
+            *self.input_metric,
+            *self.output_measure,
+            self.privacy_relation,
+        )
+    }
+}
+
+impl<DI, DO, MI, MO> Transformation<DI, DO, MI, MO>
+    where DI: 'static + Domain,
+          DI::Carrier: 'static,
+          DO: 'static + Domain,
+          DO::Carrier: 'static,
+          MI: 'static + Metric,
+          MO: 'static + Metric {
+    /// Converts this Transformation into one with polymorphic output. It's not clear if we'll need this,
+    /// but it's provided for symmetry with Measurement.
+    pub fn into_poly(self) -> Transformation<DI, PolyDomain, MI, MO> {
+        Transformation::new(
+            *self.input_domain,
+            PolyDomain::new(),
+            self.function.into_poly(),
+            *self.input_metric,
+            *self.output_metric,
+            self.stability_relation,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::dist::HammingDistance;
+    use crate::dom::AllDomain;
+    use crate::error::*;
+    use crate::meas;
+    use crate::trans;
+
+    #[test]
+    fn test_poly_measurement() -> Fallible<()> {
+        let op_plain = meas::make_base_laplace(0.0)?;
+        let arg = 99.9;
+        let res_plain = op_plain.function.eval(&arg)?;
+        assert_eq!(res_plain, arg);
+        let op_poly = op_plain.into_poly();
+        let res_poly = op_poly.function.eval_poly::<f64>(&arg)?;
+        assert_eq!(res_poly, arg);
+        let res_bogus = op_poly.function.eval_poly::<i32>(&arg);
+        assert!(res_bogus.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_poly_transformation() -> Fallible<()> {
+        let op_plain = trans::make_identity(AllDomain::new(), HammingDistance::default())?;
+        let arg = 99.9;
+        let res_plain = op_plain.function.eval(&arg)?;
+        assert_eq!(res_plain, arg);
+        let op_poly = op_plain.into_poly();
+        let res_poly = op_poly.function.eval_poly::<f64>(&arg)?;
+        assert_eq!(res_poly, arg);
+        let res_bogus = op_poly.function.eval_poly::<i32>(&arg);
+        assert!(res_bogus.is_err());
+        Ok(())
+    }
+}


### PR DESCRIPTION
Closes #80.

I kept this as a fairly conservative change. Most of the code is in separate modules (`any` and `interactive`). Aside from a few trait bounds, the existing types and logic stay the same for non-interactive Measurements and Transformations.

If/when we're happy with this, we can migrate the FFI wrappers to use the type-erased (AnyXXX) approach in #88.

* Created type-erased versions of Measurement/Transformation component types.
* Added type-erasing transformers to Measurement/Transformation.
* Defined generic Queryable abstraction.
* Implemented make_adaptive_composition() constructor.
* Added unit tests.
* Created a separate abstraction for polymorphic operations.