### PR TITLE
Fix remaining crate publishing issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,7 @@ jobs:
         run: cargo publish --verbose --manifest-path=opendp/Cargo.toml
 
       - name: Let crates.io index settle
-        run: sleep 15
+        run: sleep 60
 
       - name: Publish Cargo OpenDP-FFI
-        run: cargo publish --verbose --manifest-path=opendp-ffi/Cargo.toml
+        run: cargo publish --verbose --manifest-path=opendp-ffi/Cargo.toml --no-default-features --features use-openssl,use-mpfr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,4 +189,4 @@ jobs:
         run: sleep 60
 
       - name: Publish Cargo OpenDP-FFI
-        run: cargo publish --verbose --manifest-path=opendp-ffi/Cargo.toml --no-default-features --features use-openssl,use-mpfr
+        run: cargo publish --verbose --manifest-path=opendp-ffi/Cargo.toml


### PR DESCRIPTION
This picks up the final fixes we made to get crate publishing to work. (Going against proper procedure, I made these changes directly on the release branch, so they need to be picked up in main.)

* Added more sleep to allow crates.io index to settle before publishing opendp-ffi.
* Specified explicit features (omitting python gen) when calling cargo publish on opendp-ffi.


