### PR TITLE
re-export features from opendp crate in opendp-ffi

### DIFF
--- a/rust/opendp-ffi/Cargo.toml
+++ b/rust/opendp-ffi/Cargo.toml
@@ -6,10 +6,13 @@ edition = "2018"
 build = "build/main.rs"
 
 [dependencies]
-opendp = { path = "../opendp" }
 lazy_static = "1.4.0"
 num = "0.3.1"
 backtrace = "0.3"
+
+[dependencies.opendp]
+path = "../opendp"
+default-features = false
 
 [build-dependencies]
 serde_json = {version = "1.0.64", features = ["preserve_order"] }
@@ -17,7 +20,11 @@ serde = { version = "1.0.126", features = ["derive"] }
 indexmap = {version = "1.6.2", features = ["serde"] }
 
 [features]
+default = ["use-mpfr", "python"]
 python = []
+# re-export features from opendp
+use-mpfr = ["opendp/use-mpfr"]
+use-system-libs = ["opendp/use-system-libs"]
 
 [lib]
 crate-type = ["rlib", "cdylib"]


### PR DESCRIPTION
Closes #100 (again).

The opendp crate is a dependency of opendp-ffi, and opendp-ffi referenced opendp without `default-features = false`. This updates the opendp dependency to have no default features, re-exports the opendp features, and then enables the same default features by default in the opendp-ffi crate.

This time I tested the cargo tree output to ensure that `gmp-mpfr-sys` and `rug` do not exist in the dependency tree when the `--no-default-features` flag is set:
`cargo tree | grep -E '(rug|gmp)'`

```
├── gmp-mpfr-sys v1.3.1
├── rug v1.10.0
│   ├── gmp-mpfr-sys v1.3.1 (*)
```

vs 
`cargo tree --no-default-features | grep -E '(rug|gmp)'`
```
```

