### PR TITLE
Handle Option<T> constructor arguments as nullable pointers in FFI

### DIFF
--- a/python/src/opendp/v1/_convert.py
+++ b/python/src/opendp/v1/_convert.py
@@ -143,6 +143,9 @@ def _slice_to_py(raw: FfiSlicePtr, type_name: str) -> Any:
     if type_name == "String":
         return _slice_to_string(raw)
 
+    if type_name.startswith("Option<(") and type_name.endswith(")>"):
+        return _slice_to_option_tuple(raw, type_name)
+
     raise UnknownTypeException(type_name)
 
 
@@ -166,6 +169,9 @@ def _py_to_slice(value: Any, type_name: str) -> FfiSlicePtr:
 
     if type_name == "String":
         return _string_to_slice(value)
+
+    if type_name.startswith("Option<(") and type_name.endswith(")>"):
+        return _option_tuple_to_slice(value, type_name)
 
     raise UnknownTypeException(type_name)
 
@@ -251,6 +257,21 @@ def _slice_to_tuple(raw: FfiSlicePtr, type_name: str) -> Tuple[Any, ...]:
     # tuple of instances of python types
     return tuple(ctypes.cast(void_p, ctypes.POINTER(ATOM_MAP[name])).contents.value
                  for void_p, name in zip(ptr_data, inner_type_names))
+
+
+def _option_tuple_to_slice(val: Optional[Tuple[Any, ...]], type_name: str) -> FfiSlicePtr:
+    if val is None:
+        return _wrap_in_slice((ctypes.c_void_p * 0)(), 0)
+    else:
+        return _tuple_to_slice(val, type_name[7:-1])
+
+
+def _slice_to_option_tuple(raw: FfiSlicePtr, type_name) -> Optional[Tuple[Any, ...]]:
+    if raw.contents.len == 0:
+        return None
+    if raw.contents.len == 2:
+        return _tuple_to_slice(raw, type_name)
+    raise OpenDPException("Option<(_, _)> types must contains tuples of length 2")
 
 
 def _wrap_in_slice(ptr, len_: int) -> FfiSlicePtr:

