### PR TITLE
Push updated branches.

### DIFF
--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -17,12 +17,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Configure git user
+        run: |
+          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config --global user.name "$GITHUB_ACTOR"
+
       - name: Update latest
         if: ${{ github.ref == 'refs/heads/main' }}
-        run: git branch -f latest ${{ github.ref }}
+        run: |
+          git branch -f latest ${{ github.ref }}
+          git push origin latest
 
       - name: Update stable
         # TODO: Fix this logic to fire only if this is highest semantic version.
         # Can probably do this just by hard-wiring the major number.
         if: ${{ startsWith(github.ref, 'refs/tags/v') && ! contains(github.ref, '-rc.') }}
-        run: git branch -f stable ${{ github.ref }}
+        run: |
+          git branch -f stable ${{ github.ref }}
+          git push origin stable


### PR DESCRIPTION
Previously omitted from sync-branches workflow, this pushes the updated branches to origin.