### PR TITLE
Explicit casting traits

### DIFF
--- a/rust/opendp-ffi/src/meas/gaussian.rs
+++ b/rust/opendp-ffi/src/meas/gaussian.rs
@@ -11,6 +11,7 @@ use crate::any::AnyMeasurement;
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::util::Type;
 use opendp::dom::{AllDomain, VectorDomain};
+use opendp::traits::InfCast;
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_gaussian(
@@ -19,7 +20,7 @@ pub extern "C" fn opendp_meas__make_base_gaussian(
 ) -> FfiResult<*mut AnyMeasurement> {
     fn monomorphize<D>(scale: *const c_void) -> FfiResult<*mut AnyMeasurement> where
         D: 'static + GaussianDomain,
-        D::Atom: 'static + Clone + SampleGaussian + Float {
+        D::Atom: 'static + Clone + SampleGaussian + Float + InfCast<f64> {
         let scale = *try_as_ref!(scale as *const D::Atom);
         make_base_gaussian::<D>(scale).into_any()
     }

--- a/rust/opendp-ffi/src/meas/geometric.rs
+++ b/rust/opendp-ffi/src/meas/geometric.rs
@@ -6,12 +6,12 @@ use num::Float;
 use opendp::dom::{AllDomain, VectorDomain};
 use opendp::err;
 use opendp::meas::{GeometricDomain, make_base_geometric};
-use opendp::traits::DistanceCast;
 
 use crate::any::{AnyMeasurement, AnyObject, Downcast};
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::util::Type;
 use crate::util;
+use opendp::traits::InfCast;
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_geometric(
@@ -23,8 +23,8 @@ pub extern "C" fn opendp_meas__make_base_geometric(
         scale: *const c_void, bounds: *const AnyObject
     ) -> FfiResult<*mut AnyMeasurement>
         where D: 'static + GeometricDomain,
-              D::Atom: 'static + DistanceCast + PartialOrd,
-              QO: 'static + Float + DistanceCast,
+              D::Atom: 'static + InfCast<QO> + PartialOrd + Clone,
+              QO: 'static + Float + InfCast<D::Atom>,
               f64: From<QO> {
         let scale = try_as_ref!(scale as *const QO).clone();
         let bounds = if let Some(bounds) = util::as_ref(bounds) {

--- a/rust/opendp-ffi/src/meas/laplace.rs
+++ b/rust/opendp-ffi/src/meas/laplace.rs
@@ -6,12 +6,12 @@ use num::Float;
 use opendp::err;
 use opendp::meas::{make_base_laplace, LaplaceDomain};
 use opendp::samplers::SampleLaplace;
-use opendp::traits::DistanceCast;
 
 use crate::any::AnyMeasurement;
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::util::Type;
 use opendp::dom::{VectorDomain, AllDomain};
+use opendp::traits::InfCast;
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_laplace(
@@ -20,7 +20,7 @@ pub extern "C" fn opendp_meas__make_base_laplace(
 ) -> FfiResult<*mut AnyMeasurement> {
     fn monomorphize<D>(scale: *const c_void) -> FfiResult<*mut AnyMeasurement>
         where D: 'static + LaplaceDomain,
-              D::Atom: 'static + Clone + SampleLaplace + Float + DistanceCast {
+              D::Atom: 'static + Clone + SampleLaplace + Float + InfCast<D::Atom> {
         let scale = *try_as_ref!(scale as *const D::Atom);
         make_base_laplace::<D>(scale).into_any()
     }

--- a/rust/opendp-ffi/src/meas/stability.rs
+++ b/rust/opendp-ffi/src/meas/stability.rs
@@ -10,11 +10,11 @@ use opendp::dist::{L1Distance, L2Distance};
 use opendp::err;
 use opendp::meas::{BaseStabilityNoise, make_base_stability};
 use opendp::samplers::CastInternalReal;
+use opendp::traits::ExactIntCast;
 
 use crate::any::AnyMeasurement;
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::util::Type;
-use opendp::traits::{MaxConsecutiveInt, ExactCast};
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_stability(
@@ -30,14 +30,14 @@ pub extern "C" fn opendp_meas__make_base_stability(
         MI: Type, TIK: Type, TIC: Type,
     ) -> FfiResult<*mut AnyMeasurement>
         where TIC: 'static + Integer + Zero + One + AddAssign + Clone,
-              TOC: 'static + PartialOrd + Clone + Float + CastInternalReal + ExactCast<usize> + ExactCast<TIC> + MaxConsecutiveInt {
+              TOC: 'static + PartialOrd + Clone + Float + CastInternalReal + ExactIntCast<usize> + ExactIntCast<TIC> {
         fn monomorphize2<MI, TIK, TIC>(
             n: usize, scale: MI::Distance, threshold: MI::Distance,
         ) -> FfiResult<*mut AnyMeasurement>
             where MI: 'static + SensitivityMetric + BaseStabilityNoise,
                   TIK: 'static + Eq + Hash + Clone,
                   TIC: 'static + Integer + Zero + One + AddAssign + Clone,
-                  MI::Distance: 'static + Clone + PartialOrd + Float + CastInternalReal + ExactCast<usize> + ExactCast<TIC> + MaxConsecutiveInt {
+                  MI::Distance: 'static + Clone + PartialOrd + Float + CastInternalReal + ExactIntCast<usize> + ExactIntCast<TIC> {
             make_base_stability::<MI, TIK, TIC>(n, scale, threshold).into_any()
         }
         let scale = *try_as_ref!(scale as *const TOC);

--- a/rust/opendp-ffi/src/meas/stability.rs
+++ b/rust/opendp-ffi/src/meas/stability.rs
@@ -3,7 +3,7 @@ use std::hash::Hash;
 use std::ops::AddAssign;
 use std::os::raw::{c_char, c_void};
 
-use num::{Float, Integer, NumCast, One, Zero};
+use num::{Float, Integer, One, Zero};
 
 use opendp::core::SensitivityMetric;
 use opendp::dist::{L1Distance, L2Distance};
@@ -14,6 +14,7 @@ use opendp::samplers::CastInternalReal;
 use crate::any::AnyMeasurement;
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::util::Type;
+use opendp::traits::{MaxConsecutiveInt, ExactCast};
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_stability(
@@ -24,18 +25,19 @@ pub extern "C" fn opendp_meas__make_base_stability(
     TIK: *const c_char,  // type of input key (hashable)
     TIC: *const c_char,  // type of input count (int)
 ) -> FfiResult<*mut AnyMeasurement> {
-    fn monomorphize<TOC>(
+    fn monomorphize<TIC, TOC>(
         n: usize, scale: *const c_void, threshold: *const c_void,
         MI: Type, TIK: Type, TIC: Type,
     ) -> FfiResult<*mut AnyMeasurement>
-        where TOC: 'static + PartialOrd + Clone + NumCast + Float + CastInternalReal {
+        where TIC: 'static + Integer + Zero + One + AddAssign + Clone,
+              TOC: 'static + PartialOrd + Clone + Float + CastInternalReal + ExactCast<usize> + ExactCast<TIC> + MaxConsecutiveInt {
         fn monomorphize2<MI, TIK, TIC>(
             n: usize, scale: MI::Distance, threshold: MI::Distance,
         ) -> FfiResult<*mut AnyMeasurement>
             where MI: 'static + SensitivityMetric + BaseStabilityNoise,
                   TIK: 'static + Eq + Hash + Clone,
-                  TIC: 'static + Integer + Zero + One + AddAssign + Clone + NumCast,
-                  MI::Distance: 'static + Clone + NumCast + PartialOrd + Float + CastInternalReal {
+                  TIC: 'static + Integer + Zero + One + AddAssign + Clone,
+                  MI::Distance: 'static + Clone + PartialOrd + Float + CastInternalReal + ExactCast<usize> + ExactCast<TIC> + MaxConsecutiveInt {
             make_base_stability::<MI, TIK, TIC>(n, scale, threshold).into_any()
         }
         let scale = *try_as_ref!(scale as *const TOC);
@@ -43,7 +45,7 @@ pub extern "C" fn opendp_meas__make_base_stability(
         dispatch!(monomorphize2, [
             (MI, [L1Distance<TOC>, L2Distance<TOC>]),
             (TIK, @hashable),
-            (TIC, @integers)
+            (TIC, [TIC])
         ], (n, scale, threshold))
     }
     let MI = try_!(Type::try_from(MI));
@@ -52,6 +54,7 @@ pub extern "C" fn opendp_meas__make_base_stability(
 
     let TOC = try_!(MI.get_sensitivity_distance());
     dispatch!(monomorphize, [
+        (TIC, @integers),
         (TOC, @floats)
     ], (n, scale, threshold, MI, TIK, TIC))
 }

--- a/rust/opendp-ffi/src/trans/cast.rs
+++ b/rust/opendp-ffi/src/trans/cast.rs
@@ -5,7 +5,7 @@ use opendp::core::DatasetMetric;
 use opendp::dist::{SubstituteDistance, SymmetricDistance};
 use opendp::dom::{InherentNull, AllDomain, VectorDomain};
 use opendp::err;
-use opendp::traits::{CastFrom, CheckNull};
+use opendp::traits::{RoundCast, CheckNull};
 use opendp::trans::{make_cast, make_cast_default, make_cast_inherent, make_cast_metric, DatasetMetricCast};
 
 use crate::any::AnyTransformation;
@@ -23,7 +23,7 @@ pub extern "C" fn opendp_trans__make_cast(
 
     fn monomorphize<TI, TO>() -> FfiResult<*mut AnyTransformation>
         where TI: 'static + Clone,
-              TO: 'static + CastFrom<TI> + CheckNull {
+              TO: 'static + RoundCast<TI> + CheckNull {
         make_cast::<TI, TO>().into_any()
     }
     dispatch!(monomorphize, [(TI, @primitives), (TO, @primitives)], ())
@@ -38,7 +38,7 @@ pub extern "C" fn opendp_trans__make_cast_default(
 
     fn monomorphize<TI, TO>() -> FfiResult<*mut AnyTransformation>
         where TI: 'static + Clone,
-              TO: 'static + CastFrom<TI> + Default {
+              TO: 'static + RoundCast<TI> + Default {
         make_cast_default::<TI, TO>().into_any()
     }
     dispatch!(monomorphize, [(TI, @primitives), (TO, @primitives)], ())
@@ -53,7 +53,7 @@ pub extern "C" fn opendp_trans__make_cast_inherent(
 
     fn monomorphize<TI, TO>() -> FfiResult<*mut AnyTransformation>
         where TI: 'static + Clone,
-              TO: 'static + CastFrom<TI> + InherentNull {
+              TO: 'static + RoundCast<TI> + InherentNull {
         make_cast_inherent::<TI, TO>().into_any()
     }
     dispatch!(monomorphize, [(TI, @primitives), (TO, @floats)], ())

--- a/rust/opendp-ffi/src/trans/clamp.rs
+++ b/rust/opendp-ffi/src/trans/clamp.rs
@@ -5,10 +5,10 @@ use std::os::raw::{c_char, c_void};
 use num::One;
 
 use opendp::core::{DatasetMetric, Metric};
-use opendp::dist::{SubstituteDistance, SymmetricDistance, AbsoluteDistance, L1Distance, L2Distance};
+use opendp::dist::{SubstituteDistance, SymmetricDistance, AbsoluteDistance, L1Distance, L2Distance, IntDistance};
 use opendp::dom::{AllDomain, VectorDomain, IntervalDomain};
 use opendp::err;
-use opendp::traits::{DistanceConstant};
+use opendp::traits::{DistanceConstant, InfCast};
 use opendp::trans::{ClampableDomain, make_clamp, make_unclamp, UnclampableDomain};
 
 use crate::any::AnyTransformation;
@@ -23,6 +23,18 @@ pub extern "C" fn opendp_trans__make_clamp(
     let DI = try_!(Type::try_from(DI));
     let DIA = try_!(DI.get_domain_atom());
     let M = try_!(Type::try_from(M));
+
+    // if MetricClass::Dataset = M.get_metric_class() {
+    //     return in here
+    // }
+    //
+    // if MetricClass::Senstivity = M.get_metric_class() {
+    //     return in here
+    // }
+    // unreachable!()
+
+
+
     match try_!(M.get_metric_class()) {
         MetricClass::Dataset => {
             fn monomorphize_dataset<T>(lower: *const c_void, upper: *const c_void) -> FfiResult<*mut AnyTransformation>
@@ -42,8 +54,9 @@ pub extern "C" fn opendp_trans__make_clamp(
                 lower: *const c_void, upper: *const c_void
             ) -> FfiResult<*mut AnyTransformation>
                 where AllDomain<T>: ClampableDomain<AbsoluteDistance<Q>, Atom=T>,
-                      Q: DistanceConstant + One,
-                      T: 'static + Clone + PartialOrd {
+                      Q: DistanceConstant<IntDistance> + One,
+                      T: 'static + Clone + PartialOrd,
+                      IntDistance: InfCast<Q> {
                 let lower = try_as_ref!(lower as *const T).clone();
                 let upper = try_as_ref!(upper as *const T).clone();
                 make_clamp::<AllDomain<T>, AbsoluteDistance<Q>>(lower, upper).into_any()
@@ -91,7 +104,7 @@ pub extern "C" fn opendp_trans__make_unclamp(
                 lower: *const c_void, upper: *const c_void, DI: Type, M: Type
             ) -> FfiResult<*mut AnyTransformation>
                 where IntervalDomain<T>: UnclampableDomain<Atom=T, Carrier=T>,
-                      Q: DistanceConstant + One,
+                      Q: DistanceConstant<Q> + One,
                       T: 'static + Clone + PartialOrd {
                 fn monomorphize_sensitivity_2<DI, M>(
                     lower: DI::Atom, upper: DI::Atom,
@@ -100,7 +113,7 @@ pub extern "C" fn opendp_trans__make_unclamp(
                           DI::Carrier: Clone,
                           M: 'static + Metric,
                           DI::Atom: 'static + Clone + PartialOrd,
-                          M::Distance: DistanceConstant + One {
+                          M::Distance: DistanceConstant<M::Distance> + One {
                     make_unclamp::<DI, M>(
                         Bound::Included(lower), Bound::Included(upper),
                     ).into_any()

--- a/rust/opendp-ffi/src/trans/clamp.rs
+++ b/rust/opendp-ffi/src/trans/clamp.rs
@@ -24,17 +24,6 @@ pub extern "C" fn opendp_trans__make_clamp(
     let DIA = try_!(DI.get_domain_atom());
     let M = try_!(Type::try_from(M));
 
-    // if MetricClass::Dataset = M.get_metric_class() {
-    //     return in here
-    // }
-    //
-    // if MetricClass::Senstivity = M.get_metric_class() {
-    //     return in here
-    // }
-    // unreachable!()
-
-
-
     match try_!(M.get_metric_class()) {
         MetricClass::Dataset => {
             fn monomorphize_dataset<T>(lower: *const c_void, upper: *const c_void) -> FfiResult<*mut AnyTransformation>

--- a/rust/opendp-ffi/src/trans/count.rs
+++ b/rust/opendp-ffi/src/trans/count.rs
@@ -9,7 +9,7 @@ use num::traits::FloatConst;
 use opendp::core::{SensitivityMetric};
 use opendp::dist::{L1Distance, L2Distance, IntDistance};
 use opendp::err;
-use opendp::traits::{DistanceConstant, MaxConsecutiveInt, InfCast, ExactCast};
+use opendp::traits::{DistanceConstant, InfCast, ExactIntCast};
 use opendp::trans::{CountByConstant, make_count, make_count_by, make_count_by_categories, make_count_distinct};
 
 use crate::any::{AnyObject, AnyTransformation};
@@ -24,7 +24,7 @@ pub extern "C" fn opendp_trans__make_count(
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<TIA, TO>() -> FfiResult<*mut AnyTransformation>
         where TIA: 'static,
-              TO: 'static + ExactCast<usize> + Bounded + One + DistanceConstant<IntDistance> + MaxConsecutiveInt,
+              TO: 'static + ExactIntCast<usize> + Bounded + One + DistanceConstant<IntDistance>,
               IntDistance: InfCast<TO> {
         make_count::<TIA, TO>().into_any()
     }
@@ -44,7 +44,7 @@ pub extern "C" fn opendp_trans__make_count_distinct(
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<TIA, TO: 'static>() -> FfiResult<*mut AnyTransformation>
         where TIA: 'static + Eq + Hash,
-              TO: 'static + ExactCast<usize> + Bounded + One + DistanceConstant<IntDistance> + MaxConsecutiveInt,
+              TO: 'static + ExactIntCast<usize> + Bounded + One + DistanceConstant<IntDistance>,
               IntDistance: InfCast<TO> {
         make_count_distinct::<TIA, TO>().into_any()
     }

--- a/rust/opendp-ffi/src/trans/count.rs
+++ b/rust/opendp-ffi/src/trans/count.rs
@@ -9,7 +9,7 @@ use num::traits::FloatConst;
 use opendp::core::{SensitivityMetric};
 use opendp::dist::{L1Distance, L2Distance, IntDistance};
 use opendp::err;
-use opendp::traits::{DistanceConstant, ExactCast, MaxConsecutiveInt, InfCast};
+use opendp::traits::{DistanceConstant, MaxConsecutiveInt, InfCast};
 use opendp::trans::{CountByConstant, make_count, make_count_by, make_count_by_categories, make_count_distinct};
 
 use crate::any::{AnyObject, AnyTransformation};
@@ -24,7 +24,7 @@ pub extern "C" fn opendp_trans__make_count(
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<TIA, TO>() -> FfiResult<*mut AnyTransformation>
         where TIA: 'static,
-              TO: 'static + ExactCast<usize> + Bounded + One + DistanceConstant<IntDistance> + MaxConsecutiveInt,
+              TO: 'static + TryFrom<usize> + Bounded + One + DistanceConstant<IntDistance> + MaxConsecutiveInt,
               IntDistance: InfCast<TO> {
         make_count::<TIA, TO>().into_any()
     }

--- a/rust/opendp-ffi/src/trans/count.rs
+++ b/rust/opendp-ffi/src/trans/count.rs
@@ -9,7 +9,7 @@ use num::traits::FloatConst;
 use opendp::core::{SensitivityMetric};
 use opendp::dist::{L1Distance, L2Distance, IntDistance};
 use opendp::err;
-use opendp::traits::{DistanceConstant, MaxConsecutiveInt, InfCast};
+use opendp::traits::{DistanceConstant, MaxConsecutiveInt, InfCast, ExactCast};
 use opendp::trans::{CountByConstant, make_count, make_count_by, make_count_by_categories, make_count_distinct};
 
 use crate::any::{AnyObject, AnyTransformation};
@@ -24,7 +24,7 @@ pub extern "C" fn opendp_trans__make_count(
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<TIA, TO>() -> FfiResult<*mut AnyTransformation>
         where TIA: 'static,
-              TO: 'static + TryFrom<usize> + Bounded + One + DistanceConstant<IntDistance> + MaxConsecutiveInt,
+              TO: 'static + ExactCast<usize> + Bounded + One + DistanceConstant<IntDistance> + MaxConsecutiveInt,
               IntDistance: InfCast<TO> {
         make_count::<TIA, TO>().into_any()
     }
@@ -44,7 +44,7 @@ pub extern "C" fn opendp_trans__make_count_distinct(
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<TIA, TO: 'static>() -> FfiResult<*mut AnyTransformation>
         where TIA: 'static + Eq + Hash,
-              TO: 'static + TryFrom<usize> + Bounded + One + DistanceConstant<IntDistance>,
+              TO: 'static + ExactCast<usize> + Bounded + One + DistanceConstant<IntDistance> + MaxConsecutiveInt,
               IntDistance: InfCast<TO> {
         make_count_distinct::<TIA, TO>().into_any()
     }

--- a/rust/opendp-ffi/src/trans/mean.rs
+++ b/rust/opendp-ffi/src/trans/mean.rs
@@ -6,7 +6,7 @@ use std::os::raw::{c_char, c_uint, c_void};
 use num::Float;
 
 use opendp::err;
-use opendp::traits::{DistanceConstant, InfCast, ExactCast};
+use opendp::traits::{DistanceConstant, InfCast, ExactIntCast};
 use opendp::trans::{make_bounded_mean};
 
 use crate::any::AnyTransformation;
@@ -20,7 +20,7 @@ pub extern "C" fn opendp_trans__make_bounded_mean(
     T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<T>(lower: *const c_void, upper: *const c_void, n: usize) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactCast<usize>,
+        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactIntCast<usize>,
               for<'a> T: Sum<&'a T>,
               IntDistance: InfCast<T> {
         let lower = *try_as_ref!(lower as *const T);

--- a/rust/opendp-ffi/src/trans/mean.rs
+++ b/rust/opendp-ffi/src/trans/mean.rs
@@ -6,12 +6,13 @@ use std::os::raw::{c_char, c_uint, c_void};
 use num::Float;
 
 use opendp::err;
-use opendp::traits::DistanceConstant;
+use opendp::traits::{DistanceConstant, InfCast, ExactCast};
 use opendp::trans::{make_bounded_mean};
 
 use crate::any::AnyTransformation;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::Type;
+use opendp::dist::IntDistance;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_bounded_mean(
@@ -19,8 +20,9 @@ pub extern "C" fn opendp_trans__make_bounded_mean(
     T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<T>(lower: *const c_void, upper: *const c_void, n: usize) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant + Sub<Output=T> + Float,
-              for<'a> T: Sum<&'a T> {
+        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactCast<usize>,
+              for<'a> T: Sum<&'a T>,
+              IntDistance: InfCast<T> {
         let lower = *try_as_ref!(lower as *const T);
         let upper = *try_as_ref!(upper as *const T);
         make_bounded_mean::<T>(lower, upper, n).into_any()

--- a/rust/opendp-ffi/src/trans/sum.rs
+++ b/rust/opendp-ffi/src/trans/sum.rs
@@ -4,12 +4,13 @@ use std::ops::Sub;
 use std::os::raw::{c_char, c_uint, c_void};
 
 use opendp::err;
-use opendp::traits::{Abs, DistanceConstant};
+use opendp::traits::{Abs, DistanceConstant, InfCast};
 use opendp::trans::{make_bounded_sum, make_bounded_sum_n};
 
 use crate::any::AnyTransformation;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::Type;
+use opendp::dist::IntDistance;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_bounded_sum(
@@ -19,7 +20,8 @@ pub extern "C" fn opendp_trans__make_bounded_sum(
     fn monomorphize<T>(
         lower: *const c_void, upper: *const c_void
     ) -> FfiResult<*mut AnyTransformation>
-        where for<'a> T: DistanceConstant + Sub<Output=T> + Abs + Sum<&'a T> {
+        where for<'a> T: DistanceConstant<IntDistance> + Sub<Output=T> + Abs + Sum<&'a T>,
+              IntDistance: InfCast<T> {
         let lower = try_as_ref!(lower as *const T).clone();
         let upper = try_as_ref!(upper as *const T).clone();
         make_bounded_sum::<T>(lower, upper).into_any()
@@ -36,8 +38,9 @@ pub extern "C" fn opendp_trans__make_bounded_sum_n(
     T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<T>(lower: *const c_void, upper: *const c_void, n: usize) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant + Sub<Output=T>,
-              for<'a> T: Sum<&'a T> {
+        where T: DistanceConstant<IntDistance> + Sub<Output=T>,
+              for<'a> T: Sum<&'a T>,
+              IntDistance: InfCast<T> {
         let lower = try_as_ref!(lower as *const T).clone();
         let upper = try_as_ref!(upper as *const T).clone();
         make_bounded_sum_n::<T>(lower, upper, n).into_any()

--- a/rust/opendp-ffi/src/trans/variance.rs
+++ b/rust/opendp-ffi/src/trans/variance.rs
@@ -6,12 +6,13 @@ use std::os::raw::{c_char, c_uint, c_void};
 use num::{Float, One, Zero};
 
 use opendp::err;
-use opendp::traits::DistanceConstant;
+use opendp::traits::{DistanceConstant, InfCast, ExactCast};
 use opendp::trans::{make_bounded_covariance, make_bounded_variance};
 
 use crate::any::{AnyObject, AnyTransformation, Downcast};
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::Type;
+use opendp::dist::IntDistance;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_bounded_variance(
@@ -22,8 +23,9 @@ pub extern "C" fn opendp_trans__make_bounded_variance(
     fn monomorphize2<T>(
         lower: *const c_void, upper: *const c_void, length: usize, ddof: usize,
     ) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant + Float + for<'a> Sum<&'a T> + Sum<T>,
-              for<'a> &'a T: Sub<Output=T> + Add<&'a T, Output=T> {
+        where T: DistanceConstant<IntDistance> + Float + for<'a> Sum<&'a T> + Sum<T> + ExactCast<usize>,
+              for<'a> &'a T: Sub<Output=T> + Add<&'a T, Output=T>,
+              IntDistance: InfCast<T> {
         let lower = *try_as_ref!(lower as *const T);
         let upper = *try_as_ref!(upper as *const T);
         make_bounded_variance::<T>(lower, upper, length, ddof).into_any()
@@ -50,9 +52,10 @@ pub extern "C" fn opendp_trans__make_bounded_covariance(
         upper: *const AnyObject,
         length: usize, ddof: usize,
     ) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant + Sub<Output=T> + Sum<T> + Zero + One,
+        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Sum<T> + Zero + One + ExactCast<usize>,
               for<'a> T: Div<&'a T, Output=T> + Add<&'a T, Output=T>,
-              for<'a> &'a T: Sub<Output=T> {
+              for<'a> &'a T: Sub<Output=T>,
+              IntDistance: InfCast<T> {
         let lower = try_!(try_as_ref!(lower).downcast_ref::<(T, T)>()).clone();
         let upper = try_!(try_as_ref!(upper).downcast_ref::<(T, T)>()).clone();
         make_bounded_covariance::<T>(lower, upper, length, ddof).into_any()

--- a/rust/opendp-ffi/src/trans/variance.rs
+++ b/rust/opendp-ffi/src/trans/variance.rs
@@ -6,7 +6,7 @@ use std::os::raw::{c_char, c_uint, c_void};
 use num::{Float, One, Zero};
 
 use opendp::err;
-use opendp::traits::{DistanceConstant, InfCast, ExactCast};
+use opendp::traits::{DistanceConstant, InfCast, ExactIntCast};
 use opendp::trans::{make_bounded_covariance, make_bounded_variance};
 
 use crate::any::{AnyObject, AnyTransformation, Downcast};
@@ -23,7 +23,7 @@ pub extern "C" fn opendp_trans__make_bounded_variance(
     fn monomorphize2<T>(
         lower: *const c_void, upper: *const c_void, length: usize, ddof: usize,
     ) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Float + for<'a> Sum<&'a T> + Sum<T> + ExactCast<usize>,
+        where T: DistanceConstant<IntDistance> + Float + for<'a> Sum<&'a T> + Sum<T> + ExactIntCast<usize>,
               for<'a> &'a T: Sub<Output=T> + Add<&'a T, Output=T>,
               IntDistance: InfCast<T> {
         let lower = *try_as_ref!(lower as *const T);
@@ -52,7 +52,7 @@ pub extern "C" fn opendp_trans__make_bounded_covariance(
         upper: *const AnyObject,
         length: usize, ddof: usize,
     ) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Sum<T> + Zero + One + ExactCast<usize>,
+        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Sum<T> + Zero + One + ExactIntCast<usize>,
               for<'a> T: Div<&'a T, Output=T> + Add<&'a T, Output=T>,
               for<'a> &'a T: Sub<Output=T>,
               IntDistance: InfCast<T> {

--- a/rust/opendp-ffi/src/util.rs
+++ b/rust/opendp-ffi/src/util.rs
@@ -120,7 +120,13 @@ impl Type {
     }
 }
 
-// Convert `[A B C] i8` to `A<B<C<i8>>`
+// Convert `[A B C] i8` -> `A<B<C<i8>>`
+// 1. Reverse the array:
+// `[A B C] [] i8` -> `[B C] [A] i8` -> `[C] [B A] i8` -> `[] [C B A] i8` ->
+// 2. Recursively peel the first element off the reversed array:
+// `[] [B A] C<i8>` -> `[] [A] B<C<i8>>` ->
+// 3. The final step drops the leading arrays:
+// `A<B<C<i8>>`
 macro_rules! nest {
     ([$($all:tt)*] $arg:ty) => (nest!(@[$($all)*] [] $arg));
 

--- a/rust/opendp/src/dist.rs
+++ b/rust/opendp/src/dist.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 use crate::core::{DatasetMetric, Measure, Metric, SensitivityMetric};
 
 // default type for distances between datasets
-pub type IntDistance = u16;
+pub type IntDistance = u32;
 
 /// Measures
 #[derive(Clone)]

--- a/rust/opendp/src/dist.rs
+++ b/rust/opendp/src/dist.rs
@@ -4,6 +4,9 @@ use std::marker::PhantomData;
 
 use crate::core::{DatasetMetric, Measure, Metric, SensitivityMetric};
 
+// default type for distances between datasets
+pub type IntDistance = u16;
+
 /// Measures
 #[derive(Clone)]
 pub struct MaxDivergence<Q>(PhantomData<Q>);
@@ -45,9 +48,8 @@ impl Default for SymmetricDistance {
 impl PartialEq for SymmetricDistance {
     fn eq(&self, _other: &Self) -> bool { true }
 }
-
 impl Metric for SymmetricDistance {
-    type Distance = u32;
+    type Distance = IntDistance;
 }
 
 impl DatasetMetric for SymmetricDistance {}
@@ -64,7 +66,7 @@ impl PartialEq for SubstituteDistance {
 }
 
 impl Metric for SubstituteDistance {
-    type Distance = u32;
+    type Distance = IntDistance;
 }
 
 impl DatasetMetric for SubstituteDistance {}

--- a/rust/opendp/src/lib.rs
+++ b/rust/opendp/src/lib.rs
@@ -138,9 +138,6 @@ macro_rules! enclose {
         }
     };
 }
-macro_rules! num_cast {
-    ($v:expr; $ty:ty) => (<$ty as num::NumCast>::from($v).ok_or_else(|| err!(FailedCast)))
-}
 
 #[macro_use]
 pub mod error;

--- a/rust/opendp/src/meas/gaussian.rs
+++ b/rust/opendp/src/meas/gaussian.rs
@@ -5,14 +5,15 @@ use crate::dist::{L2Distance, SmoothedMaxDivergence, AbsoluteDistance};
 use crate::dom::{AllDomain, VectorDomain};
 use crate::error::*;
 use crate::samplers::SampleGaussian;
+use crate::traits::InfCast;
 
 // const ADDITIVE_GAUSS_CONST: f64 = 8. / 9. + (2. / PI).ln();
 const ADDITIVE_GAUSS_CONST: f64 = 0.4373061836;
 
-fn make_gaussian_privacy_relation<T: 'static + Clone + SampleGaussian + Float, MI: SensitivityMetric<Distance=T>>(scale: T) -> PrivacyRelation<MI, SmoothedMaxDivergence<T>> {
+fn make_gaussian_privacy_relation<T: 'static + Clone + SampleGaussian + Float + InfCast<f64>, MI: SensitivityMetric<Distance=T>>(scale: T) -> PrivacyRelation<MI, SmoothedMaxDivergence<T>> {
     PrivacyRelation::new_fallible(move |&d_in: &T, &(eps, del): &(T, T)| {
-        let _2 = num_cast!(2.; T)?;
-        let additive_gauss_const = num_cast!(ADDITIVE_GAUSS_CONST; T)?;
+        let _2 = T::inf_cast(2.)?;
+        let additive_gauss_const = T::inf_cast(ADDITIVE_GAUSS_CONST)?;
 
         if d_in.is_sign_negative() {
             return fallible!(InvalidDistance, "gaussian mechanism: input sensitivity must be non-negative")
@@ -65,7 +66,7 @@ impl<T> GaussianDomain for VectorDomain<AllDomain<T>>
 
 pub fn make_base_gaussian<D>(scale: D::Atom) -> Fallible<Measurement<D, D, D::Metric, SmoothedMaxDivergence<D::Atom>>>
     where D: GaussianDomain,
-          D::Atom: 'static + Clone + SampleGaussian + Float {
+          D::Atom: 'static + Clone + SampleGaussian + Float + InfCast<f64> {
     if scale.is_sign_negative() {
         return fallible!(MakeMeasurement, "scale must not be negative")
     }

--- a/rust/opendp/src/meas/gaussian.rs
+++ b/rust/opendp/src/meas/gaussian.rs
@@ -7,10 +7,12 @@ use crate::error::*;
 use crate::samplers::SampleGaussian;
 use crate::traits::InfCast;
 
-// const ADDITIVE_GAUSS_CONST: f64 = 8. / 9. + (2. / PI).ln();
+// const ADDITIVE_GAUSS_CONST: f64 = 8. / 9. + (2. / std::f64::consts::PI).ln();
 const ADDITIVE_GAUSS_CONST: f64 = 0.4373061836;
 
-fn make_gaussian_privacy_relation<T: 'static + Clone + SampleGaussian + Float + InfCast<f64>, MI: SensitivityMetric<Distance=T>>(scale: T) -> PrivacyRelation<MI, SmoothedMaxDivergence<T>> {
+fn make_gaussian_privacy_relation<T, MI>(scale: T) -> PrivacyRelation<MI, SmoothedMaxDivergence<T>>
+    where T: 'static + Clone + SampleGaussian + Float + InfCast<f64>,
+          MI: SensitivityMetric<Distance=T> {
     PrivacyRelation::new_fallible(move |&d_in: &T, &(eps, del): &(T, T)| {
         let _2 = T::inf_cast(2.)?;
         let additive_gauss_const = T::inf_cast(ADDITIVE_GAUSS_CONST)?;

--- a/rust/opendp/src/meas/geometric.rs
+++ b/rust/opendp/src/meas/geometric.rs
@@ -3,8 +3,8 @@ use crate::dist::{MaxDivergence, L1Distance, AbsoluteDistance};
 use crate::dom::{AllDomain, VectorDomain};
 use crate::error::*;
 use crate::samplers::SampleTwoSidedGeometric;
-use crate::traits::DistanceCast;
 use num::Float;
+use crate::traits::{DistanceConstant, InfCast};
 
 
 pub trait GeometricDomain: Domain {
@@ -46,8 +46,8 @@ pub fn make_base_geometric<D, QO>(
     scale: QO, bounds: Option<(D::Atom, D::Atom)>
 ) -> Fallible<Measurement<D, D, D::InputMetric, MaxDivergence<QO>>>
     where D: 'static + GeometricDomain,
-          D::Atom: 'static + DistanceCast + PartialOrd,
-          QO: 'static + Float + DistanceCast,
+          D::Atom: 'static + PartialOrd + Clone + InfCast<QO>,
+          QO: 'static + Float + DistanceConstant<D::Atom>,
           f64: From<QO> {
     if scale.is_sign_negative() { return fallible!(MakeMeasurement, "scale must not be negative") }
     if bounds.as_ref().map(|(lower, upper)| lower > upper).unwrap_or(false) {

--- a/rust/opendp/src/meas/laplace.rs
+++ b/rust/opendp/src/meas/laplace.rs
@@ -5,7 +5,7 @@ use crate::dist::{L1Distance, MaxDivergence, AbsoluteDistance};
 use crate::dom::{AllDomain, VectorDomain};
 use crate::samplers::{SampleLaplace};
 use crate::error::*;
-use crate::traits::DistanceCast;
+use crate::traits::{InfCast};
 
 pub trait LaplaceDomain: Domain {
     type Metric: SensitivityMetric<Distance=Self::Atom> + Default;
@@ -15,7 +15,7 @@ pub trait LaplaceDomain: Domain {
 }
 
 impl<T> LaplaceDomain for AllDomain<T>
-    where T: 'static + SampleLaplace + Float + DistanceCast {
+    where T: 'static + SampleLaplace + Float {
     type Metric = AbsoluteDistance<T>;
     type Atom = Self::Carrier;
 
@@ -26,7 +26,7 @@ impl<T> LaplaceDomain for AllDomain<T>
 }
 
 impl<T> LaplaceDomain for VectorDomain<AllDomain<T>>
-    where T: 'static + SampleLaplace + Float + DistanceCast {
+    where T: 'static + SampleLaplace + Float {
     type Metric = L1Distance<T>;
     type Atom = T;
 
@@ -40,7 +40,7 @@ impl<T> LaplaceDomain for VectorDomain<AllDomain<T>>
 
 pub fn make_base_laplace<D>(scale: D::Atom) -> Fallible<Measurement<D, D, D::Metric, MaxDivergence<D::Atom>>>
     where D: LaplaceDomain,
-          D::Atom: 'static + Clone + SampleLaplace + Float + DistanceCast {
+          D::Atom: 'static + Clone + SampleLaplace + Float + InfCast<D::Atom> {
     if scale.is_sign_negative() {
         return fallible!(MakeMeasurement, "scale must not be negative")
     }

--- a/rust/opendp/src/meas/stability.rs
+++ b/rust/opendp/src/meas/stability.rs
@@ -8,7 +8,7 @@ use crate::dist::{L1Distance, L2Distance, SmoothedMaxDivergence};
 use crate::dom::{AllDomain, MapDomain, SizedDomain};
 use crate::samplers::{SampleLaplace, SampleGaussian};
 use crate::error::Fallible;
-use crate::traits::{ExactCast, MaxConsecutiveInt};
+use crate::traits::{ExactIntCast, MaxConsecutiveInt};
 
 // TIK: Type of Input Key
 // TIC: Type of Input Count
@@ -37,15 +37,15 @@ pub fn make_base_stability<MI, TIK, TIC>(
     where MI: BaseStabilityNoise,
           TIK: Eq + Hash + Clone,
           TIC: Integer + Clone,
-          MI::Distance: 'static + Float + Clone + PartialOrd + ExactCast<usize> + ExactCast<TIC> + MaxConsecutiveInt {
+          MI::Distance: 'static + Float + Clone + PartialOrd + ExactIntCast<usize> + ExactIntCast<TIC> {
     if scale.is_sign_negative() {
         return fallible!(MakeMeasurement, "scale must not be negative")
     }
     if threshold.is_sign_negative() {
         return fallible!(MakeMeasurement, "threshold must not be negative")
     }
-    let _n = MI::Distance::exact_cast(n)?;
-    let _2 = MI::Distance::exact_cast(2)?;
+    let _n = MI::Distance::exact_int_cast(n)?;
+    let _2 = MI::Distance::exact_int_cast(2)?;
 
     Ok(Measurement::new(
         SizedDomain::new(MapDomain { key_domain: AllDomain::new(), value_domain: AllDomain::new() }, n),
@@ -54,7 +54,7 @@ pub fn make_base_stability<MI, TIK, TIC>(
             data.iter()
                 .map(|(k, c_in)| {
                     // cast the value to MI::Distance (output count)
-                    let c_out = MI::Distance::exact_cast(c_in.clone()).unwrap_or(MI::Distance::MAX_CONSECUTIVE);
+                    let c_out = MI::Distance::exact_int_cast(c_in.clone()).unwrap_or(MI::Distance::MAX_CONSECUTIVE);
                     // noise output count
                     Ok((k.clone(), MI::noise(c_out, scale, false)?))
                 })

--- a/rust/opendp/src/meas/stability.rs
+++ b/rust/opendp/src/meas/stability.rs
@@ -8,7 +8,7 @@ use crate::dist::{L1Distance, L2Distance, SmoothedMaxDivergence};
 use crate::dom::{AllDomain, MapDomain, SizedDomain};
 use crate::samplers::{SampleLaplace, SampleGaussian};
 use crate::error::Fallible;
-use crate::traits::{ExactIntCast, BoundedInt};
+use crate::traits::{ExactIntCast, ExactIntBounds};
 
 // TIK: Type of Input Key
 // TIC: Type of Input Count

--- a/rust/opendp/src/meas/stability.rs
+++ b/rust/opendp/src/meas/stability.rs
@@ -8,7 +8,7 @@ use crate::dist::{L1Distance, L2Distance, SmoothedMaxDivergence};
 use crate::dom::{AllDomain, MapDomain, SizedDomain};
 use crate::samplers::{SampleLaplace, SampleGaussian};
 use crate::error::Fallible;
-use crate::traits::{ExactIntCast, MaxConsecutiveInt};
+use crate::traits::{ExactIntCast, BoundedInt};
 
 // TIK: Type of Input Key
 // TIC: Type of Input Count

--- a/rust/opendp/src/meas/stability.rs
+++ b/rust/opendp/src/meas/stability.rs
@@ -1,13 +1,14 @@
 use std::collections::HashMap;
 use std::hash::Hash;
 
-use num::{Integer, Float, NumCast, Zero};
+use num::{Integer, Float, Zero};
 
 use crate::core::{Measurement, Function, PrivacyRelation, SensitivityMetric};
 use crate::dist::{L1Distance, L2Distance, SmoothedMaxDivergence};
 use crate::dom::{AllDomain, MapDomain, SizedDomain};
 use crate::samplers::{SampleLaplace, SampleGaussian};
 use crate::error::Fallible;
+use crate::traits::{ExactCast, MaxConsecutiveInt};
 
 // TIK: Type of Input Key
 // TIC: Type of Input Count
@@ -35,16 +36,16 @@ pub fn make_base_stability<MI, TIK, TIC>(
 ) -> Fallible<Measurement<CountDomain<TIK, TIC>, CountDomain<TIK, MI::Distance>, MI, SmoothedMaxDivergence<MI::Distance>>>
     where MI: BaseStabilityNoise,
           TIK: Eq + Hash + Clone,
-          TIC: Integer + Clone + NumCast,
-          MI::Distance: 'static + Float + Clone + PartialOrd + NumCast {
+          TIC: Integer + Clone,
+          MI::Distance: 'static + Float + Clone + PartialOrd + ExactCast<usize> + ExactCast<TIC> + MaxConsecutiveInt {
     if scale.is_sign_negative() {
         return fallible!(MakeMeasurement, "scale must not be negative")
     }
     if threshold.is_sign_negative() {
         return fallible!(MakeMeasurement, "threshold must not be negative")
     }
-    let _n = num_cast!(n; MI::Distance)?;
-    let _2 = num_cast!(2; MI::Distance)?;
+    let _n = MI::Distance::exact_cast(n)?;
+    let _2 = MI::Distance::exact_cast(2)?;
 
     Ok(Measurement::new(
         SizedDomain::new(MapDomain { key_domain: AllDomain::new(), value_domain: AllDomain::new() }, n),
@@ -53,7 +54,7 @@ pub fn make_base_stability<MI, TIK, TIC>(
             data.iter()
                 .map(|(k, c_in)| {
                     // cast the value to MI::Distance (output count)
-                    let c_out = num_cast!(c_in.clone(); MI::Distance)?;
+                    let c_out = MI::Distance::exact_cast(c_in.clone()).unwrap_or(MI::Distance::MAX_CONSECUTIVE);
                     // noise output count
                     Ok((k.clone(), MI::noise(c_out, scale, false)?))
                 })

--- a/rust/opendp/src/traits.rs
+++ b/rust/opendp/src/traits.rs
@@ -1,53 +1,22 @@
+use std::convert::TryFrom;
 use std::ops::{Div, Mul, Sub};
 
-use num::{NumCast, One, ToPrimitive, Zero};
+use num::{NumCast, One, Zero};
 
 use crate::error::Fallible;
-
-pub trait CheckContinuous { fn is_continuous() -> bool; }
-pub trait Ceil: Clone { fn ceil(self) -> Self; }
-macro_rules! impl_is_continuous {
-    ($($ty:ty),+) => {
-        $(
-            impl Ceil for $ty {
-                #[inline]
-                fn ceil(self) -> $ty { self.ceil() }
-            }
-            impl CheckContinuous for $ty {
-                #[inline]
-                fn is_continuous() -> bool {true}
-            }
-        )+
-    }
-}
-macro_rules! impl_is_not_continuous {
-    ($($ty:ty),+) => {
-        $(
-            impl Ceil for $ty {
-                #[inline]
-                fn ceil(self) -> $ty { self }
-            }
-            impl CheckContinuous for $ty {
-                #[inline]
-                fn is_continuous() -> bool {false}
-            }
-        )+
-    }
-}
-impl_is_continuous!(f32, f64);
-impl_is_not_continuous!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, isize, usize);
 
 /// A type that can be used as a stability or privacy constant to scale a distance.
 /// Encapsulates the necessary traits for the new_from_constant method on relations.
 /// Making a relation from a constant has the general form
 ///     d_out >= QO::distance_cast(d_in) * c    (where d_out and c have type QO: DistanceConstant)
 /// Computing this needs all of the traits DistanceConstant inherits from:
-/// - DistanceCast: casting where the distance after the cast is gte the distance before the cast
+/// - InfCast<QI>: casting where the distance after the cast is gte the distance before the cast
 /// - QO also clearly needs to support Mul and PartialOrd used in the general form above.
 /// - Div is used for the backward map:
 ///     How do you translate d_out to a d_in that can be used as a hint? |d_out| d_out / c
-pub trait DistanceConstant: 'static + Clone + DistanceCast + Div<Output=Self> + Mul<Output=Self> + PartialOrd {}
-impl<T: 'static + Clone + DistanceCast + Div<Output=Self> + Mul<Output=Self> + PartialOrd> DistanceConstant for T {}
+pub trait DistanceConstant<TI>: 'static + Clone + InfCast<TI> + Div<Output=Self> + Mul<Output=Self> + PartialOrd
+    where TI: InfCast<Self> {}
+impl<TI: InfCast<Self>, TO: 'static + Clone + InfCast<TI> + Div<Output=Self> + Mul<Output=Self> + PartialOrd> DistanceConstant<TI> for TO {}
 
 // TODO: Maybe this should be renamed to something more specific to budgeting, and add negative checks? -Mike
 pub trait FallibleSub<Rhs = Self> {
@@ -89,21 +58,6 @@ impl<T> MeasureDistance for T where T: PartialOrd + for<'a> FallibleSub<&'a Self
 pub trait MetricDistance: PartialOrd {}
 impl<T> MetricDistance for T where T: PartialOrd {}
 
-/// Fallible casting on distances where the casted value is gte the original value.
-/// The trait is unspecified for negative values.
-/// For example, casting a 128_u8 to i8 shouldn't saturate to i8::MAX (127),
-///         it should error and fail the relation.
-pub trait DistanceCast: NumCast + Ceil + CheckContinuous {
-    fn distance_cast<T: ToPrimitive + Ceil>(n: T) -> Fallible<Self>;
-}
-
-impl<QO: ToPrimitive + NumCast + CheckContinuous + Ceil> DistanceCast for QO {
-    fn distance_cast<QI: ToPrimitive + Ceil>(v: QI) -> Fallible<QO> {
-        // round away from zero when losing precision
-        QO::from(if QO::is_continuous() { v } else { v.ceil() }).ok_or_else(|| err!(FailedCast))
-    }
-}
-
 
 pub trait Abs { fn abs(self) -> Self; }
 macro_rules! impl_abs_method {
@@ -130,95 +84,265 @@ macro_rules! impl_abs_int {
 impl_abs_int!(i8, i16, i32, i64, i128);
 
 // https://docs.google.com/spreadsheets/d/1DJohiOI3EVHjwj8g4IEdFZVf7MMyFk_4oaSyjTfkO_0/edit?usp=sharing
-pub trait CastFrom<TI>: Sized {
-    fn cast(v: TI) -> Fallible<Self>;
+macro_rules! cartesian {
+    // base case
+    (@[$(($a1:tt, $a2:tt))*] [] $b:tt $init_b:tt $submacro:tt) =>
+        ($($submacro!{$a1, $a2})*);
+    // when b empty, strip off an "a" and refill b from init_b
+    (@$out:tt [$a:tt, $($at:tt)*] [] $init_b:tt $submacro:tt) =>
+        (cartesian!{@$out [$($at)*] $init_b $init_b $submacro});
+    // strip off a "b" and add a pair to $out that consists of the first "a" and first "b"
+    (@[$($out:tt)*] [$a:tt, $($at:tt)*] [$b:tt, $($bt:tt)*] $init_b:tt $submacro:tt) =>
+        (cartesian!{@[$($out)* ($a, $b)] [$a, $($at)*] [$($bt)*] $init_b $submacro});
+
+    // recurse down diagonal
+    (@diag[$($start_a:tt),*], [$mid_a:tt, $($end_a:tt),*], [$($start_b:tt),*], [$mid_b:tt, $($end_b:tt),*], $lower:tt, $diag:tt, $upper:tt) => {
+        $($lower!($mid_a, $start_b);)*
+        $diag!($mid_a, $mid_b);
+        $($upper!($mid_a, $end_b);)*
+        cartesian!{@diag[$($start_a,)* $mid_a], [$($end_a),*], [$($start_b,)* $mid_b], [$($end_b),*], $lower, $diag, $upper}
+    };
+    // base case, last element on the diagonal
+    (@diag[$($start_a:tt),*], [$last_a:tt], [$($start_b:tt),*], [$last_b:tt], $lower:tt, $diag:tt, $upper:tt) => {
+        $($lower!($last_a, $start_b);)*
+        $diag!($last_a, $last_b);
+    };
+
+    // friendly public interface
+    // execute submacro on each member of the cartesian product of a and b
+    ([$($a:tt)*], [$($b:tt)*], $submacro:tt) =>
+        (cartesian!{@[] [$($a)*,] [$($b)*,] [$($b)*,] $submacro});
+    ([$($a:tt)*], $submacro:tt) =>
+        (cartesian!{@[] [$($a)*,] [$($a)*,] [$($a)*,] $submacro});
+    // execute lower, diag and upper on the respective regions of the cartesian product of a and b
+    ([$($a:tt)*], [$($b:tt)*], $lower:tt, $diag:tt, $upper:tt) =>
+        (cartesian!{@diag[], [$($a)*], [], [$($b)*], $lower, $diag, $upper});
+    ([$($a:tt)*], $lower:tt, $diag:tt, $upper:tt) =>
+        (cartesian!{@diag[], [$($a)*], [], [$($a)*], $lower, $diag, $upper});
 }
-macro_rules! impl_num_cast {
+
+/// Fallible casting where the casted value is equal to the original value.
+pub trait ExactCast<TI>: Sized {
+    fn exact_cast(v: TI) -> Fallible<Self>;
+}
+macro_rules! impl_exact_cast_from {
+    ($ti:ty, $to:ty) => (impl ExactCast<$ti> for $to {
+        #[inline]
+        fn exact_cast(v: $ti) -> Fallible<Self> {Ok(From::from(v))}
+    })
+}
+macro_rules! impl_exact_cast_try_from {
+    ($ti:ty, $to:ty) => (impl ExactCast<$ti> for $to {
+        fn exact_cast(v: $ti) -> Fallible<Self> {
+            TryFrom::try_from(v).map_err(|e| err!(FailedCast, "{:?}", e))
+        }
+    })
+}
+// top left
+cartesian!{[u8, u16, u32, u64, u128], impl_exact_cast_try_from, impl_exact_cast_from, impl_exact_cast_from}
+// top right
+cartesian!([u8, u16, u32, u64, u128], [i8, i16, i32, i64, i128], impl_exact_cast_try_from, impl_exact_cast_try_from, impl_exact_cast_from);
+// bottom left
+cartesian!([i8, i16, i32, i64, i128], [u8, u16, u32, u64, u128], impl_exact_cast_try_from);
+// bottom right
+cartesian!{[i8, i16, i32, i64, i128], impl_exact_cast_try_from, impl_exact_cast_from, impl_exact_cast_from}
+
+macro_rules! impl_exact_cast_int_float {
+    ($int:ty, $float:ty) => (impl ExactCast<$int> for $float {
+        fn exact_cast(v_int: $int) -> Fallible<Self> {
+            let v_float = v_int as $float;
+            if <$float>::MAX_CONSECUTIVE < v_float {
+                fallible!(FailedCast, "exact_cast: integer is greater than the max consecutive integer and may be subject to rounding")
+            } else {
+                Ok(v_float)
+            }
+        }
+    })
+}
+
+cartesian!([u8, u16, i8, i16], [f32, f64], impl_exact_cast_from);
+cartesian!([u64, u128, i64, i128, usize], [f32, f64], impl_exact_cast_int_float);
+impl_exact_cast_int_float!(u32, f32);
+impl_exact_cast_from!(u32, f64);
+impl_exact_cast_int_float!(i32, f32);
+impl_exact_cast_from!(i32, f64);
+
+cartesian!([usize], [u8, u16, u32, u64, u128, i8, i16, i32, i64, i128], impl_exact_cast_try_from);
+
+/// Fallible casting where the casted value rounds towards infinity.
+/// This preserves the invariant that the casted value is gte the original value.
+/// For example, casting a 128_u8 to i8 doesn't saturate to i8::MAX (127), it errors.
+pub trait InfCast<TI>: Sized {
+    fn inf_cast(v: TI) -> Fallible<Self>;
+}
+
+macro_rules! impl_inf_cast_exact {
+    ($ti:ty, $to:ty) => (impl InfCast<$ti> for $to {
+        fn inf_cast(v: $ti) -> Fallible<Self> { ExactCast::exact_cast(v) }
+    })
+}
+cartesian!([u8, u16, u32, u64, u128, i8, i16, i32, i64, i128], impl_inf_cast_exact);
+
+
+macro_rules! impl_inf_cast_from {
+    ($ti:ty, $to:ty) => (impl InfCast<$ti> for $to {
+        #[inline]
+        fn inf_cast(v: $ti) -> Fallible<Self> { Ok(From::from(v)) }
+    })
+}
+
+pub trait MaxConsecutiveInt {
+    const MAX_CONSECUTIVE: Self;
+}
+macro_rules! impl_max_cons_int {
+    ($($ty:ty),*) => ($(impl MaxConsecutiveInt for $ty {const MAX_CONSECUTIVE: Self = Self::MAX;})*)
+}
+impl_max_cons_int!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize);
+impl MaxConsecutiveInt for f64 {
+    const MAX_CONSECUTIVE: Self = 9_007_199_254_740_992.0;
+}
+impl MaxConsecutiveInt for f32 {
+    const MAX_CONSECUTIVE: Self = 16_777_216.0;
+}
+
+macro_rules! impl_inf_cast_int_float {
+    ($int:ty, $float:ty) => (impl InfCast<$int> for $float {
+        fn inf_cast(v_int: $int) -> Fallible<Self> {
+            let v_float = v_int as $float;
+            Ok(if v_int > v_float as $int { <$float>::from_bits(v_float.to_bits() + 1) } else { v_float })
+        }
+    })
+}
+
+cartesian!([u8, u16, i8, i16], [f32, f64], impl_inf_cast_from);
+cartesian!([u64, u128, i64, i128], [f32, f64], impl_inf_cast_int_float);
+impl_inf_cast_int_float!(u32, f32);
+impl_inf_cast_from!(u32, f64);
+impl_inf_cast_int_float!(i32, f32);
+impl_inf_cast_from!(i32, f64);
+
+impl_inf_cast_from!(f32, f32);
+impl_inf_cast_from!(f32, f64);
+impl InfCast<f64> for f32 {
+    fn inf_cast(vf64: f64) -> Fallible<Self> {
+        let vf32 = vf64 as f32;
+        Ok(if vf64 > vf32 as f64 { f32::from_bits(vf32.to_bits() + 1) } else { vf32 })
+    }
+}
+impl_inf_cast_from!(f64, f64);
+
+macro_rules! impl_inf_cast_float_int {
+    ($ti:ty, $to:ty) => (impl InfCast<$ti> for $to {
+        fn inf_cast(mut v: $ti) -> Fallible<Self> {
+            v = v.ceil();
+            if (Self::MAX as $ti) < v {
+                fallible!(FailedCast, "Failed to cast float to int. Float is too large to represent as int.")
+            } else {
+                Ok(v as Self)
+            }
+        }
+    })
+}
+cartesian!([f32, f64], [u8, u16, u32, u64, u128, i8, i16, i32, i64, i128], impl_inf_cast_float_int);
+
+#[cfg(test)]
+mod test_inf_cast {
+    use crate::traits::InfCast;
+
+    enum Diff { Equal, Prev, Next, Less, Greater }
+
+    fn check_rounded_cast(input: f64, diff: Diff) {
+        let casted = f32::inf_cast(input).unwrap() as f64;
+        if input.is_nan() { assert!(casted.is_nan()); return }
+
+        let error = match diff {
+            Diff::Equal => (casted != input)
+                .then(|| "casted value must be equal to input"),
+            Diff::Greater => (casted <= input)
+                .then(|| "casted value must be greater than input value"),
+            Diff::Less => (casted >= input)
+                .then(|| "casted value must be less than input value"),
+            Diff::Next => (f64::from_bits(input.to_bits() + 1) != casted)
+                .then(|| "casted must be one step greater than input"),
+            Diff::Prev => (f64::from_bits(input.to_bits() - 1) != casted)
+                .then(|| "casted must be one step less than input"),
+        };
+        if let Some(message) = error {
+            println!("bits      {:064b}", input.to_bits());
+            println!("input     {}", input);
+            println!("output    {}", casted);
+            panic!("{}", message)
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn test_f64_f32() {
+        check_rounded_cast(0., Diff::Equal);
+        // check that the f64 one step above zero casts to a value that is greater
+        check_rounded_cast(f64::MIN_POSITIVE, Diff::Greater);
+        // check that the f64 one step below 2 casts to exactly 2
+        check_rounded_cast(1.9999999999999998, Diff::Next);
+        // for each non-negative, nonzero f32
+        for u32_bits in 1..u32::MAX / 2 {
+            let f64_value = f32::from_bits(u32_bits) as f64;
+            let u64_bits = f64_value.to_bits();
+
+            if u32_bits % 100_000_000 == 0 {
+                println!("checkpoint every 300 million tests: {}", f64_value);
+            }
+            // check that the f64 equivalent to the current f32 casts to a value that is equivalent
+            check_rounded_cast(f64_value, Diff::Equal);
+            // check that the f64 one step below the f64 equivalent to the current f32 casts to a value that is one step greater
+            check_rounded_cast(f64::from_bits(u64_bits - 1), Diff::Next);
+            // check that the f64 one step above the f64 equivalent to the current f32 casts to a value that is greater
+            check_rounded_cast(f64::from_bits(u64_bits + 1), Diff::Greater);
+        }
+    }
+}
+pub trait RoundCast<TI>: Sized {
+    fn round_cast(v: TI) -> Fallible<Self>;
+}
+macro_rules! impl_round_cast_num {
     ($TI:ty, $TO:ty) => {
-        impl CastFrom<$TI> for $TO {
-            fn cast(v: $TI) -> Fallible<Self> {
+        impl RoundCast<$TI> for $TO {
+            fn round_cast(v: $TI) -> Fallible<Self> {
                 <$TO as NumCast>::from(v).ok_or_else(|| err!(FailedCast))
             }
         }
     }
 }
-macro_rules! impl_self_cast {
-    ($T:ty) => {
-        impl CastFrom<$T> for $T {
-            fn cast(v: $T) -> Fallible<Self> {
-                Ok(v)
-            }
+
+macro_rules! impl_round_cast_self_string_bool {
+    ($T:ty, $_T:ty) => {
+        impl RoundCast<$T> for $T {
+            fn round_cast(v: $T) -> Fallible<Self> {Ok(v)}
         }
-    }
-}
-macro_rules! impl_bool_cast {
-    ($T:ty) => {
-        impl CastFrom<bool> for $T {
-            fn cast(v: bool) -> Fallible<Self> {
+        impl RoundCast<bool> for $T {
+            fn round_cast(v: bool) -> Fallible<Self> {
                 Ok(if v {Self::one()} else {Self::zero()})
             }
         }
-        impl CastFrom<$T> for bool {
-            fn cast(v: $T) -> Fallible<Self> {
-                Ok(v.is_zero())
-            }
+        impl RoundCast<$T> for bool {
+            fn round_cast(v: $T) -> Fallible<Self> {Ok(v.is_zero())}
         }
-    }
-}
-macro_rules! impl_string_cast {
-    ($T:ty) => {
-        impl CastFrom<String> for $T {
-            fn cast(v: String) -> Fallible<Self> {
+        impl RoundCast<String> for $T {
+            fn round_cast(v: String) -> Fallible<Self> {
                 v.parse::<$T>().map_err(|_e| err!(FailedCast))
             }
         }
-        impl CastFrom<$T> for String {
-            fn cast(v: $T) -> Fallible<Self> {
-                Ok(v.to_string())
-            }
+        impl RoundCast<$T> for String {
+            fn round_cast(v: $T) -> Fallible<Self> {Ok(v.to_string())}
         }
     }
 }
-macro_rules! impl_for_each {
-    ([];[$first:ty, $($end:ty),*]) => {
-        impl_self_cast!($first);
-        impl_bool_cast!($first);
-        impl_string_cast!($first);
-        $(impl_num_cast!($first, $end);)*
-
-        impl_for_each!{[$first];[$($end),*]}
-    };
-    ([$($start:ty),*];[$mid:ty, $($end:ty),*]) => {
-        $(impl_num_cast!($mid, $start);)*
-        impl_self_cast!($mid);
-        impl_bool_cast!($mid);
-        impl_string_cast!($mid);
-        $(impl_num_cast!($mid, $end);)*
-
-        impl_for_each!{[$($start),*, $mid];[$($end),*]}
-    };
-    ([$($start:ty),*];[$last:ty]) => {
-        impl_self_cast!($last);
-        impl_bool_cast!($last);
-        impl_string_cast!($last);
-        $(impl_num_cast!($last, $start);)*
-    };
-}
-impl_for_each!{[];[u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64]}
+cartesian!{[u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64], impl_round_cast_num, impl_round_cast_self_string_bool, impl_round_cast_num}
 
 // final four casts among bool and string
-impl_self_cast!(bool);
-impl_self_cast!(String);
-impl CastFrom<String> for bool {
-    fn cast(v: String) -> Fallible<Self> {
-        Ok(!v.is_empty())
-    }
-}
-impl CastFrom<bool> for String {
-    fn cast(v: bool) -> Fallible<Self> {
-        Ok(v.to_string())
-    }
-}
+impl RoundCast<bool> for bool { fn round_cast(v: bool) -> Fallible<Self> {Ok(v)} }
+impl RoundCast<String> for String { fn round_cast(v: String) -> Fallible<Self> {Ok(v)} }
+impl RoundCast<String> for bool { fn round_cast(v: String) -> Fallible<Self> { Ok(!v.is_empty()) } }
+impl RoundCast<bool> for String { fn round_cast(v: bool) -> Fallible<Self> { Ok(v.to_string()) } }
 
 pub trait CheckNull { fn is_null(&self) -> bool; }
 macro_rules! impl_check_null_for_non_null {

--- a/rust/opendp/src/traits.rs
+++ b/rust/opendp/src/traits.rs
@@ -123,7 +123,7 @@ macro_rules! cartesian {
 
 /// Fallible casting where the casted value is equal to the original value.
 /// Casting fails for any value not between Self::MIN_CONSECUTIVE and Self::MAX_CONSECUTIVE.
-pub trait ExactIntCast<TI>: Sized + BoundedInt {
+pub trait ExactIntCast<TI>: Sized + ExactIntBounds {
     fn exact_int_cast(v: TI) -> Fallible<Self>;
 }
 macro_rules! impl_exact_int_cast_from {
@@ -192,22 +192,22 @@ macro_rules! impl_inf_cast_from {
     })
 }
 
-pub trait BoundedInt {
+pub trait ExactIntBounds {
     const MAX_CONSECUTIVE: Self;
     const MIN_CONSECUTIVE: Self;
 }
-macro_rules! impl_bounded_int {
-    ($($ty:ty),*) => ($(impl BoundedInt for $ty {
+macro_rules! impl_exact_int_bounds {
+    ($($ty:ty),*) => ($(impl ExactIntBounds for $ty {
         const MAX_CONSECUTIVE: Self = Self::MAX;
         const MIN_CONSECUTIVE: Self = Self::MIN;
     })*)
 }
-impl_bounded_int!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize);
-impl BoundedInt for f64 {
+impl_exact_int_bounds!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize);
+impl ExactIntBounds for f64 {
     const MAX_CONSECUTIVE: Self = 9_007_199_254_740_992.0;
     const MIN_CONSECUTIVE: Self = -9_007_199_254_740_992.0;
 }
-impl BoundedInt for f32 {
+impl ExactIntBounds for f32 {
     const MAX_CONSECUTIVE: Self = 16_777_216.0;
     const MIN_CONSECUTIVE: Self = -16_777_216.0;
 }

--- a/rust/opendp/src/traits.rs
+++ b/rust/opendp/src/traits.rs
@@ -249,6 +249,7 @@ cartesian!([f32, f64], [u8, u16, u32, u64, u128, i8, i16, i32, i64, i128], impl_
 mod test_inf_cast {
     use crate::traits::InfCast;
 
+    #[allow(dead_code)]
     enum Diff { Equal, Prev, Next, Less, Greater }
 
     fn check_rounded_cast(input: f64, diff: Diff) {
@@ -276,6 +277,7 @@ mod test_inf_cast {
     }
 
     #[test]
+    // ignored test because it can take a while to run
     #[ignore]
     fn test_f64_f32() {
         check_rounded_cast(0., Diff::Equal);

--- a/rust/opendp/src/trans/count.rs
+++ b/rust/opendp/src/trans/count.rs
@@ -9,18 +9,18 @@ use crate::core::{Function, SensitivityMetric, StabilityRelation, Transformation
 use crate::dist::{AbsoluteDistance, SymmetricDistance, LpDistance, IntDistance};
 use crate::dom::{AllDomain, MapDomain, SizedDomain, VectorDomain};
 use crate::error::*;
-use crate::traits::{DistanceConstant, MaxConsecutiveInt, InfCast, ExactCast};
+use crate::traits::{DistanceConstant, InfCast, ExactIntCast};
 
 pub fn make_count<TIA, TO>(
 ) -> Fallible<Transformation<VectorDomain<AllDomain<TIA>>, AllDomain<TO>, SymmetricDistance, AbsoluteDistance<TO>>>
-    where TO: ExactCast<usize> + One + DistanceConstant<IntDistance> + MaxConsecutiveInt,
+    where TO: ExactIntCast<usize> + One + DistanceConstant<IntDistance>,
           IntDistance: InfCast<TO> {
     Ok(Transformation::new(
         VectorDomain::new_all(),
         AllDomain::new(),
         // think of this as: min(arg.len(), TO::max_value())
         Function::new(move |arg: &Vec<TIA>|
-            TO::exact_cast(arg.len()).unwrap_or(TO::MAX_CONSECUTIVE)),
+            TO::exact_int_cast(arg.len()).unwrap_or(TO::MAX_CONSECUTIVE)),
         SymmetricDistance::default(),
         AbsoluteDistance::default(),
         StabilityRelation::new_from_constant(TO::one())))
@@ -30,14 +30,14 @@ pub fn make_count<TIA, TO>(
 pub fn make_count_distinct<TIA, TO>(
 ) -> Fallible<Transformation<VectorDomain<AllDomain<TIA>>, AllDomain<TO>, SymmetricDistance, AbsoluteDistance<TO>>>
     where TIA: Eq + Hash,
-          TO: ExactCast<usize> + MaxConsecutiveInt + One + DistanceConstant<IntDistance>,
+          TO: ExactIntCast<usize> + One + DistanceConstant<IntDistance>,
           IntDistance: InfCast<TO> {
     Ok(Transformation::new(
         VectorDomain::new_all(),
         AllDomain::new(),
         Function::new(move |arg: &Vec<TIA>| {
             let len = arg.iter().collect::<HashSet<_>>().len();
-            TO::exact_cast(len).unwrap_or(TO::MAX_CONSECUTIVE)
+            TO::exact_int_cast(len).unwrap_or(TO::MAX_CONSECUTIVE)
         }),
         SymmetricDistance::default(),
         AbsoluteDistance::default(),

--- a/rust/opendp/src/trans/count.rs
+++ b/rust/opendp/src/trans/count.rs
@@ -10,17 +10,17 @@ use crate::core::{Function, SensitivityMetric, StabilityRelation, Transformation
 use crate::dist::{AbsoluteDistance, SymmetricDistance, LpDistance, IntDistance};
 use crate::dom::{AllDomain, MapDomain, SizedDomain, VectorDomain};
 use crate::error::*;
-use crate::traits::{DistanceConstant, MaxConsecutiveInt, ExactCast, InfCast};
+use crate::traits::{DistanceConstant, MaxConsecutiveInt, InfCast};
 
 pub fn make_count<TIA, TO>(
 ) -> Fallible<Transformation<VectorDomain<AllDomain<TIA>>, AllDomain<TO>, SymmetricDistance, AbsoluteDistance<TO>>>
-    where TO: ExactCast<usize> + One + DistanceConstant<IntDistance> + MaxConsecutiveInt, IntDistance: InfCast<TO> {
+    where TO: TryFrom<usize> + One + DistanceConstant<IntDistance> + MaxConsecutiveInt, IntDistance: InfCast<TO> {
     Ok(Transformation::new(
         VectorDomain::new_all(),
         AllDomain::new(),
         // think of this as: min(arg.len(), TO::max_value())
         Function::new(move |arg: &Vec<TIA>|
-            TO::exact_cast(arg.len()).unwrap_or(TO::MAX_CONSECUTIVE)),
+            TO::try_from(arg.len()).unwrap_or(TO::MAX_CONSECUTIVE)),
         SymmetricDistance::default(),
         AbsoluteDistance::default(),
         StabilityRelation::new_from_constant(TO::one())))

--- a/rust/opendp/src/trans/dataframe.rs
+++ b/rust/opendp/src/trans/dataframe.rs
@@ -55,7 +55,7 @@ pub fn make_create_dataframe<K>(
         }),
         SymmetricDistance::default(),
         SymmetricDistance::default(),
-        StabilityRelation::new_from_constant(1_u32)
+        StabilityRelation::new_from_constant(1)
     ))
 }
 
@@ -77,7 +77,7 @@ pub fn make_split_dataframe<K>(
         Function::new(move |arg: &String| split_dataframe(&separator, col_names.clone(), &arg)),
         SymmetricDistance::default(),
         SymmetricDistance::default(),
-        StabilityRelation::new_from_constant(1_u32)))
+        StabilityRelation::new_from_constant(1)))
 }
 
 fn replace_col<K: Eq + Hash + Debug + Clone>(key: &K, df: &DataFrame<K>, col: Column) -> Fallible<DataFrame<K>> {
@@ -109,7 +109,7 @@ pub fn make_parse_column<K, T>(key: K, impute: bool) -> Fallible<Transformation<
         Function::new_fallible(move |arg: &DataFrame<K>| parse_column::<K, T>(&key, impute, arg)),
         SymmetricDistance::default(),
         SymmetricDistance::default(),
-        StabilityRelation::new_from_constant(1_u32)))
+        StabilityRelation::new_from_constant(1)))
 }
 
 pub fn make_select_column<K, T>(key: K) -> Fallible<Transformation<DataFrameDomain<K>, VectorDomain<AllDomain<T>>, SymmetricDistance, SymmetricDistance>>
@@ -126,7 +126,7 @@ pub fn make_select_column<K, T>(key: K) -> Fallible<Transformation<DataFrameDoma
         }),
         SymmetricDistance::default(),
         SymmetricDistance::default(),
-        StabilityRelation::new_from_constant(1_u32)))
+        StabilityRelation::new_from_constant(1)))
 }
 
 fn vec_string_to_str(src: &[String]) -> Vec<&str> {
@@ -151,7 +151,7 @@ pub fn make_split_lines() -> Fallible<Transformation<AllDomain<String>, VectorDo
         }),
         SymmetricDistance::default(),
         SymmetricDistance::default(),
-        StabilityRelation::new_from_constant(1_u32)))
+        StabilityRelation::new_from_constant(1)))
 }
 
 fn parse_series<T>(col: &[&str], default_on_error: bool) -> Fallible<Vec<T>> where
@@ -184,7 +184,7 @@ pub fn make_split_records(separator: Option<&str>) -> Fallible<Transformation<Ve
         }),
         SymmetricDistance::default(),
         SymmetricDistance::default(),
-        StabilityRelation::new_from_constant(1_u32)))
+        StabilityRelation::new_from_constant(1)))
 }
 
 

--- a/rust/opendp/src/trans/manipulation.rs
+++ b/rust/opendp/src/trans/manipulation.rs
@@ -23,7 +23,7 @@ pub(crate) fn make_row_by_row<'a, DIA, DOA, M, F: 'static + Fn(&DIA::Carrier) ->
             arg.iter().map(|v| atom_function(v)).collect()),
         M::default(),
         M::default(),
-        StabilityRelation::new_from_constant(1_u32)))
+        StabilityRelation::new_from_constant(1)))
 }
 
 /// Constructs a [`Transformation`] representing an arbitrary row-by-row transformation.
@@ -42,13 +42,13 @@ pub(crate) fn make_row_by_row_fallible<DIA, DOA, M, F: 'static + Fn(&DIA::Carrie
             arg.iter().map(|v| atom_function(v)).collect()),
         M::default(),
         M::default(),
-        StabilityRelation::new_from_constant(1_u32)))
+        StabilityRelation::new_from_constant(1)))
 }
 
 /// Constructs a [`Transformation`] representing the identity function.
 pub fn make_identity<D, M>(domain: D, metric: M) -> Fallible<Transformation<D, D, M, M>>
     where D: Domain, D::Carrier: Clone,
-          M: Metric, M::Distance: DistanceConstant + One {
+          M: Metric, M::Distance: DistanceConstant<M::Distance> + One {
     Ok(Transformation::new(
         domain.clone(),
         domain,

--- a/rust/opendp/src/trans/mean.rs
+++ b/rust/opendp/src/trans/mean.rs
@@ -1,7 +1,7 @@
 use crate::core::{Transformation, Function, StabilityRelation};
 use std::ops::{Sub};
 use std::iter::Sum;
-use crate::traits::{DistanceConstant, ExactCast, InfCast};
+use crate::traits::{DistanceConstant, ExactIntCast, InfCast};
 use crate::error::Fallible;
 use crate::dom::{VectorDomain, IntervalDomain, AllDomain, SizedDomain};
 use std::collections::Bound;
@@ -11,10 +11,10 @@ use num::{Float};
 pub fn make_bounded_mean<T>(
     lower: T, upper: T, n: usize
 ) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactCast<usize>, for <'a> T: Sum<&'a T>,
+    where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactIntCast<usize>, for <'a> T: Sum<&'a T>,
           IntDistance: InfCast<T> {
-    let _n = T::exact_cast(n)?;
-    let _2 = T::exact_cast(2)?;
+    let _n = T::exact_int_cast(n)?;
+    let _2 = T::exact_int_cast(2)?;
 
     Ok(Transformation::new(
         SizedDomain::new(VectorDomain::new(

--- a/rust/opendp/src/trans/mean.rs
+++ b/rust/opendp/src/trans/mean.rs
@@ -1,19 +1,19 @@
 use crate::core::{Transformation, Function, StabilityRelation};
 use std::ops::{Sub};
 use std::iter::Sum;
-use crate::traits::DistanceConstant;
+use crate::traits::{DistanceConstant, ExactCast, InfCast};
 use crate::error::Fallible;
 use crate::dom::{VectorDomain, IntervalDomain, AllDomain, SizedDomain};
 use std::collections::Bound;
-use crate::dist::{SymmetricDistance, AbsoluteDistance};
+use crate::dist::{SymmetricDistance, AbsoluteDistance, IntDistance};
 use num::{Float};
 
 pub fn make_bounded_mean<T>(
     lower: T, upper: T, n: usize
 ) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: DistanceConstant + Sub<Output=T> + Float,
-          for <'a> T: Sum<&'a T> {
-    let _n = num_cast!(n; T)?;
+    where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactCast<usize>, for <'a> T: Sum<&'a T>,
+          IntDistance: InfCast<T> {
+    let _n = T::exact_cast(n)?;
 
     Ok(Transformation::new(
         SizedDomain::new(VectorDomain::new(

--- a/rust/opendp/src/trans/mean.rs
+++ b/rust/opendp/src/trans/mean.rs
@@ -14,6 +14,7 @@ pub fn make_bounded_mean<T>(
     where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactCast<usize>, for <'a> T: Sum<&'a T>,
           IntDistance: InfCast<T> {
     let _n = T::exact_cast(n)?;
+    let _2 = T::exact_cast(2)?;
 
     Ok(Transformation::new(
         SizedDomain::new(VectorDomain::new(
@@ -23,7 +24,7 @@ pub fn make_bounded_mean<T>(
         Function::new(move |arg: &Vec<T>| arg.iter().sum::<T>() / _n),
         SymmetricDistance::default(),
         AbsoluteDistance::default(),
-        StabilityRelation::new_from_constant((upper - lower) / _n / num_cast!(2; T)?)))
+        StabilityRelation::new_from_constant((upper - lower) / _n / _2)))
 }
 
 

--- a/rust/opendp/src/trans/sum.rs
+++ b/rust/opendp/src/trans/sum.rs
@@ -4,10 +4,10 @@ use std::iter::Sum;
 use std::ops::Sub;
 
 use crate::core::{Function, StabilityRelation, Transformation};
-use crate::dist::{SymmetricDistance, AbsoluteDistance};
+use crate::dist::{SymmetricDistance, AbsoluteDistance, IntDistance};
 use crate::dom::{AllDomain, IntervalDomain, SizedDomain, VectorDomain};
 use crate::error::*;
-use crate::traits::{Abs, DistanceConstant};
+use crate::traits::{Abs, DistanceConstant, InfCast};
 
 fn max<T: PartialOrd>(a: T, b: T) -> Option<T> {
     a.partial_cmp(&b).map(|o| if let Ordering::Less = o {b} else {a})
@@ -16,8 +16,9 @@ fn max<T: PartialOrd>(a: T, b: T) -> Option<T> {
 pub fn make_bounded_sum<T>(
     lower: T, upper: T
 ) -> Fallible<Transformation<VectorDomain<IntervalDomain<T>>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: DistanceConstant + Sub<Output=T> + Abs,
-          for <'a> T: Sum<&'a T> {
+    where T: DistanceConstant<IntDistance> + Sub<Output=T> + Abs,
+          for <'a> T: Sum<&'a T>,
+          IntDistance: InfCast<T> {
 
     Ok(Transformation::new(
         VectorDomain::new(IntervalDomain::new(
@@ -34,8 +35,8 @@ pub fn make_bounded_sum<T>(
 pub fn make_bounded_sum_n<T>(
     lower: T, upper: T, length: usize
 ) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: DistanceConstant + Sub<Output=T>,
-          for <'a> T: Sum<&'a T> {
+    where T: DistanceConstant<IntDistance> + Sub<Output=T>, for <'a> T: Sum<&'a T>,
+          IntDistance: InfCast<T> {
 
     Ok(Transformation::new(
         SizedDomain::new(VectorDomain::new(IntervalDomain::new(
@@ -45,7 +46,7 @@ pub fn make_bounded_sum_n<T>(
         SymmetricDistance::default(),
         AbsoluteDistance::default(),
         // d_out >= d_in * (M - m) / 2
-        StabilityRelation::new_from_constant((upper - lower) / T::distance_cast(2)?)))
+        StabilityRelation::new_from_constant((upper - lower) / T::inf_cast(2)?)))
 }
 
 

--- a/rust/opendp/src/trans/variance.rs
+++ b/rust/opendp/src/trans/variance.rs
@@ -5,19 +5,20 @@ use std::ops::{Div, Sub, Add};
 use num::{Float, One, Zero};
 
 use crate::core::{Function, StabilityRelation, Transformation};
-use crate::dist::{SymmetricDistance, AbsoluteDistance};
+use crate::dist::{SymmetricDistance, AbsoluteDistance, IntDistance};
 use crate::dom::{AllDomain, IntervalDomain, SizedDomain, VectorDomain};
 use crate::error::Fallible;
-use crate::traits::DistanceConstant;
+use crate::traits::{DistanceConstant, ExactCast, InfCast};
 
 
 pub fn make_bounded_variance<T>(
     lower: T, upper: T, length: usize, ddof: usize
 ) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: DistanceConstant + Float + One + Sub<Output=T> + Div<Output=T> + Sum<T> + for<'a> Sum<&'a T>,
-          for<'a> &'a T: Sub<Output=T> + Add<&'a T, Output=T> {
-    let _length = num_cast!(length; T)?;
-    let _ddof = num_cast!(ddof; T)?;
+    where T: DistanceConstant<IntDistance> + Float + One + Sub<Output=T> + Div<Output=T> + Sum<T> + for<'a> Sum<&'a T> + ExactCast<usize>,
+          for<'a> &'a T: Sub<Output=T> + Add<&'a T, Output=T>,
+          IntDistance: InfCast<T> {
+    let _length = T::exact_cast(length)?;
+    let _ddof = T::exact_cast(ddof)?;
     let _1 = T::one();
     let _2 = &_1 + &_1;
 
@@ -46,12 +47,13 @@ pub fn make_bounded_covariance<T>(
     upper: (T, T),
     length: usize, ddof: usize
 ) -> Fallible<Transformation<CovarianceDomain<T>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: DistanceConstant + Zero + One + Sub<Output=T> + Div<Output=T> + Add<Output=T> + Sum<T>,
+    where T: ExactCast<usize> + DistanceConstant<IntDistance> + Zero + One + Sub<Output=T> + Div<Output=T> + Add<Output=T> + Sum<T>,
           for <'a> T: Div<&'a T, Output=T> + Add<&'a T, Output=T>,
-          for<'a> &'a T: Sub<Output=T> {
+          for<'a> &'a T: Sub<Output=T>,
+          IntDistance: InfCast<T> {
 
-    let _length = num_cast!(length; T)?;
-    let _ddof = num_cast!(ddof; T)?;
+    let _length = T::exact_cast(length)?;
+    let _ddof = T::exact_cast(ddof)?;
     let _1 = T::one();
     let _2 = _1.clone() + &_1;
 

--- a/rust/opendp/src/trans/variance.rs
+++ b/rust/opendp/src/trans/variance.rs
@@ -8,17 +8,17 @@ use crate::core::{Function, StabilityRelation, Transformation};
 use crate::dist::{SymmetricDistance, AbsoluteDistance, IntDistance};
 use crate::dom::{AllDomain, IntervalDomain, SizedDomain, VectorDomain};
 use crate::error::Fallible;
-use crate::traits::{DistanceConstant, ExactCast, InfCast};
+use crate::traits::{DistanceConstant, ExactIntCast, InfCast};
 
 
 pub fn make_bounded_variance<T>(
     lower: T, upper: T, length: usize, ddof: usize
 ) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: DistanceConstant<IntDistance> + Float + One + Sub<Output=T> + Div<Output=T> + Sum<T> + for<'a> Sum<&'a T> + ExactCast<usize>,
+    where T: DistanceConstant<IntDistance> + Float + One + Sub<Output=T> + Div<Output=T> + Sum<T> + for<'a> Sum<&'a T> + ExactIntCast<usize>,
           for<'a> &'a T: Sub<Output=T> + Add<&'a T, Output=T>,
           IntDistance: InfCast<T> {
-    let _length = T::exact_cast(length)?;
-    let _ddof = T::exact_cast(ddof)?;
+    let _length = T::exact_int_cast(length)?;
+    let _ddof = T::exact_int_cast(ddof)?;
     let _1 = T::one();
     let _2 = &_1 + &_1;
 
@@ -47,13 +47,13 @@ pub fn make_bounded_covariance<T>(
     upper: (T, T),
     length: usize, ddof: usize
 ) -> Fallible<Transformation<CovarianceDomain<T>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: ExactCast<usize> + DistanceConstant<IntDistance> + Zero + One + Sub<Output=T> + Div<Output=T> + Add<Output=T> + Sum<T>,
+    where T: ExactIntCast<usize> + DistanceConstant<IntDistance> + Zero + One + Sub<Output=T> + Div<Output=T> + Add<Output=T> + Sum<T>,
           for <'a> T: Div<&'a T, Output=T> + Add<&'a T, Output=T>,
           for<'a> &'a T: Sub<Output=T>,
           IntDistance: InfCast<T> {
 
-    let _length = T::exact_cast(length)?;
-    let _ddof = T::exact_cast(ddof)?;
+    let _length = T::exact_int_cast(length)?;
+    let _ddof = T::exact_int_cast(ddof)?;
     let _1 = T::one();
     let _2 = _1.clone() + &_1;
 


### PR DESCRIPTION
Closes #33 

Added traits:
- `TO: RoundCast<TI>` cast from vi: TI to vo: TO with rounding to nearest, ties to even
- `TO: InfCast<TI>` cast where vi: TI <= vo: TO
- `TO: ExactIntCast<TI>` casting for integers where vi: TI == vo: TO, and vo < `TO::MAX_CONSECUTIVE`

Removed `DistanceCast` trait, which still had some edge cases that would round down:
1. When casting from f64 to f32
2. When casting an int greater than 2^p to nearest, ties to even float with precision p

Switch DistanceConstant to use InfCast, instead of DistanceCast.

Remove num::NumCast from most places in the library, in favor of the more explicit cast traits with situationally-appropriate cast behavior.

This allows TO on count queries to be float-valued, so that you can run float-mechanisms on them. We might want to think more about if we want to allow this. If we are unsure, I can add an Integer trait bound on TO.