### PR TITLE
AbsoluteDistance and downstream simplifications

### DIFF
--- a/python/example/stability_mechanism.py
+++ b/python/example/stability_mechanism.py
@@ -6,7 +6,7 @@ import numpy as np
 import opendp
 from opendp.v1.meas import make_base_laplace, make_base_stability
 from opendp.v1.trans import make_count_by
-from opendp.v1.typing import L2Sensitivity, SymmetricDistance
+from opendp.v1.typing import L2Distance, SymmetricDistance
 
 
 def get_bounded_vocabulary(corpus_path, dataset_distance):
@@ -33,7 +33,7 @@ def privatize_vocabulary(word_count, line_count, dataset_distance, budget):
         0., 1000.)
 
     print("chosen scale and threshold:", scale, threshold)
-    # stability_mech = make_base_stability(line_count, scale, threshold, L2Sensitivity[float], str, int)
+    # stability_mech = make_base_stability(line_count, scale, threshold, L2Distance[float], str, int)
     # print("does chosen scale and threshold pass:", stability_mech.check(d_in, d_out))
 
     laplace_mechanism = make_base_laplace(scale, float)
@@ -49,8 +49,8 @@ def privatize_vocabulary(word_count, line_count, dataset_distance, budget):
 
 
 def check_stability(scale, threshold, line_count, dataset_distance, budget):
-    count_by = make_count_by(line_count, SymmetricDistance, L2Sensitivity[float], str, int)
-    base_stability = make_base_stability(line_count, scale, threshold, L2Sensitivity[float], str, int)
+    count_by = make_count_by(line_count, SymmetricDistance, L2Distance[float], str, int)
+    base_stability = make_base_stability(line_count, scale, threshold, L2Distance[float], str, int)
     stability_mech = count_by >> base_stability
 
     # assuming each line is a different user, a user can influence up to max_word_count_per_individual counts

--- a/python/example/test.py
+++ b/python/example/test.py
@@ -1,7 +1,7 @@
 from opendp.v1.trans import *
 from opendp.v1.meas import *
 
-from opendp.v1.typing import HammingDistance, L1Sensitivity
+from opendp.v1.typing import HammingDistance, L1Distance
 
 
 def main():
@@ -22,17 +22,17 @@ def main():
 
     # Noisy sum, col 1
     noisy_sum_1 = (
-        make_select_column(key=1, M=HammingDistance, T=int) >>
-        make_clamp(lower=0, upper=10, M=HammingDistance) >>
-        make_bounded_sum(lower=0, upper=10, MI=HammingDistance, MO=L1Sensitivity[int]) >>
-        make_base_geometric(scale=1.0)
+            make_select_column(key=1, M=HammingDistance, T=int) >>
+            make_clamp(lower=0, upper=10, M=HammingDistance) >>
+            make_bounded_sum(lower=0, upper=10, MI=HammingDistance, MO=L1Distance[int]) >>
+            make_base_geometric(scale=1.0)
     )
 
     # Count, col 1
     noisy_count_2 = (
-        make_select_column(key=2, M=HammingDistance, T=float) >>
-        make_count(MI=HammingDistance, MO=L1Sensitivity[int], TI=float) >>
-        make_base_geometric(scale=1.0)
+            make_select_column(key=2, M=HammingDistance, T=float) >>
+            make_count(MI=HammingDistance, MO=L1Distance[int], TI=float) >>
+            make_base_geometric(scale=1.0)
     )
 
     arg = "ant, 1, 1.1\nbat, 2, 2.2\ncat, 3, 3.3"

--- a/python/src/opendp/v1/mod.py
+++ b/python/src/opendp/v1/mod.py
@@ -23,14 +23,14 @@ class Measurement(ctypes.POINTER(AnyMeasurement)):
     >>> base_geometric(100)  # -> 99
     >>>
     >>> # check the measurement's relation at
-    >>> #     (1, 0.5): (L1Sensitivity<u32>, MaxDivergence)
+    >>> #     (1, 0.5): (AbsoluteDistance<u32>, MaxDivergence)
     >>> assert base_geometric.check(1, 0.5)
     >>>
     >>> # chain with a transformation from the trans module
     >>> from opendp.v1.trans import make_count
-    >>> from opendp.v1.typing import HammingDistance, L1Sensitivity
+    >>> from opendp.v1.typing import HammingDistance
     >>> chained = (
-    >>>     make_count(MI=HammingDistance, MO=L1Sensitivity[int], TI=int) >>
+    >>>     make_count(MI=HammingDistance, TI=int) >>
     >>>     base_geometric
     >>> )
     >>>
@@ -127,19 +127,19 @@ class Transformation(ctypes.POINTER(AnyTransformation)):
     >>>
     >>> # create an instance of Transformation using a constructor from the trans module
     >>> from opendp.v1.trans import make_count
-    >>> count: Transformation = make_count(MI=SymmetricDistance, MO=L1Sensitivity[int], TI=int)
+    >>> count: Transformation = make_count(MI=SymmetricDistance, TI=int)
     >>>
     >>> # invoke the transformation (invoke and __call__ are equivalent)
     >>> count.invoke([1, 2, 3])  # -> 3
     >>> count([1, 2, 3])  # -> 3
     >>>
     >>> # check the transformation's relation at
-    >>> #     (1, 1): (SymmetricDistance, L1Sensitivity<u32>)
+    >>> #     (1, 1): (SymmetricDistance, AbsoluteDistance<u32>)
     >>> assert count.check(1, 1)
     >>>
     >>> # chain with more transformations from the trans module
     >>> from opendp.v1.trans import make_split_lines, make_cast
-    >>> from opendp.v1.typing import SymmetricDistance, L1Sensitivity
+    >>> from opendp.v1.typing import SymmetricDistance
     >>> chained = (
     >>>     make_split_lines(M=SymmetricDistance) >>
     >>>     make_cast(M=SymmetricDistance, TI=str, TO=int) >>

--- a/python/src/opendp/v1/trans.py
+++ b/python/src/opendp/v1/trans.py
@@ -268,17 +268,17 @@ def make_unclamp(
 
 def make_count(
     MI: DatasetMetric,
-    MO: SensitivityMetric,
-    TI: RuntimeTypeDescriptor
+    TI: RuntimeTypeDescriptor,
+    TO: RuntimeTypeDescriptor = "u32"
 ) -> Transformation:
     """Make a Transformation that computes a count of the number of records in data.
     
     :param MI: input dataset metric
     :type MI: DatasetMetric
-    :param MO: output sensitivity metric
-    :type MO: SensitivityMetric
     :param TI: atomic type of input data. Input data is expected to be of the form Vec<TI>.
     :type TI: RuntimeTypeDescriptor
+    :param TO: type of output integer
+    :type TO: RuntimeTypeDescriptor
     :return: A count step.
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
@@ -287,20 +287,20 @@ def make_count(
     """
     # Standardize type arguments.
     MI = RuntimeType.parse(type_name=MI)
-    MO = RuntimeType.parse(type_name=MO)
     TI = RuntimeType.parse(type_name=TI)
+    TO = RuntimeType.parse(type_name=TO)
     
     # Convert arguments to c types.
     MI = py_to_c(MI, c_type=ctypes.c_char_p)
-    MO = py_to_c(MO, c_type=ctypes.c_char_p)
     TI = py_to_c(TI, c_type=ctypes.c_char_p)
+    TO = py_to_c(TO, c_type=ctypes.c_char_p)
     
     # Call library function.
     function = lib.opendp_trans__make_count
     function.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(MI, MO, TI), Transformation))
+    return c_to_py(unwrap(function(MI, TI, TO), Transformation))
 
 
 def make_count_distinct(
@@ -801,7 +801,7 @@ def make_bounded_mean(
     upper,
     n: int,
     MI: DatasetMetric,
-    MO: SensitivityMetric
+    T: RuntimeTypeDescriptor = None
 ) -> Transformation:
     """Make a Transformation that computes the mean of bounded data. 
     Use make_clamp_vec to bound data.
@@ -812,8 +812,8 @@ def make_bounded_mean(
     :type n: int
     :param MI: input metric
     :type MI: DatasetMetric
-    :param MO: output sensitivity space
-    :type MO: SensitivityMetric
+    :param T: atomic data type
+    :type T: RuntimeTypeDescriptor
     :return: A bounded_mean step.
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
@@ -822,29 +822,28 @@ def make_bounded_mean(
     """
     # Standardize type arguments.
     MI = RuntimeType.parse(type_name=MI)
-    MO = RuntimeType.parse(type_name=MO)
-    T = MO.args[0]
+    T = RuntimeType.parse_or_infer(type_name=T, public_example=lower)
     
     # Convert arguments to c types.
     lower = py_to_c(lower, c_type=ctypes.c_void_p, type_name=T)
     upper = py_to_c(upper, c_type=ctypes.c_void_p, type_name=T)
     n = py_to_c(n, c_type=ctypes.c_uint)
     MI = py_to_c(MI, c_type=ctypes.c_char_p)
-    MO = py_to_c(MO, c_type=ctypes.c_char_p)
+    T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
     function = lib.opendp_trans__make_bounded_mean
     function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint, ctypes.c_char_p, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(lower, upper, n, MI, MO), Transformation))