--- a/python/src/opendp/v1/meas.py
+++ b/python/src/opendp/v1/meas.py
@@ -76,6 +76,7 @@ def make_base_gaussian(
 
 def make_base_geometric(
     scale,
+    bounds: Any = None,
     D: RuntimeTypeDescriptor = "AllDomain<i32>",
     QO: RuntimeTypeDescriptor = None
 ) -> Measurement:
@@ -83,6 +84,8 @@ def make_base_geometric(
     Adjust D to noise vector-valued data.
     
     :param scale: noise scale parameter to the geometric distribution
+    :param bounds: Set bounds on the count to make the algorithm run in constant-time.
+    :type bounds: Any
     :param D: Domain of the data type to be privatized. Valid values are VectorDomain<AllDomain<T>> or AllDomain<T>
     :type D: RuntimeTypeDescriptor
     :param QO: Data type of the sensitivity, scale, and budget.
@@ -96,18 +99,21 @@ def make_base_geometric(
     # Standardize type arguments.
     D = RuntimeType.parse(type_name=D)
     QO = RuntimeType.parse_or_infer(type_name=QO, public_example=scale)
+    T = get_domain_atom(D)
+    OptionT = RuntimeType(origin='Option', args=[RuntimeType(origin='Tuple', args=[T, T])])
     
     # Convert arguments to c types.
     scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=QO)
+    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=OptionT)
     D = py_to_c(D, c_type=ctypes.c_char_p)
     QO = py_to_c(QO, c_type=ctypes.c_char_p)
     
     # Call library function.
     function = lib.opendp_meas__make_base_geometric
-    function.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
+    function.argtypes = [ctypes.c_void_p, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(scale, D, QO), Measurement))
+    return c_to_py(unwrap(function(scale, bounds, D, QO), Measurement))
 
 
 def make_base_stability(

--- a/python/src/opendp/v1/typing.py
+++ b/python/src/opendp/v1/typing.py
@@ -226,6 +226,10 @@ class RuntimeType(object):
                     f"inferred type is {inferred}, expected {expected}"
 
         elif isinstance(expected, RuntimeType) and isinstance(inferred, RuntimeType):
+            # allow extra flexibility around options, as the inferred type of an Option::<T>::Some will just be T
+            if expected.origin == "Option" and inferred.origin != "Option":
+                expected = expected.args[0]
+
             assert expected.origin == inferred.origin, \
                 f"inferred type is {inferred.origin}, expected {expected.origin}"
 

--- a/python/test/test_meas.py
+++ b/python/test/test_meas.py
@@ -30,7 +30,7 @@ def test_base_vector_gaussian():
 
 def test_base_geometric():
     from opendp.v1.meas import make_base_geometric
-    meas = make_base_geometric(scale=2.)
+    meas = make_base_geometric(scale=2., bounds=(1, 10))
     print("base_geometric in constant time:", meas(100))
     assert meas.check(1, 0.5)
     assert not meas.check(1, 0.49999)
@@ -48,7 +48,7 @@ def test_base_vector_geometric():
     assert meas.check(1, 0.5)
     assert not meas.check(1, 0.49999)
 
-    meas = make_base_geometric(scale=2., D="VectorDomain<AllDomain<i32>>")
+    meas = make_base_geometric(scale=2., bounds=(10, 100), D="VectorDomain<AllDomain<i32>>")
     print("constant time vector base_geometric:", meas([100, 10, 12]))
     assert meas.check(1, 0.5)
     assert not meas.check(1, 0.49999)

--- a/rust/opendp-ffi/build/main.rs
+++ b/rust/opendp-ffi/build/main.rs
@@ -4,7 +4,7 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
 use indexmap::map::IndexMap;
-use serde::{Deserialize};
+use serde::{Deserialize, Deserializer};
 use serde_json::Value;
 
 #[cfg(feature="python")]
@@ -48,8 +48,8 @@ pub struct Argument {
     // plaintext description of the argument used to generate documentation
     description: Option<String>,
     // default value for the argument
-    #[serde(default)]
-    default: Value,
+    #[serde(default, deserialize_with = "deserialize_some")]
+    default: Option<Value>,
     // set to true if the argument represents a type
     #[serde(default)]
     is_type: bool,
@@ -58,6 +58,12 @@ pub struct Argument {
     //  to prevent the returned AnyObject from getting converted back to python
     #[serde(default)]
     do_not_convert: bool
+}
+
+// deserialize "k": null as `Some(Value::Null)` and no key as `None`.
+fn deserialize_some<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+    where T: Deserialize<'de>, D: Deserializer<'de> {
+    Deserialize::deserialize(deserializer).map(Some)
 }
 
 #[allow(dead_code)]

--- a/rust/opendp-ffi/build/python.rs
+++ b/rust/opendp-ffi/build/python.rs
@@ -139,20 +139,18 @@ impl Argument {
 /// generate an input argument, complete with name, hint and default.
 /// also returns a bool to make it possible to move arguments with defaults to the end of the signature.
 fn generate_input_argument(arg: &Argument, func: &Function, hierarchy: &HashMap<String, Vec<String>>) -> (String, bool) {
-    let default = match &arg.default {
-        // if no default value
-        Value::Null => if arg.is_type {
-            // let default value be None if it is a type arg and there is a public example
-            generate_public_example(func, arg).map(|_| "None".to_string())
-        } else {
-            // otherwise, the common path, no default is added to the code
-            None
-        }
-        Value::Bool(value) => Some(if *value {"True"} else {"False"}.to_string()),
-        Value::Number(number) => Some(number.to_string()),
-        Value::String(string) => Some(format!("\"{}\"", string)),
-        Value::Array(array) => Some(format!("{:?}", array)),
-        Value::Object(_) => unimplemented!()
+    let default = if let Some(default) = &arg.default {
+        Some(match default {
+            Value::Null => "None".to_string(),
+            Value::Bool(value) => if *value {"True"} else {"False"}.to_string(),
+            Value::Number(number) => number.to_string(),
+            Value::String(string) => format!("\"{}\"", string),
+            Value::Array(array) => format!("{:?}", array),
+            Value::Object(_) => unimplemented!()
+        })
+    } else {
+        // let default value be None if it is a type arg and there is a public example
+        generate_public_example(func, arg).map(|_| "None".to_string())
     };
     (format!(
         r#"{name}{hint}{default}"#,

--- a/rust/opendp-ffi/src/data/mod.rs
+++ b/rust/opendp-ffi/src/data/mod.rs
@@ -111,6 +111,20 @@ pub extern "C" fn opendp_data___slice_as_object(raw: *const FfiSlice, T: *const 
             .ok_or_else(|| err!(FFI, "Attempted to follow a null pointer to create a tuple"))?;
         Ok(AnyObject::new(tuple))
     }
+    fn raw_to_option_tuple<T0: 'static + Clone, T1: 'static + Clone>(raw: &FfiSlice) -> Fallible<AnyObject> {
+        if raw.len == 0 {
+            return Ok(AnyObject::new(None::<(T0, T1)>))
+        }
+        if raw.len != 2 {
+            return fallible!(FFI, "The slice length must be two when creating a tuple from FfiSlice");
+        }
+        let slice = unsafe { slice::from_raw_parts(raw.ptr as *const *const c_void, 2) };
+
+        let tuple = util::as_ref(slice[0] as *const T0).cloned()
+            .zip(util::as_ref(slice[1] as *const T1).cloned())
+            .ok_or_else(|| err!(FFI, "Attempted to follow a null pointer to create a tuple"))?;
+        Ok(AnyObject::new(Some(tuple)))
+    }
     let T = try_!(Type::try_from(T));
     let raw = try_as_ref!(raw);
     let obj = match T.contents {
@@ -134,6 +148,19 @@ pub extern "C" fn opendp_data___slice_as_object(raw: *const FfiSlice, T: *const 
             // because the only likely way to get a tuple of AnyObjects is as the output of composition.
             dispatch!(raw_to_tuple, [(types[0], @primitives), (types[1], @primitives)], (raw))
         },
+        TypeContents::GENERIC {name, args} if name == "Option" => {
+            if let TypeContents::TUPLE(ref element_ids) =  try_!(Type::of_id(&args[0])).contents {
+                if element_ids.len() != 2 {
+                    return fallible!(FFI, "Only tuples of length 2 can be loaded as an object").into();
+                }
+                let types = try_!(element_ids.iter().map(Type::of_id).collect::<Fallible<Vec<_>>>());
+                // In the inbound direction, we can handle tuples of primitives only. This is probably OK,
+                // because the only likely way to get a tuple of AnyObjects is as the output of composition.
+                dispatch!(raw_to_option_tuple, [(types[0], @primitives), (types[1], @primitives)], (raw))
+            } else {
+                return fallible!(FFI, "Only Option<(T, T)> can be loaded as an object").into();
+            }
+        }
         _ => dispatch!(raw_to_plain, [(T, @primitives)], (raw))
     };
     obj.into()
@@ -175,6 +202,16 @@ pub extern "C" fn opendp_data___object_as_slice(obj: *const AnyObject) -> FfiRes
             &tuple.1 as *const T1 as *const c_void
         ]) as *mut c_void, 2))
     }
+    fn option_tuple_to_raw<T0: 'static, T1: 'static>(obj: &AnyObject) -> Fallible<FfiSlice> {
+        Ok(if let Some(tuple) = obj.downcast_ref::<Option<(T0, T1)>>()? {
+            FfiSlice::new(util::into_raw([
+                &tuple.0 as *const T0 as *const c_void,
+                &tuple.1 as *const T1 as *const c_void
+            ]) as *mut c_void, 2)
+        } else {
+            FfiSlice::new(std::ptr::null::<()>() as *mut c_void, 0)
+        })
+    }
     let obj = try_as_ref!(obj);
     let raw = match &obj.type_.contents {
         TypeContents::PLAIN("String") => {
@@ -195,6 +232,18 @@ pub extern "C" fn opendp_data___object_as_slice(obj: *const AnyObject) -> FfiRes
             let types = try_!(element_ids.iter().map(Type::of_id).collect::<Fallible<Vec<_>>>());
             // In the outbound direction, we can handle tuples of both primitives and AnyObjects.
             dispatch!(tuple_to_raw, [(types[0], @primitives_plus), (types[1], @primitives_plus)], (obj))
+        }
+        TypeContents::GENERIC {name, args} if name == &"Option" => {
+            if let TypeContents::TUPLE(ref element_ids) =  try_!(Type::of_id(&args[0])).contents {
+                if element_ids.len() != 2 {
+                    return fallible!(FFI, "Only tuples of length 2 can be unloaded into a slice.").into();
+                }
+                let types = try_!(element_ids.iter().map(Type::of_id).collect::<Fallible<Vec<_>>>());
+                // In the outbound direction, we can handle tuples of both primitives and AnyObjects.
+                dispatch!(option_tuple_to_raw, [(types[0], @primitives), (types[1], @primitives)], (obj))
+            } else {
+                return fallible!(FFI, "Only Option<(T, T)> can be unloaded into a slice.").into();
+            }
         }
         _ => { dispatch!(plain_to_raw, [(&obj.type_, @primitives)], (obj)) }
     };

--- a/rust/opendp-ffi/src/data/mod.rs
+++ b/rust/opendp-ffi/src/data/mod.rs
@@ -111,20 +111,6 @@ pub extern "C" fn opendp_data___slice_as_object(raw: *const FfiSlice, T: *const 
             .ok_or_else(|| err!(FFI, "Attempted to follow a null pointer to create a tuple"))?;
         Ok(AnyObject::new(tuple))
     }
-    fn raw_to_option_tuple<T0: 'static + Clone, T1: 'static + Clone>(raw: &FfiSlice) -> Fallible<AnyObject> {
-        if raw.len == 0 {
-            return Ok(AnyObject::new(None::<(T0, T1)>))
-        }
-        if raw.len != 2 {
-            return fallible!(FFI, "The slice length must be two when creating a tuple from FfiSlice");
-        }
-        let slice = unsafe { slice::from_raw_parts(raw.ptr as *const *const c_void, 2) };
-
-        let tuple = util::as_ref(slice[0] as *const T0).cloned()
-            .zip(util::as_ref(slice[1] as *const T1).cloned())
-            .ok_or_else(|| err!(FFI, "Attempted to follow a null pointer to create a tuple"))?;
-        Ok(AnyObject::new(Some(tuple)))
-    }
     let T = try_!(Type::try_from(T));
     let raw = try_as_ref!(raw);
     let obj = match T.contents {
@@ -148,19 +134,6 @@ pub extern "C" fn opendp_data___slice_as_object(raw: *const FfiSlice, T: *const 
             // because the only likely way to get a tuple of AnyObjects is as the output of composition.
             dispatch!(raw_to_tuple, [(types[0], @primitives), (types[1], @primitives)], (raw))
         },
-        TypeContents::GENERIC {name, args} if name == "Option" => {
-            if let TypeContents::TUPLE(ref element_ids) =  try_!(Type::of_id(&args[0])).contents {
-                if element_ids.len() != 2 {
-                    return fallible!(FFI, "Only tuples of length 2 can be loaded as an object").into();
-                }
-                let types = try_!(element_ids.iter().map(Type::of_id).collect::<Fallible<Vec<_>>>());
-                // In the inbound direction, we can handle tuples of primitives only. This is probably OK,
-                // because the only likely way to get a tuple of AnyObjects is as the output of composition.
-                dispatch!(raw_to_option_tuple, [(types[0], @primitives), (types[1], @primitives)], (raw))
-            } else {
-                return fallible!(FFI, "Only Option<(T, T)> can be loaded as an object").into();
-            }
-        }
         _ => dispatch!(raw_to_plain, [(T, @primitives)], (raw))
     };
     obj.into()
@@ -202,16 +175,6 @@ pub extern "C" fn opendp_data___object_as_slice(obj: *const AnyObject) -> FfiRes
             &tuple.1 as *const T1 as *const c_void
         ]) as *mut c_void, 2))
     }
