### PR TITLE
hardened geometric mechanism, data processing, merged constructors

### DIFF
--- a/python/example/test.py
+++ b/python/example/test.py
@@ -25,14 +25,14 @@ def main():
         make_select_column(key=1, M=HammingDistance, T=int) >>
         make_clamp(lower=0, upper=10, M=HammingDistance) >>
         make_bounded_sum(lower=0, upper=10, MI=HammingDistance, MO=L1Sensitivity[int]) >>
-        make_base_geometric(scale=1.0, lower=0, upper=1000)
+        make_base_geometric(scale=1.0)
     )
 
     # Count, col 1
     noisy_count_2 = (
         make_select_column(key=2, M=HammingDistance, T=float) >>
         make_count(MI=HammingDistance, MO=L1Sensitivity[int], TI=float) >>
-        make_base_geometric(scale=1.0, lower=0, upper=1000)
+        make_base_geometric(scale=1.0)
     )
 
     arg = "ant, 1, 1.1\nbat, 2, 2.2\ncat, 3, 3.3"

--- a/python/example/test.py
+++ b/python/example/test.py
@@ -1,6 +1,5 @@
 from opendp.v1.trans import *
 from opendp.v1.meas import *
-from opendp.v1.core import *
 
 from opendp.v1.typing import HammingDistance, L1Sensitivity
 
@@ -8,7 +7,7 @@ from opendp.v1.typing import HammingDistance, L1Sensitivity
 def main():
 
     ### HELLO WORLD
-    identity = make_identity(HammingDistance, str)
+    identity = make_identity(M=HammingDistance, T=str)
     arg = "hello, world!"
     res = identity(arg)
     print(res)

--- a/python/example/test.py
+++ b/python/example/test.py
@@ -23,7 +23,7 @@ def main():
     # Noisy sum, col 1
     noisy_sum_1 = (
         make_select_column(key=1, M=HammingDistance, T=int) >>
-        make_clamp_vec(lower=0, upper=10, M=HammingDistance) >>
+        make_clamp(lower=0, upper=10, M=HammingDistance) >>
         make_bounded_sum(lower=0, upper=10, MI=HammingDistance, MO=L1Sensitivity[int]) >>
         make_base_geometric(scale=1.0, lower=0, upper=1000)
     )

--- a/python/src/opendp/v1/meas.py
+++ b/python/src/opendp/v1/meas.py
@@ -38,7 +38,7 @@ def make_base_laplace(
     return c_to_py(unwrap(function(scale, T), Measurement))
 
 
-def make_base_laplace_vec(
+def make_base_vector_laplace(
     scale,
     T: RuntimeTypeDescriptor = None
 ) -> Measurement:
@@ -47,7 +47,7 @@ def make_base_laplace_vec(
     :param scale: Noise scale parameter of the laplace distribution.
     :param T: Data type to be privatized.
     :type T: RuntimeTypeDescriptor
-    :return: A base_laplace_vec step.
+    :return: A base_vector_laplace step.
     :rtype: Measurement
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -61,7 +61,7 @@ def make_base_laplace_vec(
     T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_meas__make_base_laplace_vec
+    function = lib.opendp_meas__make_base_vector_laplace
     function.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
     function.restype = FfiResult
     
@@ -98,7 +98,7 @@ def make_base_gaussian(
     return c_to_py(unwrap(function(scale, T), Measurement))
 
 
-def make_base_gaussian_vec(
+def make_base_vector_gaussian(
     scale,
     T: RuntimeTypeDescriptor = None
 ) -> Measurement:
@@ -107,7 +107,7 @@ def make_base_gaussian_vec(
     :param scale: noise scale parameter to the gaussian distribution
     :param T: data type to be privatized
     :type T: RuntimeTypeDescriptor
-    :return: A base_gaussian_vec step.
+    :return: A base_vector_gaussian step.
     :rtype: Measurement
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -121,7 +121,7 @@ def make_base_gaussian_vec(
     T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_meas__make_base_gaussian_vec
+    function = lib.opendp_meas__make_base_vector_gaussian
     function.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
     function.restype = FfiResult
     
@@ -132,6 +132,7 @@ def make_base_geometric(
     scale,
     lower,
     upper,
+    constant_time: bool = False,
     T: RuntimeTypeDescriptor = None,
     QO: RuntimeTypeDescriptor = None
 ) -> Measurement:
@@ -141,6 +142,8 @@ def make_base_geometric(
     :param scale: noise scale parameter to the geometric distribution
     :param lower: Expected lower bound of data.
     :param upper: Expected upper bound of data.
+    :param constant_time: Execute the function such that the elapsed time on any input is the same.
+    :type constant_time: bool
     :param T: Data type to be privatized.
     :type T: RuntimeTypeDescriptor
     :param QO: Data type of the sensitivity space.
@@ -159,15 +162,62 @@ def make_base_geometric(
     scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=QO)
     lower = py_to_c(lower, c_type=ctypes.c_void_p, type_name=T)
     upper = py_to_c(upper, c_type=ctypes.c_void_p, type_name=T)
+    constant_time = py_to_c(constant_time, c_type=ctypes.c_bool)
     T = py_to_c(T, c_type=ctypes.c_char_p)
     QO = py_to_c(QO, c_type=ctypes.c_char_p)
     
     # Call library function.
     function = lib.opendp_meas__make_base_geometric
-    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
+    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_bool, ctypes.c_char_p, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(scale, lower, upper, T, QO), Measurement))
+    return c_to_py(unwrap(function(scale, lower, upper, constant_time, T, QO), Measurement))
+
+
+def make_base_vector_geometric(
+    scale,
+    lower,
+    upper,
+    constant_time: bool = False,
+    T: RuntimeTypeDescriptor = None,
+    QO: RuntimeTypeDescriptor = None
+) -> Measurement:
+    """Make a Measurement that adds noise from the geometric(`scale`) distribution to a vector value.
+    `lower` and `upper` are used to derive the max number of trials necessary when sampling from the geometric distribution.
+    
+    :param scale: noise scale parameter to the geometric distribution
+    :param lower: Expected lower bound of data.
+    :param upper: Expected upper bound of data.
+    :param constant_time: Execute the function such that the elapsed time on any input is the same.
+    :type constant_time: bool
+    :param T: Data type to be privatized.
+    :type T: RuntimeTypeDescriptor
+    :param QO: Data type of the sensitivity space.
+    :type QO: RuntimeTypeDescriptor
+    :return: A base_vector_geometric step.
+    :rtype: Measurement
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # Standardize type arguments.
+    T = RuntimeType.parse_or_infer(type_name=T, public_example=lower)
+    QO = RuntimeType.parse_or_infer(type_name=QO, public_example=scale)
+    
+    # Convert arguments to c types.
+    scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=QO)
+    lower = py_to_c(lower, c_type=ctypes.c_void_p, type_name=T)
+    upper = py_to_c(upper, c_type=ctypes.c_void_p, type_name=T)
+    constant_time = py_to_c(constant_time, c_type=ctypes.c_bool)
+    T = py_to_c(T, c_type=ctypes.c_char_p)
+    QO = py_to_c(QO, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_meas__make_base_vector_geometric
+    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_bool, ctypes.c_char_p, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(scale, lower, upper, constant_time, T, QO), Measurement))
 
 
 def make_base_stability(
@@ -176,7 +226,7 @@ def make_base_stability(
     threshold,
     MI: SensitivityMetric,
     TIK: RuntimeTypeDescriptor,
-    TIC: RuntimeTypeDescriptor = int
+    TIC: RuntimeTypeDescriptor = "i32"
 ) -> Measurement:
     """Make a Measurement that implements a stability-based filtering and noising.
     

--- a/python/src/opendp/v1/meas.py
+++ b/python/src/opendp/v1/meas.py
@@ -130,20 +130,12 @@ def make_base_vector_gaussian(
 
 def make_base_geometric(
     scale,
-    lower,
-    upper,
-    constant_time: bool = False,
-    T: RuntimeTypeDescriptor = None,
+    T: RuntimeTypeDescriptor = "i32",
     QO: RuntimeTypeDescriptor = None
 ) -> Measurement:
     """Make a Measurement that adds noise from the geometric(`scale`) distribution to a scalar value.
-    `lower` and `upper` are used to derive the max number of trials necessary when sampling from the geometric distribution.
     
     :param scale: noise scale parameter to the geometric distribution
-    :param lower: Expected lower bound of data.
-    :param upper: Expected upper bound of data.
-    :param constant_time: Execute the function such that the elapsed time on any input is the same.
-    :type constant_time: bool
     :param T: Data type to be privatized.
     :type T: RuntimeTypeDescriptor
     :param QO: Data type of the sensitivity space.
@@ -155,46 +147,75 @@ def make_base_geometric(
     :raises OpenDPException: packaged error from the core OpenDP library
     """
     # Standardize type arguments.
-    T = RuntimeType.parse_or_infer(type_name=T, public_example=lower)
+    T = RuntimeType.parse(type_name=T)
     QO = RuntimeType.parse_or_infer(type_name=QO, public_example=scale)
     
     # Convert arguments to c types.
     scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=QO)
-    lower = py_to_c(lower, c_type=ctypes.c_void_p, type_name=T)
-    upper = py_to_c(upper, c_type=ctypes.c_void_p, type_name=T)
-    constant_time = py_to_c(constant_time, c_type=ctypes.c_bool)
     T = py_to_c(T, c_type=ctypes.c_char_p)
     QO = py_to_c(QO, c_type=ctypes.c_char_p)
     
     # Call library function.
     function = lib.opendp_meas__make_base_geometric
-    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_bool, ctypes.c_char_p, ctypes.c_char_p]
+    function.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(scale, lower, upper, constant_time, T, QO), Measurement))
+    return c_to_py(unwrap(function(scale, T, QO), Measurement))
 
 
 def make_base_vector_geometric(
     scale,
-    lower,
-    upper,
-    constant_time: bool = False,
-    T: RuntimeTypeDescriptor = None,
+    T: RuntimeTypeDescriptor = "i32",
     QO: RuntimeTypeDescriptor = None
 ) -> Measurement:
     """Make a Measurement that adds noise from the geometric(`scale`) distribution to a vector value.
-    `lower` and `upper` are used to derive the max number of trials necessary when sampling from the geometric distribution.
     
     :param scale: noise scale parameter to the geometric distribution
-    :param lower: Expected lower bound of data.
-    :param upper: Expected upper bound of data.
-    :param constant_time: Execute the function such that the elapsed time on any input is the same.
-    :type constant_time: bool
     :param T: Data type to be privatized.
     :type T: RuntimeTypeDescriptor
     :param QO: Data type of the sensitivity space.
     :type QO: RuntimeTypeDescriptor
     :return: A base_vector_geometric step.
+    :rtype: Measurement
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # Standardize type arguments.
+    T = RuntimeType.parse(type_name=T)
+    QO = RuntimeType.parse_or_infer(type_name=QO, public_example=scale)
+    
+    # Convert arguments to c types.
+    scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=QO)
+    T = py_to_c(T, c_type=ctypes.c_char_p)
+    QO = py_to_c(QO, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_meas__make_base_vector_geometric
+    function.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(scale, T, QO), Measurement))
+
+
+def make_constant_time_base_geometric(
+    scale,
+    lower,
+    upper,
+    T: RuntimeTypeDescriptor = None,
+    QO: RuntimeTypeDescriptor = None
+) -> Measurement:
+    """Make a Measurement that adds noise from the geometric(`scale`) distribution to a scalar value.
+    `lower` and `upper` are used to derive the max number of trials necessary when sampling from the geometric distribution.
+    
+    :param scale: noise scale parameter to the geometric distribution
+    :param lower: Expected lower bound of data.
+    :param upper: Expected upper bound of data.
+    :param T: Data type to be privatized.
+    :type T: RuntimeTypeDescriptor
+    :param QO: Data type of the sensitivity space.
+    :type QO: RuntimeTypeDescriptor
+    :return: A constant_time_base_geometric step.
     :rtype: Measurement
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -208,16 +229,57 @@ def make_base_vector_geometric(
     scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=QO)
     lower = py_to_c(lower, c_type=ctypes.c_void_p, type_name=T)
     upper = py_to_c(upper, c_type=ctypes.c_void_p, type_name=T)
-    constant_time = py_to_c(constant_time, c_type=ctypes.c_bool)
     T = py_to_c(T, c_type=ctypes.c_char_p)
     QO = py_to_c(QO, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_meas__make_base_vector_geometric
-    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_bool, ctypes.c_char_p, ctypes.c_char_p]
+    function = lib.opendp_meas__make_constant_time_base_geometric
+    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(scale, lower, upper, constant_time, T, QO), Measurement))
+    return c_to_py(unwrap(function(scale, lower, upper, T, QO), Measurement))
+
+
+def make_constant_time_base_vector_geometric(
+    scale,
+    lower,
+    upper,
+    T: RuntimeTypeDescriptor = None,
+    QO: RuntimeTypeDescriptor = None
+) -> Measurement:
+    """Make a Measurement that adds noise from the geometric(`scale`) distribution to a vector value.
+    `lower` and `upper` are used to derive the max number of trials necessary when sampling from the geometric distribution.
+    
+    :param scale: noise scale parameter to the geometric distribution
+    :param lower: Expected lower bound of data.
+    :param upper: Expected upper bound of data.
+    :param T: Data type to be privatized.
+    :type T: RuntimeTypeDescriptor
+    :param QO: Data type of the sensitivity space.
+    :type QO: RuntimeTypeDescriptor
+    :return: A constant_time_base_vector_geometric step.
+    :rtype: Measurement
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # Standardize type arguments.
+    T = RuntimeType.parse_or_infer(type_name=T, public_example=lower)
+    QO = RuntimeType.parse_or_infer(type_name=QO, public_example=scale)
+    
+    # Convert arguments to c types.
+    scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=QO)
+    lower = py_to_c(lower, c_type=ctypes.c_void_p, type_name=T)
+    upper = py_to_c(upper, c_type=ctypes.c_void_p, type_name=T)
+    T = py_to_c(T, c_type=ctypes.c_char_p)
+    QO = py_to_c(QO, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_meas__make_constant_time_base_vector_geometric
+    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(scale, lower, upper, T, QO), Measurement))
 
 
 def make_base_stability(

--- a/python/src/opendp/v1/mod.py
+++ b/python/src/opendp/v1/mod.py
@@ -138,11 +138,11 @@ class Transformation(ctypes.POINTER(AnyTransformation)):
     >>> assert count.check(1, 1)
     >>>
     >>> # chain with more transformations from the trans module
-    >>> from opendp.v1.trans import make_split_lines, make_parse_series
+    >>> from opendp.v1.trans import make_split_lines, make_cast
     >>> from opendp.v1.typing import SymmetricDistance, L1Sensitivity
     >>> chained = (
     >>>     make_split_lines(M=SymmetricDistance) >>
-    >>>     make_parse_series(impute=True, M=SymmetricDistance, TO=int) >>
+    >>>     make_cast(M=SymmetricDistance, TI=str, TO=int) >>
     >>>     count
     >>> )
     >>>

--- a/python/src/opendp/v1/trans.py
+++ b/python/src/opendp/v1/trans.py
@@ -5,17 +5,21 @@ from opendp.v1.mod import *
 from opendp.v1.typing import *
 
 
-def make_identity(
+def make_cast(
     M: DatasetMetric,
-    T: RuntimeTypeDescriptor
+    TI: RuntimeTypeDescriptor,
+    TO: RuntimeTypeDescriptor
 ) -> Transformation:
-    """Make a Transformation that simply passes the data through.
+    """Make a Transformation that casts a vector of data from type `TI` to type `TO`. 
+    Failure to parse results in None, else Some<TO>.
     
     :param M: dataset metric
     :type M: DatasetMetric
-    :param T: Type of data passed to the identity function.
-    :type T: RuntimeTypeDescriptor
-    :return: A identity step.
+    :param TI: input data type to cast from
+    :type TI: RuntimeTypeDescriptor
+    :param TO: data type to cast into
+    :type TO: RuntimeTypeDescriptor
+    :return: A cast step.
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -23,18 +27,375 @@ def make_identity(
     """
     # Standardize type arguments.
     M = RuntimeType.parse(type_name=M)
+    TI = RuntimeType.parse(type_name=TI)
+    TO = RuntimeType.parse(type_name=TO)
+    
+    # Convert arguments to c types.
+    M = py_to_c(M, c_type=ctypes.c_char_p)
+    TI = py_to_c(TI, c_type=ctypes.c_char_p)
+    TO = py_to_c(TO, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_trans__make_cast
+    function.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(M, TI, TO), Transformation))
+
+
+def make_cast_default(
+    M: DatasetMetric,
+    TI: RuntimeTypeDescriptor,
+    TO: RuntimeTypeDescriptor
+) -> Transformation:
+    """Make a Transformation that casts a vector of data from type `TI` to type `TO`. If cast fails, fill with default.
+    
+    :param M: dataset metric
+    :type M: DatasetMetric
+    :param TI: input data type to cast from
+    :type TI: RuntimeTypeDescriptor
+    :param TO: data type to cast into
+    :type TO: RuntimeTypeDescriptor
+    :return: A cast_default step.
+    :rtype: Transformation
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # Standardize type arguments.
+    M = RuntimeType.parse(type_name=M)
+    TI = RuntimeType.parse(type_name=TI)
+    TO = RuntimeType.parse(type_name=TO)
+    
+    # Convert arguments to c types.
+    M = py_to_c(M, c_type=ctypes.c_char_p)
+    TI = py_to_c(TI, c_type=ctypes.c_char_p)
+    TO = py_to_c(TO, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_trans__make_cast_default
+    function.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(M, TI, TO), Transformation))
+
+
+def make_is_equal(
+    value,
+    M: DatasetMetric,
+    TI: RuntimeTypeDescriptor = None
+) -> Transformation:
+    """Make a Transformation that checks if each element is equal to `value`.
+    
+    :param value: value to check against
+    :param M: dataset metric
+    :type M: DatasetMetric
+    :param TI: input data type
+    :type TI: RuntimeTypeDescriptor
+    :return: A is_equal step.
+    :rtype: Transformation
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # Standardize type arguments.
+    M = RuntimeType.parse(type_name=M)
+    TI = RuntimeType.parse_or_infer(type_name=TI, public_example=value)
+    
+    # Convert arguments to c types.
+    value = py_to_c(value, c_type=ctypes.c_void_p, type_name=TI)
+    M = py_to_c(M, c_type=ctypes.c_char_p)
+    TI = py_to_c(TI, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_trans__make_is_equal
+    function.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(value, M, TI), Transformation))
+
+
+def make_cast_inherent(
+    M: DatasetMetric,
+    TI: RuntimeTypeDescriptor,
+    TO: RuntimeTypeDescriptor
+) -> Transformation:
+    """Make a Transformation that casts a vector of data from type `TI` to a type that can represent nullity `TO`. 
+    If cast fails, fill with `TO`'s null value.
+    
+    :param M: dataset metric
+    :type M: DatasetMetric
+    :param TI: input data type to cast from
+    :type TI: RuntimeTypeDescriptor
+    :param TO: data type to cast into
+    :type TO: RuntimeTypeDescriptor
+    :return: A cast_inherent step.
+    :rtype: Transformation
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # Standardize type arguments.
+    M = RuntimeType.parse(type_name=M)
+    TI = RuntimeType.parse(type_name=TI)
+    TO = RuntimeType.parse(type_name=TO)
+    
+    # Convert arguments to c types.
+    M = py_to_c(M, c_type=ctypes.c_char_p)
+    TI = py_to_c(TI, c_type=ctypes.c_char_p)
+    TO = py_to_c(TO, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_trans__make_cast_inherent
+    function.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(M, TI, TO), Transformation))
+
+
+def make_cast_metric(
+    MI: DatasetMetric,
+    MO: DatasetMetric,
+    T: RuntimeTypeDescriptor
+) -> Transformation:
+    """Make a Transformation that converts the dataset metric from type `MI` to type `MO`.
+    
+    :param MI: input dataset metric
+    :type MI: DatasetMetric
+    :param MO: output dataset metric
+    :type MO: DatasetMetric
+    :param T: atomic type of data
+    :type T: RuntimeTypeDescriptor
+    :return: A cast_metric step.
+    :rtype: Transformation
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # Standardize type arguments.
+    MI = RuntimeType.parse(type_name=MI)
+    MO = RuntimeType.parse(type_name=MO)
     T = RuntimeType.parse(type_name=T)
     
     # Convert arguments to c types.
+    MI = py_to_c(MI, c_type=ctypes.c_char_p)
+    MO = py_to_c(MO, c_type=ctypes.c_char_p)
+    T = py_to_c(T, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_trans__make_cast_metric
+    function.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(MI, MO, T), Transformation))
+
+
+def make_clamp(
+    lower,
+    upper,
+    M: DatasetMetric,
+    T: RuntimeTypeDescriptor = None
+) -> Transformation:
+    """Make a Transformation that clamps numeric data in Vec<`T`> between `lower` and `upper`.
+    
+    :param lower: If datum is less than lower, let datum be lower.
+    :param upper: If datum is greater than upper, let datum be upper.
+    :param M: dataset metric
+    :type M: DatasetMetric
+    :param T: type of data being clamped
+    :type T: RuntimeTypeDescriptor
+    :return: A clamp step.
+    :rtype: Transformation
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # Standardize type arguments.
+    M = RuntimeType.parse(type_name=M)
+    T = RuntimeType.parse_or_infer(type_name=T, public_example=lower)
+    
+    # Convert arguments to c types.
+    lower = py_to_c(lower, c_type=ctypes.c_void_p, type_name=T)
+    upper = py_to_c(upper, c_type=ctypes.c_void_p, type_name=T)
     M = py_to_c(M, c_type=ctypes.c_char_p)
     T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_trans__make_identity
-    function.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    function = lib.opendp_trans__make_clamp
+    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(M, T), Transformation))
+    return c_to_py(unwrap(function(lower, upper, M, T), Transformation))
+
+
+def make_unclamp(
+    lower,
+    upper,
+    M: DatasetMetric,
+    T: RuntimeTypeDescriptor = None
+) -> Transformation:
+    """Make a Transformation that translates an IntervalDomain to an AllDomain
+    
+    :param lower: Lower bound of the input data.
+    :param upper: Upper bound of the input data.
+    :param M: dataset metric
+    :type M: DatasetMetric
+    :param T: type of data being unclamped
+    :type T: RuntimeTypeDescriptor
+    :return: A unclamp step.
+    :rtype: Transformation
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # Standardize type arguments.
+    M = RuntimeType.parse(type_name=M)
+    T = RuntimeType.parse_or_infer(type_name=T, public_example=lower)
+    
+    # Convert arguments to c types.
+    lower = py_to_c(lower, c_type=ctypes.c_void_p, type_name=T)
+    upper = py_to_c(upper, c_type=ctypes.c_void_p, type_name=T)
+    M = py_to_c(M, c_type=ctypes.c_char_p)
+    T = py_to_c(T, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_trans__make_unclamp
+    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(lower, upper, M, T), Transformation))
+
+
+def make_count(
+    MI: DatasetMetric,
+    MO: SensitivityMetric,
+    TI: RuntimeTypeDescriptor
+) -> Transformation:
+    """Make a Transformation that computes a count of the number of records in data.
+    
+    :param MI: input dataset metric
+    :type MI: DatasetMetric
+    :param MO: output sensitivity metric
+    :type MO: SensitivityMetric
+    :param TI: atomic type of input data. Input data is expected to be of the form Vec<TI>.
+    :type TI: RuntimeTypeDescriptor
+    :return: A count step.
+    :rtype: Transformation
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # Standardize type arguments.
+    MI = RuntimeType.parse(type_name=MI)
+    MO = RuntimeType.parse(type_name=MO)
+    TI = RuntimeType.parse(type_name=TI)
+    
+    # Convert arguments to c types.
+    MI = py_to_c(MI, c_type=ctypes.c_char_p)
+    MO = py_to_c(MO, c_type=ctypes.c_char_p)
+    TI = py_to_c(TI, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_trans__make_count
+    function.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(MI, MO, TI), Transformation))
+
+
+def make_count_by(
+    n: int,
+    MI: DatasetMetric,
+    MO: SensitivityMetric,
+    TI: RuntimeTypeDescriptor,
+    TO: RuntimeTypeDescriptor = "i32"
+) -> Transformation:
+    """Make a Transformation that computes the count of each unique value in data. 
+    This assumes that the category set is unknown. 
+    Use make_base_stability to release this query.
+    
+    :param n: Number of records in input data.
+    :type n: int
+    :param MI: input dataset metric
+    :type MI: DatasetMetric
+    :param MO: output sensitivity metric
+    :type MO: SensitivityMetric
+    :param TI: categorical/hashable input data type. Input data must be Vec<TI>.
+    :type TI: RuntimeTypeDescriptor
+    :param TO: express counts in terms of this integral type
+    :type TO: RuntimeTypeDescriptor
+    :return: The carrier type is HashMap<TI, TO>- the counts for each unique data input.
+    :rtype: Transformation
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # Standardize type arguments.
+    MI = RuntimeType.parse(type_name=MI)
+    MO = RuntimeType.parse(type_name=MO)
+    TI = RuntimeType.parse(type_name=TI)
+    TO = RuntimeType.parse(type_name=TO)
+    
+    # Convert arguments to c types.
+    n = py_to_c(n, c_type=ctypes.c_uint)
+    MI = py_to_c(MI, c_type=ctypes.c_char_p)
+    MO = py_to_c(MO, c_type=ctypes.c_char_p)
+    TI = py_to_c(TI, c_type=ctypes.c_char_p)
+    TO = py_to_c(TO, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_trans__make_count_by
+    function.argtypes = [ctypes.c_uint, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(n, MI, MO, TI, TO), Transformation))
+
+
+def make_count_by_categories(
+    categories: Any,
+    MI: DatasetMetric,
+    MO: SensitivityMetric,
+    TI: RuntimeTypeDescriptor = None,
+    TO: RuntimeTypeDescriptor = "i32"
+) -> Transformation:
+    """Make a Transformation that computes the number of times each category appears in the data. 
+    This assumes that the category set is known.
+    
+    :param categories: The set of categories to compute counts for.
+    :type categories: Any
+    :param MI: input dataset metric
+    :type MI: DatasetMetric
+    :param MO: output sensitivity metric
+    :type MO: SensitivityMetric
+    :param TI: categorical/hashable input data type. Input data must be Vec<TI>.
+    :type TI: RuntimeTypeDescriptor
+    :param TO: express counts in terms of this integral type
+    :type TO: RuntimeTypeDescriptor
+    :return: A count_by_categories step.
+    :rtype: Transformation
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # Standardize type arguments.
+    MI = RuntimeType.parse(type_name=MI)
+    MO = RuntimeType.parse(type_name=MO)
+    TI = RuntimeType.parse_or_infer(type_name=TI, public_example=next(iter(categories), None))
+    TO = RuntimeType.parse(type_name=TO)
+    
+    # Convert arguments to c types.
+    categories = py_to_c(categories, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[TI]))
+    MI = py_to_c(MI, c_type=ctypes.c_char_p)
+    MO = py_to_c(MO, c_type=ctypes.c_char_p)
+    TI = py_to_c(TI, c_type=ctypes.c_char_p)
+    TO = py_to_c(TO, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_trans__make_count_by_categories
+    function.argtypes = [AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(categories, MI, MO, TI, TO), Transformation))
 
 
 def make_split_lines(
@@ -256,21 +617,125 @@ def make_select_column(
     return c_to_py(unwrap(function(key, M, K, T), Transformation))
 
 
-def make_clamp_vec(
+def make_identity(
+    M: DatasetMetric,
+    T: RuntimeTypeDescriptor
+) -> Transformation:
+    """Make a Transformation that simply passes the data through.
+    
+    :param M: dataset metric
+    :type M: DatasetMetric
+    :param T: Type of data passed to the identity function.
+    :type T: RuntimeTypeDescriptor
+    :return: A identity step.
+    :rtype: Transformation
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # Standardize type arguments.
+    M = RuntimeType.parse(type_name=M)
+    T = RuntimeType.parse(type_name=T)
+    
+    # Convert arguments to c types.
+    M = py_to_c(M, c_type=ctypes.c_char_p)
+    T = py_to_c(T, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_trans__make_identity
+    function.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(M, T), Transformation))
+
+
+def make_impute_constant(
+    constant,
+    M: DatasetMetric,
+    T: RuntimeTypeDescriptor = None
+) -> Transformation:
+    """Make a Transformation that replaces null/None data with `constant`.
+    Input type is Vec<Option<`T`>>, as emitted by make_cast.
+    
+    :param constant: Value to replace nulls with.
+    :param M: dataset metric
+    :type M: DatasetMetric
+    :param T: type of data being clamped
+    :type T: RuntimeTypeDescriptor
+    :return: A impute_constant step.
+    :rtype: Transformation
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # Standardize type arguments.
+    M = RuntimeType.parse(type_name=M)
+    T = RuntimeType.parse_or_infer(type_name=T, public_example=constant)
+    
+    # Convert arguments to c types.
+    constant = py_to_c(constant, c_type=ctypes.c_void_p, type_name=T)
+    M = py_to_c(M, c_type=ctypes.c_char_p)
+    T = py_to_c(T, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_trans__make_impute_constant
+    function.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(constant, M, T), Transformation))
+
+
+def make_impute_constant_inherent(
+    constant,
+    M: DatasetMetric,
+    T: RuntimeTypeDescriptor = None
+) -> Transformation:
+    """Make a Transformation that replaces null/None data with `constant`.
+    Use if nullity is represented within `T`, with input Vec<`T`>, as emitted by make_cast_inherent.
+    
+    :param constant: Value to replace nulls with.
+    :param M: dataset metric
+    :type M: DatasetMetric
+    :param T: type of data being clamped
+    :type T: RuntimeTypeDescriptor
+    :return: A impute_constant_inherent step.
+    :rtype: Transformation
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # Standardize type arguments.
+    M = RuntimeType.parse(type_name=M)
+    T = RuntimeType.parse_or_infer(type_name=T, public_example=constant)
+    
+    # Convert arguments to c types.
+    constant = py_to_c(constant, c_type=ctypes.c_void_p, type_name=T)
+    M = py_to_c(M, c_type=ctypes.c_char_p)
+    T = py_to_c(T, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_trans__make_impute_constant_inherent
+    function.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(constant, M, T), Transformation))
+
+
+def make_impute_uniform_float(
     lower,
     upper,
     M: DatasetMetric,
     T: RuntimeTypeDescriptor = None
 ) -> Transformation:
-    """Make a Transformation that clamps numeric data in Vec<`T`> between `lower` and `upper`.
+    """Make a Transformation that replaces null/None data in Vec<`T`> with `constant`
     
-    :param lower: If datum is less than lower, let datum be lower.
-    :param upper: If datum is greater than upper, let datum be upper.
+    :param lower: Lower bound of uniform distribution to sample from.
+    :param upper: Upper bound of uniform distribution to sample from.
     :param M: dataset metric
     :type M: DatasetMetric
     :param T: type of data being clamped
     :type T: RuntimeTypeDescriptor
-    :return: A clamp_vec step.
+    :return: A impute_uniform_float step.
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -287,46 +752,7 @@ def make_clamp_vec(
     T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_trans__make_clamp_vec
-    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
-    
-    return c_to_py(unwrap(function(lower, upper, M, T), Transformation))
-
-
-def make_clamp_sensitivity(
-    lower,
-    upper,
-    M: SensitivityMetric,
-    T: RuntimeTypeDescriptor = None
-) -> Transformation:
-    """Make a Transformation that clamps the non-dp result of a query of type `T` between `lower` and `upper`.
-    Used to bound the sensitivity.
-    
-    :param lower: If less than lower, return lower.
-    :param upper: If greater than upper, return upper.
-    :param M: sensitivity metric
-    :type M: SensitivityMetric
-    :param T: type of data being clamped
-    :type T: RuntimeTypeDescriptor
-    :return: A clamp_sensitivity step.
-    :rtype: Transformation
-    :raises AssertionError: if an argument's type differs from the expected type
-    :raises UnknownTypeError: if a type-argument fails to parse
-    :raises OpenDPException: packaged error from the core OpenDP library
-    """
-    # Standardize type arguments.
-    M = RuntimeType.parse(type_name=M)
-    T = RuntimeType.parse_or_infer(type_name=T, public_example=lower)
-    
-    # Convert arguments to c types.
-    lower = py_to_c(lower, c_type=ctypes.c_void_p, type_name=T)
-    upper = py_to_c(upper, c_type=ctypes.c_void_p, type_name=T)
-    M = py_to_c(M, c_type=ctypes.c_char_p)
-    T = py_to_c(T, c_type=ctypes.c_char_p)
-    
-    # Call library function.
-    function = lib.opendp_trans__make_clamp_sensitivity
+    function = lib.opendp_trans__make_impute_uniform_float
     function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
     function.restype = FfiResult
     
@@ -503,135 +929,3 @@ def make_bounded_variance(
     function.restype = FfiResult
     
     return c_to_py(unwrap(function(lower, upper, n, ddof, MI, MO), Transformation))
-
-
-def make_count(
-    MI: DatasetMetric,
-    MO: SensitivityMetric,
-    TI: RuntimeTypeDescriptor
-) -> Transformation:
-    """Make a Transformation that computes a count of the number of records in data.
-    
-    :param MI: input dataset metric
-    :type MI: DatasetMetric
-    :param MO: output sensitivity metric
-    :type MO: SensitivityMetric
-    :param TI: atomic type of input data. Input data is expected to be of the form Vec<TI>.
-    :type TI: RuntimeTypeDescriptor
-    :return: A count step.
-    :rtype: Transformation
-    :raises AssertionError: if an argument's type differs from the expected type
-    :raises UnknownTypeError: if a type-argument fails to parse
-    :raises OpenDPException: packaged error from the core OpenDP library
-    """
-    # Standardize type arguments.
-    MI = RuntimeType.parse(type_name=MI)
-    MO = RuntimeType.parse(type_name=MO)
-    TI = RuntimeType.parse(type_name=TI)
-    
-    # Convert arguments to c types.
-    MI = py_to_c(MI, c_type=ctypes.c_char_p)
-    MO = py_to_c(MO, c_type=ctypes.c_char_p)
-    TI = py_to_c(TI, c_type=ctypes.c_char_p)
-    
-    # Call library function.
-    function = lib.opendp_trans__make_count
-    function.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
-    
-    return c_to_py(unwrap(function(MI, MO, TI), Transformation))
-
-
-def make_count_by(
-    n: int,
-    MI: DatasetMetric,
-    MO: SensitivityMetric,
-    TI: RuntimeTypeDescriptor,
-    TO: RuntimeTypeDescriptor = int
-) -> Transformation:
-    """Make a Transformation that computes the count of each unique value in data. 
-    This assumes that the category set is unknown. 
-    Use make_base_stability to release this query.
-    
-    :param n: Number of records in input data.
-    :type n: int
-    :param MI: input dataset metric
-    :type MI: DatasetMetric
-    :param MO: output sensitivity metric
-    :type MO: SensitivityMetric
-    :param TI: categorical/hashable input data type. Input data must be Vec<TI>.
-    :type TI: RuntimeTypeDescriptor
-    :param TO: express counts in terms of this integral type
-    :type TO: RuntimeTypeDescriptor
-    :return: The carrier type is HashMap<TI, TO>- the counts for each unique data input.
-    :rtype: Transformation
-    :raises AssertionError: if an argument's type differs from the expected type
-    :raises UnknownTypeError: if a type-argument fails to parse
-    :raises OpenDPException: packaged error from the core OpenDP library
-    """
-    # Standardize type arguments.
-    MI = RuntimeType.parse(type_name=MI)
-    MO = RuntimeType.parse(type_name=MO)
-    TI = RuntimeType.parse(type_name=TI)
-    TO = RuntimeType.parse(type_name=TO)
-    
-    # Convert arguments to c types.
-    n = py_to_c(n, c_type=ctypes.c_uint)
-    MI = py_to_c(MI, c_type=ctypes.c_char_p)
-    MO = py_to_c(MO, c_type=ctypes.c_char_p)
-    TI = py_to_c(TI, c_type=ctypes.c_char_p)
-    TO = py_to_c(TO, c_type=ctypes.c_char_p)
-    
-    # Call library function.
-    function = lib.opendp_trans__make_count_by
-    function.argtypes = [ctypes.c_uint, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
-    
-    return c_to_py(unwrap(function(n, MI, MO, TI, TO), Transformation))
-
-
-def make_count_by_categories(
-    categories: Any,
-    MI: DatasetMetric,
-    MO: SensitivityMetric,
-    TI: RuntimeTypeDescriptor = None,
-    TO: RuntimeTypeDescriptor = int
-) -> Transformation:
-    """Make a Transformation that computes the number of times each category appears in the data. 
-    This assumes that the category set is known.
-    
-    :param categories: The set of categories to compute counts for.
-    :type categories: Any
-    :param MI: input dataset metric
-    :type MI: DatasetMetric
-    :param MO: output sensitivity metric
-    :type MO: SensitivityMetric
-    :param TI: categorical/hashable input data type. Input data must be Vec<TI>.
-    :type TI: RuntimeTypeDescriptor
-    :param TO: express counts in terms of this integral type
-    :type TO: RuntimeTypeDescriptor
-    :return: A count_by_categories step.
-    :rtype: Transformation
-    :raises AssertionError: if an argument's type differs from the expected type
-    :raises UnknownTypeError: if a type-argument fails to parse
-    :raises OpenDPException: packaged error from the core OpenDP library
-    """
-    # Standardize type arguments.
-    MI = RuntimeType.parse(type_name=MI)
-    MO = RuntimeType.parse(type_name=MO)
-    TI = RuntimeType.parse_or_infer(type_name=TI, public_example=next(iter(categories), None))
-    TO = RuntimeType.parse(type_name=TO)
-    
-    # Convert arguments to c types.
-    categories = py_to_c(categories, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[TI]))
-    MI = py_to_c(MI, c_type=ctypes.c_char_p)
-    MO = py_to_c(MO, c_type=ctypes.c_char_p)
-    TI = py_to_c(TI, c_type=ctypes.c_char_p)
-    TO = py_to_c(TO, c_type=ctypes.c_char_p)
-    
-    # Call library function.
-    function = lib.opendp_trans__make_count_by_categories
-    function.argtypes = [AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
-    
-    return c_to_py(unwrap(function(categories, MI, MO, TI, TO), Transformation))

--- a/python/src/opendp/v1/trans.py
+++ b/python/src/opendp/v1/trans.py
@@ -64,42 +64,6 @@ def make_split_lines(
     return c_to_py(unwrap(function(M), Transformation))
 
 
-def make_parse_series(
-    impute: bool,
-    M: DatasetMetric,
-    TO: RuntimeTypeDescriptor
-) -> Transformation:
-    """Make a Transformation that parses a Vec<String> into a Vec<T>.
-    
-    :param impute: Enable to impute values that fail to parse. If false, raise an error if parsing fails.
-    :type impute: bool
-    :param M: dataset metric
-    :type M: DatasetMetric
-    :param TO: atomic type of the output vector
-    :type TO: RuntimeTypeDescriptor
-    :return: A parse_series step.
-    :rtype: Transformation
-    :raises AssertionError: if an argument's type differs from the expected type
-    :raises UnknownTypeError: if a type-argument fails to parse
-    :raises OpenDPException: packaged error from the core OpenDP library
-    """
-    # Standardize type arguments.
-    M = RuntimeType.parse(type_name=M)
-    TO = RuntimeType.parse(type_name=TO)
-    
-    # Convert arguments to c types.
-    impute = py_to_c(impute, c_type=ctypes.c_bool)
-    M = py_to_c(M, c_type=ctypes.c_char_p)
-    TO = py_to_c(TO, c_type=ctypes.c_char_p)
-    
-    # Call library function.
-    function = lib.opendp_trans__make_parse_series
-    function.argtypes = [ctypes.c_bool, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
-    
-    return c_to_py(unwrap(function(impute, M, TO), Transformation))
-
-
 def make_split_records(
     separator: str,
     M: DatasetMetric

--- a/python/src/opendp/v1/trans.py
+++ b/python/src/opendp/v1/trans.py
@@ -660,7 +660,7 @@ def make_impute_constant(
     :param constant: Value to replace nulls with.
     :param M: dataset metric
     :type M: DatasetMetric
-    :param T: type of data being clamped
+    :param T: type of data being imputed
     :type T: RuntimeTypeDescriptor
     :return: A impute_constant step.
     :rtype: Transformation
@@ -696,7 +696,7 @@ def make_impute_constant_inherent(
     :param constant: Value to replace nulls with.
     :param M: dataset metric
     :type M: DatasetMetric
-    :param T: type of data being clamped
+    :param T: type of data being imputed
     :type T: RuntimeTypeDescriptor
     :return: A impute_constant_inherent step.
     :rtype: Transformation
@@ -733,7 +733,7 @@ def make_impute_uniform_float(
     :param upper: Upper bound of uniform distribution to sample from.
     :param M: dataset metric
     :type M: DatasetMetric
-    :param T: type of data being clamped
+    :param T: type of data being imputed
     :type T: RuntimeTypeDescriptor
     :return: A impute_uniform_float step.
     :rtype: Transformation

--- a/python/test/test_core.py
+++ b/python/test/test_core.py
@@ -9,7 +9,7 @@ def test_type_getters():
     assert transformation.input_carrier_type == "Vec<f64>"
 
     from opendp.v1.meas import make_base_geometric
-    measurement = make_base_geometric(scale=1.5, lower=0, upper=20)
+    measurement = make_base_geometric(scale=1.5)
     assert measurement.input_distance_type == "i32"
     assert measurement.output_distance_type == "f64"
     assert measurement.input_carrier_type == "i32"
@@ -26,7 +26,7 @@ def test_chain():
     base_laplace = make_base_laplace(scale=1.)
     print("base laplace:", base_laplace(10.))
 
-    base_geometric = make_base_geometric(scale=0.5, lower=0, upper=20)
+    base_geometric = make_base_geometric(scale=0.5)
     print("base_geometric:", base_geometric(1))
 
     chain = count >> base_geometric

--- a/python/test/test_meas.py
+++ b/python/test/test_meas.py
@@ -9,8 +9,8 @@ def test_base_laplace():
 
 
 def test_base_laplace_vec():
-    from opendp.v1.meas import make_base_laplace_vec
-    meas = make_base_laplace_vec(scale=10.5)
+    from opendp.v1.meas import make_base_vector_laplace
+    meas = make_base_vector_laplace(scale=10.5)
     print("base laplace:", meas([80., 90., 100.]))
     assert meas.check(1., 1.3)
 
@@ -23,8 +23,8 @@ def test_base_gaussian():
 
 
 def test_base_gaussian_vec():
-    from opendp.v1.meas import make_base_gaussian_vec
-    meas = make_base_gaussian_vec(scale=10.5)
+    from opendp.v1.meas import make_base_vector_gaussian
+    meas = make_base_vector_gaussian(scale=10.5)
     print("base gaussian:", meas([80., 90., 100.]))
     assert meas.check(1., (1.3, .000001))
 
@@ -33,6 +33,14 @@ def test_base_geometric():
     from opendp.v1.meas import make_base_geometric
     meas = make_base_geometric(scale=2., lower=0, upper=20)
     print("base_geometric:", meas(100))
+    assert meas.check(1, 0.5)
+    assert not meas.check(1, 0.49999)
+
+
+def test_base_geometric_vec():
+    from opendp.v1.meas import make_base_vector_geometric
+    meas = make_base_vector_geometric(scale=2., lower=0, upper=20)
+    print("base_geometric:", meas([100, 10, 12]))
     assert meas.check(1, 0.5)
     assert not meas.check(1, 0.49999)
 

--- a/python/test/test_meas.py
+++ b/python/test/test_meas.py
@@ -8,7 +8,7 @@ def test_base_laplace():
     assert meas.check(1., 1.3)
 
 
-def test_base_laplace_vec():
+def test_base_vector_laplace():
     from opendp.v1.meas import make_base_vector_laplace
     meas = make_base_vector_laplace(scale=10.5)
     print("base laplace:", meas([80., 90., 100.]))
@@ -22,7 +22,7 @@ def test_base_gaussian():
     assert meas.check(1., (1.3, .000001))
 
 
-def test_base_gaussian_vec():
+def test_base_vector_gaussian():
     from opendp.v1.meas import make_base_vector_gaussian
     meas = make_base_vector_gaussian(scale=10.5)
     print("base gaussian:", meas([80., 90., 100.]))
@@ -43,7 +43,7 @@ def test_base_geometric():
     assert not meas.check(1, 0.49999)
 
 
-def test_base_geometric_vec():
+def test_base_vector_geometric():
     from opendp.v1.meas import make_base_vector_geometric
     meas = make_base_vector_geometric(scale=2.)
     print("base_geometric:", meas([100, 10, 12]))

--- a/python/test/test_meas.py
+++ b/python/test/test_meas.py
@@ -31,7 +31,13 @@ def test_base_gaussian_vec():
 
 def test_base_geometric():
     from opendp.v1.meas import make_base_geometric
-    meas = make_base_geometric(scale=2., lower=0, upper=20)
+    meas = make_base_geometric(scale=2.)
+    print("base_geometric:", meas(100))
+    assert meas.check(1, 0.5)
+    assert not meas.check(1, 0.49999)
+
+    from opendp.v1.meas import make_constant_time_base_geometric
+    meas = make_constant_time_base_geometric(scale=2., lower=0, upper=20)
     print("base_geometric:", meas(100))
     assert meas.check(1, 0.5)
     assert not meas.check(1, 0.49999)
@@ -39,7 +45,13 @@ def test_base_geometric():
 
 def test_base_geometric_vec():
     from opendp.v1.meas import make_base_vector_geometric
-    meas = make_base_vector_geometric(scale=2., lower=0, upper=20)
+    meas = make_base_vector_geometric(scale=2.)
+    print("base_geometric:", meas([100, 10, 12]))
+    assert meas.check(1, 0.5)
+    assert not meas.check(1, 0.49999)
+
+    from opendp.v1.meas import make_constant_time_base_vector_geometric
+    meas = make_constant_time_base_vector_geometric(scale=2., lower=0, upper=20)
     print("base_geometric:", meas([100, 10, 12]))
     assert meas.check(1, 0.5)
     assert not meas.check(1, 0.49999)

--- a/python/test/test_trans.py
+++ b/python/test/test_trans.py
@@ -88,7 +88,7 @@ def test_split_dataframe():
     assert query.check(1, 1)
 
 
-def test_clamp_vec():
+def test_vector_clamp():
     from opendp.v1.trans import make_clamp
     query = make_clamp(lower=-1, upper=1, M=HammingDistance)
     assert query([-10, 0, 10]) == [-1, 0, 1]

--- a/python/test/test_trans.py
+++ b/python/test/test_trans.py
@@ -4,6 +4,48 @@ INT_DATA = list(range(1, 10))
 FLOAT_DATA = list(map(float, INT_DATA))
 
 
+def test_cast_impute():
+    from opendp.v1.trans import make_cast, make_impute_constant
+    caster = make_cast(M=HammingDistance, TI=float, TO=int) >> make_impute_constant(-1, M=HammingDistance)
+    assert caster([1., 2., 3.]) == [1, 2, 3]
+
+    caster = make_cast(M=HammingDistance, TI=float, TO=int) \
+             >> make_impute_constant(1, M=HammingDistance)
+    assert caster([float('nan'), 2.]) == [1, 2]
+
+
+def test_cast_inherent():
+    from opendp.v1.trans import make_cast_inherent
+    caster = make_cast_inherent(M=HammingDistance, TI=int, TO=float)
+
+    assert caster([1, 2]) == [1., 2.]
+
+
+def test_impute_constant_inherent():
+    from opendp.v1.trans import make_impute_constant_inherent
+    imputer = make_impute_constant_inherent(-1., M=HammingDistance)
+    assert imputer([float('nan'), 1.]) == [-1., 1.]
+
+
+def test_cast_default():
+    from opendp.v1.trans import make_cast_default
+    caster = make_cast_default(M=HammingDistance, TI=float, TO=int)
+    assert caster([float('nan'), 2.]) == [0, 2]
+
+
+def test_impute_uniform():
+    from opendp.v1.trans import make_impute_uniform_float
+    caster = make_impute_uniform_float(-1., 2., M=HammingDistance)
+    assert -1. <= caster([float('nan')])[0] <= 2.
+
+
+def test_cast_metric():
+    from opendp.v1.trans import make_cast_metric
+    caster = make_cast_metric(HammingDistance, SymmetricDistance, T=float)
+    assert caster([1., 2.]) == [1., 2.]
+    assert not caster.check(1, 1)
+
+
 def test_identity():
     from opendp.v1.trans import make_identity
     # test int

--- a/rust/opendp-ffi/build/main.rs
+++ b/rust/opendp-ffi/build/main.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 use indexmap::map::IndexMap;
 use serde::Deserialize;
+use serde_json::Value;
 
 #[cfg(feature="python")]
 pub mod python;
@@ -44,7 +45,8 @@ pub struct Argument {
     // plaintext description of the argument used to generate documentation
     description: Option<String>,
     // default value for the argument
-    default: Option<String>,
+    #[serde(default)]
+    default: Value,
     // set to true if the argument represents a type
     #[serde(default)]
     is_type: bool,

--- a/rust/opendp-ffi/build/python.rs
+++ b/rust/opendp-ffi/build/python.rs
@@ -154,8 +154,6 @@ fn generate_input_argument(arg: &Argument, func: &Function, hierarchy: &HashMap<
         Value::Array(array) => Some(format!("{:?}", array)),
         Value::Object(_) => unimplemented!()
     };
-        // .as_ref().cloned()
-        // .or_else(|| generate_public_example(func, arg).map(|_| "None".to_string()));
     (format!(
         r#"{name}{hint}{default}"#,
         name = arg.name(),

--- a/rust/opendp-ffi/build/python.rs
+++ b/rust/opendp-ffi/build/python.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use indexmap::map::IndexMap;
 
 use crate::{Argument, Function, Module, RuntimeType};
+use serde_json::Value;
 
 /// Top-level function to generate python bindings, including all modules.
 pub fn generate_bindings(modules: IndexMap<String, Module>) -> IndexMap<PathBuf, String> {
@@ -138,8 +139,23 @@ impl Argument {
 /// generate an input argument, complete with name, hint and default.
 /// also returns a bool to make it possible to move arguments with defaults to the end of the signature.
 fn generate_input_argument(arg: &Argument, func: &Function, hierarchy: &HashMap<String, Vec<String>>) -> (String, bool) {
-    let default = arg.default.as_ref().cloned()
-        .or_else(|| generate_public_example(func, arg).map(|_| "None".to_string()));
+    let default = match &arg.default {
+        // if no default value
+        Value::Null => if arg.is_type {
+            // let default value be None if it is a type arg and there is a public example
+            generate_public_example(func, arg).map(|_| "None".to_string())
+        } else {
+            // otherwise, the common path, no default is added to the code
+            None
+        }
+        Value::Bool(value) => Some(if *value {"True"} else {"False"}.to_string()),
+        Value::Number(number) => Some(number.to_string()),
+        Value::String(string) => Some(format!("\"{}\"", string)),
+        Value::Array(array) => Some(format!("{:?}", array)),
+        Value::Object(_) => unimplemented!()
+    };
+        // .as_ref().cloned()
+        // .or_else(|| generate_public_example(func, arg).map(|_| "None".to_string()));
     (format!(
         r#"{name}{hint}{default}"#,
         name = arg.name(),

--- a/rust/opendp-ffi/src/any.rs
+++ b/rust/opendp-ffi/src/any.rs
@@ -527,13 +527,13 @@ mod tests {
 
     #[test]
     fn test_any_domain() -> Fallible<()> {
-        let domain1 = IntervalDomain::new(Bound::Included(0), Bound::Included(1));
-        let domain2 = IntervalDomain::new(Bound::Included(0), Bound::Included(1));
+        let domain1 = IntervalDomain::new(Bound::Included(0), Bound::Included(1))?;
+        let domain2 = IntervalDomain::new(Bound::Included(0), Bound::Included(1))?;
         // TODO: Add Debug to Domain so we can use assert_eq!.
         assert!(domain1 == domain2);
 
-        let domain1 = AnyDomain::new(IntervalDomain::new(Bound::Included(0), Bound::Included(1)));
-        let domain2 = AnyDomain::new(IntervalDomain::new(Bound::Included(0), Bound::Included(1)));
+        let domain1 = AnyDomain::new(IntervalDomain::new(Bound::Included(0), Bound::Included(1))?);
+        let domain2 = AnyDomain::new(IntervalDomain::new(Bound::Included(0), Bound::Included(1))?);
         let domain3 = AnyDomain::new(AllDomain::<i32>::new());
         assert!(domain1 == domain2);
         assert!(domain1 != domain3);

--- a/rust/opendp-ffi/src/any.rs
+++ b/rust/opendp-ffi/src/any.rs
@@ -518,7 +518,7 @@ mod tests {
     use std::ops::Bound;
 
     use opendp::dist::{HammingDistance, L2Sensitivity, MaxDivergence, SmoothedMaxDivergence, SymmetricDistance};
-    use opendp::dom::{AllDomain, IntervalDomain};
+    use opendp::dom::{AllDomain, IntervalDomain, VectorDomain};
     use opendp::error::*;
     use opendp::meas;
     use opendp::trans;
@@ -587,7 +587,7 @@ mod tests {
         let t1 = trans::make_split_dataframe::<HammingDistance, _>(None, vec!["a".to_owned(), "b".to_owned()])?.into_any();
         let t2 = trans::make_parse_column::<HammingDistance, _, f64>("a".to_owned(), true)?.into_any();
         let t3 = trans::make_select_column::<HammingDistance, _, f64>("a".to_owned())?.into_any();
-        let t4 = trans::make_clamp_vec::<HammingDistance, _>(0.0, 10.0)?.into_any();
+        let t4 = trans::make_clamp::<VectorDomain<_>, HammingDistance>(0.0, 10.0)?.into_any();
         let t5 = trans::make_bounded_sum::<HammingDistance, L2Sensitivity<_>>(0.0, 10.0)?.into_any();
         let m1 = meas::make_base_gaussian(0.0)?.into_any();
         let chain = (t1 >> t2 >> t3 >> t4 >> t5 >> m1)?;

--- a/rust/opendp-ffi/src/any.rs
+++ b/rust/opendp-ffi/src/any.rs
@@ -589,7 +589,7 @@ mod tests {
         let t3 = trans::make_select_column::<HammingDistance, _, f64>("a".to_owned())?.into_any();
         let t4 = trans::make_clamp::<VectorDomain<_>, HammingDistance>(0.0, 10.0)?.into_any();
         let t5 = trans::make_bounded_sum::<HammingDistance, L2Sensitivity<_>>(0.0, 10.0)?.into_any();
-        let m1 = meas::make_base_gaussian(0.0)?.into_any();
+        let m1 = meas::make_base_gaussian::<AllDomain<_>>(0.0)?.into_any();
         let chain = (t1 >> t2 >> t3 >> t4 >> t5 >> m1)?;
         let arg = AnyObject::new("1.0, 10.0\n2.0, 20.0\n3.0, 30.0\n".to_owned());
         let res = chain.function.eval(&arg);

--- a/rust/opendp-ffi/src/lib.rs
+++ b/rust/opendp-ffi/src/lib.rs
@@ -121,4 +121,4 @@ mod data;
 mod glue;
 mod meas;
 mod trans;
-mod util;
+pub(crate) mod util;

--- a/rust/opendp-ffi/src/meas/bootstrap.json
+++ b/rust/opendp-ffi/src/meas/bootstrap.json
@@ -18,7 +18,7 @@
         ],
         "ret": {"c_type": "FfiResult<AnyMeasurement *>"}
     },
-    "make_base_laplace_vec": {
+    "make_base_vector_laplace": {
         "description": "Make a Measurement that adds noise from the multivariate laplace(`scale`) distribution to a vector value.",
         "args": [
             {
@@ -58,7 +58,7 @@
             "c_type": "FfiResult<AnyMeasurement *>"
         }
     },
-    "make_base_gaussian_vec": {
+    "make_base_vector_gaussian": {
         "description": "Make a Measurement that adds noise from the multivariate gaussian(`scale`) distribution to a vector value.",
         "args": [
             {
@@ -98,6 +98,56 @@
                 "c_type": "void *",
                 "rust_type": "T",
                 "description": "Expected upper bound of data."
+            },
+            {
+                "name": "constant_time",
+                "c_type": "bool",
+                "default": false,
+                "description": "Execute the function such that the elapsed time on any input is the same."
+            },
+            {
+                "name": "T",
+                "c_type": "char *",
+                "description": "Data type to be privatized.",
+                "is_type": true
+            },
+            {
+                "name": "QO",
+                "c_type": "char *",
+                "description": "Data type of the sensitivity space.",
+                "is_type": true
+            }
+        ],
+        "ret": {
+            "c_type": "FfiResult<AnyMeasurement *>"
+        }
+    },
+    "make_base_vector_geometric": {
+        "description": "Make a Measurement that adds noise from the geometric(`scale`) distribution to a vector value.\n`lower` and `upper` are used to derive the max number of trials necessary when sampling from the geometric distribution.",
+        "args": [
+            {
+                "name": "scale",
+                "c_type": "void *",
+                "rust_type": "QO",
+                "description": "noise scale parameter to the geometric distribution"
+            },
+            {
+                "name": "lower",
+                "c_type": "void *",
+                "rust_type": "T",
+                "description": "Expected lower bound of data."
+            },
+            {
+                "name": "upper",
+                "c_type": "void *",
+                "rust_type": "T",
+                "description": "Expected upper bound of data."
+            },
+            {
+                "name": "constant_time",
+                "c_type": "bool",
+                "default": false,
+                "description": "Execute the function such that the elapsed time on any input is the same."
             },
             {
                 "name": "T",
@@ -154,7 +204,7 @@
                 "c_type": "char *",
                 "description": "Data type of input count- must be integral.",
                 "is_type": true,
-                "default": "int"
+                "default": "i32"
             }
         ],
         "ret": {

--- a/rust/opendp-ffi/src/meas/bootstrap.json
+++ b/rust/opendp-ffi/src/meas/bootstrap.json
@@ -79,6 +79,60 @@
         }
     },
     "make_base_geometric": {
+        "description": "Make a Measurement that adds noise from the geometric(`scale`) distribution to a scalar value.",
+        "args": [
+            {
+                "name": "scale",
+                "c_type": "void *",
+                "rust_type": "QO",
+                "description": "noise scale parameter to the geometric distribution"
+            },
+            {
+                "name": "T",
+                "c_type": "char *",
+                "default": "i32",
+                "description": "Data type to be privatized.",
+                "is_type": true
+            },
+            {
+                "name": "QO",
+                "c_type": "char *",
+                "description": "Data type of the sensitivity space.",
+                "is_type": true
+            }
+        ],
+        "ret": {
+            "c_type": "FfiResult<AnyMeasurement *>"
+        }
+    },
+    "make_base_vector_geometric": {
+        "description": "Make a Measurement that adds noise from the geometric(`scale`) distribution to a vector value.",
+        "args": [
+            {
+                "name": "scale",
+                "c_type": "void *",
+                "rust_type": "QO",
+                "description": "noise scale parameter to the geometric distribution"
+            },
+            {
+                "name": "T",
+                "c_type": "char *",
+                "default": "i32",
+                "description": "Data type to be privatized.",
+                "is_type": true
+            },
+            {
+                "name": "QO",
+                "c_type": "char *",
+                "description": "Data type of the sensitivity space.",
+                "is_type": true
+            }
+        ],
+        "ret": {
+            "c_type": "FfiResult<AnyMeasurement *>"
+        }
+    },
+    "make_constant_time_base_geometric": {
         "description": "Make a Measurement that adds noise from the geometric(`scale`) distribution to a scalar value.\n`lower` and `upper` are used to derive the max number of trials necessary when sampling from the geometric distribution.",
         "args": [
             {
@@ -100,12 +154,6 @@
                 "description": "Expected upper bound of data."
             },
             {
-                "name": "constant_time",
-                "c_type": "bool",
-                "default": false,
-                "description": "Execute the function such that the elapsed time on any input is the same."
-            },
-            {
                 "name": "T",
                 "c_type": "char *",
                 "description": "Data type to be privatized.",
@@ -122,7 +170,7 @@
             "c_type": "FfiResult<AnyMeasurement *>"
         }
     },
-    "make_base_vector_geometric": {
+    "make_constant_time_base_vector_geometric": {
         "description": "Make a Measurement that adds noise from the geometric(`scale`) distribution to a vector value.\n`lower` and `upper` are used to derive the max number of trials necessary when sampling from the geometric distribution.",
         "args": [
             {
@@ -142,12 +190,6 @@
                 "c_type": "void *",
                 "rust_type": "T",
                 "description": "Expected upper bound of data."
-            },
-            {
-                "name": "constant_time",
-                "c_type": "bool",
-                "default": false,
-                "description": "Execute the function such that the elapsed time on any input is the same."
             },
             {
                 "name": "T",

--- a/rust/opendp-ffi/src/meas/gaussian.rs
+++ b/rust/opendp-ffi/src/meas/gaussian.rs
@@ -54,7 +54,8 @@ mod tests {
 
     #[test]
     fn test_make_base_gaussian() -> Fallible<()> {
-        let measurement = Result::from(opendp_meas__make_base_gaussian(util::into_raw(0.0) as *const c_void, "f64".to_char_p()))?;
+        let measurement = Result::from(opendp_meas__make_base_gaussian(
+            util::into_raw(0.0) as *const c_void, "f64".to_char_p()))?;
         let arg = AnyObject::new_raw(1.0);
         let res = core::opendp_core__measurement_invoke(&measurement, arg);
         let res: f64 = Fallible::from(res)?.downcast()?;
@@ -64,7 +65,8 @@ mod tests {
 
     #[test]
     fn test_make_base_gaussian_vec() -> Fallible<()> {
-        let measurement = Result::from(opendp_meas__make_base_gaussian_vec(util::into_raw(0.0) as *const c_void, "f64".to_char_p()))?;
+        let measurement = Result::from(opendp_meas__make_base_vector_gaussian(
+            util::into_raw(0.0) as *const c_void, "f64".to_char_p()))?;
         let arg = AnyObject::new_raw(vec![1.0, 2.0, 3.0]);
         let res = core::opendp_core__measurement_invoke(&measurement, arg);
         let res: Vec<f64> = Fallible::from(res)?.downcast()?;

--- a/rust/opendp-ffi/src/meas/gaussian.rs
+++ b/rust/opendp-ffi/src/meas/gaussian.rs
@@ -27,7 +27,7 @@ pub extern "C" fn opendp_meas__make_base_gaussian(
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_meas__make_base_gaussian_vec(
+pub extern "C" fn opendp_meas__make_base_vector_gaussian(
     scale: *const c_void,
     T: *const c_char,
 ) -> FfiResult<*mut AnyMeasurement> {

--- a/rust/opendp-ffi/src/meas/gaussian.rs
+++ b/rust/opendp-ffi/src/meas/gaussian.rs
@@ -4,12 +4,13 @@ use std::os::raw::{c_char, c_void};
 use num::Float;
 
 use opendp::err;
-use opendp::meas::{make_base_gaussian, make_base_gaussian_vec};
+use opendp::meas::{make_base_gaussian};
 use opendp::samplers::SampleGaussian;
 
 use crate::any::AnyMeasurement;
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::util::Type;
+use opendp::dom::{AllDomain, VectorDomain};
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_gaussian(
@@ -19,7 +20,7 @@ pub extern "C" fn opendp_meas__make_base_gaussian(
     fn monomorphize<T>(scale: *const c_void) -> FfiResult<*mut AnyMeasurement> where
         T: 'static + Clone + SampleGaussian + Float {
         let scale = *try_as_ref!(scale as *const T);
-        make_base_gaussian::<T>(scale).into_any()
+        make_base_gaussian::<AllDomain<T>>(scale).into_any()
     }
     let T = try_!(Type::try_from(T));
     dispatch!(monomorphize, [(T, @floats)], (scale))
@@ -33,7 +34,7 @@ pub extern "C" fn opendp_meas__make_base_gaussian_vec(
     fn monomorphize<T>(scale: *const c_void) -> FfiResult<*mut AnyMeasurement> where
         T: 'static + Clone + SampleGaussian + Float {
         let scale = *try_as_ref!(scale as *const T);
-        make_base_gaussian_vec::<T>(scale).into_any()
+        make_base_gaussian::<VectorDomain<_>>(scale).into_any()
     }
     let T = try_!(Type::try_from(T));
     dispatch!(monomorphize, [(T, @floats)], (scale))

--- a/rust/opendp-ffi/src/meas/geometric.rs
+++ b/rust/opendp-ffi/src/meas/geometric.rs
@@ -70,7 +70,7 @@ mod tests {
     use crate::any::{AnyObject, Downcast};
     use crate::core;
     use crate::util;
-    use crate::util::ToCharP;
+    use crate::util::{ToCharP, from_bool};
 
     use super::*;
 
@@ -80,6 +80,7 @@ mod tests {
             util::into_raw(0.0) as *const c_void,
             util::into_raw(0) as *const c_void,
             util::into_raw(100) as *const c_void,
+            from_bool(false),
             "i32".to_char_p(),
             "f64".to_char_p(),
         ))?;

--- a/rust/opendp-ffi/src/meas/geometric.rs
+++ b/rust/opendp-ffi/src/meas/geometric.rs
@@ -1,65 +1,105 @@
 use std::convert::TryFrom;
 use std::os::raw::{c_char, c_void};
 
-use num::{CheckedAdd, CheckedSub, Float, Zero, Bounded};
+use num::{CheckedAdd, CheckedSub, Float, Zero, Bounded, One};
 
 use opendp::err;
 use opendp::meas::make_base_geometric;
-use opendp::samplers::SampleGeometric;
+use opendp::samplers::{SampleGeometric, SampleTwoSidedGeometric};
 use opendp::traits::DistanceCast;
 
 use crate::any::AnyMeasurement;
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
-use crate::util::{Type, to_bool, c_bool};
+use crate::util::Type;
 use opendp::dom::{AllDomain, VectorDomain};
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_geometric(
-    scale: *const c_void, min: *const c_void, max: *const c_void, constant_time: c_bool,
-    T: *const c_char, QO: *const c_char,
+    scale: *const c_void, T: *const c_char, QO: *const c_char,
 ) -> FfiResult<*mut AnyMeasurement> {
     fn monomorphize<T, QO>(
-        scale: *const c_void, min: *const c_void, max: *const c_void, constant_time: bool
+        scale: *const c_void
     ) -> FfiResult<*mut AnyMeasurement>
-        where T: 'static + Clone + SampleGeometric + CheckedSub<Output=T> + CheckedAdd<Output=T> + DistanceCast + Zero + PartialOrd + Bounded,
+        where T: 'static + Clone + SampleTwoSidedGeometric + DistanceCast + One + PartialOrd,
               QO: 'static + Float + DistanceCast, f64: From<QO> {
         let scale = *try_as_ref!(scale as *const QO);
-        let min = try_as_ref!(min as *const T).clone();
-        let max = try_as_ref!(max as *const T).clone();
-        make_base_geometric::<AllDomain<T>, QO>(scale, min, max, constant_time).into_any()
+        make_base_geometric::<AllDomain<T>, QO>(scale, None).into_any()
     }
-    let constant_time = to_bool(constant_time);
     let T = try_!(Type::try_from(T));
     let QO = try_!(Type::try_from(QO));
     dispatch!(monomorphize, [
         (T, @integers),
         (QO, @floats)
-    ], (scale, min, max, constant_time))
+    ], (scale))
 }
 
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_vector_geometric(
-    scale: *const c_void, min: *const c_void, max: *const c_void, constant_time: c_bool,
-    T: *const c_char, QO: *const c_char,
+    scale: *const c_void, T: *const c_char, QO: *const c_char,
 ) -> FfiResult<*mut AnyMeasurement> {
     fn monomorphize<T, QO>(
-        scale: *const c_void, min: *const c_void, max: *const c_void, constant_time: bool
+        scale: *const c_void
     ) -> FfiResult<*mut AnyMeasurement>
-        where T: 'static + Clone + SampleGeometric + CheckedSub<Output=T> + CheckedAdd<Output=T> + DistanceCast + Zero + PartialOrd + Bounded,
+        where T: 'static + Clone + SampleGeometric + CheckedSub<Output=T> + CheckedAdd<Output=T> + DistanceCast + Zero + One + PartialOrd + Bounded,
               QO: 'static + Float + DistanceCast, f64: From<QO> {
         let scale = *try_as_ref!(scale as *const QO);
-        let min = try_as_ref!(min as *const T).clone();
-        let max = try_as_ref!(max as *const T).clone();
-        make_base_geometric::<VectorDomain<_>, QO>(scale, min, max, constant_time).into_any()
+        make_base_geometric::<VectorDomain<AllDomain<T>>, QO>(scale, None).into_any()
     }
-    let constant_time = to_bool(constant_time);
     let T = try_!(Type::try_from(T));
     let QO = try_!(Type::try_from(QO));
     dispatch!(monomorphize, [
         (T, @integers),
         (QO, @floats)
-    ], (scale, min, max, constant_time))
+    ], (scale))
+}
+
+
+#[no_mangle]
+pub extern "C" fn opendp_meas__make_constant_time_base_geometric(
+    scale: *const c_void, min: *const c_void, max: *const c_void,
+    T: *const c_char, QO: *const c_char,
+) -> FfiResult<*mut AnyMeasurement> {
+    fn monomorphize<T, QO>(
+        scale: *const c_void, min: *const c_void, max: *const c_void
+    ) -> FfiResult<*mut AnyMeasurement>
+        where T: 'static + Clone + SampleGeometric + CheckedSub<Output=T> + CheckedAdd<Output=T> + DistanceCast + Zero + One + PartialOrd + Bounded,
+              QO: 'static + Float + DistanceCast, f64: From<QO> {
+        let scale = *try_as_ref!(scale as *const QO);
+        let min = try_as_ref!(min as *const T).clone();
+        let max = try_as_ref!(max as *const T).clone();
+        make_base_geometric::<AllDomain<T>, QO>(scale, Some((min, max))).into_any()
+    }
+    let T = try_!(Type::try_from(T));
+    let QO = try_!(Type::try_from(QO));
+    dispatch!(monomorphize, [
+        (T, @integers),
+        (QO, @floats)
+    ], (scale, min, max))
+}
+
+
+#[no_mangle]
+pub extern "C" fn opendp_meas__make_constant_time_base_vector_geometric(
+    scale: *const c_void, min: *const c_void, max: *const c_void,
+    T: *const c_char, QO: *const c_char,
+) -> FfiResult<*mut AnyMeasurement> {
+    fn monomorphize<T, QO>(
+        scale: *const c_void, min: *const c_void, max: *const c_void
+    ) -> FfiResult<*mut AnyMeasurement>
+        where T: 'static + Clone + SampleGeometric + CheckedSub<Output=T> + CheckedAdd<Output=T> + DistanceCast + Zero + One + PartialOrd + Bounded,
+              QO: 'static + Float + DistanceCast, f64: From<QO> {
+        let scale = *try_as_ref!(scale as *const QO);
+        let min = try_as_ref!(min as *const T).clone();
+        let max = try_as_ref!(max as *const T).clone();
+        make_base_geometric::<VectorDomain<_>, QO>(scale, Some((min, max))).into_any()
+    }
+    let T = try_!(Type::try_from(T));
+    let QO = try_!(Type::try_from(QO));
+    dispatch!(monomorphize, [
+        (T, @integers),
+        (QO, @floats)
+    ], (scale, min, max))
 }
 
 
@@ -70,17 +110,16 @@ mod tests {
     use crate::any::{AnyObject, Downcast};
     use crate::core;
     use crate::util;
-    use crate::util::{ToCharP, from_bool};
+    use crate::util::ToCharP;
 
     use super::*;
 
     #[test]
     fn test_make_base_simple_geometric() -> Fallible<()> {
-        let measurement = Result::from(opendp_meas__make_base_geometric(
+        let measurement = Result::from(opendp_meas__make_constant_time_base_geometric(
             util::into_raw(0.0) as *const c_void,
             util::into_raw(0) as *const c_void,
             util::into_raw(100) as *const c_void,
-            from_bool(false),
             "i32".to_char_p(),
             "f64".to_char_p(),
         ))?;

--- a/rust/opendp-ffi/src/meas/laplace.rs
+++ b/rust/opendp-ffi/src/meas/laplace.rs
@@ -4,13 +4,14 @@ use std::os::raw::{c_char, c_void};
 use num::Float;
 
 use opendp::err;
-use opendp::meas::{make_base_laplace, make_base_laplace_vec};
+use opendp::meas::{make_base_laplace};
 use opendp::samplers::SampleLaplace;
 use opendp::traits::DistanceCast;
 
 use crate::any::AnyMeasurement;
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::util::Type;
+use opendp::dom::{VectorDomain, AllDomain};
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_laplace(
@@ -20,21 +21,21 @@ pub extern "C" fn opendp_meas__make_base_laplace(
     fn monomorphize<T>(scale: *const c_void) -> FfiResult<*mut AnyMeasurement>
         where T: 'static + Clone + SampleLaplace + Float + DistanceCast {
         let scale = *try_as_ref!(scale as *const T);
-        make_base_laplace::<T>(scale).into_any()
+        make_base_laplace::<AllDomain<T>>(scale).into_any()
     }
     let T = try_!(Type::try_from(T));
     dispatch!(monomorphize, [(T, @floats)], (scale))
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_meas__make_base_laplace_vec(
+pub extern "C" fn opendp_meas__make_base_vector_laplace(
     scale: *const c_void,
     T: *const c_char,
 ) -> FfiResult<*mut AnyMeasurement> {
     fn monomorphize<T>(scale: *const c_void) -> FfiResult<*mut AnyMeasurement>
         where T: 'static + Clone + SampleLaplace + Float + DistanceCast {
         let scale = *try_as_ref!(scale as *const T);
-        make_base_laplace_vec::<T>(scale).into_any()
+        make_base_laplace::<VectorDomain<_>>(scale).into_any()
     }
     let T = try_!(Type::try_from(T));
     dispatch!(monomorphize, [(T, @floats)], (scale))
@@ -64,7 +65,7 @@ mod tests {
 
     #[test]
     fn test_make_base_laplace_vec() -> Fallible<()> {
-        let measurement = Result::from(opendp_meas__make_base_laplace_vec(util::into_raw(0.0) as *const c_void, "f64".to_char_p()))?;
+        let measurement = Result::from(opendp_meas__make_base_vector_laplace(util::into_raw(0.0) as *const c_void, "f64".to_char_p()))?;
         let arg = AnyObject::new_raw(vec![1.0, 2.0, 3.0]);
         let res = core::opendp_core__measurement_invoke(&measurement, arg);
         let res: Vec<f64> = Fallible::from(res)?.downcast()?;

--- a/rust/opendp-ffi/src/trans/bootstrap.json
+++ b/rust/opendp-ffi/src/trans/bootstrap.json
@@ -33,30 +33,6 @@
         ],
         "ret": {"c_type": "FfiResult<AnyTransformation *>"}
     },
-    "make_parse_series": {
-        "description": "Make a Transformation that parses a Vec<String> into a Vec<T>.",
-        "args": [
-            {
-                "name": "impute",
-                "c_type": "bool",
-                "description": "Enable to impute values that fail to parse. If false, raise an error if parsing fails."
-            },
-            {
-                "name": "M",
-                "c_type": "char *",
-                "hint": "DatasetMetric",
-                "is_type": true,
-                "description": "dataset metric"
-            },
-            {
-                "name": "TO",
-                "c_type": "char *",
-                "is_type": true,
-                "description": "atomic type of the output vector"
-            }
-        ],
-        "ret": {"c_type": "FfiResult<AnyTransformation *>"}
-    },
     "make_split_records": {
         "description": "Make a Transformation that splits each record in a Vec<String> into a Vec<Vec<String>>.",
         "args": [

--- a/rust/opendp-ffi/src/trans/bootstrap.json
+++ b/rust/opendp-ffi/src/trans/bootstrap.json
@@ -500,7 +500,7 @@
                 "name": "T",
                 "c_type": "char *",
                 "is_type": true,
-                "description": "type of data being clamped"
+                "description": "type of data being imputed"
             }
         ],
         "ret": {"c_type": "FfiResult<AnyTransformation *>"}
@@ -525,7 +525,7 @@
                 "name": "T",
                 "c_type": "char *",
                 "is_type": true,
-                "description": "type of data being clamped"
+                "description": "type of data being imputed"
             }
         ],
         "ret": {"c_type": "FfiResult<AnyTransformation *>"}
@@ -556,7 +556,7 @@
                 "name": "T",
                 "c_type": "char *",
                 "is_type": true,
-                "description": "type of data being clamped"
+                "description": "type of data being imputed"
             }
         ],
         "ret": {"c_type": "FfiResult<AnyTransformation *>"}

--- a/rust/opendp-ffi/src/trans/bootstrap.json
+++ b/rust/opendp-ffi/src/trans/bootstrap.json
@@ -1,24 +1,300 @@
 {
-    "make_identity": {
-        "description": "Make a Transformation that simply passes the data through.",
+    "make_cast": {
+        "description": "Make a Transformation that casts a vector of data from type `TI` to type `TO`. \nFailure to parse results in None, else Some<TO>.",
         "args": [
             {
                 "name": "M",
                 "c_type": "char *",
                 "hint": "DatasetMetric",
-                "description": "dataset metric",
-                "is_type": true
+                "is_type": true,
+                "description": "dataset metric"
+            },
+            {
+                "name": "TI",
+                "c_type": "char *",
+                "is_type": true,
+                "description": "input data type to cast from"
+            },
+            {
+                "name": "TO",
+                "c_type": "char *",
+                "is_type": true,
+                "description": "data type to cast into"
+            }
+        ],
+        "ret": {"c_type": "FfiResult<AnyTransformation *>"}
+    },
+    "make_cast_default": {
+        "description": "Make a Transformation that casts a vector of data from type `TI` to type `TO`. If cast fails, fill with default.",
+        "args": [
+            {
+                "name": "M",
+                "c_type": "char *",
+                "hint": "DatasetMetric",
+                "is_type": true,
+                "description": "dataset metric"
+            },
+            {
+                "name": "TI",
+                "c_type": "char *",
+                "is_type": true,
+                "description": "input data type to cast from"
+            },
+            {
+                "name": "TO",
+                "c_type": "char *",
+                "is_type": true,
+                "description": "data type to cast into"
+            }
+        ],
+        "ret": {"c_type": "FfiResult<AnyTransformation *>"}
+    },
+    "make_is_equal": {
+        "description": "Make a Transformation that checks if each element is equal to `value`.",
+        "args": [
+            {
+                "name": "value",
+                "c_type": "void *",
+                "rust_type": "TI",
+                "description": "value to check against"
+            },
+            {
+                "name": "M",
+                "c_type": "char *",
+                "hint": "DatasetMetric",
+                "is_type": true,
+                "description": "dataset metric"
+            },
+            {
+                "name": "TI",
+                "c_type": "char *",
+                "is_type": true,
+                "description": "input data type"
+            }
+        ],
+        "ret": {"c_type": "FfiResult<AnyTransformation *>"}
+    },
+    "make_cast_inherent": {
+        "description": "Make a Transformation that casts a vector of data from type `TI` to a type that can represent nullity `TO`. \nIf cast fails, fill with `TO`'s null value.",
+        "args": [
+            {
+                "name": "M",
+                "c_type": "char *",
+                "hint": "DatasetMetric",
+                "is_type": true,
+                "description": "dataset metric"
+            },
+            {
+                "name": "TI",
+                "c_type": "char *",
+                "is_type": true,
+                "description": "input data type to cast from"
+            },
+            {
+                "name": "TO",
+                "c_type": "char *",
+                "is_type": true,
+                "description": "data type to cast into"
+            }
+        ],
+        "ret": {"c_type": "FfiResult<AnyTransformation *>"}
+    },
+    "make_cast_metric": {
+        "description": "Make a Transformation that converts the dataset metric from type `MI` to type `MO`.",
+        "args": [
+            {
+                "name": "MI",
+                "c_type": "char *",
+                "hint": "DatasetMetric",
+                "is_type": true,
+                "description": "input dataset metric"
+            },
+            {
+                "name": "MO",
+                "c_type": "char *",
+                "hint": "DatasetMetric",
+                "is_type": true,
+                "description": "output dataset metric"
             },
             {
                 "name": "T",
                 "c_type": "char *",
-                "description": "Type of data passed to the identity function.",
-                "is_type": true
+                "is_type": true,
+                "description": "atomic type of data"
+            }
+        ],
+        "ret": {"c_type": "FfiResult<AnyTransformation *>"}
+    },
+    "make_clamp": {
+        "description": "Make a Transformation that clamps numeric data in Vec<`T`> between `lower` and `upper`.",
+        "args": [
+            {
+                "name": "lower",
+                "c_type": "void *",
+                "rust_type": "T",
+                "description": "If datum is less than lower, let datum be lower."
+            },
+            {
+                "name": "upper",
+                "c_type": "void *",
+                "rust_type": "T",
+                "description": "If datum is greater than upper, let datum be upper."
+            },
+            {
+                "name": "M",
+                "c_type": "char *",
+                "hint": "DatasetMetric",
+                "is_type": true,
+                "description": "dataset metric"
+            },
+            {
+                "name": "T",
+                "c_type": "char *",
+                "is_type": true,
+                "description": "type of data being clamped"
+            }
+        ],
+        "ret": {"c_type": "FfiResult<AnyTransformation *>"}
+    },
+    "make_unclamp": {
+        "description": "Make a Transformation that translates an IntervalDomain to an AllDomain",
+        "args": [
+            {
+                "name": "lower",
+                "c_type": "void *",
+                "rust_type": "T",
+                "description": "Lower bound of the input data."
+            },
+            {
+                "name": "upper",
+                "c_type": "void *",
+                "rust_type": "T",
+                "description": "Upper bound of the input data."
+            },
+            {
+                "name": "M",
+                "c_type": "char *",
+                "hint": "DatasetMetric",
+                "is_type": true,
+                "description": "dataset metric"
+            },
+            {
+                "name": "T",
+                "c_type": "char *",
+                "is_type": true,
+                "description": "type of data being unclamped"
+            }
+        ],
+        "ret": {"c_type": "FfiResult<AnyTransformation *>"}
+    },
+    "make_count": {
+        "description": "Make a Transformation that computes a count of the number of records in data.",
+        "args": [
+            {
+                "name": "MI",
+                "c_type": "char *",
+                "hint": "DatasetMetric",
+                "is_type": true,
+                "description": "input dataset metric"
+            },
+            {
+                "name": "MO",
+                "c_type": "char *",
+                "hint": "SensitivityMetric",
+                "is_type": true,
+                "description": "output sensitivity metric"
+            },
+            {
+                "name": "TI",
+                "c_type": "char *",
+                "is_type": true,
+                "description": "atomic type of input data. Input data is expected to be of the form Vec<TI>."
+            }
+        ],
+        "ret": {"c_type": "FfiResult<AnyTransformation *>"}
+    },
+    "make_count_by": {
+        "description": "Make a Transformation that computes the count of each unique value in data. \nThis assumes that the category set is unknown. \nUse make_base_stability to release this query.",
+        "args": [
+            {
+                "name": "n",
+                "c_type": "unsigned int",
+                "description": "Number of records in input data."
+            },
+            {
+                "name": "MI",
+                "c_type": "char *",
+                "hint": "DatasetMetric",
+                "is_type": true,
+                "description": "input dataset metric"
+            },
+            {
+                "name": "MO",
+                "c_type": "char *",
+                "hint": "SensitivityMetric",
+                "is_type": true,
+                "description": "output sensitivity metric"
+            },
+            {
+                "name": "TI",
+                "c_type": "char *",
+                "is_type": true,
+                "description": "categorical/hashable input data type. Input data must be Vec<TI>."
+            },
+            {
+                "name": "TO",
+                "c_type": "char *",
+                "is_type": true,
+                "description": "express counts in terms of this integral type",
+                "default": "i32"
             }
         ],
         "ret": {
-            "c_type": "FfiResult<AnyTransformation *>"
+            "c_type": "FfiResult<AnyTransformation *>",
+            "description": "The carrier type is HashMap<TI, TO>- the counts for each unique data input."
         }
+    },
+    "make_count_by_categories": {
+        "description": "Make a Transformation that computes the number of times each category appears in the data. \nThis assumes that the category set is known.",
+        "args": [
+            {
+                "name": "categories",
+                "c_type": "AnyObject *",
+                "rust_type": {
+                    "origin": "Vec",
+                    "args": ["TI"]
+                },
+                "description": "The set of categories to compute counts for."
+            },
+            {
+                "name": "MI",
+                "c_type": "char *",
+                "hint": "DatasetMetric",
+                "is_type": true,
+                "description": "input dataset metric"
+            },
+            {
+                "name": "MO",
+                "c_type": "char *",
+                "hint": "SensitivityMetric",
+                "is_type": true,
+                "description": "output sensitivity metric"
+            },
+            {
+                "name": "TI",
+                "c_type": "char *",
+                "is_type": true,
+                "description": "categorical/hashable input data type. Input data must be Vec<TI>."
+            },
+            {
+                "name": "TO",
+                "c_type": "char *",
+                "is_type": true,
+                "description": "express counts in terms of this integral type",
+                "default": "i32"
+            }
+        ],
+        "ret": {"c_type": "FfiResult<AnyTransformation *>"}
     },
     "make_split_lines": {
         "description": "Make a Transformation that takes a string and splits it into a Vec<String> of its lines.",
@@ -183,20 +459,35 @@
         ],
         "ret": {"c_type": "FfiResult<AnyTransformation *>"}
     },
-    "make_clamp_vec": {
-        "description": "Make a Transformation that clamps numeric data in Vec<`T`> between `lower` and `upper`.",
+    "make_identity": {
+        "description": "Make a Transformation that simply passes the data through.",
         "args": [
             {
-                "name": "lower",
-                "c_type": "void *",
-                "rust_type": "T",
-                "description": "If datum is less than lower, let datum be lower."
+                "name": "M",
+                "c_type": "char *",
+                "hint": "DatasetMetric",
+                "description": "dataset metric",
+                "is_type": true
             },
             {
-                "name": "upper",
+                "name": "T",
+                "c_type": "char *",
+                "description": "Type of data passed to the identity function.",
+                "is_type": true
+            }
+        ],
+        "ret": {
+            "c_type": "FfiResult<AnyTransformation *>"
+        }
+    },
+    "make_impute_constant": {
+        "description": "Make a Transformation that replaces null/None data with `constant`.\nInput type is Vec<Option<`T`>>, as emitted by make_cast.",
+        "args": [
+            {
+                "name": "constant",
                 "c_type": "void *",
                 "rust_type": "T",
-                "description": "If datum is greater than upper, let datum be upper."
+                "description": "Value to replace nulls with."
             },
             {
                 "name": "M",
@@ -214,27 +505,52 @@
         ],
         "ret": {"c_type": "FfiResult<AnyTransformation *>"}
     },
-    "make_clamp_sensitivity": {
-        "description": "Make a Transformation that clamps the non-dp result of a query of type `T` between `lower` and `upper`.\nUsed to bound the sensitivity.",
+    "make_impute_constant_inherent": {
+        "description": "Make a Transformation that replaces null/None data with `constant`.\nUse if nullity is represented within `T`, with input Vec<`T`>, as emitted by make_cast_inherent.",
+        "args": [
+            {
+                "name": "constant",
+                "c_type": "void *",
+                "rust_type": "T",
+                "description": "Value to replace nulls with."
+            },
+            {
+                "name": "M",
+                "c_type": "char *",
+                "hint": "DatasetMetric",
+                "is_type": true,
+                "description": "dataset metric"
+            },
+            {
+                "name": "T",
+                "c_type": "char *",
+                "is_type": true,
+                "description": "type of data being clamped"
+            }
+        ],
+        "ret": {"c_type": "FfiResult<AnyTransformation *>"}
+    },
+    "make_impute_uniform_float": {
+        "description": "Make a Transformation that replaces null/None data in Vec<`T`> with `constant`",
         "args": [
             {
                 "name": "lower",
                 "c_type": "void *",
                 "rust_type": "T",
-                "description": "If less than lower, return lower."
+                "description": "Lower bound of uniform distribution to sample from."
             },
             {
                 "name": "upper",
                 "c_type": "void *",
                 "rust_type": "T",
-                "description": "If greater than upper, return upper."
+                "description": "Upper bound of uniform distribution to sample from."
             },
             {
                 "name": "M",
                 "c_type": "char *",
-                "hint": "SensitivityMetric",
+                "hint": "DatasetMetric",
                 "is_type": true,
-                "description": "sensitivity metric"
+                "description": "dataset metric"
             },
             {
                 "name": "T",
@@ -400,7 +716,7 @@
             {
                 "name": "ddof",
                 "c_type": "unsigned int",
-                "default": "1",
+                "default": 1,
                 "description": "Delta degrees of freedom. Set to 0 if not a sample, 1 for sample estimate."
             },
             {
@@ -430,114 +746,5 @@
         "ret": {
             "c_type": "FfiResult<AnyTransformation *>"
         }
-    },
-    "make_count": {
-        "description": "Make a Transformation that computes a count of the number of records in data.",
-        "args": [
-            {
-                "name": "MI",
-                "c_type": "char *",
-                "hint": "DatasetMetric",
-                "is_type": true,
-                "description": "input dataset metric"
-            },
-            {
-                "name": "MO",
-                "c_type": "char *",
-                "hint": "SensitivityMetric",
-                "is_type": true,
-                "description": "output sensitivity metric"
-            },
-            {
-                "name": "TI",
-                "c_type": "char *",
-                "is_type": true,
-                "description": "atomic type of input data. Input data is expected to be of the form Vec<TI>."
-            }
-        ],
-        "ret": {"c_type": "FfiResult<AnyTransformation *>"}
-    },
-    "make_count_by": {
-        "description": "Make a Transformation that computes the count of each unique value in data. \nThis assumes that the category set is unknown. \nUse make_base_stability to release this query.",
-        "args": [
-            {
-                "name": "n",
-                "c_type": "unsigned int",
-                "description": "Number of records in input data."
-            },
-            {
-                "name": "MI",
-                "c_type": "char *",
-                "hint": "DatasetMetric",
-                "is_type": true,
-                "description": "input dataset metric"
-            },
-            {
-                "name": "MO",
-                "c_type": "char *",
-                "hint": "SensitivityMetric",
-                "is_type": true,
-                "description": "output sensitivity metric"
-            },
-            {
-                "name": "TI",
-                "c_type": "char *",
-                "is_type": true,
-                "description": "categorical/hashable input data type. Input data must be Vec<TI>."
-            },
-            {
-                "name": "TO",
-                "c_type": "char *",
-                "is_type": true,
-                "description": "express counts in terms of this integral type",
-                "default": "int"
-            }
-        ],
-        "ret": {
-            "c_type": "FfiResult<AnyTransformation *>",
-            "description": "The carrier type is HashMap<TI, TO>- the counts for each unique data input."
-        }
-    },
-    "make_count_by_categories": {
-        "description": "Make a Transformation that computes the number of times each category appears in the data. \nThis assumes that the category set is known.",
-        "args": [
-            {
-                "name": "categories",
-                "c_type": "AnyObject *",
-                "rust_type": {
-                    "origin": "Vec",
-                    "args": ["TI"]
-                },
-                "description": "The set of categories to compute counts for."
-            },
-            {
-                "name": "MI",
-                "c_type": "char *",
-                "hint": "DatasetMetric",
-                "is_type": true,
-                "description": "input dataset metric"
-            },
-            {
-                "name": "MO",
-                "c_type": "char *",
-                "hint": "SensitivityMetric",
-                "is_type": true,
-                "description": "output sensitivity metric"
-            },
-            {
-                "name": "TI",
-                "c_type": "char *",
-                "is_type": true,
-                "description": "categorical/hashable input data type. Input data must be Vec<TI>."
-            },
-            {
-                "name": "TO",
-                "c_type": "char *",
-                "is_type": true,
-                "description": "express counts in terms of this integral type",
-                "default": "int"
-            }
-        ],
-        "ret": {"c_type": "FfiResult<AnyTransformation *>"}
     }
 }

--- a/rust/opendp-ffi/src/trans/cast.rs
+++ b/rust/opendp-ffi/src/trans/cast.rs
@@ -1,16 +1,16 @@
 use std::convert::TryFrom;
-use std::os::raw::c_char;
+use std::os::raw::{c_char, c_void};
 
 use opendp::core::DatasetMetric;
 use opendp::dist::{HammingDistance, SymmetricDistance};
-use opendp::dom::InherentNull;
+use opendp::dom::{InherentNull, AllDomain, VectorDomain};
 use opendp::err;
 use opendp::traits::CastFrom;
-use opendp::trans::make_cast;
+use opendp::trans::{make_cast, make_cast_default, make_is_equal, make_cast_inherent, make_cast_metric, DatasetMetricCast};
 
 use crate::any::AnyTransformation;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
-use crate::util::{Type, to_bool, c_bool};
+use crate::util::{c_bool, to_bool, Type};
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_cast(
@@ -39,6 +39,80 @@ pub extern "C" fn opendp_trans__make_cast(
     }
 }
 
+#[no_mangle]
+pub extern "C" fn opendp_trans__make_cast_default(
+    M: *const c_char, TI: *const c_char, TO: *const c_char,
+) -> FfiResult<*mut AnyTransformation> {
+    let M = try_!(Type::try_from(M));
+    let TI = try_!(Type::try_from(TI));
+    let TO = try_!(Type::try_from(TO));
+
+    fn monomorphize<M, TI, TO>() -> FfiResult<*mut AnyTransformation> where
+        M: 'static + DatasetMetric,
+        TI: 'static + Clone,
+        TO: 'static + CastFrom<TI> + Default {
+        make_cast_default::<M, TI, TO>().into_any()
+    }
+    dispatch!(monomorphize, [(M, @dist_dataset), (TI, @primitives), (TO, @primitives)], ())
+}
+
+#[no_mangle]
+pub extern "C" fn opendp_trans__make_is_equal(
+    constant: *const c_void,
+    M: *const c_char, TI: *const c_char,
+) -> FfiResult<*mut AnyTransformation> {
+    let M = try_!(Type::try_from(M));
+    let TI = try_!(Type::try_from(TI));
+
+    fn monomorphize<M, TI>(value: *const c_void) -> FfiResult<*mut AnyTransformation> where
+        M: 'static + DatasetMetric,
+        TI: 'static + Clone + PartialEq {
+        let value = try_as_ref!(value as *const TI).clone();
+        make_is_equal::<M, TI>(value).into_any()
+    }
+    dispatch!(monomorphize, [(M, @dist_dataset), (TI, @primitives)], (constant))
+}
+
+#[no_mangle]
+pub extern "C" fn opendp_trans__make_cast_inherent(
+    M: *const c_char, TI: *const c_char, TO: *const c_char,
+) -> FfiResult<*mut AnyTransformation> {
+    let M = try_!(Type::try_from(M));
+    let TI = try_!(Type::try_from(TI));
+    let TO = try_!(Type::try_from(TO));
+
+    fn monomorphize<M, TI, TO>() -> FfiResult<*mut AnyTransformation>
+        where M: 'static + DatasetMetric,
+              TI: 'static + Clone,
+              TO: 'static + CastFrom<TI> + InherentNull {
+        make_cast_inherent::<M, TI, TO>().into_any()
+    }
+    dispatch!(monomorphize, [(M, @dist_dataset), (TI, @primitives), (TO, @floats)], ())
+}
+
+// The scope of this function has been reduced in the FFI layer from accepting any arbitrary domain,
+//      to assuming the domain is VectorDomain<AllDomain<T>>.
+// This is because we don't have an established way of passing arbitrary domains over FFI
+#[no_mangle]
+pub extern "C" fn opendp_trans__make_cast_metric(
+    MI: *const c_char, MO: *const c_char, T: *const c_char,
+) -> FfiResult<*mut AnyTransformation> {
+    let MI = try_!(Type::try_from(MI));
+    let MO = try_!(Type::try_from(MO));
+    let T = try_!(Type::try_from(T));
+
+    fn monomorphize<MI, MO, T>() -> FfiResult<*mut AnyTransformation>
+        where MI: 'static + DatasetMetric,
+              MO: 'static + DatasetMetric,
+              (MI, MO): DatasetMetricCast,
+              T: 'static + Clone {
+        make_cast_metric::<VectorDomain<AllDomain<T>>, MI, MO>(
+            VectorDomain::new_all()
+        ).into_any()
+    }
+    dispatch!(monomorphize, [(MI, @dist_dataset), (MO, @dist_dataset), (T, @primitives)], ())
+}
+
 
 #[cfg(test)]
 mod tests {
@@ -46,7 +120,7 @@ mod tests {
 
     use crate::any::{AnyObject, Downcast};
     use crate::core;
-    use crate::util::{ToCharP, from_bool};
+    use crate::util::{from_bool, ToCharP};
 
     use super::*;
 

--- a/rust/opendp-ffi/src/trans/cast.rs
+++ b/rust/opendp-ffi/src/trans/cast.rs
@@ -1,0 +1,67 @@
+use std::convert::TryFrom;
+use std::os::raw::c_char;
+
+use opendp::core::DatasetMetric;
+use opendp::dist::{HammingDistance, SymmetricDistance};
+use opendp::dom::InherentNull;
+use opendp::err;
+use opendp::traits::CastFrom;
+use opendp::trans::make_cast;
+
+use crate::any::AnyTransformation;
+use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
+use crate::util::{Type, to_bool, c_bool};
+
+#[no_mangle]
+pub extern "C" fn opendp_trans__make_cast(
+    M: *const c_char, TI: *const c_char, TO: *const c_char, inherent: c_bool
+) -> FfiResult<*mut AnyTransformation> {
+    let M = try_!(Type::try_from(M));
+    let TI = try_!(Type::try_from(TI));
+    let TO = try_!(Type::try_from(TO));
+
+    if to_bool(inherent) {
+        fn monomorphize<M, TI, TO>() -> FfiResult<*mut AnyTransformation> where
+            M: 'static + DatasetMetric,
+            TI: 'static + Clone,
+            TO: 'static + CastFrom<TI> + InherentNull {
+            make_cast::<M, TI, TO>().into_any()
+        }
+        dispatch!(monomorphize, [(M, @dist_dataset), (TI, @primitives), (TO, @floats)], ())
+    } else {
+        fn monomorphize<M, TI, TO>() -> FfiResult<*mut AnyTransformation> where
+            M: 'static + DatasetMetric,
+            TI: 'static + Clone,
+            TO: 'static + CastFrom<TI> {
+            make_cast::<M, TI, TO>().into_any()
+        }
+        dispatch!(monomorphize, [(M, @dist_dataset), (TI, @primitives), (TO, @primitives)], ())
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use opendp::error::Fallible;
+
+    use crate::any::{AnyObject, Downcast};
+    use crate::core;
+    use crate::util::{ToCharP, from_bool};
+
+    use super::*;
+
+    #[test]
+    fn test_make_cast_vec() -> Fallible<()> {
+        let transformation = Result::from(opendp_trans__make_cast(
+            "SymmetricDistance".to_char_p(),
+            "i32".to_char_p(),
+            "f64".to_char_p(),
+            from_bool(true),
+        ))?;
+        let arg = AnyObject::new_raw(vec![1, 2, 3]);
+        let res = core::opendp_core__transformation_invoke(&transformation, arg);
+        let res: Vec<Option<f64>> = Fallible::from(res)?.downcast()?;
+        assert_eq!(res, vec![Some(1.0), Some(2.0), Some(3.0)]);
+        Ok(())
+    }
+}

--- a/rust/opendp-ffi/src/trans/cast.rs
+++ b/rust/opendp-ffi/src/trans/cast.rs
@@ -14,7 +14,8 @@ use crate::util::{c_bool, to_bool, Type};
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_cast(
-    M: *const c_char, TI: *const c_char, TO: *const c_char, inherent: c_bool
+    inherent: c_bool,
+    M: *const c_char, TI: *const c_char, TO: *const c_char
 ) -> FfiResult<*mut AnyTransformation> {
     let M = try_!(Type::try_from(M));
     let TI = try_!(Type::try_from(TI));
@@ -127,10 +128,10 @@ mod tests {
     #[test]
     fn test_make_cast_vec() -> Fallible<()> {
         let transformation = Result::from(opendp_trans__make_cast(
+            from_bool(true),
             "SymmetricDistance".to_char_p(),
             "i32".to_char_p(),
             "f64".to_char_p(),
-            from_bool(true),
         ))?;
         let arg = AnyObject::new_raw(vec![1, 2, 3]);
         let res = core::opendp_core__transformation_invoke(&transformation, arg);

--- a/rust/opendp-ffi/src/trans/clamp.rs
+++ b/rust/opendp-ffi/src/trans/clamp.rs
@@ -1,0 +1,111 @@
+use std::convert::TryFrom;
+use std::ops::Sub;
+use std::os::raw::{c_char, c_void};
+
+use num::One;
+
+use opendp::core::{DatasetMetric, SensitivityMetric};
+use opendp::dist::{HammingDistance, SymmetricDistance, L1Sensitivity, L2Sensitivity};
+use opendp::dom::{AllDomain, VectorDomain};
+use opendp::err;
+use opendp::traits::{DistanceCast, DistanceConstant};
+use opendp::trans::{ClampableDomain, make_clamp};
+
+use crate::any::AnyTransformation;
+use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
+use crate::util::{MetricClass, Type};
+
+#[no_mangle]
+pub extern "C" fn opendp_trans__make_clamp(
+    lower: *const c_void, upper: *const c_void,
+    M: *const c_char, T: *const c_char,
+) -> FfiResult<*mut AnyTransformation> {
+    fn monomorphize_dataset<M, T>(lower: *const c_void, upper: *const c_void) -> FfiResult<*mut AnyTransformation>
+        where VectorDomain<AllDomain<T>>: ClampableDomain<M, Atom=T>,
+              M: 'static + DatasetMetric,
+              T: 'static + Clone + PartialOrd {
+        let lower = try_as_ref!(lower as *const T).clone();
+        let upper = try_as_ref!(upper as *const T).clone();
+        make_clamp::<VectorDomain<AllDomain<T>>, M>(
+            lower, upper,
+        ).into_any()
+    }
+
+    fn monomorphize_sensitivity<Q: DistanceConstant + One>(
+        lower: *const c_void, upper: *const c_void, M: Type, T: Type,
+    ) -> FfiResult<*mut AnyTransformation> {
+        fn monomorphize_sensitivity_2<M, T>(
+            lower: *const c_void, upper: *const c_void,
+        ) -> FfiResult<*mut AnyTransformation>
+            where AllDomain<T>: ClampableDomain<M, Atom=T>,
+                  M: 'static + SensitivityMetric,
+                  M::Distance: DistanceConstant + One,
+                  T: 'static + Clone + PartialOrd + DistanceCast + Sub<Output=T> {
+            let lower = try_as_ref!(lower as *const T).clone();
+            let upper = try_as_ref!(upper as *const T).clone();
+            make_clamp::<AllDomain<T>, M>(
+                lower, upper,
+            ).into_any()
+        }
+        dispatch!(monomorphize_sensitivity_2, [
+            (M, [L1Sensitivity<Q>, L2Sensitivity<Q>]),
+            (T, @numbers)
+        ], (lower, upper))
+    }
+
+    let M = try_!(Type::try_from(M));
+    let T = try_!(Type::try_from(T));
+    match try_!(M.get_metric_class()) {
+        MetricClass::Dataset =>
+            dispatch!(monomorphize_dataset, [(M, @dist_dataset), (T, @numbers)], (lower, upper)),
+        MetricClass::Sensitivity => {
+            let Q = try_!(M.get_sensitivity_distance());
+            dispatch!(monomorphize_sensitivity, [(Q, @numbers)], (lower, upper, M, T))
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use std::os::raw::c_void;
+
+    use opendp::error::Fallible;
+
+    use crate::any::{AnyObject, Downcast};
+    use crate::core;
+    use crate::util;
+    use crate::util::ToCharP;
+    use crate::trans::clamp::opendp_trans__make_clamp;
+
+    #[test]
+    fn test_make_clamp_sensitivity() -> Fallible<()> {
+        let transformation = Result::from(opendp_trans__make_clamp(
+            util::into_raw(0.0) as *const c_void,
+            util::into_raw(10.0) as *const c_void,
+            "L2Sensitivity<f64>".to_char_p(),
+            "f64".to_char_p(),
+        ))?;
+        let arg = AnyObject::new_raw(-1.0);
+        let res = core::opendp_core__transformation_invoke(&transformation, arg);
+        let res: f64 = Fallible::from(res)?.downcast()?;
+        assert_eq!(res, 0.0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_make_clamp_vec() -> Fallible<()> {
+        let transformation = Result::from(opendp_trans__make_clamp(
+            util::into_raw(0.0) as *const c_void,
+            util::into_raw(10.0) as *const c_void,
+            "SymmetricDistance".to_char_p(),
+            "f64".to_char_p(),
+        ))?;
+        let arg = AnyObject::new_raw(vec![-1.0, 5.0, 11.0]);
+        let res = core::opendp_core__transformation_invoke(&transformation, arg);
+        let res: Vec<f64> = Fallible::from(res)?.downcast()?;
+        assert_eq!(res, vec![0.0, 5.0, 10.0]);
+        Ok(())
+    }
+
+}

--- a/rust/opendp-ffi/src/trans/clamp.rs
+++ b/rust/opendp-ffi/src/trans/clamp.rs
@@ -1,15 +1,15 @@
 use std::convert::TryFrom;
-use std::ops::Sub;
+use std::ops::{Sub, Bound};
 use std::os::raw::{c_char, c_void};
 
 use num::One;
 
-use opendp::core::{DatasetMetric, SensitivityMetric};
+use opendp::core::{DatasetMetric, SensitivityMetric, Domain};
 use opendp::dist::{HammingDistance, SymmetricDistance, L1Sensitivity, L2Sensitivity};
-use opendp::dom::{AllDomain, VectorDomain};
+use opendp::dom::{AllDomain, VectorDomain, IntervalDomain};
 use opendp::err;
 use opendp::traits::{DistanceCast, DistanceConstant};
-use opendp::trans::{ClampableDomain, make_clamp};
+use opendp::trans::{ClampableDomain, make_clamp, make_unclamp, UnclampableDomain};
 
 use crate::any::AnyTransformation;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
@@ -45,6 +45,64 @@ pub extern "C" fn opendp_trans__make_clamp(
             let upper = try_as_ref!(upper as *const T).clone();
             make_clamp::<AllDomain<T>, M>(
                 lower, upper,
+            ).into_any()
+        }
+        dispatch!(monomorphize_sensitivity_2, [
+            (M, [L1Sensitivity<Q>, L2Sensitivity<Q>]),
+            (T, @numbers)
+        ], (lower, upper))
+    }
+
+    let M = try_!(Type::try_from(M));
+    let T = try_!(Type::try_from(T));
+    match try_!(M.get_metric_class()) {
+        MetricClass::Dataset =>
+            dispatch!(monomorphize_dataset, [(M, @dist_dataset), (T, @numbers)], (lower, upper)),
+        MetricClass::Sensitivity => {
+            let Q = try_!(M.get_sensitivity_distance());
+            dispatch!(monomorphize_sensitivity, [(Q, @numbers)], (lower, upper, M, T))
+        }
+    }
+}
+
+
+#[no_mangle]
+pub extern "C" fn opendp_trans__make_unclamp(
+    lower: *const c_void, upper: *const c_void,
+    M: *const c_char, T: *const c_char,
+) -> FfiResult<*mut AnyTransformation> {
+
+    fn monomorphize_dataset<M, T>(
+        lower: *const c_void, upper: *const c_void
+    ) -> FfiResult<*mut AnyTransformation>
+        where VectorDomain<IntervalDomain<T>>: UnclampableDomain<Atom=T>,
+              <VectorDomain<IntervalDomain<T>> as Domain>::Carrier: Clone,
+              M: 'static + DatasetMetric,
+              T: 'static + Clone + PartialOrd {
+        let lower = try_as_ref!(lower as *const T).clone();
+        let upper = try_as_ref!(upper as *const T).clone();
+        make_unclamp::<VectorDomain<IntervalDomain<T>>, M>(
+            Bound::Included(lower), Bound::Included(upper),
+        ).into_any()
+    }
+
+    fn monomorphize_sensitivity<Q: DistanceConstant + One>(
+        lower: *const c_void, upper: *const c_void, M: Type, T: Type,
+    ) -> FfiResult<*mut AnyTransformation> {
+
+        fn monomorphize_sensitivity_2<M, T>(
+            lower: *const c_void, upper: *const c_void,
+        ) -> FfiResult<*mut AnyTransformation>
+            where IntervalDomain<T>: UnclampableDomain<Atom=T>,
+                  <IntervalDomain<T> as Domain>::Carrier: Clone,
+                  M: 'static + SensitivityMetric,
+                  M::Distance: DistanceConstant + One,
+                  T: 'static + Clone + PartialOrd + DistanceCast + Sub<Output=T> {
+
+            let lower = try_as_ref!(lower as *const T).clone();
+            let upper = try_as_ref!(upper as *const T).clone();
+            make_unclamp::<IntervalDomain<T>, M>(
+                Bound::Included(lower), Bound::Included(upper),
             ).into_any()
         }
         dispatch!(monomorphize_sensitivity_2, [

--- a/rust/opendp-ffi/src/trans/clamp.rs
+++ b/rust/opendp-ffi/src/trans/clamp.rs
@@ -152,7 +152,7 @@ mod tests {
     }
 
     #[test]
-    fn test_make_clamp_vec() -> Fallible<()> {
+    fn test_make_vector_clamp() -> Fallible<()> {
         let transformation = Result::from(opendp_trans__make_clamp(
             util::into_raw(0.0) as *const c_void,
             util::into_raw(10.0) as *const c_void,

--- a/rust/opendp-ffi/src/trans/count.rs
+++ b/rust/opendp-ffi/src/trans/count.rs
@@ -29,7 +29,8 @@ pub extern "C" fn opendp_trans__make_count(
     ) -> FfiResult<*mut AnyTransformation> {
         fn monomorphize2<MI, MO, T: 'static>() -> FfiResult<*mut AnyTransformation>
             where MI: 'static + DatasetMetric + Clone,
-                  MO: 'static + SensitivityMetric + Clone {
+                  MO: 'static + SensitivityMetric + Clone,
+                  MO::Distance: TryFrom<usize> + Bounded + One + DistanceConstant {
             make_count::<MI, MO, T>().into_any()
         }
         dispatch!(monomorphize2, [

--- a/rust/opendp-ffi/src/trans/count.rs
+++ b/rust/opendp-ffi/src/trans/count.rs
@@ -28,9 +28,8 @@ pub extern "C" fn opendp_trans__make_count(
         MI: Type, MO: Type, T: Type
     ) -> FfiResult<*mut AnyTransformation> {
         fn monomorphize2<MI, MO, T: 'static>() -> FfiResult<*mut AnyTransformation>
-            where MI: 'static + DatasetMetric<Distance=u32> + Clone,
-                  MO: 'static + SensitivityMetric + Clone,
-                  MO::Distance: TryFrom<usize> + Bounded + One + DistanceConstant {
+            where MI: 'static + DatasetMetric + Clone,
+                  MO: 'static + SensitivityMetric + Clone {
             make_count::<MI, MO, T>().into_any()
         }
         dispatch!(monomorphize2, [
@@ -62,7 +61,7 @@ pub extern "C" fn opendp_trans__make_count_by_categories(
     ) -> FfiResult<*mut AnyTransformation>
         where QO: DistanceConstant + FloatConst + One {
         fn monomorphize2<MI, MO, TI, TO>(categories: *const AnyObject) -> FfiResult<*mut AnyTransformation>
-            where MI: 'static + DatasetMetric<Distance=u32>,
+            where MI: 'static + DatasetMetric,
                   MO: 'static + SensitivityMetric,
                   TI: 'static + Eq + Hash + Clone,
                   TO: 'static + Integer + Zero + One + AddAssign,
@@ -100,7 +99,7 @@ pub extern "C" fn opendp_trans__make_count_by(
     ) -> FfiResult<*mut AnyTransformation>
         where QO: DistanceConstant + FloatConst + One {
         fn monomorphize2<MI, MO, TI, TO>(n: usize) -> FfiResult<*mut AnyTransformation>
-            where MI: 'static + DatasetMetric<Distance=u32>,
+            where MI: 'static + DatasetMetric,
                   MO: 'static + SensitivityMetric,
                   TI: 'static + Eq + Hash + Clone,
                   TO: 'static + Integer + Zero + One + AddAssign,

--- a/rust/opendp-ffi/src/trans/dataframe.rs
+++ b/rust/opendp-ffi/src/trans/dataframe.rs
@@ -19,7 +19,7 @@ pub extern "C" fn opendp_trans__make_split_lines(
     M: *const c_char
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<M>() -> FfiResult<*mut AnyTransformation>
-        where M: 'static + DatasetMetric<Distance=u32> + Clone {
+        where M: 'static + DatasetMetric + Clone {
         make_split_lines::<M>().into_any()
     }
     let M = try_!(Type::try_from(M));
@@ -32,7 +32,7 @@ pub extern "C" fn opendp_trans__make_parse_series(
     M: *const c_char, TO: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<M, TO>(impute: bool) -> FfiResult<*mut AnyTransformation>
-        where M: 'static + DatasetMetric<Distance=u32> + Clone,
+        where M: 'static + DatasetMetric + Clone,
               TO: 'static + FromStr + Default,
               TO::Err: Debug {
         make_parse_series::<M, TO>(impute).into_any()
@@ -53,7 +53,7 @@ pub extern "C" fn opendp_trans__make_split_records(
     M: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<M>(separator: Option<&str>) -> FfiResult<*mut AnyTransformation>
-        where M: 'static + DatasetMetric<Distance=u32> + Clone {
+        where M: 'static + DatasetMetric + Clone {
         make_split_records::<M>(separator).into_any()
     }
     let M = try_!(Type::try_from(M));
@@ -68,7 +68,7 @@ pub extern "C" fn opendp_trans__make_create_dataframe(
     M: *const c_char, K: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<M, K>(col_names: *const AnyObject) -> FfiResult<*mut AnyTransformation>
-        where M: 'static + DatasetMetric<Distance=u32> + Clone,
+        where M: 'static + DatasetMetric + Clone,
               K: 'static + Eq + Hash + Clone {
         let col_names = try_!(try_as_ref!(col_names).downcast_ref::<Vec<K>>()).clone();
         make_create_dataframe::<M, K>(col_names).into_any()
@@ -87,7 +87,7 @@ pub extern "C" fn opendp_trans__make_split_dataframe(
     M: *const c_char, K: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<M, K>(separator: Option<&str>, col_names: *const AnyObject) -> FfiResult<*mut AnyTransformation>
-        where M: 'static + DatasetMetric<Distance=u32> + Clone,
+        where M: 'static + DatasetMetric + Clone,
               K: 'static + Eq + Hash + Debug + Clone {
         let col_names = try_!(try_as_ref!(col_names).downcast_ref::<Vec<K>>()).clone();
         make_split_dataframe::<M, K>(separator, col_names).into_any()
@@ -105,7 +105,7 @@ pub extern "C" fn opendp_trans__make_parse_column(
     M: *const c_char, K: *const c_char, T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<M, K, T>(key: *const c_void, impute: bool) -> FfiResult<*mut AnyTransformation> where
-        M: 'static + DatasetMetric<Distance=u32> + Clone,
+        M: 'static + DatasetMetric + Clone,
         K: 'static + Hash + Eq + Debug + Clone,
         T: 'static + Debug + Clone + PartialEq + FromStr + Default,
         T::Err: Debug {
@@ -130,7 +130,7 @@ pub extern "C" fn opendp_trans__make_select_column(
     M: *const c_char, K: *const c_char, T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<M, K, T>(key: *const c_void) -> FfiResult<*mut AnyTransformation> where
-        M: 'static + DatasetMetric<Distance=u32> + Clone,
+        M: 'static + DatasetMetric + Clone,
         K: 'static + Hash + Eq + Debug + Clone,
         T: 'static + Debug + Clone + PartialEq {
         let key = try_as_ref!(key as *const K).clone();

--- a/rust/opendp-ffi/src/trans/dataframe.rs
+++ b/rust/opendp-ffi/src/trans/dataframe.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use opendp::core::DatasetMetric;
 use opendp::dist::{HammingDistance, SymmetricDistance};
 use opendp::err;
-use opendp::trans::{make_create_dataframe, make_parse_column, make_parse_series, make_select_column, make_split_dataframe, make_split_lines, make_split_records};
+use opendp::trans::{make_create_dataframe, make_parse_column, make_select_column, make_split_dataframe, make_split_lines, make_split_records};
 
 use crate::any::{AnyObject, AnyTransformation, Downcast};
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
@@ -24,27 +24,6 @@ pub extern "C" fn opendp_trans__make_split_lines(
     }
     let M = try_!(Type::try_from(M));
     dispatch!(monomorphize, [(M, @dist_dataset)], ())
-}
-
-#[no_mangle]
-pub extern "C" fn opendp_trans__make_parse_series(
-    impute: c_bool,
-    M: *const c_char, TO: *const c_char,
-) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<M, TO>(impute: bool) -> FfiResult<*mut AnyTransformation>
-        where M: 'static + DatasetMetric + Clone,
-              TO: 'static + FromStr + Default,
-              TO::Err: Debug {
-        make_parse_series::<M, TO>(impute).into_any()
-    }
-    let M = try_!(Type::try_from(M));
-    let TO = try_!(Type::try_from(TO));
-    let impute = util::to_bool(impute);
-
-    dispatch!(monomorphize, [
-        (M, @dist_dataset),
-        (TO, @primitives)
-    ], (impute))
 }
 
 #[no_mangle]

--- a/rust/opendp-ffi/src/trans/impute.rs
+++ b/rust/opendp-ffi/src/trans/impute.rs
@@ -13,7 +13,7 @@ use opendp::trans::{ImputableDomain, make_impute_constant, make_impute_uniform_f
 
 use crate::any::AnyTransformation;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
-use crate::util::{c_bool, to_bool, Type};
+use crate::util::Type;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_impute_uniform_float(
@@ -39,39 +39,45 @@ pub extern "C" fn opendp_trans__make_impute_uniform_float(
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_impute_constant(
-    constant: *const c_void, inherent: c_bool,
+    constant: *const c_void,
     M: *const c_char, T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     let M = try_!(Type::try_from(M));
     let T = try_!(Type::try_from(T));
 
-    if to_bool(inherent) {
-
-        fn monomorphize_inherent<M, T>(
-            constant: *const c_void
-        ) -> FfiResult<*mut AnyTransformation>
-            where InherentNullDomain<AllDomain<T>>: ImputableDomain<NonNull=T>,
-                  M: 'static + DatasetMetric,
-                  T: 'static + Clone + InherentNull {
-            let constant = try_as_ref!(constant as *const T).clone();
-            make_impute_constant::<InherentNullDomain<AllDomain<T>>, M>(
-                constant
-            ).into_any()
-        }
-        dispatch!(monomorphize_inherent, [(M, @dist_dataset), (T, @floats)], (constant))
-    } else {
-
-        fn monomorphize_option<M, T>(
-            constant: *const c_void
-        ) -> FfiResult<*mut AnyTransformation>
-            where OptionNullDomain<AllDomain<T>>: ImputableDomain<NonNull=T>,
-                  M: 'static + DatasetMetric,
-                  T: 'static + Clone {
-            let constant = try_as_ref!(constant as *const T).clone();
-            make_impute_constant::<OptionNullDomain<AllDomain<T>>, M>(
-                constant,
-            ).into_any()
-        }
-        dispatch!(monomorphize_option, [(M, @dist_dataset), (T, @primitives)], (constant))
+    fn monomorphize_option<M, T>(
+        constant: *const c_void
+    ) -> FfiResult<*mut AnyTransformation>
+        where OptionNullDomain<AllDomain<T>>: ImputableDomain<NonNull=T>,
+              M: 'static + DatasetMetric,
+              T: 'static + Clone {
+        let constant = try_as_ref!(constant as *const T).clone();
+        make_impute_constant::<OptionNullDomain<AllDomain<T>>, M>(
+            constant,
+        ).into_any()
     }
+    dispatch!(monomorphize_option, [(M, @dist_dataset), (T, @primitives)], (constant))
+}
+
+
+#[no_mangle]
+pub extern "C" fn opendp_trans__make_impute_constant_inherent(
+    constant: *const c_void,
+    M: *const c_char, T: *const c_char,
+) -> FfiResult<*mut AnyTransformation> {
+    let M = try_!(Type::try_from(M));
+    let T = try_!(Type::try_from(T));
+
+    fn monomorphize_inherent<M, T>(
+        constant: *const c_void
+    ) -> FfiResult<*mut AnyTransformation>
+        where InherentNullDomain<AllDomain<T>>: ImputableDomain<NonNull=T>,
+              M: 'static + DatasetMetric,
+              T: 'static + Clone + InherentNull {
+        let constant = try_as_ref!(constant as *const T).clone();
+        make_impute_constant::<InherentNullDomain<AllDomain<T>>, M>(
+            constant
+        ).into_any()
+    }
+    dispatch!(monomorphize_inherent, [(M, @dist_dataset), (T, @floats)], (constant))
 }

--- a/rust/opendp-ffi/src/trans/impute.rs
+++ b/rust/opendp-ffi/src/trans/impute.rs
@@ -39,8 +39,8 @@ pub extern "C" fn opendp_trans__make_impute_uniform_float(
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_impute_constant(
-    constant: *const c_void,
-    M: *const c_char, T: *const c_char, inherent: c_bool,
+    constant: *const c_void, inherent: c_bool,
+    M: *const c_char, T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     let M = try_!(Type::try_from(M));
     let T = try_!(Type::try_from(T));

--- a/rust/opendp-ffi/src/trans/impute.rs
+++ b/rust/opendp-ffi/src/trans/impute.rs
@@ -1,13 +1,51 @@
-// use std::os::raw::{c_char, c_void};
-// use crate::core::FfiResult;
-// use crate::any::AnyTransformation;
-// use opendp::trans::make_impute_constant;
+use std::convert::TryFrom;
+use std::os::raw::{c_char, c_void};
 
+use opendp::core::DatasetMetric;
+use opendp::dist::{HammingDistance, SymmetricDistance};
+use opendp::dom::{AllDomain, InherentNull, InherentNullDomain, OptionNullDomain};
+use opendp::err;
+use opendp::trans::{ImputableDomain, make_impute_constant};
 
-// #[no_mangle]
-// pub extern "C" fn opendp_trans__make_impute_constant(
-//     lower: *const c_void, upper: *const c_void,
-//     M: *const c_char, T: *const c_char,
-// ) -> FfiResult<*mut AnyTransformation> {
-//
-// }
+use crate::any::AnyTransformation;
+use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
+use crate::util::{c_bool, Type, to_bool};
+
+#[no_mangle]
+pub extern "C" fn opendp_trans__make_impute_constant(
+    constant: *const c_void,
+    M: *const c_char, T: *const c_char, inherent: c_bool,
+) -> FfiResult<*mut AnyTransformation> {
+    let M = try_!(Type::try_from(M));
+    let T = try_!(Type::try_from(T));
+
+    if to_bool(inherent) {
+
+        fn monomorphize_inherent<M, T>(
+            constant: *const c_void
+        ) -> FfiResult<*mut AnyTransformation>
+            where InherentNullDomain<AllDomain<T>>: ImputableDomain<NonNull=T>,
+                  M: 'static + DatasetMetric,
+                  T: 'static + Clone + InherentNull {
+            let constant = try_as_ref!(constant as *const T).clone();
+            make_impute_constant::<InherentNullDomain<AllDomain<T>>, M>(
+                constant
+            ).into_any()
+        }
+        dispatch!(monomorphize_inherent, [(M, @dist_dataset), (T, @floats)], (constant))
+    } else {
+
+        fn monomorphize_option<M, T>(
+            constant: *const c_void
+        ) -> FfiResult<*mut AnyTransformation>
+            where OptionNullDomain<AllDomain<T>>: ImputableDomain<NonNull=T>,
+                  M: 'static + DatasetMetric,
+                  T: 'static + Clone {
+            let constant = try_as_ref!(constant as *const T).clone();
+            make_impute_constant::<OptionNullDomain<AllDomain<T>>, M>(
+                constant,
+            ).into_any()
+        }
+        dispatch!(monomorphize_option, [(M, @dist_dataset), (T, @primitives)], (constant))
+    }
+}

--- a/rust/opendp-ffi/src/trans/impute.rs
+++ b/rust/opendp-ffi/src/trans/impute.rs
@@ -1,0 +1,13 @@
+use std::os::raw::{c_char, c_void};
+use crate::core::FfiResult;
+use crate::any::AnyTransformation;
+use opendp::trans::make_impute_constant;
+
+
+// #[no_mangle]
+// pub extern "C" fn opendp_trans__make_impute_constant(
+//     lower: *const c_void, upper: *const c_void,
+//     M: *const c_char, T: *const c_char,
+// ) -> FfiResult<*mut AnyTransformation> {
+//
+// }

--- a/rust/opendp-ffi/src/trans/impute.rs
+++ b/rust/opendp-ffi/src/trans/impute.rs
@@ -1,15 +1,41 @@
 use std::convert::TryFrom;
+use std::ops::{Add, Mul, Sub};
 use std::os::raw::{c_char, c_void};
+
+use num::Float;
 
 use opendp::core::DatasetMetric;
 use opendp::dist::{HammingDistance, SymmetricDistance};
 use opendp::dom::{AllDomain, InherentNull, InherentNullDomain, OptionNullDomain};
 use opendp::err;
-use opendp::trans::{ImputableDomain, make_impute_constant};
+use opendp::samplers::SampleUniform;
+use opendp::trans::{ImputableDomain, make_impute_constant, make_impute_uniform_float};
 
 use crate::any::AnyTransformation;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
-use crate::util::{c_bool, Type, to_bool};
+use crate::util::{c_bool, to_bool, Type};
+
+#[no_mangle]
+pub extern "C" fn opendp_trans__make_impute_uniform_float(
+    lower: *const c_void, upper: *const c_void,
+    M: *const c_char, T: *const c_char,
+) -> FfiResult<*mut AnyTransformation> {
+    let M = try_!(Type::try_from(M));
+    let T = try_!(Type::try_from(T));
+
+    fn monomorphize<M, T>(
+        lower: *const c_void, upper: *const c_void,
+    ) -> FfiResult<*mut AnyTransformation>
+        where M: 'static + DatasetMetric,
+              for<'a> T: 'static + Float + SampleUniform + Clone + Sub<Output=T> + Mul<&'a T, Output=T> + Add<&'a T, Output=T> + InherentNull {
+        let lower = try_as_ref!(lower as *const T).clone();
+        let upper = try_as_ref!(upper as *const T).clone();
+        make_impute_uniform_float::<M, T>(
+            lower, upper,
+        ).into_any()
+    }
+    dispatch!(monomorphize, [(M, @dist_dataset), (T, @floats)], (lower, upper))
+}
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_impute_constant(

--- a/rust/opendp-ffi/src/trans/impute.rs
+++ b/rust/opendp-ffi/src/trans/impute.rs
@@ -1,7 +1,7 @@
-use std::os::raw::{c_char, c_void};
-use crate::core::FfiResult;
-use crate::any::AnyTransformation;
-use opendp::trans::make_impute_constant;
+// use std::os::raw::{c_char, c_void};
+// use crate::core::FfiResult;
+// use crate::any::AnyTransformation;
+// use opendp::trans::make_impute_constant;
 
 
 // #[no_mangle]

--- a/rust/opendp-ffi/src/trans/manipulation.rs
+++ b/rust/opendp-ffi/src/trans/manipulation.rs
@@ -175,8 +175,8 @@ mod tests {
         ))?;
         let arg = AnyObject::new_raw(vec![1, 2, 3]);
         let res = core::opendp_core__transformation_invoke(&transformation, arg);
-        let res: Vec<f64> = Fallible::from(res)?.downcast()?;
-        assert_eq!(res, vec![1.0, 2.0, 3.0]);
+        let res: Vec<Option<f64>> = Fallible::from(res)?.downcast()?;
+        assert_eq!(res, vec![Some(1.0), Some(2.0), Some(3.0)]);
         Ok(())
     }
 }

--- a/rust/opendp-ffi/src/trans/mean.rs
+++ b/rust/opendp-ffi/src/trans/mean.rs
@@ -31,7 +31,7 @@ pub extern "C" fn opendp_trans__make_bounded_mean(
                   MO: 'static + SensitivityMetric,
                   MO::Distance: DistanceConstant + Sub<Output=MO::Distance> + Float,
                   for<'a> MO::Distance: Sum<&'a MO::Distance>,
-                  (MI, MO): BoundedMeanConstant<MI, MO> {
+                  (MI, MO): BoundedMeanConstant<MO::Distance> {
             make_bounded_mean::<MI, MO>(lower, upper, n).into_any()
         }
         let lower = *try_as_ref!(lower as *const T);

--- a/rust/opendp-ffi/src/trans/mean.rs
+++ b/rust/opendp-ffi/src/trans/mean.rs
@@ -27,7 +27,7 @@ pub extern "C" fn opendp_trans__make_bounded_mean(
         where T: DistanceConstant + Sub<Output=T> + Float,
               for<'a> T: Sum<&'a T> {
         fn monomorphize2<MI, MO>(lower: MO::Distance, upper: MO::Distance, n: usize) -> FfiResult<*mut AnyTransformation>
-            where MI: 'static + DatasetMetric<Distance=u32>,
+            where MI: 'static + DatasetMetric,
                   MO: 'static + SensitivityMetric,
                   MO::Distance: DistanceConstant + Sub<Output=MO::Distance> + Float,
                   for<'a> MO::Distance: Sum<&'a MO::Distance>,

--- a/rust/opendp-ffi/src/trans/mod.rs
+++ b/rust/opendp-ffi/src/trans/mod.rs
@@ -4,4 +4,5 @@ pub mod sum;
 pub mod count;
 pub mod mean;
 pub mod variance;
+pub mod impute;
 

--- a/rust/opendp-ffi/src/trans/mod.rs
+++ b/rust/opendp-ffi/src/trans/mod.rs
@@ -5,4 +5,6 @@ pub mod count;
 pub mod mean;
 pub mod variance;
 pub mod impute;
+pub mod clamp;
+pub mod cast;
 

--- a/rust/opendp-ffi/src/trans/sum.rs
+++ b/rust/opendp-ffi/src/trans/sum.rs
@@ -24,7 +24,7 @@ pub extern "C" fn opendp_trans__make_bounded_sum(
     ) -> FfiResult<*mut AnyTransformation>
         where for<'a> T: DistanceConstant + Sub<Output=T> + Abs + Sum<&'a T> {
         fn monomorphize2<MI, MO>(lower: MO::Distance, upper: MO::Distance) -> FfiResult<*mut AnyTransformation>
-            where MI: 'static + DatasetMetric<Distance=u32>,
+            where MI: 'static + DatasetMetric,
                   MO: 'static + SensitivityMetric,
                   for<'a> MO::Distance: DistanceConstant + Sub<Output=MO::Distance> + Abs + Sum<&'a MO::Distance>,
                   (MI, MO): BoundedSumConstant<MI, MO> {

--- a/rust/opendp-ffi/src/trans/sum.rs
+++ b/rust/opendp-ffi/src/trans/sum.rs
@@ -27,7 +27,7 @@ pub extern "C" fn opendp_trans__make_bounded_sum(
             where MI: 'static + DatasetMetric,
                   MO: 'static + SensitivityMetric,
                   for<'a> MO::Distance: DistanceConstant + Sub<Output=MO::Distance> + Abs + Sum<&'a MO::Distance>,
-                  (MI, MO): BoundedSumConstant<MI, MO> {
+                  (MI, MO): BoundedSumConstant<MO::Distance> {
             make_bounded_sum::<MI, MO>(lower, upper).into_any()
         }
         let lower = try_as_ref!(lower as *const T).clone();

--- a/rust/opendp-ffi/src/trans/variance.rs
+++ b/rust/opendp-ffi/src/trans/variance.rs
@@ -31,7 +31,7 @@ pub extern "C" fn opendp_trans__make_bounded_variance(
         fn monomorphize2<MI, MO>(
             lower: MO::Distance, upper: MO::Distance, length: usize, ddof: usize,
         ) -> FfiResult<*mut AnyTransformation>
-            where MI: 'static + DatasetMetric<Distance=u32>,
+            where MI: 'static + DatasetMetric,
                   MO: 'static + SensitivityMetric,
                   MO::Distance: DistanceConstant + Float + for<'a> Sum<&'a MO::Distance> + Sum<MO::Distance>,
                   for<'a> &'a MO::Distance: Sub<Output=MO::Distance>,
@@ -75,7 +75,7 @@ pub extern "C" fn opendp_trans__make_bounded_covariance(
             upper: (MO::Distance, MO::Distance),
             length: usize, ddof: usize,
         ) -> FfiResult<*mut AnyTransformation>
-            where MI: 'static + DatasetMetric<Distance=u32>,
+            where MI: 'static + DatasetMetric,
                   MO: 'static + SensitivityMetric,
                   MO::Distance: DistanceConstant + Sub<Output=MO::Distance> + Sum<MO::Distance> + Zero + One,
                   for<'a> MO::Distance: Div<&'a MO::Distance, Output=MO::Distance> + Add<&'a MO::Distance, Output=MO::Distance>,

--- a/rust/opendp-ffi/src/trans/variance.rs
+++ b/rust/opendp-ffi/src/trans/variance.rs
@@ -35,7 +35,7 @@ pub extern "C" fn opendp_trans__make_bounded_variance(
                   MO: 'static + SensitivityMetric,
                   MO::Distance: DistanceConstant + Float + for<'a> Sum<&'a MO::Distance> + Sum<MO::Distance>,
                   for<'a> &'a MO::Distance: Sub<Output=MO::Distance>,
-                  (MI, MO): BoundedVarianceConstant<MI, MO> {
+                  (MI, MO): BoundedVarianceConstant<MO::Distance> {
             make_bounded_variance::<MI, MO>(lower, upper, length, ddof).into_any()
         }
         let lower = *try_as_ref!(lower as *const T);
@@ -80,7 +80,7 @@ pub extern "C" fn opendp_trans__make_bounded_covariance(
                   MO::Distance: DistanceConstant + Sub<Output=MO::Distance> + Sum<MO::Distance> + Zero + One,
                   for<'a> MO::Distance: Div<&'a MO::Distance, Output=MO::Distance> + Add<&'a MO::Distance, Output=MO::Distance>,
                   for<'a> &'a MO::Distance: Sub<Output=MO::Distance>,
-                  (MI, MO): BoundedCovarianceConstant<MI, MO> {
+                  (MI, MO): BoundedCovarianceConstant<MO::Distance> {
             make_bounded_covariance::<MI, MO>(lower, upper, length, ddof).into_any()
         }
         let lower = try_!(try_as_ref!(lower).downcast_ref::<(T, T)>()).clone();

--- a/rust/opendp-ffi/src/util.rs
+++ b/rust/opendp-ffi/src/util.rs
@@ -73,6 +73,8 @@ impl Type {
     }
 }
 
+pub enum MetricClass { Dataset, Sensitivity }
+
 impl Type {
     pub fn get_sensitivity_distance(&self) -> Fallible<Type> {
         if let TypeContents::GENERIC {args, name} = &self.contents {
@@ -85,6 +87,19 @@ impl Type {
             Type::of_id(&args[0])
         } else {
             fallible!(TypeParse, "Expected a sensitivity type that is generic with respect to one distance type- for example, L1Sensitivity<u32>")
+        }
+    }
+    pub fn get_metric_class(&self) -> Fallible<MetricClass> {
+        if self == &Type::of::<HammingDistance>() || self == &Type::of::<SymmetricDistance>() {
+            Ok(MetricClass::Dataset)
+        } else if let TypeContents::GENERIC { name, .. } = &self.contents {
+            if name.ends_with("Sensitivity") {
+                Ok(MetricClass::Sensitivity)
+            } else {
+                return fallible!(TypeParse, "Expected a metric type name, received {:?}", name)
+            }
+        } else {
+            fallible!(TypeParse, "Expected a metric type.")
         }
     }
 }

--- a/rust/opendp-ffi/src/util.rs
+++ b/rust/opendp-ffi/src/util.rs
@@ -87,19 +87,6 @@ impl Type {
             fallible!(TypeParse, "Expected a sensitivity type that is generic with respect to one distance type- for example, L1Sensitivity<u32>")
         }
     }
-    pub fn get_sensitivity_distance(&self) -> Fallible<Type> {
-        if let TypeContents::GENERIC {args, name} = &self.contents {
-            if !name.ends_with("Sensitivity") {
-                return fallible!(TypeParse, "Expected a sensitivity type name, received {:?}", name)
-            }
-            if args.len() != 1 {
-                return fallible!(TypeParse, "Sensitivity must have one generic argument")
-            }
-            Type::of_id(&args[0])
-        } else {
-            fallible!(TypeParse, "Expected a sensitivity type that is generic with respect to one distance type- for example, L1Sensitivity<u32>")
-        }
-    }
 }
 
 /// Builds a [`Type`] from a compact invocation, choosing an appropriate [`TypeContents`].

--- a/rust/opendp-ffi/src/util.rs
+++ b/rust/opendp-ffi/src/util.rs
@@ -87,6 +87,19 @@ impl Type {
             fallible!(TypeParse, "Expected a sensitivity type that is generic with respect to one distance type- for example, L1Sensitivity<u32>")
         }
     }
+    pub fn get_sensitivity_distance(&self) -> Fallible<Type> {
+        if let TypeContents::GENERIC {args, name} = &self.contents {
+            if !name.ends_with("Sensitivity") {
+                return fallible!(TypeParse, "Expected a sensitivity type name, received {:?}", name)
+            }
+            if args.len() != 1 {
+                return fallible!(TypeParse, "Sensitivity must have one generic argument")
+            }
+            Type::of_id(&args[0])
+        } else {
+            fallible!(TypeParse, "Expected a sensitivity type that is generic with respect to one distance type- for example, L1Sensitivity<u32>")
+        }
+    }
 }
 
 /// Builds a [`Type`] from a compact invocation, choosing an appropriate [`TypeContents`].

--- a/rust/opendp/src/chain.rs
+++ b/rust/opendp/src/chain.rs
@@ -223,7 +223,7 @@ impl<DI, DX, DO, MI, MX, MO> Shr<Transformation<DX, DO, MX, MO>> for Fallible<Tr
 mod test_shift_op {
     use crate::dist::HammingDistance;
     use crate::meas::geometric::make_base_geometric;
-    use crate::trans::{make_bounded_sum, make_parse_series, make_split_lines, make_clamp_vec};
+    use crate::trans::{make_bounded_sum, make_parse_series, make_split_lines, make_clamp};
 
     use super::*;
 
@@ -231,7 +231,7 @@ mod test_shift_op {
     fn test_shr() -> Fallible<()> {
         let meas = make_split_lines::<HammingDistance>()?
             >> make_parse_series(true)?
-            >> make_clamp_vec(0, 1)?
+            >> make_clamp(0, 1)?
             >> make_bounded_sum(0, 1)?
             >> make_base_geometric(1., 0, 10)?;
         meas?;

--- a/rust/opendp/src/chain.rs
+++ b/rust/opendp/src/chain.rs
@@ -234,7 +234,7 @@ mod test_shift_op {
             make_cast_default()? >>
             make_clamp(0, 1)? >>
             make_bounded_sum(0, 1)? >>
-            make_base_geometric(1., 0, 10, false)?
+            make_base_geometric(1., Some((0, 10)))?
         ).map(|_| ())
     }
 }

--- a/rust/opendp/src/chain.rs
+++ b/rust/opendp/src/chain.rs
@@ -233,7 +233,7 @@ mod test_shift_op {
             >> make_parse_series(true)?
             >> make_clamp(0, 1)?
             >> make_bounded_sum(0, 1)?
-            >> make_base_geometric(1., 0, 10)?;
+            >> make_base_geometric(1., 0, 10, false)?;
         meas?;
         Ok(())
     }

--- a/rust/opendp/src/chain.rs
+++ b/rust/opendp/src/chain.rs
@@ -223,18 +223,18 @@ impl<DI, DX, DO, MI, MX, MO> Shr<Transformation<DX, DO, MX, MO>> for Fallible<Tr
 mod test_shift_op {
     use crate::dist::HammingDistance;
     use crate::meas::geometric::make_base_geometric;
-    use crate::trans::{make_bounded_sum, make_parse_series, make_split_lines, make_clamp};
+    use crate::trans::{make_bounded_sum, make_cast_default, make_clamp, make_split_lines};
 
     use super::*;
 
     #[test]
     fn test_shr() -> Fallible<()> {
-        let meas = make_split_lines::<HammingDistance>()?
-            >> make_parse_series(true)?
-            >> make_clamp(0, 1)?
-            >> make_bounded_sum(0, 1)?
-            >> make_base_geometric(1., 0, 10, false)?;
-        meas?;
-        Ok(())
+        (
+            make_split_lines::<HammingDistance>()? >>
+            make_cast_default()? >>
+            make_clamp(0, 1)? >>
+            make_bounded_sum(0, 1)? >>
+            make_base_geometric(1., 0, 10, false)?
+        ).map(|_| ())
     }
 }

--- a/rust/opendp/src/chain.rs
+++ b/rust/opendp/src/chain.rs
@@ -223,7 +223,7 @@ impl<DI, DX, DO, MI, MX, MO> Shr<Transformation<DX, DO, MX, MO>> for Fallible<Tr
 mod test_shift_op {
     use crate::dist::HammingDistance;
     use crate::meas::geometric::make_base_geometric;
-    use crate::trans::{make_bounded_sum, make_clamp_vec, make_parse_series, make_split_lines};
+    use crate::trans::{make_bounded_sum, make_parse_series, make_split_lines, make_clamp_vec};
 
     use super::*;
 

--- a/rust/opendp/src/chain.rs
+++ b/rust/opendp/src/chain.rs
@@ -220,7 +220,7 @@ impl<DI, DX, DO, MI, MX, MO> Shr<Transformation<DX, DO, MX, MO>> for Fallible<Tr
 
 
 #[cfg(test)]
-mod test_shift_op {
+mod tests_shr {
     use crate::dist::HammingDistance;
     use crate::meas::geometric::make_base_geometric;
     use crate::trans::{make_bounded_sum, make_cast_default, make_clamp, make_split_lines};

--- a/rust/opendp/src/core.rs
+++ b/rust/opendp/src/core.rs
@@ -83,7 +83,7 @@ pub trait Measure: Default + Clone + PartialEq {
 }
 
 /// An indicator trait that is only implemented for dataset distances.
-pub trait DatasetMetric: Metric {}
+pub trait DatasetMetric: Metric<Distance=u32> {}
 
 /// An indicator trait that is only implemented for statistic distances.
 pub trait SensitivityMetric: Metric {}

--- a/rust/opendp/src/dist.rs
+++ b/rust/opendp/src/dist.rs
@@ -69,42 +69,22 @@ impl Metric for HammingDistance {
 
 impl DatasetMetric for HammingDistance {}
 
-pub struct L1Sensitivity<Q>(PhantomData<Q>);
-
-impl<Q> Default for L1Sensitivity<Q> {
-    fn default() -> Self { L1Sensitivity(PhantomData) }
+// Sensitivity in P-space
+pub struct LPSensitivity<Q, const P: usize>(PhantomData<Q>);
+impl<Q, const P: usize> Default for LPSensitivity<Q, P> {
+    fn default() -> Self { LPSensitivity(PhantomData) }
 }
 
-impl<Q> Clone for L1Sensitivity<Q> {
+impl<Q, const P: usize> Clone for LPSensitivity<Q, P> {
     fn clone(&self) -> Self { Self::default() }
 }
-
-impl<Q> PartialEq for L1Sensitivity<Q> {
+impl<Q, const P: usize> PartialEq for LPSensitivity<Q, P> {
     fn eq(&self, _other: &Self) -> bool { true }
 }
-
-impl<Q> Metric for L1Sensitivity<Q> {
+impl<Q, const P: usize> Metric for LPSensitivity<Q, P> {
     type Distance = Q;
 }
+impl<Q, const P: usize> SensitivityMetric for LPSensitivity<Q, P> {}
 
-impl<Q> SensitivityMetric for L1Sensitivity<Q> {}
-
-pub struct L2Sensitivity<Q>(PhantomData<Q>);
-
-impl<Q> Default for L2Sensitivity<Q> {
-    fn default() -> Self { L2Sensitivity(PhantomData) }
-}
-
-impl<Q> Clone for L2Sensitivity<Q> {
-    fn clone(&self) -> Self { Self::default() }
-}
-
-impl<Q> PartialEq for L2Sensitivity<Q> {
-    fn eq(&self, _other: &Self) -> bool { true }
-}
-
-impl<Q> Metric for L2Sensitivity<Q> {
-    type Distance = Q;
-}
-
-impl<Q> SensitivityMetric for L2Sensitivity<Q> {}
+pub type L1Sensitivity<Q> = LPSensitivity<Q, 1>;
+pub type L2Sensitivity<Q> = LPSensitivity<Q, 2>;

--- a/rust/opendp/src/dom.rs
+++ b/rust/opendp/src/dom.rs
@@ -182,3 +182,20 @@ impl<D: Domain> Domain for SizedDomain<D> {
         self.element_domain.member(val)
     }
 }
+
+/// A domain with a built-in representation of nullity, that may be null
+#[derive(Clone, PartialEq)]
+pub struct NullableDomain<D: Domain> {
+    pub element_domain: D,
+}
+impl<D: Domain> NullableDomain<D> {
+    pub fn new(member_domain: D) -> Self {
+        NullableDomain { element_domain: member_domain }
+    }
+}
+impl<D: Domain> Domain for NullableDomain<D> {
+    type Carrier = D::Carrier;
+    fn member(&self, val: &Self::Carrier) -> bool {
+        self.element_domain.member(val)
+    }
+}

--- a/rust/opendp/src/dom.rs
+++ b/rust/opendp/src/dom.rs
@@ -185,34 +185,34 @@ impl<D: Domain> Domain for SizedDomain<D> {
 
 /// A domain with a built-in representation of nullity, that may take on null values at runtime
 #[derive(Clone, PartialEq)]
-pub struct InternalNullDomain<D: Domain>
-    where D::Carrier: InternalNull {
+pub struct InherentNullDomain<D: Domain>
+    where D::Carrier: InherentNull {
     pub element_domain: D,
 }
-impl<D: Domain> InternalNullDomain<D> where D::Carrier: InternalNull {
+impl<D: Domain> InherentNullDomain<D> where D::Carrier: InherentNull {
     pub fn new(member_domain: D) -> Self {
-        InternalNullDomain { element_domain: member_domain }
+        InherentNullDomain { element_domain: member_domain }
     }
 }
-impl<D: Domain> Domain for InternalNullDomain<D> where D::Carrier: InternalNull {
+impl<D: Domain> Domain for InherentNullDomain<D> where D::Carrier: InherentNull {
     type Carrier = D::Carrier;
     fn member(&self, val: &Self::Carrier) -> bool {
         if val.is_null() {return true}
         self.element_domain.member(val)
     }
 }
-pub trait InternalNull {
+pub trait InherentNull {
     fn is_null(&self) -> bool;
     const NULL: Self;
 }
-macro_rules! impl_internal_null_float {
-    ($($ty:ty),+) => ($(impl InternalNull for $ty {
+macro_rules! impl_inherent_null_float {
+    ($($ty:ty),+) => ($(impl InherentNull for $ty {
         #[inline]
         fn is_null(&self) -> bool { self.is_nan() }
         const NULL: Self = Self::NAN;
     })+)
 }
-impl_internal_null_float!(f64, f32);
+impl_inherent_null_float!(f64, f32);
 
 /// A domain that represents nullity via the Option type.
 /// The value inside is non-null by definition.

--- a/rust/opendp/src/interactive.rs
+++ b/rust/opendp/src/interactive.rs
@@ -253,7 +253,7 @@ mod tests {
         // Noisy count
         let measurement1 = (
             make_count()? >>
-            make_base_geometric(1.0 / d_out_query, count_bounds.0, count_bounds.1)?
+            make_base_geometric(1.0 / d_out_query, count_bounds.0, count_bounds.1, false)?
         )?.into_poly();
         let query1 = (measurement1, d_out_query);
         let _result1: i32 = queryable.eval_poly(&query1)?;

--- a/rust/opendp/src/interactive.rs
+++ b/rust/opendp/src/interactive.rs
@@ -261,7 +261,7 @@ mod tests {
 
         // Noisy sum
         let measurement2 = (
-            make_clamp_vec(val_bounds.0, val_bounds.1)? >>
+            make_clamp(val_bounds.0, val_bounds.1)? >>
             make_bounded_sum(val_bounds.0, val_bounds.1)? >>
             make_base_laplace(1.0 / d_out_query)?
         )?.into_poly();

--- a/rust/opendp/src/interactive.rs
+++ b/rust/opendp/src/interactive.rs
@@ -253,7 +253,7 @@ mod tests {
         // Noisy count
         let measurement1 = (
             make_count()? >>
-            make_base_geometric(1.0 / d_out_query, count_bounds.0, count_bounds.1, false)?
+            make_base_geometric(1.0 / d_out_query, Some(count_bounds))?
         )?.into_poly();
         let query1 = (measurement1, d_out_query);
         let _result1: i32 = queryable.eval_poly(&query1)?;

--- a/rust/opendp/src/lib.rs
+++ b/rust/opendp/src/lib.rs
@@ -38,11 +38,12 @@
 //! use opendp::core;
 //! use opendp::meas;
 //! use opendp::trans;
-//! use opendp::trans::{manipulation, sum, make_split_lines, make_parse_series, make_clamp_vec, make_bounded_sum};
+//! use opendp::trans::{manipulation, sum, make_split_lines, make_parse_series, make_clamp, make_bounded_sum};
 //! use opendp::dist::{HammingDistance, L1Sensitivity};
 //! use opendp::error::*;
 //! use opendp::chain::{make_chain_tt, make_chain_mt};
 //! use opendp::meas::make_base_laplace;
+//! use opendp::dom::VectorDomain;
 //!
 //! pub fn example() -> Fallible<()> {
 //!     let data = "56\n15\n97\n56\n6\n17\n2\n19\n16\n50".to_owned();
@@ -56,7 +57,7 @@
 //!     let load_numbers = make_chain_tt(&parse_series, &split_lines, None)?;
 //!
 //!     // Construct a Measurement to calculate a noisy sum.
-//!     let clamp = make_clamp_vec(bounds.0, bounds.1)?;
+//!     let clamp = make_clamp::<VectorDomain<_>, _>(bounds.0, bounds.1)?;
 //!     let bounded_sum = make_bounded_sum(bounds.0, bounds.1)?;
 //!     let laplace = make_base_laplace(sigma)?;
 //!     let intermediate = make_chain_tt(&bounded_sum, &clamp, None)?;

--- a/rust/opendp/src/lib.rs
+++ b/rust/opendp/src/lib.rs
@@ -38,7 +38,7 @@
 //! use opendp::core;
 //! use opendp::meas;
 //! use opendp::trans;
-//! use opendp::trans::{manipulation, sum, make_split_lines, make_parse_series, make_clamp, make_bounded_sum};
+//! use opendp::trans::{manipulation, sum, make_split_lines, make_cast_default, make_clamp, make_bounded_sum};
 //! use opendp::dist::{HammingDistance, L1Sensitivity};
 //! use opendp::error::*;
 //! use opendp::chain::{make_chain_tt, make_chain_mt};
@@ -53,8 +53,8 @@
 //!
 //!     // Construct a Transformation to load the numbers.
 //!     let split_lines = make_split_lines::<HammingDistance>()?;
-//!     let parse_series = make_parse_series::<HammingDistance, f64>(true)?;
-//!     let load_numbers = make_chain_tt(&parse_series, &split_lines, None)?;
+//!     let cast = make_cast_default::<HammingDistance, String, f64>()?;
+//!     let load_numbers = make_chain_tt(&cast, &split_lines, None)?;
 //!
 //!     // Construct a Measurement to calculate a noisy sum.
 //!     let clamp = make_clamp::<VectorDomain<_>, _>(bounds.0, bounds.1)?;

--- a/rust/opendp/src/meas/geometric.rs
+++ b/rust/opendp/src/meas/geometric.rs
@@ -63,9 +63,39 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_make_geometric_mechanism() {
+    fn test_make_geometric_mechanism_bounded() {
         let measurement = make_base_geometric::<AllDomain<_>, f64>(10.0, Some((200, 210))).unwrap_test();
         let arg = 205;
+        let _ret = measurement.function.eval(&arg).unwrap_test();
+        println!("{:?}", _ret);
+
+        assert!(measurement.privacy_relation.eval(&1, &0.5).unwrap_test());
+    }
+
+    #[test]
+    fn test_make_vector_geometric_mechanism_bounded() {
+        let measurement = make_base_geometric::<VectorDomain<_>, f64>(10.0, Some((200, 210))).unwrap_test();
+        let arg = vec![1, 2, 3, 4];
+        let _ret = measurement.function.eval(&arg).unwrap_test();
+        println!("{:?}", _ret);
+
+        assert!(measurement.privacy_relation.eval(&1, &0.5).unwrap_test());
+    }
+
+    #[test]
+    fn test_make_geometric_mechanism() {
+        let measurement = make_base_geometric::<AllDomain<_>, f64>(10.0, None).unwrap_test();
+        let arg = 205;
+        let _ret = measurement.function.eval(&arg).unwrap_test();
+        println!("{:?}", _ret);
+
+        assert!(measurement.privacy_relation.eval(&1, &0.5).unwrap_test());
+    }
+
+    #[test]
+    fn test_make_vector_geometric_mechanism() {
+        let measurement = make_base_geometric::<VectorDomain<_>, f64>(10.0, None).unwrap_test();
+        let arg = vec![1, 2, 3, 4];
         let _ret = measurement.function.eval(&arg).unwrap_test();
         println!("{:?}", _ret);
 

--- a/rust/opendp/src/meas/geometric.rs
+++ b/rust/opendp/src/meas/geometric.rs
@@ -1,37 +1,57 @@
-use crate::core::{Function, Measurement, PrivacyRelation};
+use crate::core::{Function, Measurement, PrivacyRelation, Domain};
 use crate::dist::{MaxDivergence, L1Sensitivity};
-use crate::dom::AllDomain;
+use crate::dom::{AllDomain, VectorDomain};
 use crate::error::*;
-use crate::samplers::{SampleBernoulli, SampleGeometric, SampleUniform};
+use crate::samplers::SampleTwoSidedGeometric;
 use crate::traits::DistanceCast;
-use num::{Float, CheckedAdd, CheckedSub, Zero};
+use num::Float;
+use std::ops::Sub;
 
 
-pub fn make_base_geometric<T, QO>(scale: QO, min: T, max: T) -> Fallible<Measurement<AllDomain<T>, AllDomain<T>, L1Sensitivity<T>, MaxDivergence<QO>>>
-    where T: 'static + Clone + SampleGeometric + CheckedSub<Output=T> + CheckedAdd<Output=T> + DistanceCast + Zero,
-          QO: 'static + Float + DistanceCast, f64: From<QO> {
-    if scale.is_sign_negative() {
-        return fallible!(MakeMeasurement, "scale must not be negative")
+pub trait GeometricDomain: Domain {
+    type Atom;
+    fn new() -> Self;
+    fn noise_function(scale: f64, max_trials: Self::Atom, constant_time: bool) -> Function<Self, Self>;
+}
+
+
+impl<T> GeometricDomain for AllDomain<T>
+    where T: 'static + Clone + SampleTwoSidedGeometric {
+    type Atom = Self::Carrier;
+
+    fn new() -> Self { AllDomain::new() }
+    fn noise_function(scale: f64, max_trials: T, constant_time: bool) -> Function<Self, Self> {
+        Function::new_fallible(move |arg: &Self::Carrier|
+            T::sample_two_sided_geometric(arg.clone(), scale, max_trials.clone(), constant_time))
     }
-    let max_trials: T = max - min;
-    let alpha: f64 = (-f64::from(scale).recip()).exp();
+}
+
+impl<T> GeometricDomain for VectorDomain<AllDomain<T>>
+    where T: 'static + Clone + SampleTwoSidedGeometric {
+    type Atom = T;
+
+    fn new() -> Self { VectorDomain::new_all() }
+    fn noise_function(scale: f64, max_trials: T, constant_time: bool) -> Function<Self, Self> {
+        Function::new_fallible(move |arg: &Self::Carrier| arg.iter()
+            .map(|v| T::sample_two_sided_geometric(v.clone(), scale, max_trials.clone(), constant_time))
+            .collect())
+    }
+}
+
+pub fn make_base_geometric<D, QO>(
+    scale: QO, min: D::Atom, max: D::Atom, constant_time: bool
+) -> Fallible<Measurement<D, D, L1Sensitivity<D::Atom>, MaxDivergence<QO>>>
+    where D: 'static + GeometricDomain,
+          D::Atom: 'static + DistanceCast + Sub<Output=D::Atom>,
+          QO: 'static + Float + DistanceCast,
+          f64: From<QO> {
+    if scale.is_sign_negative() { return fallible!(MakeMeasurement, "scale must not be negative") }
+    let max_trials: D::Atom = max - min;
 
     Ok(Measurement::new(
-        AllDomain::new(),
-        AllDomain::new(),
-        Function::new_fallible(move |arg: &T| -> Fallible<T> {
-            // return 0 noise with probability (1-alpha) / (1+alpha), otherwise sample from geometric
-            Ok(if f64::sample_standard_uniform(false)? < (1. - alpha) / (1. + alpha) {
-                arg.clone()
-            } else {
-                let noise = T::sample_geometric(1. - alpha, max_trials.clone(), false)?;
-                if bool::sample_standard_bernoulli()? {
-                    arg.clone().checked_add(&noise)
-                } else {
-                    arg.clone().checked_sub(&noise)
-                }.unwrap_or_else(T::zero)
-            })
-        }),
+        D::new(),
+        D::new(),
+        D::noise_function(f64::from(scale), max_trials, constant_time),
         L1Sensitivity::default(),
         MaxDivergence::default(),
         PrivacyRelation::new_from_constant(scale.recip())))
@@ -43,7 +63,7 @@ mod tests {
 
     #[test]
     fn test_make_geometric_mechanism() {
-        let measurement = make_base_geometric::<i32, f64>(10.0, 200, 210).unwrap_test();
+        let measurement = make_base_geometric::<AllDomain<_>, f64>(10.0, 200, 210, false).unwrap_test();
         let arg = 205;
         let _ret = measurement.function.eval(&arg).unwrap_test();
 

--- a/rust/opendp/src/meas/stability.rs
+++ b/rust/opendp/src/meas/stability.rs
@@ -98,7 +98,7 @@ pub fn make_base_stability<MI, TIK, TIC>(
 
 
 #[cfg(test)]
-mod test_stability {
+mod tests {
     use super::*;
 
     #[test]

--- a/rust/opendp/src/meas/stability.rs
+++ b/rust/opendp/src/meas/stability.rs
@@ -17,16 +17,16 @@ pub type CountDomain<TIK, TIC> = SizedDomain<MapDomain<AllDomain<TIK>, AllDomain
 
 // tie metric with distribution
 pub trait BaseStabilityNoise: Metric {
-    fn noise(shift: Self::Distance, scale: Self::Distance, enforce_constant_time: bool) -> Fallible<Self::Distance>;
+    fn noise(shift: Self::Distance, scale: Self::Distance, constant_time: bool) -> Fallible<Self::Distance>;
 }
 impl<TOC: SampleLaplace> BaseStabilityNoise for L1Sensitivity<TOC> {
-    fn noise(shift: Self::Distance, scale: Self::Distance, enforce_constant_time: bool) -> Fallible<Self::Distance> {
-        Self::Distance::sample_laplace(shift, scale, enforce_constant_time)
+    fn noise(shift: Self::Distance, scale: Self::Distance, constant_time: bool) -> Fallible<Self::Distance> {
+        Self::Distance::sample_laplace(shift, scale, constant_time)
     }
 }
 impl<TOC: SampleGaussian> BaseStabilityNoise for L2Sensitivity<TOC> {
-    fn noise(shift: Self::Distance, scale: Self::Distance, enforce_constant_time: bool) -> Fallible<Self::Distance> {
-        Self::Distance::sample_gaussian(shift, scale, enforce_constant_time)
+    fn noise(shift: Self::Distance, scale: Self::Distance, constant_time: bool) -> Fallible<Self::Distance> {
+        Self::Distance::sample_gaussian(shift, scale, constant_time)
     }
 }
 

--- a/rust/opendp/src/poly.rs
+++ b/rust/opendp/src/poly.rs
@@ -90,7 +90,7 @@ mod tests {
 
     #[test]
     fn test_poly_measurement() -> Fallible<()> {
-        let op_plain = meas::make_base_laplace(0.0)?;
+        let op_plain = meas::make_base_laplace::<AllDomain<_>>(0.0)?;
         let arg = 99.9;
         let res_plain = op_plain.function.eval(&arg)?;
         assert_eq!(res_plain, arg);

--- a/rust/opendp/src/samplers.rs
+++ b/rust/opendp/src/samplers.rs
@@ -312,7 +312,7 @@ pub trait SampleTwoSidedGeometric: SampleGeometric {
     /// Sample from the censored two-sided geometric distribution with parameter `prob`.
     /// If `bounds` is None, there are no timing protections, and the support is:
     ///     [Self::MIN, Self::MAX]
-    /// If `trials` is Some, execution runs in constant time, and the support is
+    /// If `bounds` is Some, execution runs in constant time, and the support is
     ///     [Self::MIN, Self::MAX] ∩ {shift ±= {1, 2, 3, ..., `trials`}}
     ///
     /// Tail probabilities of the uncensored two-sided geometric accumulate at the extrema of the support.

--- a/rust/opendp/src/trans/cast.rs
+++ b/rust/opendp/src/trans/cast.rs
@@ -40,15 +40,15 @@ pub fn make_cast_default<M, TI, TO>() -> Fallible<Transformation<VectorDomain<Al
 
 /// A [`Transformation`] that checks equality elementwise with `value`.
 /// Maps a Vec<T> -> Vec<bool>
-pub fn make_is_equal<M, T>(
-    value: T
-) -> Fallible<Transformation<VectorDomain<AllDomain<T>>, VectorDomain<AllDomain<bool>>, M, M>>
+pub fn make_is_equal<M, TI>(
+    value: TI
+) -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<AllDomain<bool>>, M, M>>
     where M: DatasetMetric,
-          T: 'static + Eq {
+          TI: 'static + PartialEq {
     Ok(Transformation::new(
         VectorDomain::new_all(),
         VectorDomain::new_all(),
-        Function::new(move |arg: &Vec<T>| arg.iter().map(|v| v == &value).collect()),
+        Function::new(move |arg: &Vec<TI>| arg.iter().map(|v| v == &value).collect()),
         M::default(),
         M::default(),
         StabilityRelation::new_from_constant(M::Distance::one())

--- a/rust/opendp/src/trans/cast.rs
+++ b/rust/opendp/src/trans/cast.rs
@@ -1,0 +1,162 @@
+use crate::error::Fallible;
+use crate::core::{Transformation, DatasetMetric, Function, StabilityRelation};
+use crate::dom::{VectorDomain, AllDomain};
+use crate::traits::{DistanceConstant, CastFrom};
+use num::One;
+
+
+/// A [`Transformation`] that casts elements between types
+/// Maps a Vec<TI> -> Vec<Option<TO>>
+pub fn make_cast_vec<M, TI, TO>() -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<AllDomain<Option<TO>>>, M, M>>
+    where M: DatasetMetric<Distance=u32>,
+          TI: Clone, TO: CastFrom<TI> {
+    Ok(Transformation::new(
+        VectorDomain::new_all(),
+        VectorDomain::new_all(),
+        Function::new(move |arg: &Vec<TI>| arg.iter()
+            .map(|v| TO::cast(v.clone()).ok())
+            .collect()),
+        M::default(),
+        M::default(),
+        StabilityRelation::new_from_constant(1_u32)))
+}
+
+/// A [`Transformation`] that casts elements between types. Fills with TO::default if parsing fails.
+/// Maps a Vec<TI> -> Vec<TO>
+pub fn make_cast_vec_default<M, TI, TO>() -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<AllDomain<TO>>, M, M>>
+    where M: DatasetMetric<Distance=u32>,
+          TI: Clone, TO: CastFrom<TI> + Default {
+    Ok(Transformation::new(
+        VectorDomain::new_all(),
+        VectorDomain::new_all(),
+        Function::new(move |arg: &Vec<TI>| arg.iter()
+            .map(|v| TO::cast(v.clone()).unwrap_or_default())
+            .collect()),
+        M::default(),
+        M::default(),
+        StabilityRelation::new_from_constant(1_u32)))
+}
+
+/// A [`Transformation`] that checks equality elementwise with `value`.
+/// Maps a Vec<T> -> Vec<bool>
+pub fn make_is_equal<M, T>(
+    value: T
+) -> Fallible<Transformation<VectorDomain<AllDomain<T>>, VectorDomain<AllDomain<bool>>, M, M>>
+    where M: DatasetMetric,
+          T: 'static + Eq,
+          M::Distance: One + DistanceConstant {
+    Ok(Transformation::new(
+        VectorDomain::new_all(),
+        VectorDomain::new_all(),
+        Function::new(move |arg: &Vec<T>| arg.iter().map(|v| v == &value).collect()),
+        M::default(),
+        M::default(),
+        StabilityRelation::new_from_constant(M::Distance::one())
+    ))
+}
+
+// casting primitive types is not exposed over ffi.
+// Need a way to also cast M::Distance that doesn't allow changing M
+// pub fn make_cast<M, TI, TO>() -> Fallible<Transformation<AllDomain<TI>, AllDomain<TO>, M, M>>
+//     where M: Metric,
+//           M::Distance: DistanceConstant + One,
+//           TI: Clone,
+//           TO: 'static + CastFrom<TI> + Default {
+//     Ok(Transformation::new(
+//         AllDomain::new(),
+//         AllDomain::new(),
+//         Function::new(move |v: &TI| TO::cast(v.clone()).unwrap_or_else(|_| TO::default())),
+//         M::default(),
+//         M::default(),
+//         StabilityRelation::new_from_constant(M::Distance::one())))
+// }
+
+#[cfg(test)]
+mod test_manipulations {
+
+    use super::*;
+    use crate::dist::{SymmetricDistance, HammingDistance};
+    use crate::error::ExplainUnwrap;
+
+
+    #[test]
+    fn test_cast() {
+        macro_rules! test_pair {
+            ($from:ty, $to:ty) => {
+                let caster = make_cast_vec::<SymmetricDistance, $from, $to>().unwrap_test();
+                caster.function.eval(&vec!(<$from>::default())).unwrap_test();
+                let caster = make_cast_vec::<HammingDistance, $from, $to>().unwrap_test();
+                caster.function.eval(&vec!(<$from>::default())).unwrap_test();
+            }
+        }
+        macro_rules! test_cartesian {
+            ([];[$first:ty, $($end:ty),*]) => {
+                test_pair!($first, $first);
+                $(test_pair!($first, $end);)*
+
+                test_cartesian!{[$first];[$($end),*]}
+            };
+            ([$($start:ty),*];[$mid:ty, $($end:ty),*]) => {
+                $(test_pair!($mid, $start);)*
+                test_pair!($mid, $mid);
+                $(test_pair!($mid, $end);)*
+
+                test_cartesian!{[$($start),*, $mid];[$($end),*]}
+            };
+            ([$($start:ty),*];[$last:ty]) => {
+                test_pair!($last, $last);
+                $(test_pair!($last, $start);)*
+            };
+        }
+        test_cartesian!{[];[u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String, bool]}
+    }
+
+    #[test]
+    fn test_cast_unsigned() -> Fallible<()> {
+        let caster = make_cast_vec_default::<SymmetricDistance, f64, u8>()?;
+        assert_eq!(caster.function.eval(&vec![-1.])?, vec![u8::default()]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_cast_parse() -> Fallible<()> {
+        let data = vec!["2".to_string(), "3".to_string(), "a".to_string(), "".to_string()];
+
+        let caster = make_cast_vec_default::<SymmetricDistance, String, u8>()?;
+        assert_eq!(caster.function.eval(&data)?, vec![2, 3, u8::default(), u8::default()]);
+
+        let caster = make_cast_vec_default::<SymmetricDistance, String, f64>()?;
+        assert_eq!(caster.function.eval(&data)?, vec![2., 3., f64::default(), f64::default()]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_cast_floats() -> Fallible<()> {
+        let data = vec![f64::NAN, f64::NEG_INFINITY, f64::INFINITY];
+        let caster = make_cast_vec_default::<SymmetricDistance, f64, String>()?;
+        assert_eq!(
+            caster.function.eval(&data)?,
+            vec!["NaN".to_string(), "-inf".to_string(), "inf".to_string()]);
+
+        let caster = make_cast_vec_default::<SymmetricDistance, f64, u8>()?;
+        assert_eq!(
+            caster.function.eval(&vec![f64::NAN, f64::NEG_INFINITY, f64::INFINITY])?,
+            vec![u8::default(), u8::default(), u8::default()]);
+
+        let data = vec!["1e+2", "1e2", "1e+02", "1.e+02", "1.0E+02", "1.0E+00002", "01.E+02", "1.0E2"]
+            .into_iter().map(|v| v.to_string()).collect();
+        let caster = make_cast_vec_default::<SymmetricDistance, String, f64>()?;
+        assert!(caster.function.eval(&data)?.into_iter().all(|v| v == 100.));
+        Ok(())
+    }
+
+    #[test]
+    fn test_is_equal() -> Fallible<()> {
+        let is_equal = make_is_equal::<HammingDistance, _>("alpha".to_string())?;
+        let arg = vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string()];
+        let ret = is_equal.function.eval(&arg)?;
+        assert_eq!(ret, vec![true, false, false]);
+        assert!(is_equal.stability_relation.eval(&1, &1)?);
+        Ok(())
+    }
+}

--- a/rust/opendp/src/trans/clamp.rs
+++ b/rust/opendp/src/trans/clamp.rs
@@ -120,11 +120,11 @@ mod test_manipulations {
 
     use super::*;
     use crate::dist::{SymmetricDistance, HammingDistance};
-    use crate::trans::{make_clamp_vec, make_unclamp_vec};
+    use crate::trans::{make_clamp, make_unclamp_vec};
 
     #[test]
-    fn test_unclamp() -> Fallible<()> {
-        let clamp = make_clamp_vec::<SymmetricDistance, u8>(2, 3)?;
+    fn test_make_unclamp() -> Fallible<()> {
+        let clamp = make_clamp::<VectorDomain<_>, SymmetricDistance>(2, 3)?;
         let unclamp = make_unclamp_vec(2, 3)?;
 
         (clamp >> unclamp).map(|_| ())
@@ -132,7 +132,7 @@ mod test_manipulations {
 
     #[test]
     fn test_make_clamp() {
-        let transformation = make_clamp_vec::<HammingDistance, i32>(0, 10).unwrap_test();
+        let transformation = make_clamp::<VectorDomain<_>, HammingDistance>(0, 10).unwrap_test();
         let arg = vec![-10, -5, 0, 5, 10, 20];
         let ret = transformation.function.eval(&arg).unwrap_test();
         let expected = vec![0, 0, 0, 5, 10, 10];

--- a/rust/opendp/src/trans/clamp.rs
+++ b/rust/opendp/src/trans/clamp.rs
@@ -19,7 +19,6 @@ pub trait ClampableDomain<M, DO>: Domain
 
 impl<M, T> ClampableDomain<M, VectorDomain<IntervalDomain<T>>> for VectorDomain<AllDomain<T>>
     where M: DatasetMetric,
-          M::Distance: DistanceConstant + One,
           T: 'static + PartialOrd + Clone, {
     type Atom = T;
     fn new_input_domain() -> Self { VectorDomain::new_all() }

--- a/rust/opendp/src/trans/clamp.rs
+++ b/rust/opendp/src/trans/clamp.rs
@@ -1,0 +1,110 @@
+use std::collections::Bound;
+
+use num::One;
+
+use crate::core::{DatasetMetric, Function, Metric, StabilityRelation, Transformation, SensitivityMetric};
+use crate::dom::{AllDomain, IntervalDomain, VectorDomain};
+use crate::error::*;
+use crate::traits::{DistanceConstant, DistanceCast};
+use std::ops::Sub;
+
+pub fn make_clamp_vec<M, T>(lower: T, upper: T) -> Fallible<Transformation<VectorDomain<AllDomain<T>>, VectorDomain<IntervalDomain<T>>, M, M>>
+    where M: DatasetMetric,
+          T: 'static + Clone + PartialOrd,
+          M::Distance: DistanceConstant + One {
+    if lower > upper { return fallible!(MakeTransformation, "lower may not be greater than upper") }
+    Ok(Transformation::new(
+        VectorDomain::new_all(),
+        VectorDomain::new(IntervalDomain::new(Bound::Included(lower.clone()), Bound::Included(upper.clone()))),
+        Function::new(move |arg: &Vec<T>| arg.iter().map(|e| clamp(&lower, &upper, e)).collect()),
+        M::default(),
+        M::default(),
+        // clamping has a c-stability of one, as well as a lipschitz constant of one
+        StabilityRelation::new_from_constant(M::Distance::one())))
+}
+
+fn min<T: PartialOrd>(a: T, b: T) -> T { if a < b {a} else {b} }
+
+pub fn make_clamp_sensitivity<M, T>(lower: T, upper: T) -> Fallible<Transformation<AllDomain<T>, IntervalDomain<T>, M, M>>
+    where M: SensitivityMetric,
+          T: 'static + Clone + PartialOrd + DistanceCast + Sub<Output=T>,
+          M::Distance: DistanceConstant + One {
+    if lower > upper { return fallible!(MakeTransformation, "lower may not be greater than upper") }
+    Ok(Transformation::new(
+        AllDomain::new(),
+        IntervalDomain::new(Bound::Included(lower.clone()), Bound::Included(upper.clone())),
+        Function::new(enclose!((lower, upper), move |arg: &T| clamp(&lower, &upper, arg))),
+        M::default(),
+        M::default(),
+        // the sensitivity is at most upper - lower
+        StabilityRelation::new_all(
+            // relation
+            enclose!((lower, upper), move |d_in: &M::Distance, d_out: &M::Distance|
+                Ok(d_out.clone() >= min(d_in.clone(), M::Distance::distance_cast(upper.clone() - lower.clone())?))),
+            // forward map
+            Some(enclose!((lower, upper), move |d_in: &M::Distance|
+                Ok(Box::new(min(d_in.clone(), M::Distance::distance_cast(upper.clone() - lower.clone())?))))),
+            // backward map
+            None::<fn(&_)->_>
+        )))
+}
+
+fn clamp<T: Clone + PartialOrd>(lower: &T, upper: &T, x: &T) -> T {
+    (if x < lower { lower } else if x > upper { upper } else { x }).clone()
+}
+
+
+pub fn make_unclamp_vec<M, T>(lower: T, upper: T) -> Fallible<Transformation<VectorDomain<IntervalDomain<T>>, VectorDomain<AllDomain<T>>, M, M>>
+    where M: Metric,
+          T: 'static + Clone + PartialOrd,
+          M::Distance: DistanceConstant + One {
+    Ok(Transformation::new(
+        VectorDomain::new(IntervalDomain::new(Bound::Included(lower), Bound::Included(upper))),
+        VectorDomain::new_all(),
+        Function::new(move |arg: &Vec<T>| arg.clone()),
+        M::default(),
+        M::default(),
+        StabilityRelation::new_from_constant(M::Distance::one())
+    ))
+}
+
+pub fn make_unclamp<M, T>(lower: Bound<T>, upper: Bound<T>) -> Fallible<Transformation<IntervalDomain<T>, AllDomain<T>, M, M>>
+    where M: Metric,
+          T: 'static + Clone + PartialOrd,
+          M::Distance: DistanceConstant + One {
+    Ok(Transformation::new(
+        IntervalDomain::new(lower, upper),
+        AllDomain::new(),
+        Function::new(move |arg: &T| arg.clone()),
+        M::default(),
+        M::default(),
+        StabilityRelation::new_from_constant(M::Distance::one())
+    ))
+}
+
+
+
+#[cfg(test)]
+mod test_manipulations {
+
+    use super::*;
+    use crate::dist::{SymmetricDistance, HammingDistance};
+    use crate::trans::{make_clamp_vec, make_unclamp_vec};
+
+    #[test]
+    fn test_unclamp() -> Fallible<()> {
+        let clamp = make_clamp_vec::<SymmetricDistance, u8>(2, 3)?;
+        let unclamp = make_unclamp_vec(2, 3)?;
+
+        (clamp >> unclamp).map(|_| ())
+    }
+
+    #[test]
+    fn test_make_clamp() {
+        let transformation = make_clamp_vec::<HammingDistance, i32>(0, 10).unwrap_test();
+        let arg = vec![-10, -5, 0, 5, 10, 20];
+        let ret = transformation.function.eval(&arg).unwrap_test();
+        let expected = vec![0, 0, 0, 5, 10, 10];
+        assert_eq!(ret, expected);
+    }
+}

--- a/rust/opendp/src/trans/count.rs
+++ b/rust/opendp/src/trans/count.rs
@@ -15,7 +15,7 @@ use crate::traits::DistanceConstant;
 
 
 pub fn make_count<MI, MO, TI>() -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, AllDomain<MO::Distance>, MI, MO>>
-    where MI: DatasetMetric<Distance=u32>,
+    where MI: DatasetMetric,
           MO: SensitivityMetric,
           MO::Distance: TryFrom<usize> + Bounded + One + DistanceConstant {
     Ok(Transformation::new(
@@ -53,7 +53,7 @@ impl<MO: SensitivityMetric> CountByConstant<SymmetricDistance, MO> for (Symmetri
 
 // count with unknown n, known categories
 pub fn make_count_by_categories<MI, MO, TI, TO>(categories: Vec<TI>) -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, SizedDomain<VectorDomain<AllDomain<TO>>>, MI, MO>>
-    where MI: DatasetMetric<Distance=u32>,
+    where MI: DatasetMetric,
           MO: SensitivityMetric,
           TI: 'static + Eq + Hash,
           TO: Integer + Zero + One + AddAssign,
@@ -89,7 +89,7 @@ pub fn make_count_by_categories<MI, MO, TI, TO>(categories: Vec<TI>) -> Fallible
 
 // count with known n, unknown categories
 pub fn make_count_by<MI, MO, TI, TO>(n: usize) -> Fallible<Transformation<SizedDomain<VectorDomain<AllDomain<TI>>>, SizedDomain<MapDomain<AllDomain<TI>, AllDomain<TO>>>, MI, MO>>
-    where MI: DatasetMetric<Distance=u32>,
+    where MI: DatasetMetric,
           MO: SensitivityMetric,
           TI: 'static + Eq + Hash + Clone,
           TO: Integer + Zero + One + AddAssign,

--- a/rust/opendp/src/trans/dataframe.rs
+++ b/rust/opendp/src/trans/dataframe.rs
@@ -168,22 +168,6 @@ fn parse_series<T>(col: &[&str], default_on_error: bool) -> Fallible<Vec<T>> whe
     }
 }
 
-pub fn make_parse_series<M, TO>(impute: bool) -> Fallible<Transformation<VectorDomain<AllDomain<String>>, VectorDomain<AllDomain<TO>>, M, M>>
-    where M: Clone + DatasetMetric,
-          TO: FromStr + Default,
-          TO::Err: Debug {
-    Ok(Transformation::new(
-        VectorDomain::new_all(),
-        VectorDomain::new_all(),
-        Function::new_fallible(move |arg: &Vec<String>| -> Fallible<Vec<TO>> {
-            let arg = vec_string_to_str(arg);
-            parse_series(&arg, impute)
-        }),
-        M::default(),
-        M::default(),
-        StabilityRelation::new_from_constant(1_u32)))
-}
-
 fn split_records<'a>(separator: &str, lines: &[&'a str]) -> Vec<Vec<&'a str>> {
     fn split<'a>(line: &'a str, separator: &str) -> Vec<&'a str> {
         line.split(separator).into_iter().map(|e| e.trim()).collect()

--- a/rust/opendp/src/trans/dataframe.rs
+++ b/rust/opendp/src/trans/dataframe.rs
@@ -226,15 +226,6 @@ mod tests {
     }
 
     #[test]
-    fn test_make_parse_series() {
-        let transformation = make_parse_series::<HammingDistance, i32>(true).unwrap_test();
-        let arg = vec!["1".to_owned(), "2".to_owned(), "3".to_owned(), "foo".to_owned()];
-        let ret = transformation.function.eval(&arg).unwrap_test();
-        let expected = vec![1, 2, 3, 0];
-        assert_eq!(ret, expected);
-    }
-
-    #[test]
     fn test_make_split_records() {
         let transformation = make_split_records::<HammingDistance>(None).unwrap_test();
         let arg = vec!["ant, foo".to_owned(), "bat, bar".to_owned(), "cat, baz".to_owned()];

--- a/rust/opendp/src/trans/dataframe.rs
+++ b/rust/opendp/src/trans/dataframe.rs
@@ -44,7 +44,7 @@ fn create_dataframe_domain<K: Eq + Hash>() -> DataFrameDomain<K> {
 pub fn make_create_dataframe<M, K>(
     col_names: Vec<K>
 ) -> Fallible<Transformation<VectorDomain<VectorDomain<AllDomain<String>>>, DataFrameDomain<K>, M, M>>
-    where M: Clone + DatasetMetric<Distance=u32>,
+    where M: Clone + DatasetMetric,
           K: 'static + Eq + Hash + Clone {
     Ok(Transformation::new(
         VectorDomain::new(VectorDomain::new_all()),
@@ -70,7 +70,7 @@ pub fn make_split_dataframe<M, K>(
     separator: Option<&str>, col_names: Vec<K>
 ) -> Fallible<Transformation<AllDomain<String>, DataFrameDomain<K>, M, M>>
     where K: 'static + Hash + Eq + Clone,
-          M: Clone + DatasetMetric<Distance=u32> {
+          M: Clone + DatasetMetric {
     let separator = separator.unwrap_or(",").to_owned();
     Ok(Transformation::new(
         AllDomain::new(),
@@ -101,7 +101,7 @@ fn parse_column<K, T>(key: &K, impute: bool, df: &DataFrame<K>) -> Fallible<Data
 }
 
 pub fn make_parse_column<M, K, T>(key: K, impute: bool) -> Fallible<Transformation<DataFrameDomain<K>, DataFrameDomain<K>, M, M>>
-    where M: Clone + DatasetMetric<Distance=u32>,
+    where M: Clone + DatasetMetric,
           K: 'static + Hash + Eq + Debug + Clone,
           T: 'static + Debug + FromStr + Clone + Default + PartialEq,
           T::Err: Debug {
@@ -115,7 +115,7 @@ pub fn make_parse_column<M, K, T>(key: K, impute: bool) -> Fallible<Transformati
 }
 
 pub fn make_select_column<M, K, T>(key: K) -> Fallible<Transformation<DataFrameDomain<K>, VectorDomain<AllDomain<T>>, M, M>>
-    where M: Clone + DatasetMetric<Distance=u32>,
+    where M: Clone + DatasetMetric,
           K: 'static + Eq + Hash + Debug,
           T: 'static + Debug + Clone + PartialEq {
     Ok(Transformation::new(
@@ -146,7 +146,7 @@ fn split_lines(s: &str) -> Vec<&str> {
 
 /// A [`Transformation`] that takes a `String` and splits it into a `Vec<String>` of its lines.
 pub fn make_split_lines<M>() -> Fallible<Transformation<AllDomain<String>, VectorDomain<AllDomain<String>>, M, M>>
-    where M: Clone + DatasetMetric<Distance=u32> {
+    where M: Clone + DatasetMetric {
     Ok(Transformation::new(
         AllDomain::<String>::new(),
         VectorDomain::new_all(),
@@ -169,7 +169,7 @@ fn parse_series<T>(col: &[&str], default_on_error: bool) -> Fallible<Vec<T>> whe
 }
 
 pub fn make_parse_series<M, TO>(impute: bool) -> Fallible<Transformation<VectorDomain<AllDomain<String>>, VectorDomain<AllDomain<TO>>, M, M>>
-    where M: Clone + DatasetMetric<Distance=u32>,
+    where M: Clone + DatasetMetric,
           TO: FromStr + Default,
           TO::Err: Debug {
     Ok(Transformation::new(
@@ -192,7 +192,7 @@ fn split_records<'a>(separator: &str, lines: &[&'a str]) -> Vec<Vec<&'a str>> {
 }
 
 pub fn make_split_records<M>(separator: Option<&str>) -> Fallible<Transformation<VectorDomain<AllDomain<String>>, VectorDomain<VectorDomain<AllDomain<String>>>, M, M>>
-    where M: Clone + DatasetMetric<Distance=u32> {
+    where M: Clone + DatasetMetric {
     let separator = separator.unwrap_or(",").to_owned();
     Ok(Transformation::new(
         VectorDomain::new_all(),

--- a/rust/opendp/src/trans/impute.rs
+++ b/rust/opendp/src/trans/impute.rs
@@ -36,13 +36,13 @@ pub fn make_impute_uniform_float<M, T>(
         StabilityRelation::new_from_constant(M::Distance::one())))
 }
 
-// utility trait to replace null with a constant, regardless of the representation of null
+// utility trait to impute with a constant, regardless of the representation of null
 pub trait ImputeNull: Domain {
     type Inner;
     fn impute_null<'a>(default: &'a Self::Carrier, constant: &'a Self::Inner) -> &'a Self::Inner;
     fn new() -> Self;
 }
-// how to replace null, when null represented as Option<T>
+// how to impute, when null represented as Option<T>
 impl<T: Clone> ImputeNull for AllDomain<Option<T>> {
     type Inner = T;
     fn impute_null<'a>(default: &'a Self::Carrier, constant: &'a Self::Inner) -> &'a Self::Inner {
@@ -50,7 +50,7 @@ impl<T: Clone> ImputeNull for AllDomain<Option<T>> {
     }
     fn new() -> Self { AllDomain::new() }
 }
-// how to replace null, when null represented as T with internal nullity
+// how to impute, when null represented as T with internal nullity
 impl<T: Float> ImputeNull for NullableDomain<AllDomain<T>> {
     type Inner = Self::Carrier;
     fn impute_null<'a>(default: &'a Self::Carrier, constant: &'a Self::Inner) -> &'a Self::Inner {
@@ -60,7 +60,8 @@ impl<T: Float> ImputeNull for NullableDomain<AllDomain<T>> {
 }
 
 /// A [`Transformation`] that imputes elementwise with a constant value.
-/// Maps a Vec<Option<T>> -> Vec<T>
+/// Maps a Vec<Option<T>> -> Vec<T> if input domain is AllDomain<Option<T>>,
+///     or Vec<T> -> Vec<T> if input domain is NullableDomain<AllDomain<T>>
 pub fn make_impute_constant<DAtom, M>(
     constant: DAtom::Inner
 ) -> Fallible<Transformation<VectorDomain<DAtom>, VectorDomain<AllDomain<DAtom::Inner>>, M, M>>

--- a/rust/opendp/src/trans/impute.rs
+++ b/rust/opendp/src/trans/impute.rs
@@ -7,16 +7,14 @@ use crate::dom::{AllDomain, InternalNullDomain, VectorDomain, OptionNullDomain};
 use crate::error::Fallible;
 use crate::dom::InternalNull;
 use crate::samplers::SampleUniform;
-use crate::traits::DistanceConstant;
 
 /// A [`Transformation`] that imputes elementwise with a sample from Uniform(lower, upper).
 /// Maps a Vec<T> -> Vec<T>, where the input is a type with built-in nullity.
 pub fn make_impute_uniform_float<M, T>(
     lower: T, upper: T,
 ) -> Fallible<Transformation<VectorDomain<InternalNullDomain<AllDomain<T>>>, VectorDomain<AllDomain<T>>, M, M>>
-    where M: DatasetMetric<Distance=u32>,
-          for<'a> T: 'static + Float + SampleUniform + Clone + Sub<Output=T> + Mul<&'a T, Output=T> + Add<&'a T, Output=T> + InternalNull,
-          M::Distance: One + DistanceConstant {
+    where M: DatasetMetric,
+          for<'a> T: 'static + Float + SampleUniform + Clone + Sub<Output=T> + Mul<&'a T, Output=T> + Add<&'a T, Output=T> + InternalNull {
     if lower.is_nan() { return fallible!(MakeTransformation, "lower may not be nan"); }
     if upper.is_nan() { return fallible!(MakeTransformation, "upper may not be nan"); }
     if lower > upper { return fallible!(MakeTransformation, "lower may not be greater than upper") }
@@ -72,8 +70,7 @@ pub fn make_impute_constant<DA, M>(
 ) -> Fallible<Transformation<VectorDomain<DA>, VectorDomain<AllDomain<DA::NonNull>>, M, M>>
     where DA: ImputableDomain,
           DA::NonNull: 'static + Clone,
-          M: DatasetMetric<Distance=u32>,
-          M::Distance: One + DistanceConstant {
+          M: DatasetMetric {
     if DA::is_null(&constant) { return fallible!(MakeTransformation, "Constant may not be null.") }
 
     Ok(Transformation::new(

--- a/rust/opendp/src/trans/impute.rs
+++ b/rust/opendp/src/trans/impute.rs
@@ -76,11 +76,11 @@ pub fn make_impute_constant<DA, M>(
 
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::dist::HammingDistance;
     use crate::error::ExplainUnwrap;
     use crate::trans::{make_impute_constant, make_impute_uniform_float};
-    use crate::dom::OptionNullDomain;
+    use crate::dom::{OptionNullDomain, InherentNullDomain};
 
     #[test]
     fn test_impute_uniform() {
@@ -94,12 +94,23 @@ mod test {
     }
 
     #[test]
-    fn test_impute_constant() {
+    fn test_impute_constant_option() {
         let imputer = make_impute_constant::<OptionNullDomain<_>, HammingDistance>("IMPUTED".to_string()).unwrap_test();
 
         let result = imputer.function.eval(&vec![Some("A".to_string()), None]).unwrap_test();
 
         assert_eq!(result, vec!["A".to_string(), "IMPUTED".to_string()]);
+        assert!(imputer.stability_relation
+            .eval(&1, &1).unwrap_test());
+    }
+
+    #[test]
+    fn test_impute_constant_inherent() {
+        let imputer = make_impute_constant::<InherentNullDomain<_>, HammingDistance>(12.).unwrap_test();
+
+        let result = imputer.function.eval(&vec![f64::NAN, 23.]).unwrap_test();
+
+        assert_eq!(result, vec![12., 23.]);
         assert!(imputer.stability_relation
             .eval(&1, &1).unwrap_test());
     }

--- a/rust/opendp/src/trans/impute.rs
+++ b/rust/opendp/src/trans/impute.rs
@@ -1,0 +1,87 @@
+use std::ops::{Add, Mul, Sub};
+
+use num::{Float, One};
+
+use crate::core::{DatasetMetric, Function, StabilityRelation, Transformation};
+use crate::dom::{AllDomain, VectorDomain, NullableDomain};
+use crate::error::Fallible;
+use crate::samplers::SampleUniform;
+use crate::traits::DistanceConstant;
+
+/// A [`Transformation`] that imputes elementwise with a sample from Uniform(lower, upper).
+/// Maps a Vec<T> -> Vec<T>, where the input is a type with built-in nullity.
+pub fn make_impute_uniform_float<M, T>(
+    lower: T, upper: T,
+) -> Fallible<Transformation<VectorDomain<NullableDomain<AllDomain<T>>>, VectorDomain<AllDomain<T>>, M, M>>
+    where M: DatasetMetric<Distance=u32>,
+          for<'a> T: 'static + Float + SampleUniform + Clone + Sub<Output=T> + Mul<&'a T, Output=T> + Add<&'a T, Output=T>,
+          M::Distance: One + DistanceConstant {
+    if lower.is_nan() { return fallible!(MakeTransformation, "lower may not be nan"); }
+    if upper.is_nan() { return fallible!(MakeTransformation, "upper may not be nan"); }
+    if lower > upper { return fallible!(MakeTransformation, "lower may not be greater than upper") }
+    let scale = upper.clone() - lower.clone();
+
+    Ok(Transformation::new(
+        VectorDomain::new(NullableDomain::new(AllDomain::new())),
+        VectorDomain::new_all(),
+        Function::new_fallible(move |arg: &Vec<T>| {
+            arg.iter().map(|v| {
+                if v.is_nan() {
+                    T::sample_standard_uniform(false).map(|v| v * &scale + &lower)
+                } else { Ok(v.clone()) }
+            }).collect()
+        }),
+        M::default(),
+        M::default(),
+        StabilityRelation::new_from_constant(M::Distance::one())))
+}
+
+/// A [`Transformation`] that imputes elementwise with a constant value.
+/// Maps a Vec<Option<T>> -> Vec<T>
+pub fn make_impute_constant<M, T>(
+    constant: T
+) -> Fallible<Transformation<VectorDomain<AllDomain<Option<T>>>, VectorDomain<AllDomain<T>>, M, M>>
+    where M: DatasetMetric<Distance=u32>,
+          T: 'static + Clone,
+          M::Distance: One + DistanceConstant {
+
+    Ok(Transformation::new(
+        VectorDomain::new_all(),
+        VectorDomain::new_all(),
+        Function::new(move |arg: &Vec<Option<T>>| arg.iter()
+            .map(|v| v.as_ref().cloned().unwrap_or_else(|| constant.clone()))
+            .collect()),
+        M::default(),
+        M::default(),
+        StabilityRelation::new_from_constant(M::Distance::one())))
+}
+
+
+#[cfg(test)]
+mod test {
+    use crate::dist::HammingDistance;
+    use crate::error::ExplainUnwrap;
+    use crate::trans::{make_impute_uniform_float, make_impute_constant};
+
+    #[test]
+    fn test_impute_uniform() {
+        let imputer = make_impute_uniform_float::<HammingDistance, f64>(2.0, 2.0).unwrap_test();
+
+        let result = imputer.function.eval(&vec![1.0, f64::NAN]).unwrap_test();
+
+        assert_eq!(result, vec![1., 2.]);
+        assert!(imputer.stability_relation
+            .eval(&1, &1).unwrap_test());
+    }
+
+    #[test]
+    fn test_impute_constant() {
+        let imputer = make_impute_constant::<HammingDistance, _>("IMPUTED".to_string()).unwrap_test();
+
+        let result = imputer.function.eval(&vec![Some("A".to_string()), None]).unwrap_test();
+
+        assert_eq!(result, vec!["A".to_string(), "IMPUTED".to_string()]);
+        assert!(imputer.stability_relation
+            .eval(&1, &1).unwrap_test());
+    }
+}

--- a/rust/opendp/src/trans/manipulation.rs
+++ b/rust/opendp/src/trans/manipulation.rs
@@ -1,9 +1,48 @@
 use num::One;
 
-use crate::core::{Domain, Function, Metric, StabilityRelation, Transformation};
+use crate::core::{Domain, Function, Metric, StabilityRelation, Transformation, DatasetMetric};
 use crate::error::*;
 use crate::traits::{DistanceConstant};
+use crate::dom::VectorDomain;
 
+
+/// Constructs a [`Transformation`] representing an arbitrary row-by-row transformation.
+pub(crate) fn make_row_by_row<'a, DIA, DOA, M, F: 'static + Fn(&DIA::Carrier) -> DOA::Carrier>(
+    atom_input_domain: DIA,
+    atom_output_domain: DOA,
+    atom_function: F
+) -> Fallible<Transformation<VectorDomain<DIA>, VectorDomain<DOA>, M, M>>
+    where DIA: Domain, DOA: Domain,
+          DIA::Carrier: 'static, DOA::Carrier: 'static,
+          M: DatasetMetric {
+    Ok(Transformation::new(
+        VectorDomain::new(atom_input_domain),
+        VectorDomain::new(atom_output_domain),
+        Function::new(move |arg: &Vec<DIA::Carrier>|
+            arg.iter().map(|v| atom_function(v)).collect()),
+        M::default(),
+        M::default(),
+        StabilityRelation::new_from_constant(1_u32)))
+}
+
+/// Constructs a [`Transformation`] representing an arbitrary row-by-row transformation.
+pub(crate) fn make_row_by_row_fallible<DIA, DOA, M, F: 'static + Fn(&DIA::Carrier) -> Fallible<DOA::Carrier>>(
+    atom_input_domain: DIA,
+    atom_output_domain: DOA,
+    atom_function: F
+) -> Fallible<Transformation<VectorDomain<DIA>, VectorDomain<DOA>, M, M>>
+    where DIA: Domain, DOA: Domain,
+          DIA::Carrier: 'static, DOA::Carrier: 'static,
+          M: DatasetMetric {
+    Ok(Transformation::new(
+        VectorDomain::new(atom_input_domain),
+        VectorDomain::new(atom_output_domain),
+        Function::new_fallible(move |arg: &Vec<DIA::Carrier>|
+            arg.iter().map(|v| atom_function(v)).collect()),
+        M::default(),
+        M::default(),
+        StabilityRelation::new_from_constant(1_u32)))
+}
 
 /// Constructs a [`Transformation`] representing the identity function.
 pub fn make_identity<D, M>(domain: D, metric: M) -> Fallible<Transformation<D, D, M, M>>
@@ -17,7 +56,6 @@ pub fn make_identity<D, M>(domain: D, metric: M) -> Fallible<Transformation<D, D
         metric,
         StabilityRelation::new_from_constant(M::Distance::one())))
 }
-
 
 
 #[cfg(test)]

--- a/rust/opendp/src/trans/manipulation.rs
+++ b/rust/opendp/src/trans/manipulation.rs
@@ -1,12 +1,8 @@
-use std::collections::Bound;
-
 use num::One;
 
-use crate::core::{DatasetMetric, Domain, Function, Metric, StabilityRelation, Transformation, SensitivityMetric};
-use crate::dom::{AllDomain, IntervalDomain, VectorDomain};
+use crate::core::{Domain, Function, Metric, StabilityRelation, Transformation};
 use crate::error::*;
-use crate::traits::{CastFrom, DistanceConstant, DistanceCast};
-use std::ops::Sub;
+use crate::traits::{DistanceConstant};
 
 
 /// Constructs a [`Transformation`] representing the identity function.
@@ -22,195 +18,14 @@ pub fn make_identity<D, M>(domain: D, metric: M) -> Fallible<Transformation<D, D
         StabilityRelation::new_from_constant(M::Distance::one())))
 }
 
-pub fn make_clamp_vec<M, T>(lower: T, upper: T) -> Fallible<Transformation<VectorDomain<AllDomain<T>>, VectorDomain<IntervalDomain<T>>, M, M>>
-    where M: Metric,
-          T: 'static + Clone + PartialOrd,
-          M::Distance: DistanceConstant + One {
-    if lower > upper { return fallible!(MakeTransformation, "lower may not be greater than upper") }
-    Ok(Transformation::new(
-        VectorDomain::new_all(),
-        VectorDomain::new(IntervalDomain::new(Bound::Included(lower.clone()), Bound::Included(upper.clone()))),
-        Function::new(move |arg: &Vec<T>| arg.iter().map(|e| clamp(&lower, &upper, e)).collect()),
-        M::default(),
-        M::default(),
-        // clamping has a c-stability of one, as well as a lipschitz constant of one
-        StabilityRelation::new_from_constant(M::Distance::one())))
-}
 
-fn min<T: PartialOrd>(a: T, b: T) -> T { if a < b {a} else {b} }
-
-pub fn make_clamp_sensitivity<M, T>(lower: T, upper: T) -> Fallible<Transformation<AllDomain<T>, IntervalDomain<T>, M, M>>
-    where M: SensitivityMetric,
-          T: 'static + Clone + PartialOrd + DistanceCast + Sub<Output=T>,
-          M::Distance: DistanceConstant + One {
-    if lower > upper { return fallible!(MakeTransformation, "lower may not be greater than upper") }
-    Ok(Transformation::new(
-        AllDomain::new(),
-        IntervalDomain::new(Bound::Included(lower.clone()), Bound::Included(upper.clone())),
-        Function::new(enclose!((lower, upper), move |arg: &T| clamp(&lower, &upper, arg))),
-        M::default(),
-        M::default(),
-        // the sensitivity is at most upper - lower
-        StabilityRelation::new_all(
-            // relation
-            enclose!((lower, upper), move |d_in: &M::Distance, d_out: &M::Distance|
-                Ok(d_out.clone() >= min(d_in.clone(), M::Distance::distance_cast(upper.clone() - lower.clone())?))),
-            // forward map
-            Some(enclose!((lower, upper), move |d_in: &M::Distance|
-                Ok(Box::new(min(d_in.clone(), M::Distance::distance_cast(upper.clone() - lower.clone())?))))),
-            // backward map
-            None::<fn(&_)->_>
-        )))
-}
-
-fn clamp<T: Clone + PartialOrd>(lower: &T, upper: &T, x: &T) -> T {
-    (if x < lower { lower } else if x > upper { upper } else { x }).clone()
-}
-
-
-pub fn make_unclamp_vec<M, T>(lower: T, upper: T) -> Fallible<Transformation<VectorDomain<IntervalDomain<T>>, VectorDomain<AllDomain<T>>, M, M>>
-    where M: Metric,
-          T: 'static + Clone + PartialOrd,
-          M::Distance: DistanceConstant + One {
-    Ok(Transformation::new(
-        VectorDomain::new(IntervalDomain::new(Bound::Included(lower), Bound::Included(upper))),
-        VectorDomain::new_all(),
-        Function::new(move |arg: &Vec<T>| arg.clone()),
-        M::default(),
-        M::default(),
-        StabilityRelation::new_from_constant(M::Distance::one())
-    ))
-}
-
-pub fn make_unclamp<M, T>(lower: Bound<T>, upper: Bound<T>) -> Fallible<Transformation<IntervalDomain<T>, AllDomain<T>, M, M>>
-    where M: Metric,
-          T: 'static + Clone + PartialOrd,
-          M::Distance: DistanceConstant + One {
-    Ok(Transformation::new(
-        IntervalDomain::new(lower, upper),
-        AllDomain::new(),
-        Function::new(move |arg: &T| arg.clone()),
-        M::default(),
-        M::default(),
-        StabilityRelation::new_from_constant(M::Distance::one())
-    ))
-}
-
-
-pub fn make_cast_vec<M, TI, TO>() -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<AllDomain<TO>>, M, M>>
-    where M: DatasetMetric<Distance=u32>,
-          TI: Clone, TO: CastFrom<TI> + Default {
-    Ok(Transformation::new(
-        VectorDomain::new_all(),
-        VectorDomain::new_all(),
-        Function::new(move |arg: &Vec<TI>| arg.iter()
-            .map(|v| TO::cast(v.clone()).unwrap_or_else(|_| TO::default()))
-            .collect()),
-        M::default(),
-        M::default(),
-        StabilityRelation::new_from_constant(1_u32)))
-}
-
-// casting primitive types is not exposed over ffi.
-// Need a way to also cast M::Distance that doesn't allow changing M
-pub fn make_cast<M, TI, TO>() -> Fallible<Transformation<AllDomain<TI>, AllDomain<TO>, M, M>>
-    where M: Metric,
-          M::Distance: DistanceConstant + One,
-          TI: Clone,
-          TO: 'static + CastFrom<TI> + Default {
-    Ok(Transformation::new(
-        AllDomain::new(),
-        AllDomain::new(),
-        Function::new(move |v: &TI| TO::cast(v.clone()).unwrap_or_else(|_| TO::default())),
-        M::default(),
-        M::default(),
-        StabilityRelation::new_from_constant(M::Distance::one())))
-}
 
 #[cfg(test)]
 mod test_manipulations {
 
     use super::*;
-    use crate::dist::{SymmetricDistance, HammingDistance};
-    use crate::trans::manipulation::{make_identity};
-
-    #[test]
-    fn test_unclamp() -> Fallible<()> {
-        let clamp = make_clamp_vec::<SymmetricDistance, u8>(2, 3)?;
-        let unclamp = make_unclamp_vec(2, 3)?;
-
-        (clamp >> unclamp).map(|_| ())
-    }
-
-    #[test]
-    fn test_cast() {
-        macro_rules! test_pair {
-            ($from:ty, $to:ty) => {
-                let caster = make_cast_vec::<SymmetricDistance, $from, $to>().unwrap_test();
-                caster.function.eval(&vec!(<$from>::default())).unwrap_test();
-                let caster = make_cast_vec::<HammingDistance, $from, $to>().unwrap_test();
-                caster.function.eval(&vec!(<$from>::default())).unwrap_test();
-            }
-        }
-        macro_rules! test_cartesian {
-            ([];[$first:ty, $($end:ty),*]) => {
-                test_pair!($first, $first);
-                $(test_pair!($first, $end);)*
-
-                test_cartesian!{[$first];[$($end),*]}
-            };
-            ([$($start:ty),*];[$mid:ty, $($end:ty),*]) => {
-                $(test_pair!($mid, $start);)*
-                test_pair!($mid, $mid);
-                $(test_pair!($mid, $end);)*
-
-                test_cartesian!{[$($start),*, $mid];[$($end),*]}
-            };
-            ([$($start:ty),*];[$last:ty]) => {
-                test_pair!($last, $last);
-                $(test_pair!($last, $start);)*
-            };
-        }
-        test_cartesian!{[];[u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String, bool]}
-    }
-
-    #[test]
-    fn test_cast_unsigned() -> Fallible<()> {
-        let caster = make_cast_vec::<SymmetricDistance, f64, u8>()?;
-        assert_eq!(caster.function.eval(&vec![-1.])?, vec![u8::default()]);
-        Ok(())
-    }
-    #[test]
-    fn test_cast_parse() -> Fallible<()> {
-        let data = vec!["2".to_string(), "3".to_string(), "a".to_string(), "".to_string()];
-
-        let caster = make_cast_vec::<SymmetricDistance, String, u8>()?;
-        assert_eq!(caster.function.eval(&data)?, vec![2, 3, u8::default(), u8::default()]);
-
-        let caster = make_cast_vec::<SymmetricDistance, String, f64>()?;
-        assert_eq!(caster.function.eval(&data)?, vec![2., 3., f64::default(), f64::default()]);
-        Ok(())
-    }
-
-    #[test]
-    fn test_cast_floats() -> Fallible<()> {
-        let data = vec![f64::NAN, f64::NEG_INFINITY, f64::INFINITY];
-        let caster = make_cast_vec::<SymmetricDistance, f64, String>()?;
-        assert_eq!(
-            caster.function.eval(&data)?,
-            vec!["NaN".to_string(), "-inf".to_string(), "inf".to_string()]);
-
-        let caster = make_cast_vec::<SymmetricDistance, f64, u8>()?;
-        assert_eq!(
-            caster.function.eval(&vec![f64::NAN, f64::NEG_INFINITY, f64::INFINITY])?,
-            vec![u8::default(), u8::default(), u8::default()]);
-
-        let data = vec!["1e+2", "1e2", "1e+02", "1.e+02", "1.0E+02", "1.0E+00002", "01.E+02", "1.0E2"]
-            .into_iter().map(|v| v.to_string()).collect();
-        let caster = make_cast_vec::<SymmetricDistance, String, f64>()?;
-        assert!(caster.function.eval(&data)?.into_iter().all(|v| v == 100.));
-        Ok(())
-    }
+    use crate::dist::{HammingDistance};
+    use crate::dom::AllDomain;
 
     #[test]
     fn test_identity() {
@@ -218,15 +33,5 @@ mod test_manipulations {
         let arg = 99;
         let ret = identity.function.eval(&arg).unwrap_test();
         assert_eq!(ret, 99);
-    }
-
-
-    #[test]
-    fn test_make_clamp() {
-        let transformation = make_clamp_vec::<HammingDistance, i32>(0, 10).unwrap_test();
-        let arg = vec![-10, -5, 0, 5, 10, 20];
-        let ret = transformation.function.eval(&arg).unwrap_test();
-        let expected = vec![0, 0, 0, 5, 10, 10];
-        assert_eq!(ret, expected);
     }
 }

--- a/rust/opendp/src/trans/mean.rs
+++ b/rust/opendp/src/trans/mean.rs
@@ -31,7 +31,7 @@ impl<MO: Metric<Distance=T>, T> BoundedMeanConstant<SymmetricDistance, MO> for (
 pub fn make_bounded_mean<MI, MO>(
     lower: MO::Distance, upper: MO::Distance, n: usize
 ) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<MO::Distance>>>, AllDomain<MO::Distance>, MI, MO>>
-    where MI: DatasetMetric<Distance=u32>,
+    where MI: DatasetMetric,
           MO: SensitivityMetric,
           MO::Distance: DistanceConstant + Sub<Output=MO::Distance> + Float,
           for <'a> MO::Distance: Sum<&'a MO::Distance>,

--- a/rust/opendp/src/trans/mean.rs
+++ b/rust/opendp/src/trans/mean.rs
@@ -36,12 +36,11 @@ pub fn make_bounded_mean<MI, MO>(
           MO::Distance: DistanceConstant + Sub<Output=MO::Distance> + Float,
           for <'a> MO::Distance: Sum<&'a MO::Distance>,
           (MI, MO): BoundedMeanConstant<MI, MO> {
-    if lower > upper { return fallible!(MakeTransformation, "lower bound may not be greater than upper bound") }
     let _n = num_cast!(n; MO::Distance)?;
 
     Ok(Transformation::new(
         SizedDomain::new(VectorDomain::new(
-            IntervalDomain::new(Bound::Included(lower), Bound::Included(upper))),
+            IntervalDomain::new(Bound::Included(lower), Bound::Included(upper))?),
                          n),
         AllDomain::new(),
         Function::new(move |arg: &Vec<MO::Distance>| arg.iter().sum::<MO::Distance>() / _n),

--- a/rust/opendp/src/trans/mod.rs
+++ b/rust/opendp/src/trans/mod.rs
@@ -9,6 +9,9 @@ pub mod sum;
 pub mod count;
 pub mod mean;
 pub mod variance;
+pub mod impute;
+pub mod clamp;
+pub mod cast;
 
 pub use crate::trans::dataframe::*;
 pub use crate::trans::manipulation::*;
@@ -16,3 +19,6 @@ pub use crate::trans::sum::*;
 pub use crate::trans::count::*;
 pub use crate::trans::mean::*;
 pub use crate::trans::variance::*;
+pub use crate::trans::impute::*;
+pub use crate::trans::clamp::*;
+pub use crate::trans::cast::*;

--- a/rust/opendp/src/trans/sum.rs
+++ b/rust/opendp/src/trans/sum.rs
@@ -35,7 +35,7 @@ impl<MO: Metric> BoundedSumConstant<SymmetricDistance, MO> for (SymmetricDistanc
 pub fn make_bounded_sum<MI, MO>(
     lower: MO::Distance, upper: MO::Distance
 ) -> Fallible<Transformation<VectorDomain<IntervalDomain<MO::Distance>>, AllDomain<MO::Distance>, MI, MO>>
-    where MI: DatasetMetric<Distance=u32>,
+    where MI: DatasetMetric,
           MO: SensitivityMetric,
           MO::Distance: DistanceConstant + Sub<Output=MO::Distance>,
           for <'a> MO::Distance: Sum<&'a MO::Distance>,

--- a/rust/opendp/src/trans/sum.rs
+++ b/rust/opendp/src/trans/sum.rs
@@ -40,10 +40,10 @@ pub fn make_bounded_sum<MI, MO>(
           MO::Distance: DistanceConstant + Sub<Output=MO::Distance>,
           for <'a> MO::Distance: Sum<&'a MO::Distance>,
           (MI, MO): BoundedSumConstant<MI, MO> {
-    if lower > upper { return fallible!(MakeTransformation, "lower bound may not be greater than upper bound") }
 
     Ok(Transformation::new(
-        VectorDomain::new(IntervalDomain::new(Bound::Included(lower.clone()), Bound::Included(upper.clone()))),
+        VectorDomain::new(IntervalDomain::new(
+            Bound::Included(lower.clone()), Bound::Included(upper.clone()))?),
         AllDomain::new(),
         Function::new(|arg: &Vec<MO::Distance>| arg.iter().sum()),
         MI::default(),
@@ -58,10 +58,10 @@ pub fn make_bounded_sum_n<MO>(
     where MO: SensitivityMetric,
           MO::Distance: DistanceConstant + Sub<Output=MO::Distance>,
           for <'a> MO::Distance: Sum<&'a MO::Distance> {
-    if lower > upper { return fallible!(MakeTransformation, "lower bound may not be greater than upper bound") }
 
     Ok(Transformation::new(
-        SizedDomain::new(VectorDomain::new(IntervalDomain::new(Bound::Included(lower.clone()), Bound::Included(upper.clone()))), length),
+        SizedDomain::new(VectorDomain::new(IntervalDomain::new(
+            Bound::Included(lower.clone()), Bound::Included(upper.clone()))?), length),
         AllDomain::new(),
         Function::new(|arg: &Vec<MO::Distance>| arg.iter().sum()),
         SymmetricDistance::default(),

--- a/rust/opendp/src/trans/variance.rs
+++ b/rust/opendp/src/trans/variance.rs
@@ -4,33 +4,33 @@ use std::ops::{Div, Sub, Add};
 
 use num::{Float, One, Zero, NumCast};
 
-use crate::core::{DatasetMetric, Function, Metric, SensitivityMetric, StabilityRelation, Transformation};
-use crate::dist::{HammingDistance, SymmetricDistance};
+use crate::core::{DatasetMetric, Function, SensitivityMetric, StabilityRelation, Transformation};
+use crate::dist::{HammingDistance, SymmetricDistance, LPSensitivity};
 use crate::dom::{AllDomain, IntervalDomain, SizedDomain, VectorDomain};
 use crate::error::Fallible;
 use crate::traits::DistanceConstant;
 
 
-pub trait BoundedVarianceConstant<MI: Metric, MO: Metric> {
-    fn get_stability(lower: MO::Distance, upper: MO::Distance, length: usize, ddof: usize) -> Fallible<MO::Distance>;
+pub trait BoundedVarianceConstant<T> {
+    fn get_stability(lower: T, upper: T, length: usize, ddof: usize) -> Fallible<T>;
 }
 
-impl<MO: Metric> BoundedVarianceConstant<HammingDistance, MO> for (HammingDistance, MO)
-    where MO::Distance: Float + Sub<Output=MO::Distance> + Div<Output=MO::Distance> + NumCast + One {
-    fn get_stability(lower: MO::Distance, upper: MO::Distance, length: usize, ddof: usize) -> Fallible<MO::Distance> {
-        let _length = num_cast!(length; MO::Distance)?;
-        let _1 = MO::Distance::one();
-        let _ddof = num_cast!(ddof; MO::Distance)?;
+impl<T, const P: usize> BoundedVarianceConstant<T> for (HammingDistance, LPSensitivity<T, P>)
+    where T: Float + Sub<Output=T> + Div<Output=T> + NumCast + One {
+    fn get_stability(lower: T, upper: T, length: usize, ddof: usize) -> Fallible<T> {
+        let _length = num_cast!(length; T)?;
+        let _1 = T::one();
+        let _ddof = num_cast!(ddof; T)?;
         Ok((upper - lower).powi(2) * (_length - _1) / _length / (_length - _ddof))
     }
 }
 
-impl<MO: Metric> BoundedVarianceConstant<SymmetricDistance, MO> for (SymmetricDistance, MO)
-    where MO::Distance: Float + Sub<Output=MO::Distance> + Div<Output=MO::Distance> + NumCast + One {
-    fn get_stability(lower: MO::Distance, upper: MO::Distance, length: usize, ddof: usize) -> Fallible<MO::Distance> {
-        let _length = num_cast!(length; MO::Distance)?;
-        let _1 = MO::Distance::one();
-        let _ddof = num_cast!(ddof; MO::Distance)?;
+impl<T, const P: usize> BoundedVarianceConstant<T> for (SymmetricDistance, LPSensitivity<T, P>)
+    where T: Float + Sub<Output=T> + Div<Output=T> + NumCast + One {
+    fn get_stability(lower: T, upper: T, length: usize, ddof: usize) -> Fallible<T> {
+        let _length = num_cast!(length; T)?;
+        let _1 = T::one();
+        let _ddof = num_cast!(ddof; T)?;
         Ok((upper - lower).powi(2) * _length / (_length + _1) / (_length - _ddof))
     }
 }
@@ -42,7 +42,7 @@ pub fn make_bounded_variance<MI, MO>(
           MO: SensitivityMetric,
           MO::Distance: DistanceConstant + Sub<Output=MO::Distance> + Float + Sum<MO::Distance> + for<'a> Sum<&'a MO::Distance>,
           for<'a> &'a MO::Distance: Sub<Output=MO::Distance>,
-          (MI, MO): BoundedVarianceConstant<MI, MO> {
+          (MI, MO): BoundedVarianceConstant<MO::Distance> {
     let _length = num_cast!(length; MO::Distance)?;
     let _ddof = num_cast!(ddof; MO::Distance)?;
 
@@ -60,26 +60,26 @@ pub fn make_bounded_variance<MI, MO>(
 }
 
 
-pub trait BoundedCovarianceConstant<MI: Metric, MO: Metric> {
-    fn get_stability_constant(lower: (MO::Distance, MO::Distance), upper: (MO::Distance, MO::Distance), length: usize, ddof: usize) -> Fallible<MO::Distance>;
+pub trait BoundedCovarianceConstant<T> {
+    fn get_stability_constant(lower: (T, T), upper: (T, T), length: usize, ddof: usize) -> Fallible<T>;
 }
 
-impl<MO: Metric> BoundedCovarianceConstant<HammingDistance, MO> for (HammingDistance, MO)
-    where MO::Distance: Clone + Sub<Output=MO::Distance> + Div<Output=MO::Distance> + NumCast + One {
-    fn get_stability_constant(lower: (MO::Distance, MO::Distance), upper: (MO::Distance, MO::Distance), length: usize, ddof: usize) -> Fallible<MO::Distance> {
-        let _length = num_cast!(length; MO::Distance)?;
-        let _1 = MO::Distance::one();
-        let _ddof = num_cast!(ddof; MO::Distance)?;
+impl<T, const P: usize> BoundedCovarianceConstant<T> for (HammingDistance, LPSensitivity<T, P>)
+    where T: Clone + Sub<Output=T> + Div<Output=T> + NumCast + One {
+    fn get_stability_constant(lower: (T, T), upper: (T, T), length: usize, ddof: usize) -> Fallible<T> {
+        let _length = num_cast!(length; T)?;
+        let _1 = T::one();
+        let _ddof = num_cast!(ddof; T)?;
         Ok((upper.0 - lower.0) * (upper.1 - lower.1) * (_length.clone() - _1) / _length.clone() / (_length - _ddof))
     }
 }
 
-impl<MO: Metric> BoundedCovarianceConstant<SymmetricDistance, MO> for (SymmetricDistance, MO)
-    where MO::Distance: Clone + Sub<Output=MO::Distance> + Div<Output=MO::Distance> + Add<Output=MO::Distance> + NumCast + One {
-    fn get_stability_constant(lower: (MO::Distance, MO::Distance), upper: (MO::Distance, MO::Distance), length: usize, ddof: usize) -> Fallible<MO::Distance> {
-        let _length = num_cast!(length; MO::Distance)?;
-        let _1 = MO::Distance::one();
-        let _ddof = num_cast!(ddof; MO::Distance)?;
+impl<T, const P: usize> BoundedCovarianceConstant<T> for (SymmetricDistance, LPSensitivity<T, P>)
+    where T: Clone + Sub<Output=T> + Div<Output=T> + Add<Output=T> + NumCast + One {
+    fn get_stability_constant(lower: (T, T), upper: (T, T), length: usize, ddof: usize) -> Fallible<T> {
+        let _length = num_cast!(length; T)?;
+        let _1 = T::one();
+        let _ddof = num_cast!(ddof; T)?;
         Ok((upper.0 - lower.0) * (upper.1 - lower.1) * _length.clone() / (_length.clone() + _1) / (_length - _ddof))
     }
 }
@@ -96,7 +96,7 @@ pub fn make_bounded_covariance<MI, MO>(
           MO::Distance: DistanceConstant + Sub<Output=MO::Distance> + Sum<MO::Distance> + Zero,
           for <'a> MO::Distance: Div<&'a MO::Distance, Output=MO::Distance> + Add<&'a MO::Distance, Output=MO::Distance>,
           for<'a> &'a MO::Distance: Sub<Output=MO::Distance>,
-          (MI, MO): BoundedCovarianceConstant<MI, MO> {
+          (MI, MO): BoundedCovarianceConstant<MO::Distance> {
 
     let _length = num_cast!(length; MO::Distance)?;
     let _ddof = num_cast!(ddof; MO::Distance)?;

--- a/rust/opendp/src/trans/variance.rs
+++ b/rust/opendp/src/trans/variance.rs
@@ -38,7 +38,7 @@ impl<MO: Metric> BoundedVarianceConstant<SymmetricDistance, MO> for (SymmetricDi
 pub fn make_bounded_variance<MI, MO>(
     lower: MO::Distance, upper: MO::Distance, length: usize, ddof: usize
 ) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<MO::Distance>>>, AllDomain<MO::Distance>, MI, MO>>
-    where MI: DatasetMetric<Distance=u32>,
+    where MI: DatasetMetric,
           MO: SensitivityMetric,
           MO::Distance: DistanceConstant + Sub<Output=MO::Distance> + Float + Sum<MO::Distance> + for<'a> Sum<&'a MO::Distance>,
           for<'a> &'a MO::Distance: Sub<Output=MO::Distance>,
@@ -92,7 +92,7 @@ pub fn make_bounded_covariance<MI, MO>(
     upper: (MO::Distance, MO::Distance),
     length: usize, ddof: usize
 ) -> Fallible<Transformation<CovarianceDomain<MO::Distance>, AllDomain<MO::Distance>, MI, MO>>
-    where MI: DatasetMetric<Distance=u32>,
+    where MI: DatasetMetric,
           MO: SensitivityMetric,
           MO::Distance: DistanceConstant + Sub<Output=MO::Distance> + Sum<MO::Distance> + Zero,
           for <'a> MO::Distance: Div<&'a MO::Distance, Output=MO::Distance> + Add<&'a MO::Distance, Output=MO::Distance>,

--- a/rust/opendp/src/trans/variance.rs
+++ b/rust/opendp/src/trans/variance.rs
@@ -43,13 +43,12 @@ pub fn make_bounded_variance<MI, MO>(
           MO::Distance: DistanceConstant + Sub<Output=MO::Distance> + Float + Sum<MO::Distance> + for<'a> Sum<&'a MO::Distance>,
           for<'a> &'a MO::Distance: Sub<Output=MO::Distance>,
           (MI, MO): BoundedVarianceConstant<MI, MO> {
-    if lower > upper { return fallible!(MakeTransformation, "lower bound may not be greater than upper bound"); }
     let _length = num_cast!(length; MO::Distance)?;
     let _ddof = num_cast!(ddof; MO::Distance)?;
 
     Ok(Transformation::new(
         SizedDomain::new(VectorDomain::new(
-            IntervalDomain::new(Bound::Included(lower), Bound::Included(upper))), length),
+            IntervalDomain::new(Bound::Included(lower), Bound::Included(upper))?), length),
         AllDomain::new(),
         Function::new(move |arg: &Vec<MO::Distance>| {
             let mean = arg.iter().sum::<MO::Distance>() / _length;
@@ -99,14 +98,13 @@ pub fn make_bounded_covariance<MI, MO>(
           for<'a> &'a MO::Distance: Sub<Output=MO::Distance>,
           (MI, MO): BoundedCovarianceConstant<MI, MO> {
 
-    if lower > upper { return fallible!(MakeTransformation, "lower bound may not be greater than upper bound"); }
     let _length = num_cast!(length; MO::Distance)?;
     let _ddof = num_cast!(ddof; MO::Distance)?;
 
 
     Ok(Transformation::new(
         SizedDomain::new(VectorDomain::new(
-            IntervalDomain::new(Bound::Included(lower.clone()), Bound::Included(upper.clone()))), length),
+            IntervalDomain::new(Bound::Included(lower.clone()), Bound::Included(upper.clone()))?), length),
         AllDomain::new(),
         Function::new(move |arg: &Vec<(MO::Distance, MO::Distance)>| {
             let (sum_l, sum_r) = arg.iter().fold(


### PR DESCRIPTION
Geometric mechanism:
- Hardened constant-time geometric mechanism against an unaccounted delta term if input is outside the provided bounds. 
- Added non-constant-time version of the geometric mechanism that needs no bounds.
- Added overflow/underflow protection on all flavors of the geometric mechanism.
- Added vector-geometric constructor
- Added shift and direction arguments to SampleGeometric
- Added SampleTwoSidedGeometric sampler

Expanded data processing:
- Added several imputation constructors
- Added OptionNullDomain and InherentNullDomain for representations of nullity
- Added/revised casters for emitting data in OptionNullDomain or InherentNullDomain
- Removed make_parse_series
- Added make_cast_metric for casting among metrics
- Added make_is_equal for conversion to bool

Merged constructor functions:
- Many constructors have multiple flavors for different domains. They can be merged by making the domain itself generic.
- These have not been plumbed through FFI
- Merged all vector vs. scalar flavors of measurements
- Merged impute, clamp 

Misc:
- Maintain additional type information in JSON default value for better language-specific code-generation.
- make_row_by_row constructor that is private to the crate, for building row-by-row transforms
- Hairy temporary dispatch for some merged constructors based on indicators
    * this will be removed once the domains are plumbed through FFI
- The DatasetMetric trait bound inherits from Metric<Distance=u32>, simplifying code throughout the library
- Removed unnecessary generics among trait bounds in aggregators
- Added const-generic LPSensitivity, and let L1Sensitivity/L2Sensitivity be aliases for LPSensitivity<Q, 1>/LPSensitivity<Q, 2>
- The IntervalDomain constructor validates that bounds make sense, de-duplicating checks in constructors.

Closes #21.
Closes #145.
Closes #146.
Closes #144.