### PR TITLE
Fix crate publishing issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,5 +182,8 @@ jobs:
       - name: Publish Cargo OpenDP
         run: cargo publish --verbose --manifest-path=opendp/Cargo.toml
 
+      - name: Let crates.io index settle
+        run: sleep 15
+
       - name: Publish Cargo OpenDP-FFI
         run: cargo publish --verbose --manifest-path=opendp-ffi/Cargo.toml


### PR DESCRIPTION
* Add sleep to allow crates.io index to settle before publishing opendp-ffi