-    fn option_tuple_to_raw<T0: 'static, T1: 'static>(obj: &AnyObject) -> Fallible<FfiSlice> {
-        Ok(if let Some(tuple) = obj.downcast_ref::<Option<(T0, T1)>>()? {
-            FfiSlice::new(util::into_raw([
-                &tuple.0 as *const T0 as *const c_void,
-                &tuple.1 as *const T1 as *const c_void
-            ]) as *mut c_void, 2)
-        } else {
-            FfiSlice::new(std::ptr::null::<()>() as *mut c_void, 0)
-        })
-    }
     let obj = try_as_ref!(obj);
     let raw = match &obj.type_.contents {
         TypeContents::PLAIN("String") => {
@@ -232,18 +195,6 @@ pub extern "C" fn opendp_data___object_as_slice(obj: *const AnyObject) -> FfiRes
             let types = try_!(element_ids.iter().map(Type::of_id).collect::<Fallible<Vec<_>>>());
             // In the outbound direction, we can handle tuples of both primitives and AnyObjects.
             dispatch!(tuple_to_raw, [(types[0], @primitives_plus), (types[1], @primitives_plus)], (obj))
-        }
-        TypeContents::GENERIC {name, args} if name == &"Option" => {
-            if let TypeContents::TUPLE(ref element_ids) =  try_!(Type::of_id(&args[0])).contents {
-                if element_ids.len() != 2 {
-                    return fallible!(FFI, "Only tuples of length 2 can be unloaded into a slice.").into();
-                }
-                let types = try_!(element_ids.iter().map(Type::of_id).collect::<Fallible<Vec<_>>>());
-                // In the outbound direction, we can handle tuples of both primitives and AnyObjects.
-                dispatch!(option_tuple_to_raw, [(types[0], @primitives), (types[1], @primitives)], (obj))
-            } else {
-                return fallible!(FFI, "Only Option<(T, T)> can be unloaded into a slice.").into();
-            }
         }
         _ => { dispatch!(plain_to_raw, [(&obj.type_, @primitives)], (obj)) }
     };

