### PR TITLE
Properly handle overflows in aggregators

### DIFF
--- a/rust/opendp-ffi/src/trans/count.rs
+++ b/rust/opendp-ffi/src/trans/count.rs
@@ -1,6 +1,5 @@
 use std::convert::TryFrom;
 use std::hash::Hash;
-use std::ops::AddAssign;
 use std::os::raw::{c_char, c_uint};
 
 use num::{Bounded, Integer, One, Zero};
@@ -9,7 +8,7 @@ use num::traits::FloatConst;
 use opendp::core::{SensitivityMetric};
 use opendp::dist::{L1Distance, L2Distance, IntDistance};
 use opendp::err;
-use opendp::traits::{DistanceConstant, InfCast, ExactIntCast};
+use opendp::traits::{DistanceConstant, InfCast, ExactIntCast, SaturatingAdd};
 use opendp::trans::{CountByConstant, make_count, make_count_by, make_count_by_categories, make_count_distinct};
 
 use crate::any::{AnyObject, AnyTransformation};
@@ -72,7 +71,7 @@ pub extern "C" fn opendp_trans__make_count_by_categories(
             where MO: 'static + SensitivityMetric + CountByConstant<MO::Distance>,
                   MO::Distance: DistanceConstant<IntDistance> + One,
                   TI: 'static + Eq + Hash + Clone,
-                  TO: 'static + Integer + Zero + One + AddAssign,
+                  TO: 'static + Integer + Zero + One + SaturatingAdd,
                   IntDistance: InfCast<MO::Distance> {
             let categories = try_!(try_as_ref!(categories).downcast_ref::<Vec<TI>>()).clone();
             make_count_by_categories::<MO, TI, TO>(categories).into_any()
@@ -107,7 +106,7 @@ pub extern "C" fn opendp_trans__make_count_by(
             where MO: 'static + SensitivityMetric + CountByConstant<MO::Distance>,
                   MO::Distance: DistanceConstant<IntDistance> + FloatConst + One,
                   TI: 'static + Eq + Hash + Clone,
-                  TO: 'static + Integer + Zero + One + AddAssign,
+                  TO: 'static + Integer + Zero + One + SaturatingAdd,
                   IntDistance: InfCast<MO::Distance> {
             make_count_by::<MO, TI, TO>(n).into_any()
         }

--- a/rust/opendp-ffi/src/trans/mean.rs
+++ b/rust/opendp-ffi/src/trans/mean.rs
@@ -6,7 +6,7 @@ use std::os::raw::{c_char, c_uint, c_void};
 use num::Float;
 
 use opendp::err;
-use opendp::traits::{DistanceConstant, InfCast, ExactIntCast};
+use opendp::traits::{DistanceConstant, InfCast, ExactIntCast, CheckedMul};
 use opendp::trans::{make_bounded_mean};
 
 use crate::any::AnyTransformation;
@@ -20,7 +20,7 @@ pub extern "C" fn opendp_trans__make_bounded_mean(
     T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<T>(lower: *const c_void, upper: *const c_void, n: usize) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactIntCast<usize>,
+        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactIntCast<usize> + CheckedMul,
               for<'a> T: Sum<&'a T>,
               IntDistance: InfCast<T> {
         let lower = *try_as_ref!(lower as *const T);

--- a/rust/opendp-ffi/src/trans/sum.rs
+++ b/rust/opendp-ffi/src/trans/sum.rs
@@ -4,12 +4,13 @@ use std::ops::Sub;
 use std::os::raw::{c_char, c_uint, c_void};
 
 use opendp::err;
-use opendp::traits::{Abs, DistanceConstant, InfCast};
+use opendp::traits::{Abs, DistanceConstant, InfCast, SaturatingAdd, ExactIntCast, CheckedMul};
 use opendp::trans::{make_bounded_sum, make_bounded_sum_n};
 
 use crate::any::AnyTransformation;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::Type;
+use num::Zero;
 use opendp::dist::IntDistance;
 
 #[no_mangle]
@@ -20,7 +21,7 @@ pub extern "C" fn opendp_trans__make_bounded_sum(
     fn monomorphize<T>(
         lower: *const c_void, upper: *const c_void
     ) -> FfiResult<*mut AnyTransformation>
-        where for<'a> T: DistanceConstant<IntDistance> + Sub<Output=T> + Abs + Sum<&'a T>,
+        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Abs + SaturatingAdd + Zero,
               IntDistance: InfCast<T> {
         let lower = try_as_ref!(lower as *const T).clone();
         let upper = try_as_ref!(upper as *const T).clone();
@@ -38,7 +39,7 @@ pub extern "C" fn opendp_trans__make_bounded_sum_n(
     T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<T>(lower: *const c_void, upper: *const c_void, n: usize) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Sub<Output=T>,
+        where T: DistanceConstant<IntDistance> + Sub<Output=T> + ExactIntCast<usize> + CheckedMul,
               for<'a> T: Sum<&'a T>,
               IntDistance: InfCast<T> {
         let lower = try_as_ref!(lower as *const T).clone();

--- a/rust/opendp-ffi/src/trans/variance.rs
+++ b/rust/opendp-ffi/src/trans/variance.rs
@@ -6,7 +6,7 @@ use std::os::raw::{c_char, c_uint, c_void};
 use num::{Float, One, Zero};
 
 use opendp::err;
-use opendp::traits::{DistanceConstant, InfCast, ExactIntCast};
+use opendp::traits::{DistanceConstant, InfCast, ExactIntCast, CheckedMul};
 use opendp::trans::{make_bounded_covariance, make_bounded_variance};
 
 use crate::any::{AnyObject, AnyTransformation, Downcast};
@@ -23,7 +23,7 @@ pub extern "C" fn opendp_trans__make_bounded_variance(
     fn monomorphize2<T>(
         lower: *const c_void, upper: *const c_void, length: usize, ddof: usize,
     ) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Float + for<'a> Sum<&'a T> + Sum<T> + ExactIntCast<usize>,
+        where T: DistanceConstant<IntDistance> + Float + for<'a> Sum<&'a T> + Sum<T> + ExactIntCast<usize> + CheckedMul,
               for<'a> &'a T: Sub<Output=T> + Add<&'a T, Output=T>,
               IntDistance: InfCast<T> {
         let lower = *try_as_ref!(lower as *const T);
@@ -52,7 +52,7 @@ pub extern "C" fn opendp_trans__make_bounded_covariance(
         upper: *const AnyObject,
         length: usize, ddof: usize,
     ) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Sum<T> + Zero + One + ExactIntCast<usize>,
+        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Sum<T> + Zero + One + ExactIntCast<usize> + CheckedMul,
               for<'a> T: Div<&'a T, Output=T> + Add<&'a T, Output=T>,
               for<'a> &'a T: Sub<Output=T>,
               IntDistance: InfCast<T> {

--- a/rust/opendp/src/traits.rs
+++ b/rust/opendp/src/traits.rs
@@ -416,12 +416,13 @@ macro_rules! impl_math_float {
     ($($t:ty),+) => {
         $(impl SaturatingAdd for $t {
             fn saturating_add(&self, v: &Self) -> Self {
-                self + v
+                (self + v).clamp(<$t>::MIN, <$t>::MAX)
             }
         })+
         $(impl CheckedMul for $t {
             fn checked_mul(&self, v: &Self) -> Option<Self> {
-                Some(self * v)
+                let y = self * v;
+                y.is_finite().then(|| y)
             }
         })+
     }

--- a/rust/opendp/src/trans/mean.rs
+++ b/rust/opendp/src/trans/mean.rs
@@ -1,7 +1,7 @@
 use crate::core::{Transformation, Function, StabilityRelation};
 use std::ops::{Sub};
 use std::iter::Sum;
-use crate::traits::{DistanceConstant, ExactIntCast, InfCast};
+use crate::traits::{DistanceConstant, ExactIntCast, InfCast, CheckedMul};
 use crate::error::Fallible;
 use crate::dom::{VectorDomain, IntervalDomain, AllDomain, SizedDomain};
 use std::collections::Bound;
@@ -11,10 +11,15 @@ use num::{Float};
 pub fn make_bounded_mean<T>(
     lower: T, upper: T, n: usize
 ) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactIntCast<usize>, for <'a> T: Sum<&'a T>,
+    where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactIntCast<usize>, for <'a> T: Sum<&'a T> + CheckedMul,
           IntDistance: InfCast<T> {
     let _n = T::exact_int_cast(n)?;
     let _2 = T::exact_int_cast(2)?;
+
+    if lower.checked_mul(&_n).is_none()
+        || upper.checked_mul(&_n).is_none() {
+        return fallible!(MakeTransformation, "Detected potential for overflow when computing function.")
+    }
 
     Ok(Transformation::new(
         SizedDomain::new(VectorDomain::new(

--- a/rust/opendp/src/trans/variance.rs
+++ b/rust/opendp/src/trans/variance.rs
@@ -8,19 +8,24 @@ use crate::core::{Function, StabilityRelation, Transformation};
 use crate::dist::{SymmetricDistance, AbsoluteDistance, IntDistance};
 use crate::dom::{AllDomain, IntervalDomain, SizedDomain, VectorDomain};
 use crate::error::Fallible;
-use crate::traits::{DistanceConstant, ExactIntCast, InfCast};
+use crate::traits::{DistanceConstant, ExactIntCast, InfCast, CheckedMul};
 
 
 pub fn make_bounded_variance<T>(
     lower: T, upper: T, length: usize, ddof: usize
 ) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: DistanceConstant<IntDistance> + Float + One + Sub<Output=T> + Div<Output=T> + Sum<T> + for<'a> Sum<&'a T> + ExactIntCast<usize>,
+    where T: DistanceConstant<IntDistance> + Float + One + Sub<Output=T> + Div<Output=T> + Sum<T> + for<'a> Sum<&'a T> + ExactIntCast<usize> + CheckedMul,
           for<'a> &'a T: Sub<Output=T> + Add<&'a T, Output=T>,
           IntDistance: InfCast<T> {
     let _length = T::exact_int_cast(length)?;
     let _ddof = T::exact_int_cast(ddof)?;
     let _1 = T::one();
     let _2 = &_1 + &_1;
+
+    let range = (&upper - &lower) / _2.clone();
+    if range.clone().checked_mul(&range).is_none() {
+        return fallible!(MakeTransformation, "Detected potential for overflow when computing function.")
+    }
 
     Ok(Transformation::new(
         SizedDomain::new(VectorDomain::new(
@@ -47,7 +52,7 @@ pub fn make_bounded_covariance<T>(
     upper: (T, T),
     length: usize, ddof: usize
 ) -> Fallible<Transformation<CovarianceDomain<T>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: ExactIntCast<usize> + DistanceConstant<IntDistance> + Zero + One + Sub<Output=T> + Div<Output=T> + Add<Output=T> + Sum<T>,
+    where T: ExactIntCast<usize> + DistanceConstant<IntDistance> + Zero + One + Sub<Output=T> + Div<Output=T> + Add<Output=T> + Sum<T> + CheckedMul,
           for <'a> T: Div<&'a T, Output=T> + Add<&'a T, Output=T>,
           for<'a> &'a T: Sub<Output=T>,
           IntDistance: InfCast<T> {
@@ -56,6 +61,11 @@ pub fn make_bounded_covariance<T>(
     let _ddof = T::exact_int_cast(ddof)?;
     let _1 = T::one();
     let _2 = _1.clone() + &_1;
+
+    if ((&upper.0 - &lower.0) / _2.clone()).checked_mul(
+        &((&upper.1 - &lower.1) / _2.clone())).is_none() {
+        return fallible!(MakeTransformation, "Detected potential for overflow when computing function.")
+    }
 
     Ok(Transformation::new(
         SizedDomain::new(VectorDomain::new(


### PR DESCRIPTION
Closes #178

Adjusts:
- make_bounded_sum (by check)
- make_bounded_sum_n (by saturation)
- make_bounded_variance (by check)
- make_bounded_covariance (by check)
- make_bounded_mean (by check)
- make_count_by_categories (by saturation)
- make_count_by (by saturation)

(by check) means checked arithmetic is performed to compute the maximum/minimum value that may happen at runtime. If the checked arithmetic fails, the computation may fail, so the constructor fails to build the transformation.

(by saturation) means the function itself uses saturating math instead of wrapping or panicking math, which preserves the privacy semantics.