+    return c_to_py(unwrap(function(lower, upper, n, MI, T), Transformation))
 
 
 def make_bounded_sum(
     lower,
     upper,
     MI: DatasetMetric,
-    MO: SensitivityMetric
+    T: RuntimeTypeDescriptor = None
 ) -> Transformation:
     """Make a Transformation that computes the sum of bounded data. 
     Use make_clamp_vec to bound data.
@@ -853,8 +852,8 @@ def make_bounded_sum(
     :param upper: Upper bound of input data.
     :param MI: input dataset metric
     :type MI: DatasetMetric
-    :param MO: output sensitivity metric
-    :type MO: SensitivityMetric
+    :param T: atomic type of data
+    :type T: RuntimeTypeDescriptor
     :return: A bounded_sum step.
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
@@ -863,28 +862,27 @@ def make_bounded_sum(
     """
     # Standardize type arguments.
     MI = RuntimeType.parse(type_name=MI)
-    MO = RuntimeType.parse(type_name=MO)
-    T = MO.args[0]
+    T = RuntimeType.parse_or_infer(type_name=T, public_example=lower)
     
     # Convert arguments to c types.
     lower = py_to_c(lower, c_type=ctypes.c_void_p, type_name=T)
     upper = py_to_c(upper, c_type=ctypes.c_void_p, type_name=T)
     MI = py_to_c(MI, c_type=ctypes.c_char_p)
-    MO = py_to_c(MO, c_type=ctypes.c_char_p)
+    T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
     function = lib.opendp_trans__make_bounded_sum
     function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(lower, upper, MI, MO), Transformation))
+    return c_to_py(unwrap(function(lower, upper, MI, T), Transformation))
 
 
 def make_bounded_sum_n(
     lower,
     upper,
     n: int,
-    MO: SensitivityMetric
+    T: RuntimeTypeDescriptor = None
 ) -> Transformation:
     """Make a Transformation that computes the sum of bounded data with known length. 
     This uses a restricted-sensitivity proof that takes advantage of known N for better utility. 
@@ -894,8 +892,8 @@ def make_bounded_sum_n(
     :param upper: Upper bound of input data.
     :param n: Number of records in input data.
     :type n: int
-    :param MO: output sensitivity metric
-    :type MO: SensitivityMetric
+    :param T: atomic type of data
+    :type T: RuntimeTypeDescriptor
     :return: A bounded_sum_n step.
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
@@ -903,21 +901,20 @@ def make_bounded_sum_n(
     :raises OpenDPException: packaged error from the core OpenDP library
     """
     # Standardize type arguments.
-    MO = RuntimeType.parse(type_name=MO)
-    T = MO.args[0]
+    T = RuntimeType.parse_or_infer(type_name=T, public_example=lower)
     
     # Convert arguments to c types.
     lower = py_to_c(lower, c_type=ctypes.c_void_p, type_name=T)
     upper = py_to_c(upper, c_type=ctypes.c_void_p, type_name=T)
     n = py_to_c(n, c_type=ctypes.c_uint)
-    MO = py_to_c(MO, c_type=ctypes.c_char_p)
+    T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
     function = lib.opendp_trans__make_bounded_sum_n
     function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(lower, upper, n, MO), Transformation))
+    return c_to_py(unwrap(function(lower, upper, n, T), Transformation))
 
 
 def make_bounded_variance(
@@ -925,8 +922,8 @@ def make_bounded_variance(
     upper,
     n: int,
     MI: DatasetMetric,
-    MO: SensitivityMetric,
-    ddof: int = 1
+    ddof: int = 1,
+    T: RuntimeTypeDescriptor = None
 ) -> Transformation:
     """Make a Transformation that computes the variance of bounded data. 
     Use make_clamp_vec to bound data.
@@ -939,8 +936,8 @@ def make_bounded_variance(
     :type ddof: int
     :param MI: input dataset metric
     :type MI: DatasetMetric
-    :param MO: output sensitivity metric
-    :type MO: SensitivityMetric
+    :param T: atomic data type
+    :type T: RuntimeTypeDescriptor
     :return: A bounded_variance step.
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
@@ -949,8 +946,7 @@ def make_bounded_variance(
     """
     # Standardize type arguments.
     MI = RuntimeType.parse(type_name=MI)
-    MO = RuntimeType.parse(type_name=MO)
-    T = MO.args[0]
+    T = RuntimeType.parse_or_infer(type_name=T, public_example=lower)
     
     # Convert arguments to c types.
     lower = py_to_c(lower, c_type=ctypes.c_void_p, type_name=T)
@@ -958,11 +954,11 @@ def make_bounded_variance(
     n = py_to_c(n, c_type=ctypes.c_uint)
     ddof = py_to_c(ddof, c_type=ctypes.c_uint)
     MI = py_to_c(MI, c_type=ctypes.c_char_p)
-    MO = py_to_c(MO, c_type=ctypes.c_char_p)
+    T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
     function = lib.opendp_trans__make_bounded_variance
     function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint, ctypes.c_uint, ctypes.c_char_p, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(lower, upper, n, ddof, MI, MO), Transformation))
+    return c_to_py(unwrap(function(lower, upper, n, ddof, MI, T), Transformation))

--- a/python/src/opendp/v1/typing.py
+++ b/python/src/opendp/v1/typing.py
@@ -64,11 +64,11 @@ class RuntimeType(object):
 
         :examples:
 
-        >>> from opendp.v1.typing import RuntimeType, L1Sensitivity
+        >>> from opendp.v1.typing import RuntimeType, L1Distance
         >>> assert RuntimeType.parse(int) == "i32"
         >>> assert RuntimeType.parse("i32") == "i32"