--- a/rust/opendp-ffi/src/meas/bootstrap.json
+++ b/rust/opendp-ffi/src/meas/bootstrap.json
@@ -74,6 +74,13 @@
                 "description": "noise scale parameter to the geometric distribution"
             },
             {
+                "name": "bounds",
+                "c_type": "AnyObject *",
+                "rust_type": "OptionT",
+                "default": null,
+                "description": "Set bounds on the count to make the algorithm run in constant-time."
+            },
+            {
                 "name": "D",
                 "c_type": "char *",
                 "default": "AllDomain<i32>",
@@ -85,6 +92,30 @@
                 "c_type": "char *",
                 "description": "Data type of the sensitivity, scale, and budget.",
                 "is_type": true
+            }
+        ],
+        "derived_types": [
+            {
+                "name": "T",
+                "rust_type": {
+                    "function": "get_domain_atom",
+                    "params": [
+                        "D"
+                    ]
+                }
+            },
+            {
+                "name": "OptionT",
+                "rust_type": {
+                    "origin": "Option",
+                    "args": [
+                        {
+                            "origin": "Tuple",
+                            "args": ["T", "T"]
+                        }
+                    ]
+                },
+                "generics": ["T"]
             }
         ],
         "ret": {

--- a/rust/opendp-ffi/src/meas/geometric.rs
+++ b/rust/opendp-ffi/src/meas/geometric.rs
@@ -11,6 +11,7 @@ use opendp::traits::DistanceCast;
 use crate::any::{AnyMeasurement, AnyObject, Downcast};
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::util::Type;
+use crate::util;
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_geometric(
@@ -26,7 +27,9 @@ pub extern "C" fn opendp_meas__make_base_geometric(
               QO: 'static + Float + DistanceCast,
               f64: From<QO> {
         let scale = try_as_ref!(scale as *const QO).clone();
-        let bounds = try_!(try_as_ref!(bounds).downcast_ref::<Option<(D::Atom, D::Atom)>>()).clone();
+        let bounds = if let Some(bounds) = util::as_ref(bounds) {
+            Some(try_!(bounds.downcast_ref::<(D::Atom, D::Atom)>()).clone())
+        } else {None};
         make_base_geometric::<D, QO>(scale, bounds).into_any()
     }
     let D = try_!(Type::try_from(D));

--- a/rust/opendp-ffi/src/meas/geometric.rs
+++ b/rust/opendp-ffi/src/meas/geometric.rs
@@ -8,24 +8,25 @@ use opendp::err;
 use opendp::meas::{GeometricDomain, make_base_geometric};
 use opendp::traits::DistanceCast;
 
-use crate::any::{AnyMeasurement};
+use crate::any::{AnyMeasurement, AnyObject, Downcast};
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::util::Type;
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_geometric(
     scale: *const c_void,
+    bounds: *const AnyObject,
     D: *const c_char, QO: *const c_char
 ) -> FfiResult<*mut AnyMeasurement> {
     fn monomorphize<D, QO>(
-        scale: *const c_void
+        scale: *const c_void, bounds: *const AnyObject
     ) -> FfiResult<*mut AnyMeasurement>
         where D: 'static + GeometricDomain,
               D::Atom: 'static + DistanceCast + PartialOrd,
               QO: 'static + Float + DistanceCast,
               f64: From<QO> {
         let scale = try_as_ref!(scale as *const QO).clone();
-        let bounds = None;
+        let bounds = try_!(try_as_ref!(bounds).downcast_ref::<Option<(D::Atom, D::Atom)>>()).clone();
         make_base_geometric::<D, QO>(scale, bounds).into_any()
     }
     let D = try_!(Type::try_from(D));
@@ -40,7 +41,7 @@ pub extern "C" fn opendp_meas__make_base_geometric(
             VectorDomain<AllDomain<i128>>
         ]),
         (QO, @floats)
-    ], (scale))
+    ], (scale, bounds))
 }
 
 
