### PR TITLE
Moved bogus status check in workflows.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,8 +6,6 @@ on:
   workflow_run:
     workflows: ["Sync Branches"]
     types: [completed]
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -19,6 +17,8 @@ jobs:
       # don't attempt to load binaries when sourcing the library
       OPENDP_HEADLESS: true
 
+    # Run only if sync-branches workflow succeeded.
+    if: ${{ github.event.workflow_run.conclusion == "success" }}
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -13,7 +13,6 @@ on:
 jobs:
   sync-branches:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == "success" }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
There was a bogus status check in sync-branches.yml; this has been moved to docs.yml.

Note: This means that we can't run docs.yml manually, because it needs to check this status, but that's probably not a big deal.