### PR TITLE
Fetch all refs for docs.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,8 +21,11 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          # Make sure we get all refs needed to build docs for different versions
+          fetch-depth: 0
       # Runs a set of commands using the runners shell
       - name: Run a multi-line script
         run: |


### PR DESCRIPTION
When checking out the repo in the docs workflow, we need to fetch all refs (in addition to including in smv_remote_whitelist config variable).