@@ -59,6 +60,7 @@ mod tests {
     fn test_make_base_simple_geometric() -> Fallible<()> {
         let measurement = Result::from(opendp_meas__make_base_geometric(
             util::into_raw(0.0) as *const c_void,
+            AnyObject::new_raw(None::<(i32, i32)>),
             "AllDomain<i32>".to_char_p(),
             "f64".to_char_p(),
         ))?;
@@ -73,6 +75,7 @@ mod tests {
     fn test_make_base_simple_constant_time_geometric() -> Fallible<()> {
         let measurement = Result::from(opendp_meas__make_base_geometric(
             util::into_raw(0.0) as *const c_void,
+            util::into_raw(AnyObject::new(Some((0, 100)))),
             "AllDomain<i32>".to_char_p(),
             "f64".to_char_p(),
         ))?;

--- a/rust/opendp-ffi/src/util.rs
+++ b/rust/opendp-ffi/src/util.rs
@@ -219,6 +219,8 @@ lazy_static! {
             type_vec![Vec, <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String, AnyObject>],
             // OptionNullDomain<AllDomain<_>>::Carrier
             type_vec![[Vec Option], <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String, AnyObject>],
+            // geometric mechanism
+            type_vec![Option, <(u8, u8), (u16, u16), (u32, u32), (u64, u64), (u128, u128), (i8, i8), (i16, i16), (i32, i32), (i64, i64), (i128, i128)>],
 
             // domains
             type_vec![AllDomain, <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String>],


### PR DESCRIPTION
Closes #165 
Generally allow null pointers to be interpreted as None in rust, when the FFI argument is meant to be an Option<T>
This is used for constructing a constant-time base geometric from ffi.