### PR TITLE
Fixed point exploration

### DIFF
--- a/rust/opendp-ffi/Cargo.toml
+++ b/rust/opendp-ffi/Cargo.toml
@@ -14,6 +14,7 @@ build = "build/main.rs"
 lazy_static = "1.4.0"
 num = "0.3.1"
 backtrace = "0.3"
+fixed = "1.9"
 
 [dependencies.opendp]
 path = "../opendp"

--- a/rust/opendp-ffi/src/dispatch.rs
+++ b/rust/opendp-ffi/src/dispatch.rs
@@ -110,7 +110,7 @@ macro_rules! disp_expand {
         disp_expand!($function, ($rt_type, [i32, f64, String, usize, AnyObject]), $rt_dispatch_types, $type_args, $args)
     };
     ($function:ident, ($rt_type:expr, @numbers),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
-        disp_expand!($function, ($rt_type, [u32, i32, f64]), $rt_dispatch_types, $type_args, $args)
+        disp_expand!($function, ($rt_type, [u32, i32, f64, I6F2]), $rt_dispatch_types, $type_args, $args)
     };
     ($function:ident, ($rt_type:expr, @hashable),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
         disp_expand!($function, ($rt_type, [String]), $rt_dispatch_types, $type_args, $args)

--- a/rust/opendp-ffi/src/trans/clamp.rs
+++ b/rust/opendp-ffi/src/trans/clamp.rs
@@ -10,6 +10,8 @@ use crate::any::{AnyTransformation, AnyObject, Downcast};
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::Type;
 
+use opendp::types::*;
+
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_clamp(
     bounds: *const AnyObject,

--- a/rust/opendp-ffi/src/trans/index.rs
+++ b/rust/opendp-ffi/src/trans/index.rs
@@ -10,6 +10,7 @@ use crate::any::{AnyObject, AnyTransformation};
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::Type;
 use crate::any::Downcast;
+use opendp::types::*;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_find(

--- a/rust/opendp-ffi/src/trans/manipulation.rs
+++ b/rust/opendp-ffi/src/trans/manipulation.rs
@@ -12,6 +12,8 @@ use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::{Type, TypeContents};
 use opendp::traits::{CheckNull, DistanceConstant};
 use num::One;
+use fixed::types::I16F16;
+use opendp::types::*;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_identity(

--- a/rust/opendp-ffi/src/trans/resize.rs
+++ b/rust/opendp-ffi/src/trans/resize.rs
@@ -11,6 +11,8 @@ use crate::any::Downcast;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::Type;
 
+use opendp::types::*;
+
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_bounded_resize(
     size: c_uint, bounds: *const AnyObject,

--- a/rust/opendp-ffi/src/trans/sum.rs
+++ b/rust/opendp-ffi/src/trans/sum.rs
@@ -4,7 +4,7 @@ use std::ops::Sub;
 use std::os::raw::{c_char, c_uint};
 
 use opendp::err;
-use opendp::traits::{Abs, DistanceConstant, InfCast, SaturatingAdd, ExactIntCast, CheckedMul, CheckNull};
+use opendp::traits::{DistanceConstant, InfCast, SaturatingAdd, ExactIntCast, CheckedMul, CheckNull, CheckedAbs};
 use opendp::trans::{make_bounded_sum, make_sized_bounded_sum};
 
 use crate::any::{AnyTransformation, AnyObject, Downcast};
@@ -12,6 +12,8 @@ use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::Type;
 use num::Zero;
 use opendp::dist::IntDistance;
+
+use opendp::types::*;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_bounded_sum(
@@ -21,7 +23,7 @@ pub extern "C" fn opendp_trans__make_bounded_sum(
     fn monomorphize<T>(
         bounds: *const AnyObject,
     ) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Abs + SaturatingAdd + Zero + CheckNull,
+        where T: DistanceConstant<IntDistance> + Sub<Output=T> + SaturatingAdd + Zero + CheckNull + CheckedAbs,
               IntDistance: InfCast<T> {
         let bounds = try_!(try_as_ref!(bounds).downcast_ref::<(T, T)>()).clone();
         make_bounded_sum::<T>(bounds).into_any()

--- a/rust/opendp/Cargo.toml
+++ b/rust/opendp/Cargo.toml
@@ -19,6 +19,7 @@ statrs = "0.13.0"
 rug = { version = "1.9.0", default-features = false, features = ["integer", "float", "rand"], optional = true }
 gmp-mpfr-sys = { version = "=1.2.4", default-features = false, features = ["mpfr"], optional = true }
 openssl = { version = "0.10.29", features = ["vendored"], optional = true }
+fixed = {version = "1.9", features = ["num-traits"]}
 
 [features]
 default = ["use-openssl", "use-mpfr"]

--- a/rust/opendp/src/lib.rs
+++ b/rust/opendp/src/lib.rs
@@ -167,3 +167,4 @@ pub mod traits;
 pub mod trans;
 pub mod comb;
 pub mod accuracy;
+pub mod types;

--- a/rust/opendp/src/types.rs
+++ b/rust/opendp/src/types.rs
@@ -1,0 +1,6 @@
+pub use fixed::{
+    FixedI128, FixedI16, FixedI32, FixedI64, FixedI8, FixedU128, FixedU16, FixedU32, FixedU64,
+    FixedU8,
+};
+
+pub use fixed::types::*;


### PR DESCRIPTION
Initial exploration of integrating the fixed crate into OpenDP. 

- The bulk of the work to be done here is implementing macros that extend our traits to fixed point types
- Choosing the types to monomorphize in the ffi crate is hairy, as there are two axes of bit depths