-        >>> assert RuntimeType.parse(L1Sensitivity[int]) == "L1Sensitivity<i32>"
-        >>> assert RuntimeType.parse(L1Sensitivity["f32"]) == "L1Sensitivity<f32>"
+        >>> assert RuntimeType.parse(L1Distance[int]) == "L1Distance<i32>"
+        >>> assert RuntimeType.parse(L1Distance["f32"]) == "L1Distance<f32>"
         >>> from typing import List
         >>> assert RuntimeType.parse(List[int]) == "Vec<int>"
         """
@@ -104,8 +104,9 @@ class RuntimeType(object):
             closeness = {
                 'HammingDistance': HammingDistance,
                 'SymmetricDistance': SymmetricDistance,
-                'L1Sensitivity': L1Sensitivity,
-                'L2Sensitivity': L2Sensitivity,
+                'AbsoluteDistance': AbsoluteDistance,
+                'L1Distance': L1Distance,
+                'L2Distance': L2Distance,
                 'MaxDivergence': MaxDivergence,
                 'SmoothedMaxDivergence': SmoothedMaxDivergence
             }.get(origin)
@@ -143,7 +144,7 @@ class RuntimeType(object):
 
         :examples:
 
-        >>> from opendp.v1.typing import RuntimeType, L1Sensitivity
+        >>> from opendp.v1.typing import RuntimeType, L1Distance
         >>> assert RuntimeType.infer(23) == "i32"
         >>> assert RuntimeType.infer(12.) == "f64"
         >>> assert RuntimeType.infer(["A", "B"]) == "Vec<String>"
@@ -247,8 +248,9 @@ class SensitivityMetric(RuntimeType):
         return SensitivityMetric(self.origin, [self.parse(type_name=associated_type)])
 
 
-L1Sensitivity = SensitivityMetric('L1Sensitivity')
-L2Sensitivity = SensitivityMetric('L2Sensitivity')
+AbsoluteDistance = SensitivityMetric('AbsoluteDistance')
+L1Distance = SensitivityMetric('L1Distance')
+L2Distance = SensitivityMetric('L2Distance')
 
 
 class PrivacyMeasure(RuntimeType):

--- a/python/test/test_core.py
+++ b/python/test/test_core.py
@@ -1,9 +1,9 @@
-from opendp.v1.typing import HammingDistance, L1Sensitivity
+from opendp.v1.typing import HammingDistance, L1Distance
 
 
 def test_type_getters():
     from opendp.v1.trans import make_bounded_mean
-    transformation = make_bounded_mean(lower=0., upper=10., n=9, MI=HammingDistance, MO=L1Sensitivity[float])
+    transformation = make_bounded_mean(lower=0., upper=10., n=9, MI=HammingDistance, T=float)
     assert transformation.input_distance_type == "u32"
     assert transformation.output_distance_type == "f64"
     assert transformation.input_carrier_type == "Vec<f64>"
@@ -20,7 +20,7 @@ def test_chain():
     from opendp.v1.meas import make_base_laplace, make_base_geometric
 
     data = [1, 2, 3, 4, 5]
-    count = make_count(MI=HammingDistance, MO=L1Sensitivity[int], TI=int)
+    count = make_count(MI=HammingDistance, TI=int, TO=int)
     print("count:", count(data))
 
     base_laplace = make_base_laplace(scale=1.)

--- a/python/test/test_meas.py
+++ b/python/test/test_meas.py
@@ -1,4 +1,3 @@
-from opendp.v1.typing import HammingDistance, L1Sensitivity
 
 
 def test_base_laplace():
@@ -62,8 +61,8 @@ def test_base_vector_geometric():
 #     from opendp.v1.trans import make_count_by
 #     from opendp.v1.meas import make_base_stability
 #     meas = (
-#         make_count_by(n=10, MI=HammingDistance, MO=L1Sensitivity[float], TI=int) >>
-#         make_base_stability(n=10, scale=20., threshold=1., MI=L1Sensitivity[float], TIK=int)
+#         make_count_by(n=10, MI=HammingDistance, MO=L1Distance[float], TI=int) >>
+#         make_base_stability(n=10, scale=20., threshold=1., MI=L1Distance[float], TIK=int)
 #     )
 #     print("base gaussian:", meas([3] * 4 + [5] * 6))
 #     assert meas.check(1., (1.3, .000001))

--- a/python/test/test_trans.py
+++ b/python/test/test_trans.py
@@ -1,4 +1,4 @@
-from opendp.v1.typing import HammingDistance, L1Sensitivity, SymmetricDistance
+from opendp.v1.typing import HammingDistance, L1Distance, SymmetricDistance, AbsoluteDistance
 
 INT_DATA = list(range(1, 10))
 FLOAT_DATA = list(map(float, INT_DATA))
@@ -139,26 +139,26 @@ def test_vector_clamp():
 
 def test_clamp_sensitivity():
     from opendp.v1.trans import make_clamp
-    query = make_clamp(lower=-1, upper=1, M=L1Sensitivity[int])
+    query = make_clamp(lower=-1, upper=1, M=AbsoluteDistance[int])
     assert query(20) == 1
     assert query.check(20, 2)
 
 
 def test_bounded_mean():
     from opendp.v1.trans import make_bounded_mean
-    query = make_bounded_mean(lower=0., upper=10., n=9, MI=HammingDistance, MO=L1Sensitivity[float])
+    query = make_bounded_mean(lower=0., upper=10., n=9, MI=HammingDistance)
     assert query(FLOAT_DATA) == 5.
     assert query.check(1, 10. / 9.)
 
 
 def test_bounded_sum():
     from opendp.v1.trans import make_bounded_sum
-    query = make_bounded_sum(lower=0., upper=10., MI=HammingDistance, MO=L1Sensitivity[float])
+    query = make_bounded_sum(lower=0., upper=10., MI=HammingDistance)
     assert query(FLOAT_DATA) == 45.
     # TODO: tighten the check
     assert query.check(1, 20.)
 
-    query = make_bounded_sum(lower=0, upper=10, MI=HammingDistance, MO=L1Sensitivity[int])
+    query = make_bounded_sum(lower=0, upper=10, MI=HammingDistance)
     assert query(INT_DATA) == 45
     # TODO: tighten the check
     assert query.check(1, 20)
@@ -172,7 +172,7 @@ def test_bounded_sum():
 
 def test_bounded_sum_n():
     from opendp.v1.trans import make_bounded_sum_n
-    query = make_bounded_sum_n(lower=0., upper=10., n=9, MO=L1Sensitivity[float])
+    query = make_bounded_sum_n(lower=0., upper=10., n=9)
     assert query(FLOAT_DATA) == 45.
     # TODO: tighten this check
     assert query.check(1, 20.)
@@ -180,14 +180,14 @@ def test_bounded_sum_n():
 
 def test_bounded_variance():
     from opendp.v1.trans import make_bounded_variance
-    query = make_bounded_variance(lower=0., upper=10., n=9, MI=HammingDistance, MO=L1Sensitivity[float])
+    query = make_bounded_variance(lower=0., upper=10., n=9, MI=HammingDistance)
     assert query(FLOAT_DATA) == 7.5
     assert query.check(1, 20.)
 
 
 def test_count():
     from opendp.v1.trans import make_count
-    transformation = make_count(SymmetricDistance, L1Sensitivity["i32"], int)
+    transformation = make_count(SymmetricDistance, TI=int, TO=int)
     arg = [1, 2, 3]
     ret = transformation(arg)
     assert ret == 3
@@ -205,7 +205,7 @@ def test_count_distinct():
 
 def test_count_by():
     from opendp.v1.trans import make_count_by
-    query = make_count_by(n=9, MI=HammingDistance, MO=L1Sensitivity[float], TI=int)
+    query = make_count_by(n=9, MI=HammingDistance, MO=L1Distance[float], TI=int)
     # TODO: cannot test until hashmap data unloader is added
     # assert query(INT_DATA) == {i + 1: 1 for i in range(9)}
     print('first')
@@ -214,6 +214,6 @@ def test_count_by():
 
 def test_count_by_categories():
     from opendp.v1.trans import make_count_by_categories
-    query = make_count_by_categories(categories=[1, 3, 4], MI=HammingDistance, MO=L1Sensitivity[float])
+    query = make_count_by_categories(categories=[1, 3, 4], MI=HammingDistance, MO=L1Distance[float])
     assert query(INT_DATA) == [1, 1, 1, 6]
     assert query.check(1, 2.)

--- a/python/test/test_trans.py
+++ b/python/test/test_trans.py
@@ -196,7 +196,7 @@ def test_count():
 
 def test_count_distinct():
     from opendp.v1.trans import make_count_distinct
-    transformation = make_count_distinct(SymmetricDistance, L1Sensitivity["i32"], int)
+    transformation = make_count_distinct(SymmetricDistance, L1Distance["i32"], int)
     arg = [1, 2, 3, 2, 7, 3, 4]
     ret = transformation(arg)
     assert ret == 5

--- a/python/test/test_typing.py
+++ b/python/test/test_typing.py
@@ -2,7 +2,7 @@ import sys
 from typing import List, Tuple, Any
 
 from opendp.v1.mod import UnknownTypeException
-from opendp.v1.typing import RuntimeType, L1Sensitivity, SensitivityMetric, L2Sensitivity, DatasetMetric
+from opendp.v1.typing import RuntimeType, L1Distance, SensitivityMetric, L2Distance, DatasetMetric
 
 
 def test_typing_hint():
@@ -21,7 +21,7 @@ def test_typing_hint():
     assert str(RuntimeType.parse(List[List[str]])) == "Vec<Vec<String>>"
     assert str(RuntimeType.parse((List[int], (int, bool)))) == '(Vec<i32>, (i32, bool))'
     assert isinstance(RuntimeType.parse('HammingDistance'), DatasetMetric)
-    assert isinstance(RuntimeType.parse('L1Sensitivity<f64>'), SensitivityMetric)
+    assert isinstance(RuntimeType.parse('L1Distance<f64>'), SensitivityMetric)
 
     try:
         RuntimeType.parse(List[Any])
@@ -31,15 +31,15 @@ def test_typing_hint():
 
 
 def test_sensitivity():
-    assert isinstance(L1Sensitivity[int], SensitivityMetric)
+    assert isinstance(L1Distance[int], SensitivityMetric)
     assert not isinstance(RuntimeType.parse('(f32)'), SensitivityMetric)
-    assert str(L1Sensitivity[int]) == "L1Sensitivity<i32>"
+    assert str(L1Distance[int]) == "L1Distance<i32>"
 
 
 def test_tuples():
     assert str(RuntimeType.parse((float, int))) == "(f64, i32)"
-    assert str(RuntimeType.parse(('f32', (int, 'L1Sensitivity<i32>')))) == '(f32, (i32, L1Sensitivity<i32>))'
-    assert str(RuntimeType.parse(('f32', (int, L2Sensitivity[float])))) == '(f32, (i32, L2Sensitivity<f64>))'
+    assert str(RuntimeType.parse(('f32', (int, 'L1Distance<i32>')))) == '(f32, (i32, L1Distance<i32>))'
+    assert str(RuntimeType.parse(('f32', (int, L2Distance[float])))) == '(f32, (i32, L2Distance<f64>))'
 
 
 def test_c():

--- a/rust/opendp-ffi/src/any.rs
+++ b/rust/opendp-ffi/src/any.rs
@@ -517,7 +517,7 @@ impl<DI: 'static + Domain, DO: 'static + Domain, MI: 'static + Metric, MO: 'stat
 mod tests {
     use std::ops::Bound;
 
-    use opendp::dist::{HammingDistance, L2Sensitivity, MaxDivergence, SmoothedMaxDivergence, SymmetricDistance};
+    use opendp::dist::{HammingDistance, MaxDivergence, SmoothedMaxDivergence, SymmetricDistance};
     use opendp::dom::{AllDomain, IntervalDomain, VectorDomain};
     use opendp::error::*;
     use opendp::meas;
@@ -588,7 +588,7 @@ mod tests {
         let t2 = trans::make_parse_column::<HammingDistance, _, f64>("a".to_owned(), true)?.into_any();
         let t3 = trans::make_select_column::<HammingDistance, _, f64>("a".to_owned())?.into_any();
         let t4 = trans::make_clamp::<VectorDomain<_>, HammingDistance>(0.0, 10.0)?.into_any();
-        let t5 = trans::make_bounded_sum::<HammingDistance, L2Sensitivity<_>>(0.0, 10.0)?.into_any();
+        let t5 = trans::make_bounded_sum::<HammingDistance, _>(0.0, 10.0)?.into_any();
         let m1 = meas::make_base_gaussian::<AllDomain<_>>(0.0)?.into_any();
         let chain = (t1 >> t2 >> t3 >> t4 >> t5 >> m1)?;
         let arg = AnyObject::new("1.0, 10.0\n2.0, 20.0\n3.0, 30.0\n".to_owned());

--- a/rust/opendp-ffi/src/meas/stability.rs
+++ b/rust/opendp-ffi/src/meas/stability.rs
@@ -6,7 +6,7 @@ use std::os::raw::{c_char, c_void};
 use num::{Float, Integer, NumCast, One, Zero};
 
 use opendp::core::SensitivityMetric;
-use opendp::dist::{L1Sensitivity, L2Sensitivity};
+use opendp::dist::{L1Distance, L2Distance};
 use opendp::err;
 use opendp::meas::{BaseStabilityNoise, make_base_stability};
 use opendp::samplers::CastInternalReal;
@@ -41,7 +41,7 @@ pub extern "C" fn opendp_meas__make_base_stability(
         let scale = *try_as_ref!(scale as *const TOC);
         let threshold = *try_as_ref!(threshold as *const TOC);
         dispatch!(monomorphize2, [
-            (MI, [L1Sensitivity<TOC>, L2Sensitivity<TOC>]),
+            (MI, [L1Distance<TOC>, L2Distance<TOC>]),
             (TIK, @hashable),
             (TIC, @integers)
         ], (n, scale, threshold))

--- a/rust/opendp-ffi/src/trans/bootstrap.json
+++ b/rust/opendp-ffi/src/trans/bootstrap.json
@@ -198,17 +198,17 @@
                 "description": "input dataset metric"
             },
             {
-                "name": "MO",
-                "c_type": "char *",
-                "hint": "SensitivityMetric",
-                "is_type": true,
-                "description": "output sensitivity metric"
-            },
-            {
                 "name": "TI",
                 "c_type": "char *",
                 "is_type": true,
                 "description": "atomic type of input data. Input data is expected to be of the form Vec<TI>."
+            },
+            {
+                "name": "TO",
+                "c_type": "char *",
+                "default": "u32",
+                "is_type": true,
+                "description": "type of output integer"
             }
         ],
         "ret": {"c_type": "FfiResult<AnyTransformation *>"}
@@ -615,20 +615,10 @@
                 "description": "input metric"
             },
             {
-                "name": "MO",
-                "c_type": "char *",
-                "hint": "SensitivityMetric",
-                "is_type": true,
-                "description": "output sensitivity space"
-            }
-        ],
-        "derived_types": [
-            {
                 "name": "T",
-                "rust_type": {
-                    "root": "MO",
-                    "index": 0
-                }
+                "c_type": "char *",
+                "is_type": true,
+                "description": "atomic data type"
             }
         ],
         "ret": {
@@ -658,20 +648,10 @@
                 "description": "input dataset metric"
             },
             {
-                "name": "MO",
-                "c_type": "char *",
-                "hint": "SensitivityMetric",
-                "is_type": true,
-                "description": "output sensitivity metric"
-            }
-        ],
-        "derived_types": [
-            {
                 "name": "T",
-                "rust_type": {
-                    "root": "MO",
-                    "index": 0
-                }
+                "c_type": "char *",
+                "is_type": true,
+                "description": "atomic type of data"
             }
         ],
         "ret": {
@@ -699,20 +679,10 @@
                 "description": "Number of records in input data."
             },
             {
-                "name": "MO",
-                "c_type": "char *",
-                "hint": "SensitivityMetric",
-                "is_type": true,
-                "description": "output sensitivity metric"
-            }
-        ],
-        "derived_types": [
-            {
                 "name": "T",
-                "rust_type": {
-                    "root": "MO",
-                    "index": 0
-                }
+                "c_type": "char *",
+                "is_type": true,
+                "description": "atomic type of data"
             }
         ],
         "ret": {
@@ -753,20 +723,10 @@
                 "description": "input dataset metric"
             },
             {
-                "name": "MO",
-                "c_type": "char *",
-                "hint": "SensitivityMetric",
-                "is_type": true,
-                "description": "output sensitivity metric"
-            }
-        ],
-        "derived_types": [
-            {
                 "name": "T",
-                "rust_type": {
-                    "root": "MO",
-                    "index": 0
-                }
+                "c_type": "char *",
+                "is_type": true,
+                "description": "atomic data type"
             }
         ],
         "ret": {

--- a/rust/opendp-ffi/src/trans/clamp.rs
+++ b/rust/opendp-ffi/src/trans/clamp.rs
@@ -5,7 +5,7 @@ use std::os::raw::{c_char, c_void};
 use num::One;
 
 use opendp::core::{DatasetMetric, SensitivityMetric, Domain};
-use opendp::dist::{HammingDistance, SymmetricDistance, L1Sensitivity, L2Sensitivity};
+use opendp::dist::{HammingDistance, SymmetricDistance, AbsoluteDistance, L1Distance, L2Distance};
 use opendp::dom::{AllDomain, VectorDomain, IntervalDomain};
 use opendp::err;
 use opendp::traits::{DistanceCast, DistanceConstant};
@@ -48,7 +48,7 @@ pub extern "C" fn opendp_trans__make_clamp(
             ).into_any()
         }
         dispatch!(monomorphize_sensitivity_2, [
-            (M, [L1Sensitivity<Q>, L2Sensitivity<Q>]),
+            (M, [AbsoluteDistance<Q>]),
             (T, @numbers)
         ], (lower, upper))
     }
@@ -106,7 +106,7 @@ pub extern "C" fn opendp_trans__make_unclamp(
             ).into_any()
         }
         dispatch!(monomorphize_sensitivity_2, [
-            (M, [L1Sensitivity<Q>, L2Sensitivity<Q>]),
+            (M, [AbsoluteDistance<Q>, L1Distance<Q>, L2Distance<Q>]),
             (T, @numbers)
         ], (lower, upper))
     }
@@ -141,7 +141,7 @@ mod tests {
         let transformation = Result::from(opendp_trans__make_clamp(
             util::into_raw(0.0) as *const c_void,
             util::into_raw(10.0) as *const c_void,
-            "L2Sensitivity<f64>".to_char_p(),
+            "AbsoluteDistance<f64>".to_char_p(),
             "f64".to_char_p(),
         ))?;
         let arg = AnyObject::new_raw(-1.0);

--- a/rust/opendp-ffi/src/trans/count.rs
+++ b/rust/opendp-ffi/src/trans/count.rs
@@ -59,7 +59,7 @@ pub extern "C" fn opendp_trans__make_count_distinct(
         }
         dispatch!(monomorphize2, [
             (MI, [SymmetricDistance, HammingDistance]),
-            (MO, [L1Sensitivity<QO>, L2Sensitivity<QO>]),
+            (MO, [L1Distance<QO>, L2Distance<QO>]),
             (T, @hashable)
         ], ())
     }

--- a/rust/opendp-ffi/src/trans/mean.rs
+++ b/rust/opendp-ffi/src/trans/mean.rs
@@ -5,8 +5,8 @@ use std::os::raw::{c_char, c_uint, c_void};
 
 use num::Float;
 
-use opendp::core::{DatasetMetric, SensitivityMetric};
-use opendp::dist::{HammingDistance, L1Sensitivity, L2Sensitivity, SymmetricDistance};
+use opendp::core::DatasetMetric;
+use opendp::dist::{HammingDistance, SymmetricDistance};
 use opendp::err;
 use opendp::traits::DistanceConstant;
 use opendp::trans::{BoundedMeanConstant, make_bounded_mean};
@@ -18,34 +18,24 @@ use crate::util::Type;
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_bounded_mean(
     lower: *const c_void, upper: *const c_void, n: c_uint,
-    MI: *const c_char, MO: *const c_char,
+    MI: *const c_char, T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<T>(
-        lower: *const c_void, upper: *const c_void, n: usize,
-        MI: Type, MO: Type,
-    ) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant + Sub<Output=T> + Float,
-              for<'a> T: Sum<&'a T> {
-        fn monomorphize2<MI, MO>(lower: MO::Distance, upper: MO::Distance, n: usize) -> FfiResult<*mut AnyTransformation>
-            where MI: 'static + DatasetMetric,
-                  MO: 'static + SensitivityMetric,
-                  MO::Distance: DistanceConstant + Sub<Output=MO::Distance> + Float,
-                  for<'a> MO::Distance: Sum<&'a MO::Distance>,
-                  (MI, MO): BoundedMeanConstant<MO::Distance> {
-            make_bounded_mean::<MI, MO>(lower, upper, n).into_any()
-        }
+    fn monomorphize<MI, T>(lower: *const c_void, upper: *const c_void, n: usize) -> FfiResult<*mut AnyTransformation>
+        where MI: 'static + DatasetMetric,
+              T: DistanceConstant + Sub<Output=T> + Float,
+              for<'a> T: Sum<&'a T>,
+              MI: BoundedMeanConstant<T> {
         let lower = *try_as_ref!(lower as *const T);
         let upper = *try_as_ref!(upper as *const T);
-        dispatch!(monomorphize2, [
-            (MI, [HammingDistance, SymmetricDistance]),
-            (MO, [L1Sensitivity<T>, L2Sensitivity<T>])
-        ], (lower, upper, n))
+        make_bounded_mean::<MI, T>(lower, upper, n).into_any()
     }
     let n = n as usize;
     let MI = try_!(Type::try_from(MI));
-    let MO = try_!(Type::try_from(MO));
-    let T = try_!(MO.get_sensitivity_distance());
-    dispatch!(monomorphize, [(T, @floats)], (lower, upper, n, MI, MO))
+    let T = try_!(Type::try_from(T));
+    dispatch!(monomorphize, [
+        (MI, [HammingDistance, SymmetricDistance]),
+        (T, @floats)
+    ], (lower, upper, n))
 }
 
 
@@ -67,7 +57,7 @@ mod tests {
             util::into_raw(10.0) as *const c_void,
             3 as c_uint,
             "SymmetricDistance".to_char_p(),
-            "L2Sensitivity<f64>".to_char_p(),
+            "f64".to_char_p(),
         ))?;
         let arg = AnyObject::new_raw(vec![1.0, 2.0, 3.0]);
         let res = core::opendp_core__transformation_invoke(&transformation, arg);

--- a/rust/opendp-ffi/src/trans/sum.rs
+++ b/rust/opendp-ffi/src/trans/sum.rs
@@ -3,8 +3,8 @@ use std::iter::Sum;
 use std::ops::Sub;
 use std::os::raw::{c_char, c_uint, c_void};
 
-use opendp::core::{DatasetMetric, SensitivityMetric};
-use opendp::dist::{HammingDistance, L1Sensitivity, L2Sensitivity, SymmetricDistance};
+use opendp::core::{DatasetMetric};
+use opendp::dist::{HammingDistance, SymmetricDistance};
 use opendp::err;
 use opendp::traits::{Abs, DistanceConstant};
 use opendp::trans::{BoundedSumConstant, make_bounded_sum, make_bounded_sum_n};
@@ -16,61 +16,41 @@ use crate::util::Type;
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_bounded_sum(
     lower: *const c_void, upper: *const c_void,
-    MI: *const c_char, MO: *const c_char,
+    MI: *const c_char, T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<T>(
-        lower: *const c_void, upper: *const c_void,
-        MI: Type, MO: Type,
+    fn monomorphize<MI, T>(
+        lower: *const c_void, upper: *const c_void
     ) -> FfiResult<*mut AnyTransformation>
-        where for<'a> T: DistanceConstant + Sub<Output=T> + Abs + Sum<&'a T> {
-        fn monomorphize2<MI, MO>(lower: MO::Distance, upper: MO::Distance) -> FfiResult<*mut AnyTransformation>
-            where MI: 'static + DatasetMetric,
-                  MO: 'static + SensitivityMetric,
-                  for<'a> MO::Distance: DistanceConstant + Sub<Output=MO::Distance> + Abs + Sum<&'a MO::Distance>,
-                  (MI, MO): BoundedSumConstant<MO::Distance> {
-            make_bounded_sum::<MI, MO>(lower, upper).into_any()
-        }
+        where MI: 'static + DatasetMetric,
+              for<'a> T: DistanceConstant + Sub<Output=T> + Abs + Sum<&'a T>,
+              MI: BoundedSumConstant<T> {
         let lower = try_as_ref!(lower as *const T).clone();
         let upper = try_as_ref!(upper as *const T).clone();
-        dispatch!(monomorphize2, [
-            (MI, [HammingDistance, SymmetricDistance]),
-            (MO, [L1Sensitivity<T>, L2Sensitivity<T>])
-        ], (lower, upper))
+        make_bounded_sum::<MI, T>(lower, upper).into_any()
     }
     let MI = try_!(Type::try_from(MI));
-    let MO = try_!(Type::try_from(MO));
-    let T = try_!(MO.get_sensitivity_distance());
-    dispatch!(monomorphize, [(T, @numbers)], (lower, upper, MI, MO))
+    let T = try_!(Type::try_from(T));
+    dispatch!(monomorphize, [
+        (MI, [HammingDistance, SymmetricDistance]),
+        (T, @numbers)
+    ], (lower, upper))
 }
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_bounded_sum_n(
     lower: *const c_void, upper: *const c_void, n: c_uint,
-    MO: *const c_char,
+    T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<T>(
-        lower: *const c_void, upper: *const c_void, n: usize,
-        MO: Type,
-    ) -> FfiResult<*mut AnyTransformation>
+    fn monomorphize<T>(lower: *const c_void, upper: *const c_void, n: usize) -> FfiResult<*mut AnyTransformation>
         where T: DistanceConstant + Sub<Output=T>,
               for<'a> T: Sum<&'a T> {
-        fn monomorphize2<MO>(lower: MO::Distance, upper: MO::Distance, n: usize) -> FfiResult<*mut AnyTransformation>
-            where MO: 'static + SensitivityMetric,
-                  MO::Distance: DistanceConstant + Sub<Output=MO::Distance>,
-                  for<'a> MO::Distance: Sum<&'a MO::Distance> {
-            make_bounded_sum_n::<MO>(lower, upper, n).into_any()
-        }
         let lower = try_as_ref!(lower as *const T).clone();
         let upper = try_as_ref!(upper as *const T).clone();
-        dispatch!(monomorphize2, [
-            (MO, [L1Sensitivity<T>, L2Sensitivity<T>])
-        ], (lower, upper, n))
+        make_bounded_sum_n::<T>(lower, upper, n).into_any()
     }
     let n = n as usize;
-
-    let MO = try_!(Type::try_from(MO));
-    let TO = try_!(MO.get_sensitivity_distance());
-    dispatch!(monomorphize, [(TO, @numbers)], (lower, upper, n, MO))
+    let T = try_!(Type::try_from(T));
+    dispatch!(monomorphize, [(T, @numbers)], (lower, upper, n))
 }
 
 
@@ -91,7 +71,7 @@ mod tests {
             util::into_raw(0.0) as *const c_void,
             util::into_raw(10.0) as *const c_void,
             "SymmetricDistance".to_char_p(),
-            "L2Sensitivity<f64>".to_char_p(),
+            "f64".to_char_p(),
         ))?;
         let arg = AnyObject::new_raw(vec![1.0, 2.0, 3.0]);
         let res = core::opendp_core__transformation_invoke(&transformation, arg);
@@ -106,7 +86,7 @@ mod tests {
             util::into_raw(0.0) as *const c_void,
             util::into_raw(10.0) as *const c_void,
             3 as c_uint,
-            "L2Sensitivity<f64>".to_char_p(),
+            "f64".to_char_p(),
         ))?;
         let arg = AnyObject::new_raw(vec![1.0, 2.0, 3.0]);
         let res = core::opendp_core__transformation_invoke(&transformation, arg);

--- a/rust/opendp/src/chain.rs
+++ b/rust/opendp/src/chain.rs
@@ -88,7 +88,7 @@ pub fn make_basic_composition<DI, DO0, DO1, MI, MO>(measurement0: &Measurement<D
 #[cfg(test)]
 mod tests {
     use crate::core::*;
-    use crate::dist::{L1Sensitivity, MaxDivergence};
+    use crate::dist::{L1Distance, MaxDivergence};
     use crate::dom::AllDomain;
     use crate::error::ExplainUnwrap;
 
@@ -99,14 +99,14 @@ mod tests {
         let input_domain0 = AllDomain::<u8>::new();
         let output_domain0 = AllDomain::<i32>::new();
         let function0 = Function::new(|a: &u8| (a + 1) as i32);
-        let input_metric0 = L1Sensitivity::<i32>::default();
-        let output_metric0 = L1Sensitivity::<i32>::default();
+        let input_metric0 = L1Distance::<i32>::default();
+        let output_metric0 = L1Distance::<i32>::default();
         let stability_relation0 = StabilityRelation::new_from_constant(1);
         let transformation0 = Transformation::new(input_domain0, output_domain0, function0, input_metric0, output_metric0, stability_relation0);
         let input_domain1 = AllDomain::<i32>::new();
         let output_domain1 = AllDomain::<f64>::new();
         let function1 = Function::new(|a: &i32| (a + 1) as f64);
-        let input_metric1 = L1Sensitivity::<i32>::default();
+        let input_metric1 = L1Distance::<i32>::default();
         let output_measure1 = MaxDivergence::default();
         let privacy_relation1 = PrivacyRelation::new(|_d_in: &i32, _d_out: &f64| true);
         let measurement1 = Measurement::new(input_domain1, output_domain1, function1, input_metric1, output_measure1, privacy_relation1);
@@ -121,15 +121,15 @@ mod tests {
         let input_domain0 = AllDomain::<u8>::new();
         let output_domain0 = AllDomain::<i32>::new();
         let function0 = Function::new(|a: &u8| (a + 1) as i32);
-        let input_metric0 = L1Sensitivity::<i32>::default();
-        let output_metric0 = L1Sensitivity::<i32>::default();
+        let input_metric0 = L1Distance::<i32>::default();
+        let output_metric0 = L1Distance::<i32>::default();
         let stability_relation0 = StabilityRelation::new_from_constant(1);
         let transformation0 = Transformation::new(input_domain0, output_domain0, function0, input_metric0, output_metric0, stability_relation0);
         let input_domain1 = AllDomain::<i32>::new();
         let output_domain1 = AllDomain::<f64>::new();
         let function1 = Function::new(|a: &i32| (a + 1) as f64);
-        let input_metric1 = L1Sensitivity::<i32>::default();
-        let output_metric1 = L1Sensitivity::<i32>::default();
+        let input_metric1 = L1Distance::<i32>::default();
+        let output_metric1 = L1Distance::<i32>::default();
         let stability_relation1 = StabilityRelation::new_from_constant(1);
         let transformation1 = Transformation::new(input_domain1, output_domain1, function1, input_metric1, output_metric1, stability_relation1);
         let chain = make_chain_tt(&transformation1, &transformation0, None).unwrap_test();
@@ -143,14 +143,14 @@ mod tests {
         let input_domain0 = AllDomain::<i32>::new();
         let output_domain0 = AllDomain::<f32>::new();
         let function0 = Function::new(|arg: &i32| (arg + 1) as f32);
-        let input_metric0 = L1Sensitivity::<i32>::default();
+        let input_metric0 = L1Distance::<i32>::default();
         let output_measure0 = MaxDivergence::default();
         let privacy_relation0 = PrivacyRelation::new(|_d_in: &i32, _d_out: &f64| true);
         let measurement0 = Measurement::new(input_domain0, output_domain0, function0, input_metric0, output_measure0, privacy_relation0);
         let input_domain1 = AllDomain::<i32>::new();
         let output_domain1 = AllDomain::<f64>::new();
         let function1 = Function::new(|arg: &i32| (arg - 1) as f64);
-        let input_metric1 = L1Sensitivity::<i32>::default();
+        let input_metric1 = L1Distance::<i32>::default();
         let output_measure1 = MaxDivergence::default();
         let privacy_relation1 = PrivacyRelation::new(|_d_in: &i32, _d_out: &f64| true);
         let measurement1 = Measurement::new(input_domain1, output_domain1, function1, input_metric1, output_measure1, privacy_relation1);

--- a/rust/opendp/src/core.rs
+++ b/rust/opendp/src/core.rs
@@ -398,7 +398,7 @@ impl<DI: Domain, DO: Domain, MI: Metric, MO: Metric> Transformation<DI, DO, MI, 
 
 #[cfg(test)]
 mod tests {
-    use crate::dist::L1Sensitivity;
+    use crate::dist::L1Distance;
     use crate::dom::AllDomain;
     use crate::error::ExplainUnwrap;
 
@@ -409,8 +409,8 @@ mod tests {
         let input_domain = AllDomain::<i32>::new();
         let output_domain = AllDomain::<i32>::new();
         let function = Function::new(|arg: &i32| arg.clone());
-        let input_metric = L1Sensitivity::<i32>::default();
-        let output_metric = L1Sensitivity::<i32>::default();
+        let input_metric = L1Distance::<i32>::default();
+        let output_metric = L1Distance::<i32>::default();
         let stability_relation = StabilityRelation::new_from_constant(1);
         let identity = Transformation::new(input_domain, output_domain, function, input_metric, output_metric, stability_relation);
         let arg = 99;

--- a/rust/opendp/src/dist.rs
+++ b/rust/opendp/src/dist.rs
@@ -70,21 +70,38 @@ impl Metric for HammingDistance {
 impl DatasetMetric for HammingDistance {}
 
 // Sensitivity in P-space
-pub struct LPSensitivity<Q, const P: usize>(PhantomData<Q>);
-impl<Q, const P: usize> Default for LPSensitivity<Q, P> {
-    fn default() -> Self { LPSensitivity(PhantomData) }
+pub struct LpDistance<Q, const P: usize>(PhantomData<Q>);
+impl<Q, const P: usize> Default for LpDistance<Q, P> {
+    fn default() -> Self { LpDistance(PhantomData) }
 }
 
-impl<Q, const P: usize> Clone for LPSensitivity<Q, P> {
+impl<Q, const P: usize> Clone for LpDistance<Q, P> {
     fn clone(&self) -> Self { Self::default() }
 }
-impl<Q, const P: usize> PartialEq for LPSensitivity<Q, P> {
+impl<Q, const P: usize> PartialEq for LpDistance<Q, P> {
     fn eq(&self, _other: &Self) -> bool { true }
 }
-impl<Q, const P: usize> Metric for LPSensitivity<Q, P> {
+impl<Q, const P: usize> Metric for LpDistance<Q, P> {
     type Distance = Q;
 }
-impl<Q, const P: usize> SensitivityMetric for LPSensitivity<Q, P> {}
+impl<Q, const P: usize> SensitivityMetric for LpDistance<Q, P> {}
 
-pub type L1Sensitivity<Q> = LPSensitivity<Q, 1>;
-pub type L2Sensitivity<Q> = LPSensitivity<Q, 2>;
+pub type L1Distance<Q> = LpDistance<Q, 1>;
+pub type L2Distance<Q> = LpDistance<Q, 2>;
+
+
+pub struct AbsoluteDistance<Q>(PhantomData<Q>);
+impl<Q> Default for AbsoluteDistance<Q> {
+    fn default() -> Self { AbsoluteDistance(PhantomData) }
+}
+
+impl<Q> Clone for AbsoluteDistance<Q> {
+    fn clone(&self) -> Self { Self::default() }
+}
+impl<Q> PartialEq for AbsoluteDistance<Q> {
+    fn eq(&self, _other: &Self) -> bool { true }
+}
+impl<Q> Metric for AbsoluteDistance<Q> {
+    type Distance = Q;
+}
+impl<Q> SensitivityMetric for AbsoluteDistance<Q> {}

--- a/rust/opendp/src/interactive.rs
+++ b/rust/opendp/src/interactive.rs
@@ -154,7 +154,7 @@ pub fn make_adaptive_composition<DI, DO, MI, MO>(
 
 #[cfg(test)]
 mod tests {
-    use crate::dist::{HammingDistance, L1Sensitivity, MaxDivergence};
+    use crate::dist::{HammingDistance, MaxDivergence, AbsoluteDistance};
     use crate::dom::VectorDomain;
     use crate::error::*;
     use crate::meas::*;
@@ -163,12 +163,12 @@ mod tests {
 
     use super::*;
 
-    fn make_dummy_meas<TO: From<i32>>() -> Measurement<AllDomain<i32>, AllDomain<TO>, L1Sensitivity<f64>, MaxDivergence<f64>> {
+    fn make_dummy_meas<TO: From<i32>>() -> Measurement<AllDomain<i32>, AllDomain<TO>, AbsoluteDistance<f64>, MaxDivergence<f64>> {
         Measurement::new(
             AllDomain::new(),
             AllDomain::new(),
             Function::new(|a: &i32| TO::from(a.clone())),
-            L1Sensitivity::<f64>::default(),
+            AbsoluteDistance::<f64>::default(),
             MaxDivergence::<f64>::default(),
             PrivacyRelation::new(|d_in, d_out| d_out <= d_in),
         )

--- a/rust/opendp/src/lib.rs
+++ b/rust/opendp/src/lib.rs
@@ -39,7 +39,7 @@
 //! use opendp::meas;
 //! use opendp::trans;
 //! use opendp::trans::{manipulation, sum, make_split_lines, make_cast_default, make_clamp, make_bounded_sum};
-//! use opendp::dist::{HammingDistance, L1Sensitivity};
+//! use opendp::dist::{HammingDistance, L1Distance};
 //! use opendp::error::*;
 //! use opendp::chain::{make_chain_tt, make_chain_mt};
 //! use opendp::meas::make_base_laplace;
@@ -97,14 +97,14 @@
 //! #### Example Transformation Constructor
 //! ```
 //!# use opendp::core::{Transformation, StabilityRelation, Function};
-//!# use opendp::dist::L1Sensitivity;
+//!# use opendp::dist::L1Distance;
 //!# use opendp::dom::AllDomain;
-//! pub fn make_i32_identity() -> Transformation<AllDomain<i32>, AllDomain<i32>, L1Sensitivity<i32>, L1Sensitivity<i32>> {
+//! pub fn make_i32_identity() -> Transformation<AllDomain<i32>, AllDomain<i32>, L1Distance<i32>, L1Distance<i32>> {
 //!     let input_domain = AllDomain::new();
 //!     let output_domain = AllDomain::new();
 //!     let function = Function::new(|arg: &i32| -> i32 { *arg });
-//!     let input_metric = L1Sensitivity::default();
-//!     let output_metric = L1Sensitivity::default();
+//!     let input_metric = L1Distance::default();
+//!     let output_metric = L1Distance::default();
 //!     let stability_relation = StabilityRelation::new_from_constant(1);
 //!     Transformation::new(input_domain, output_domain, function, input_metric, output_metric, stability_relation)
 //! }

--- a/rust/opendp/src/meas/geometric.rs
+++ b/rust/opendp/src/meas/geometric.rs
@@ -1,5 +1,5 @@
-use crate::core::{Function, Measurement, PrivacyRelation, Domain};
-use crate::dist::{MaxDivergence, L1Sensitivity};
+use crate::core::{Function, Measurement, PrivacyRelation, Domain, SensitivityMetric};
+use crate::dist::{MaxDivergence, L1Distance, AbsoluteDistance};
 use crate::dom::{AllDomain, VectorDomain};
 use crate::error::*;
 use crate::samplers::SampleTwoSidedGeometric;
@@ -8,6 +8,9 @@ use num::Float;
 
 
 pub trait GeometricDomain: Domain {
+    type InputMetric: SensitivityMetric<Distance=Self::Atom> + Default;
+    // Atom is an alias for Self::InputMetric::Distance.
+    // It would be possible to fill this with associated type defaults: https://github.com/rust-lang/rust/issues/29661
     type Atom;
     fn new() -> Self;
     fn noise_function(scale: f64, bounds: Option<(Self::Atom, Self::Atom)>) -> Function<Self, Self>;
@@ -16,7 +19,8 @@ pub trait GeometricDomain: Domain {
 
 impl<T> GeometricDomain for AllDomain<T>
     where T: 'static + Clone + SampleTwoSidedGeometric {
-    type Atom = Self::Carrier;
+    type InputMetric = AbsoluteDistance<T>;
+    type Atom = T;
 
     fn new() -> Self { AllDomain::new() }
     fn noise_function(scale: f64, bounds: Option<(T, T)>) -> Function<Self, Self> {
@@ -27,6 +31,7 @@ impl<T> GeometricDomain for AllDomain<T>
 
 impl<T> GeometricDomain for VectorDomain<AllDomain<T>>
     where T: 'static + Clone + SampleTwoSidedGeometric {
+    type InputMetric = L1Distance<T>;
     type Atom = T;
 
     fn new() -> Self { VectorDomain::new_all() }
@@ -39,7 +44,7 @@ impl<T> GeometricDomain for VectorDomain<AllDomain<T>>
 
 pub fn make_base_geometric<D, QO>(
     scale: QO, bounds: Option<(D::Atom, D::Atom)>
-) -> Fallible<Measurement<D, D, L1Sensitivity<D::Atom>, MaxDivergence<QO>>>
+) -> Fallible<Measurement<D, D, D::InputMetric, MaxDivergence<QO>>>
     where D: 'static + GeometricDomain,
           D::Atom: 'static + DistanceCast + PartialOrd,
           QO: 'static + Float + DistanceCast,
@@ -53,7 +58,7 @@ pub fn make_base_geometric<D, QO>(
         D::new(),
         D::new(),
         D::noise_function(f64::from(scale), bounds),
-        L1Sensitivity::default(),
+        D::InputMetric::default(),
         MaxDivergence::default(),
         PrivacyRelation::new_from_constant(scale.recip())))
 }

--- a/rust/opendp/src/trans/count.rs
+++ b/rust/opendp/src/trans/count.rs
@@ -154,7 +154,7 @@ mod tests {
 
     #[test]
     fn test_make_count_distinct() {
-        let transformation = make_count_distinct::<SymmetricDistance, L1Sensitivity<i32>, _>().unwrap_test();
+        let transformation = make_count_distinct::<SymmetricDistance, L1Distance<i32>, _>().unwrap_test();
         let arg = vec![1, 1, 3, 4, 4];
         let ret = transformation.function.eval(&arg).unwrap_test();
         let expected = 3;

--- a/rust/opendp/src/trans/mean.rs
+++ b/rust/opendp/src/trans/mean.rs
@@ -1,18 +1,18 @@
-use crate::core::{DatasetMetric, Transformation, Function, StabilityRelation, SensitivityMetric};
+use crate::core::{DatasetMetric, Transformation, Function, StabilityRelation};
 use std::ops::{Sub, Div};
 use std::iter::Sum;
 use crate::traits::DistanceConstant;
 use crate::error::Fallible;
 use crate::dom::{VectorDomain, IntervalDomain, AllDomain, SizedDomain};
 use std::collections::Bound;
-use crate::dist::{HammingDistance, SymmetricDistance, LPSensitivity};
+use crate::dist::{HammingDistance, SymmetricDistance, AbsoluteDistance};
 use num::{NumCast, Float};
 
 pub trait BoundedMeanConstant<T> {
     fn get_stability(lower: T, upper: T, n: usize) -> Fallible<T>;
 }
 
-impl<T, const P: usize> BoundedMeanConstant<T> for (HammingDistance, LPSensitivity<T, P>)
+impl<T> BoundedMeanConstant<T> for HammingDistance
     where T: Sub<Output=T> + Div<Output=T> + NumCast {
     fn get_stability(lower: T, upper: T, n: usize) -> Fallible<T> {
         let n = T::from(n).ok_or_else(|| err!(FailedCast))?;
@@ -21,32 +21,30 @@ impl<T, const P: usize> BoundedMeanConstant<T> for (HammingDistance, LPSensitivi
 }
 
 // postprocessing the sum
-impl<T, const P: usize> BoundedMeanConstant<T> for (SymmetricDistance, LPSensitivity<T, P>)
+impl<T> BoundedMeanConstant<T> for SymmetricDistance
     where T: Sub<Output=T> + Div<Output=T> + NumCast {
     fn get_stability(lower: T, upper: T, n: usize) -> Fallible<T> {
         Ok((upper - lower) / num_cast!(n; T)? / num_cast!(2; T)?)
     }
 }
 
-pub fn make_bounded_mean<MI, MO>(
-    lower: MO::Distance, upper: MO::Distance, n: usize
-) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<MO::Distance>>>, AllDomain<MO::Distance>, MI, MO>>
-    where MI: DatasetMetric,
-          MO: SensitivityMetric,
-          MO::Distance: DistanceConstant + Sub<Output=MO::Distance> + Float,
-          for <'a> MO::Distance: Sum<&'a MO::Distance>,
-          (MI, MO): BoundedMeanConstant<MO::Distance> {
-    let _n = num_cast!(n; MO::Distance)?;
+pub fn make_bounded_mean<MI, T>(
+    lower: T, upper: T, n: usize
+) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, MI, AbsoluteDistance<T>>>
+    where MI: BoundedMeanConstant<T> + DatasetMetric,
+          T: DistanceConstant + Sub<Output=T> + Float,
+          for <'a> T: Sum<&'a T> {
+    let _n = num_cast!(n; T)?;
 
     Ok(Transformation::new(
         SizedDomain::new(VectorDomain::new(
             IntervalDomain::new(Bound::Included(lower), Bound::Included(upper))?),
                          n),
         AllDomain::new(),
-        Function::new(move |arg: &Vec<MO::Distance>| arg.iter().sum::<MO::Distance>() / _n),
+        Function::new(move |arg: &Vec<T>| arg.iter().sum::<T>() / _n),
         MI::default(),
-        MO::default(),
-        StabilityRelation::new_from_constant(<(MI, MO)>::get_stability(lower, upper, n)?)))
+        AbsoluteDistance::default(),
+        StabilityRelation::new_from_constant(MI::get_stability(lower, upper, n)?)))
 }
 
 
@@ -54,13 +52,12 @@ pub fn make_bounded_mean<MI, MO>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dist::{L1Sensitivity, L2Sensitivity};
     use crate::error::ExplainUnwrap;
     use crate::trans::mean::make_bounded_mean;
 
     #[test]
     fn test_make_bounded_mean_hamming() {
-        let transformation = make_bounded_mean::<HammingDistance, L1Sensitivity<f64>>(0., 10., 5).unwrap_test();
+        let transformation = make_bounded_mean::<HammingDistance, f64>(0., 10., 5).unwrap_test();
         let arg = vec![1., 2., 3., 4., 5.];
         let ret = transformation.function.eval(&arg).unwrap_test();
         let expected = 3.;
@@ -70,7 +67,7 @@ mod tests {
 
     #[test]
     fn test_make_bounded_mean_symmetric() {
-        let transformation = make_bounded_mean::<SymmetricDistance, L2Sensitivity<f64>>(0., 10., 5).unwrap_test();
+        let transformation = make_bounded_mean::<SymmetricDistance, f64>(0., 10., 5).unwrap_test();
         let arg = vec![1., 2., 3., 4., 5.];
         let ret = transformation.function.eval(&arg).unwrap_test();
         let expected = 3.;

--- a/rust/opendp/src/trans/sum.rs
+++ b/rust/opendp/src/trans/sum.rs
@@ -3,11 +3,11 @@ use std::collections::Bound;
 use std::iter::Sum;
 use std::ops::Sub;
 
-use crate::core::{DatasetMetric, Function, SensitivityMetric, StabilityRelation, Transformation};
-use crate::dist::{HammingDistance, SymmetricDistance, LPSensitivity};
+use crate::core::{DatasetMetric, Function, StabilityRelation, Transformation};
+use crate::dist::{HammingDistance, SymmetricDistance, AbsoluteDistance};
 use crate::dom::{AllDomain, IntervalDomain, SizedDomain, VectorDomain};
 use crate::error::*;
-use crate::traits::{Abs, DistanceCast, DistanceConstant};
+use crate::traits::{Abs, DistanceConstant};
 
 fn max<T: PartialOrd>(a: T, b: T) -> Option<T> {
     a.partial_cmp(&b).map(|o| if let Ordering::Less = o {b} else {a})
@@ -17,14 +17,14 @@ pub trait BoundedSumConstant<T> {
     fn get_stability_constant(lower: T, upper: T) -> Fallible<T>;
 }
 
-impl<T, const P: usize> BoundedSumConstant<T> for (HammingDistance, LPSensitivity<T, P>)
+impl<T> BoundedSumConstant<T> for HammingDistance
     where T: 'static + Sub<Output=T> {
     fn get_stability_constant(lower: T, upper: T) -> Fallible<T> {
         Ok(upper - lower)
     }
 }
 
-impl<T, const P: usize> BoundedSumConstant<T> for (SymmetricDistance, LPSensitivity<T, P>)
+impl<T> BoundedSumConstant<T> for SymmetricDistance
     where T: 'static + PartialOrd + Abs {
     fn get_stability_constant(lower: T, upper: T) -> Fallible<T> {
         max(lower.abs(), upper.abs())
@@ -32,53 +32,49 @@ impl<T, const P: usize> BoundedSumConstant<T> for (SymmetricDistance, LPSensitiv
     }
 }
 
-pub fn make_bounded_sum<MI, MO>(
-    lower: MO::Distance, upper: MO::Distance
-) -> Fallible<Transformation<VectorDomain<IntervalDomain<MO::Distance>>, AllDomain<MO::Distance>, MI, MO>>
-    where MI: DatasetMetric,
-          MO: SensitivityMetric,
-          MO::Distance: DistanceConstant + Sub<Output=MO::Distance>,
-          for <'a> MO::Distance: Sum<&'a MO::Distance>,
-          (MI, MO): BoundedSumConstant<MO::Distance> {
+pub fn make_bounded_sum<MI, T>(
+    lower: T, upper: T
+) -> Fallible<Transformation<VectorDomain<IntervalDomain<T>>, AllDomain<T>, MI, AbsoluteDistance<T>>>
+    where MI: BoundedSumConstant<T> + DatasetMetric,
+          T: DistanceConstant + Sub<Output=T>,
+          for <'a> T: Sum<&'a T> {
 
     Ok(Transformation::new(
         VectorDomain::new(IntervalDomain::new(
             Bound::Included(lower.clone()), Bound::Included(upper.clone()))?),
         AllDomain::new(),
-        Function::new(|arg: &Vec<MO::Distance>| arg.iter().sum()),
+        Function::new(|arg: &Vec<T>| arg.iter().sum()),
         MI::default(),
-        MO::default(),
-        StabilityRelation::new_from_constant(<(MI, MO)>::get_stability_constant(lower, upper)?)))
+        AbsoluteDistance::default(),
+        StabilityRelation::new_from_constant(MI::get_stability_constant(lower, upper)?)))
 }
 
 
-pub fn make_bounded_sum_n<MO>(
-    lower: MO::Distance, upper: MO::Distance, length: usize
-) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<MO::Distance>>>, AllDomain<MO::Distance>, SymmetricDistance, MO>>
-    where MO: SensitivityMetric,
-          MO::Distance: DistanceConstant + Sub<Output=MO::Distance>,
-          for <'a> MO::Distance: Sum<&'a MO::Distance> {
+pub fn make_bounded_sum_n<T>(
+    lower: T, upper: T, length: usize
+) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
+    where T: DistanceConstant + Sub<Output=T>,
+          for <'a> T: Sum<&'a T> {
 
     Ok(Transformation::new(
         SizedDomain::new(VectorDomain::new(IntervalDomain::new(
             Bound::Included(lower.clone()), Bound::Included(upper.clone()))?), length),
         AllDomain::new(),
-        Function::new(|arg: &Vec<MO::Distance>| arg.iter().sum()),
+        Function::new(|arg: &Vec<T>| arg.iter().sum()),
         SymmetricDistance::default(),
-        MO::default(),
+        AbsoluteDistance::default(),
         // d_out >= d_in * (M - m) / 2
-        StabilityRelation::new_from_constant((upper - lower) / MO::Distance::distance_cast(2)?)))
+        StabilityRelation::new_from_constant((upper - lower) / T::distance_cast(2)?)))
 }
 
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dist::{L1Sensitivity, L2Sensitivity};
 
     #[test]
     fn test_make_bounded_sum_l1() {
-        let transformation = make_bounded_sum::<HammingDistance, L1Sensitivity<i32>>(0, 10).unwrap_test();
+        let transformation = make_bounded_sum::<HammingDistance, i32>(0, 10).unwrap_test();
         let arg = vec![1, 2, 3, 4, 5];
         let ret = transformation.function.eval(&arg).unwrap_test();
         let expected = 15;
@@ -87,7 +83,7 @@ mod tests {
 
     #[test]
     fn test_make_bounded_sum_l2() {
-        let transformation = make_bounded_sum::<HammingDistance, L2Sensitivity<i32>>(0, 10).unwrap_test();
+        let transformation = make_bounded_sum::<HammingDistance, i32>(0, 10).unwrap_test();
         let arg = vec![1, 2, 3, 4, 5];
         let ret = transformation.function.eval(&arg).unwrap_test();
         let expected = 15;
@@ -96,7 +92,7 @@ mod tests {
 
     #[test]
     fn test_make_bounded_sum_n() {
-        let transformation = make_bounded_sum_n::<L2Sensitivity<i32>>(0, 10, 5).unwrap_test();
+        let transformation = make_bounded_sum_n::<i32>(0, 10, 5).unwrap_test();
         let arg = vec![1, 2, 3, 4, 5];
         let ret = transformation.function.eval(&arg).unwrap_test();
         let expected = 15;


### PR DESCRIPTION
Closes #143
Affects #141 (I shouldn't have said "closes" as it seems that issue is ongoing)

I added an AbsoluteDistance metric and made all code that uses LpSensitivity on scalars use the AbsoluteDistance instead. This caused a number of places where the types were simplified, which significantly changes the public interfaces.
Also renamed LPSensitivity to LpSensitivity.