### PR TITLE
use-openssl crate feature

### DIFF
--- a/rust/opendp-ffi/Cargo.toml
+++ b/rust/opendp-ffi/Cargo.toml
@@ -20,10 +20,11 @@ serde = { version = "1.0.126", features = ["derive"] }
 indexmap = {version = "1.6.2", features = ["serde"] }
 
 [features]
-default = ["use-mpfr", "python"]
+default = ["use-openssl", "use-mpfr", "python"]
 python = []
-# re-export features from opendp
+use-openssl = ["opendp/use-openssl"]
 use-mpfr = ["opendp/use-mpfr"]
+# re-export features from opendp
 use-system-libs = ["opendp/use-system-libs"]
 
 [lib]

--- a/rust/opendp/Cargo.toml
+++ b/rust/opendp/Cargo.toml
@@ -15,6 +15,7 @@ statrs = "0.13.0"
 [dependencies.openssl]
 version = "0.10.29"
 features = ["vendored"]
+optional = true
 
 [dependencies.rug]
 version = "1.9.0"
@@ -29,9 +30,11 @@ features = ["mpfr"]
 optional = true
 
 [features]
-default = ["use-mpfr"]
-# re-export use-system-libs from mpfr
+default = ["use-openssl", "use-mpfr"]
+
+use-openssl = ["openssl"]
 use-mpfr = ["gmp-mpfr-sys", "rug"]
+# re-export use-system-libs from mpfr
 use-system-libs = ["use-mpfr", "gmp-mpfr-sys/use-system-libs"]
 
 [lib]


### PR DESCRIPTION
Closes #100 (again).

This places openssl behind a default `use-openssl` feature flag. Using --no-default-features will now remove openssl and gmp/mpfr from the dependencies.