### PR TITLE
fix pypi token, move VERSION check to release.yml

### DIFF
--- a/.github/assert_version.py
+++ b/.github/assert_version.py
@@ -3,6 +3,7 @@ import toml
 
 # all version numbers should be:
 version = open("../VERSION", 'r').read()
+assert version != "0.0.0-development", "Please update the repository with the current version."
 print("Checking if all version numbers are synchronized at", version)
 
 # check that python version is set properly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,7 @@ jobs:
     needs: [ python-pre-publish-windows, python-pre-publish-mac, python-pre-publish-linux ]
     runs-on: ubuntu-20.04
     env:
+      # https://pypi.org/help/#apitoken
       TWINE_USERNAME: __token__
       TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,9 +174,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Login
-        run: cargo login $CRATES_IO_API_TOKEN
-        env:
-          CRATES_IO_API_TOKEN: ${{ secrets.CRATES_IO_API_TOKEN }}
+        run: cargo login ${{ secrets.CRATES_IO_API_TOKEN }}
 
       - name: Publish Cargo OpenDP
         run: cargo publish --dry-run --verbose --manifest-path=opendp/Cargo.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Assert version
+        run: |
+          pip install toml
+          (cd ../.github && python assert_version.py)
+
   python-pre-publish-windows:
     runs-on: windows-latest
     needs: credential-check
@@ -109,7 +114,8 @@ jobs:
     needs: [ python-pre-publish-windows, python-pre-publish-mac, python-pre-publish-linux ]
     runs-on: ubuntu-20.04
     env:
-      TWINE_USERNAME: ${{ secrets.PYPI_API_TOKEN }}
+      TWINE_USERNAME: __token__
+      TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -14,11 +14,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Assert version
-        run: |
-          pip install toml
-          (cd ../.github && python assert_version.py)
-
       - name: Cache Rust dependencies
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
I'm using this piece from the twine api to feed the api key into twine via CI: https://pypi.org/help/#apitoken