### PR TITLE
Fixed tuple issues in opendp_data__object_as_slice()

### DIFF
--- a/rust/opendp-ffi/src/any.rs
+++ b/rust/opendp-ffi/src/any.rs
@@ -206,9 +206,9 @@ impl AnyMeasureDistance {
             distance: AnyBoxClonePartialEq::new_clone_partial_eq(distance),
             partial_cmp_glue: Glue::new(|self_: &Self, other: &Self| -> Option<Ordering> {
                 let self_ = self_.downcast_ref::<Q>().unwrap_assert("downcast of AnyMeasureDistance to constructed type will always work");
-                let other = other.downcast_ref::<Q>();
+                let other = other.downcast_ref::<Q>().ok()?;
                 // FIXME: Do we want to have a FalliblePartialCmp for this?
-                other.map_or(None, |o| self_.partial_cmp(o))
+                self_.partial_cmp(other)
             }),
             sub_glue: Glue::new(|self_: Self, rhs: &Self| -> Fallible<Self> {
                 let distance = self_.downcast::<Q>()?;

--- a/rust/opendp-ffi/src/core/mod.rs
+++ b/rust/opendp-ffi/src/core/mod.rs
@@ -97,15 +97,10 @@ impl<T> From<Error> for FfiResult<T> {
 
 impl<T: PartialEq> PartialEq for FfiResult<*mut T> {
     fn eq(&self, other: &Self) -> bool {
-        match self {
-            Self::Ok(ok) => match other {
-                Self::Ok(other_ok) => util::as_ref(*ok) == util::as_ref(*other_ok),
-                _ => false
-            },
-            Self::Err(err) => match other {
-                Self::Err(other_err) => util::as_ref(*err) == util::as_ref(*other_err),
-                _ => false
-            }
+        match (self, other) {
+            (Self::Ok(self_), Self::Ok(other)) => util::as_ref(*self_) == util::as_ref(*other),
+            (Self::Err(self_), Self::Err(other)) => util::as_ref(*self_) == util::as_ref(*other),
+            _ => false
         }
     }
 }

--- a/rust/opendp-ffi/src/util.rs
+++ b/rust/opendp-ffi/src/util.rs
@@ -10,6 +10,7 @@ use std::str::Utf8Error;
 use opendp::{err, fallible};
 use opendp::dist::{HammingDistance, L1Sensitivity, L2Sensitivity, SymmetricDistance};
 use opendp::error::*;
+use crate::any::AnyObject;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum TypeContents {
@@ -150,14 +151,14 @@ lazy_static! {
     static ref TYPES: Vec<Type> = {
         let types: Vec<Type> = vec![
             vec![t!(())],
-            type_vec![bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String],
-            type_vec![(bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String)],
-            type_vec![[bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String]; 1], // Arrays are here just for unit tests, unlikely we'll use them.
-            type_vec![[bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String]],
+            type_vec![bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String, AnyObject],
+            type_vec![(bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String, AnyObject)],
+            type_vec![[bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String, AnyObject]; 1], // Arrays are here just for unit tests, unlikely we'll use them.
+            type_vec![[bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String, AnyObject]],
             type_vec![HammingDistance, SymmetricDistance],
             type_vec![L1Sensitivity, <u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64>],
             type_vec![L2Sensitivity, <u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64>],
-            type_vec![Vec, <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String>],
+            type_vec![Vec, <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String, AnyObject>],
         ].into_iter().flatten().collect();
         let descriptors: HashSet<_> = types.iter().map(|e| e.descriptor).collect();
         assert_eq!(descriptors.len(), types.len());


### PR DESCRIPTION
Closes #97.

Note that, snuck into this change, there's a cfg thing in dispatch.rs so that dev and test builds will compile with a limited set of types for faster monomorphization. If this is a problem, I'm happy to back it out and keep it in my own clone.

* Cleaned up tuple logic.
* Added AnyObject support to type dispatch.
* Wrote some unit tests to cover tuple cases.
* Made a cfg with a stripped-down set of types for fast compilation of dev target.
* Picked up suggested tweaks from #96 PR review.