### PR TITLE
TotalOrd trait; AllDomain<T: CheckNull>; simplify clampers

### DIFF
--- a/python/src/opendp/trans.py
+++ b/python/src/opendp/trans.py
@@ -201,17 +201,14 @@ def make_cast_metric(
 def make_clamp(
     lower,
     upper,
-    DI: RuntimeTypeDescriptor = "VectorDomain<AllDomain<T>>",
-    M: RuntimeTypeDescriptor = "SymmetricDistance"
+    T: RuntimeTypeDescriptor = None
 ) -> Transformation:
-    """Make a Transformation that clamps numeric data in Vec<`T`> between `lower` and `upper`. Set DI to AllDomain<T> for clamping aggregated values.
+    """Make a Transformation that clamps numeric data in Vec<`T`> between `lower` and `upper`.
     
     :param lower: If datum is less than lower, let datum be lower.
     :param upper: If datum is greater than upper, let datum be upper.
-    :param DI: input domain. One of VectorDomain<AllDomain<_>> or AllDomain<_>.
-    :type DI: RuntimeTypeDescriptor
-    :param M: metric. Set to SymmetricDistance when clamping datasets, or AbsoluteDistance<_> when clamping aggregated scalars
-    :type M: RuntimeTypeDescriptor
+    :param T: atomic data type
+    :type T: RuntimeTypeDescriptor
     :return: A clamp step.
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
@@ -219,39 +216,32 @@ def make_clamp(
     :raises OpenDPException: packaged error from the core OpenDP library
     """
     # Standardize type arguments.
-    DI = RuntimeType.parse(type_name=DI, generics=["T"])
-    M = RuntimeType.parse(type_name=M)
-    T = get_domain_atom_or_infer(DI, lower)
-    DI = DI.substitute(T=T)
+    T = RuntimeType.parse_or_infer(type_name=T, public_example=lower)
     
     # Convert arguments to c types.
     lower = py_to_c(lower, c_type=ctypes.c_void_p, type_name=T)
     upper = py_to_c(upper, c_type=ctypes.c_void_p, type_name=T)
-    DI = py_to_c(DI, c_type=ctypes.c_char_p)
-    M = py_to_c(M, c_type=ctypes.c_char_p)
+    T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
     function = lib.opendp_trans__make_clamp
-    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
+    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(lower, upper, DI, M), Transformation))
+    return c_to_py(unwrap(function(lower, upper, T), Transformation))
 
 
 def make_unclamp(
     lower,
     upper,
-    M: RuntimeTypeDescriptor,
-    T: RuntimeTypeDescriptor = "VectorDomain<IntervalDomain<T>>"
+    T: RuntimeTypeDescriptor = None
 ) -> Transformation:
-    """Make a Transformation that unclamps a VectorDomain<IntervalDomain<T>> to a VectorDomain<AllDomain<T>>. Set DI to IntervalDomain<T> to work on scalars.
+    """Make a Transformation that unclamps a VectorDomain<IntervalDomain<T>> to a VectorDomain<AllDomain<T>>.
     
     :param lower: Lower bound of the input data.
     :param upper: Upper bound of the input data.
-    :param T: domain of data being unclamped
+    :param T: atomic data type
     :type T: RuntimeTypeDescriptor
-    :param M: metric to use on the input and output spaces
-    :type M: RuntimeTypeDescriptor
     :return: A unclamp step.
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
@@ -260,20 +250,18 @@ def make_unclamp(
     """
     # Standardize type arguments.
     T = RuntimeType.parse_or_infer(type_name=T, public_example=lower)
-    M = RuntimeType.parse(type_name=M)
     
     # Convert arguments to c types.
     lower = py_to_c(lower, c_type=ctypes.c_void_p, type_name=T)
     upper = py_to_c(upper, c_type=ctypes.c_void_p, type_name=T)
     T = py_to_c(T, c_type=ctypes.c_char_p)
-    M = py_to_c(M, c_type=ctypes.c_char_p)
     
     # Call library function.
     function = lib.opendp_trans__make_unclamp
-    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
+    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(lower, upper, T, M), Transformation))
+    return c_to_py(unwrap(function(lower, upper, T), Transformation))
 
 
 def make_count(
@@ -753,16 +741,21 @@ def make_bounded_mean(
     return c_to_py(unwrap(function(lower, upper, n, T), Transformation))
 
 
-def make_resize_constant(
+def make_resize_constant_bounded(
     constant,
     length: int,
+    lower,
+    upper,
     TA: RuntimeTypeDescriptor = None
 ) -> Transformation:
     """Make a Transformation that either truncates or imputes records with `constant` in a Vec<`T`> to match a provided `length`.
+    WARNING: This function is temporary. It will be replaced by a more general make_resize_constant that accepts domains.
     
     :param constant: Value to impute with.
     :param length: Number of records in output data.
     :type length: int
+    :param lower: Lower bound of data in input domain
+    :param upper: Upper bound of data in input domain
     :param TA: Atomic type.
     :type TA: RuntimeTypeDescriptor
     :return: A vector of the same type `TA`, but with the provided `length`.
@@ -777,14 +770,16 @@ def make_resize_constant(
     # Convert arguments to c types.
     constant = py_to_c(constant, c_type=ctypes.c_void_p, type_name=TA)
     length = py_to_c(length, c_type=ctypes.c_uint)
+    lower = py_to_c(lower, c_type=ctypes.c_void_p, type_name=TA)
+    upper = py_to_c(upper, c_type=ctypes.c_void_p, type_name=TA)
     TA = py_to_c(TA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_trans__make_resize_constant
-    function.argtypes = [ctypes.c_void_p, ctypes.c_uint, ctypes.c_char_p]
+    function = lib.opendp_trans__make_resize_constant_bounded
+    function.argtypes = [ctypes.c_void_p, ctypes.c_uint, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(constant, length, TA), Transformation))
+    return c_to_py(unwrap(function(constant, length, lower, upper, TA), Transformation))
 
 
 def make_bounded_sum(

--- a/python/test/test_trans.py
+++ b/python/test/test_trans.py
@@ -154,18 +154,11 @@ def test_split_dataframe():
     assert query.check(1, 1)
 
 
-def test_vector_clamp():
+def test_clamp():
     from opendp.trans import make_clamp
     query = make_clamp(lower=-1, upper=1)
     assert query([-10, 0, 10]) == [-1, 0, 1]
     assert query.check(1, 1)
-
-
-def test_clamp_sensitivity():
-    from opendp.trans import make_clamp
-    query = make_clamp(lower=-1, upper=1, DI="AllDomain<i32>", M=AbsoluteDistance[int])
-    assert query(20) == 1
-    assert query.check(20, 2)
 
 
 def test_bounded_mean():
@@ -243,9 +236,9 @@ def test_count_by_categories():
 
 
 def test_resize():
-    from opendp.trans import make_resize_constant
-    query = make_resize_constant(True, 4)
-    assert query([True, True, False]) == [True, True, False, True]
+    from opendp.trans import make_resize_constant_bounded
+    query = make_resize_constant_bounded(constant=0, length=4, lower=0, upper=10)
+    assert query([-1, 2, 5]) == [-1, 2, 5, 0]
     assert not query.check(1, 1)
     assert query.check(1, 2)
     assert query.check(2, 2)

--- a/rust/opendp-ffi/src/any.rs
+++ b/rust/opendp-ffi/src/any.rs
@@ -497,7 +497,7 @@ mod tests {
     use std::ops::Bound;
 
     use opendp::dist::{SubstituteDistance, MaxDivergence, SmoothedMaxDivergence, SymmetricDistance};
-    use opendp::dom::{AllDomain, IntervalDomain, VectorDomain};
+    use opendp::dom::{AllDomain, IntervalDomain};
     use opendp::error::*;
     use opendp::meas;
     use opendp::trans;
@@ -566,7 +566,7 @@ mod tests {
         let t1 = trans::make_split_dataframe(None, vec!["a".to_owned(), "b".to_owned()])?.into_any();
         let t2 = trans::make_parse_column::<_, f64>("a".to_owned(), true)?.into_any();
         let t3 = trans::make_select_column::<_, f64>("a".to_owned())?.into_any();
-        let t4 = trans::make_clamp::<VectorDomain<_>, SymmetricDistance>(0.0, 10.0)?.into_any();
+        let t4 = trans::make_clamp(0.0, 10.0)?.into_any();
         let t5 = trans::make_bounded_sum(0.0, 10.0)?.into_any();
         let m1 = meas::make_base_gaussian::<AllDomain<_>>(0.0)?.into_any();
         let chain = (t1 >> t2 >> t3 >> t4 >> t5 >> m1)?;

--- a/rust/opendp-ffi/src/core/chain.rs
+++ b/rust/opendp-ffi/src/core/chain.rs
@@ -42,9 +42,10 @@ mod tests {
     use crate::util;
 
     use super::*;
+    use opendp::traits::CheckNull;
 
     // TODO: Find all the places we've duplicated this code and replace with common function.
-    pub fn make_test_measurement<T: Clone>() -> Measurement<AllDomain<T>, AllDomain<T>, SymmetricDistance, MaxDivergence<f64>> {
+    pub fn make_test_measurement<T: Clone + CheckNull>() -> Measurement<AllDomain<T>, AllDomain<T>, SymmetricDistance, MaxDivergence<f64>> {
         Measurement::new(
             AllDomain::new(),
             AllDomain::new(),
@@ -56,7 +57,7 @@ mod tests {
     }
 
     // TODO: Find all the places we've duplicated this code and replace with common function.
-    pub fn make_test_transformation<T: Clone>() -> Transformation<AllDomain<T>, AllDomain<T>, SymmetricDistance, SymmetricDistance> {
+    pub fn make_test_transformation<T: Clone + CheckNull>() -> Transformation<AllDomain<T>, AllDomain<T>, SymmetricDistance, SymmetricDistance> {
         trans::make_identity(AllDomain::<T>::new(), SymmetricDistance::default()).unwrap_test()
     }
 

--- a/rust/opendp-ffi/src/core/mod.rs
+++ b/rust/opendp-ffi/src/core/mod.rs
@@ -288,6 +288,7 @@ mod tests {
     use crate::util::ToCharP;
 
     use super::*;
+    use opendp::traits::CheckNull;
 
     #[test]
     fn test_ffi_error_from_error() {
@@ -354,7 +355,7 @@ mod tests {
     }
 
     // TODO: Find all the places we've duplicated this code and replace with common function.
-    pub fn make_test_measurement<T: Clone>() -> Measurement<AllDomain<T>, AllDomain<T>, SymmetricDistance, MaxDivergence<f64>> {
+    pub fn make_test_measurement<T: Clone + CheckNull>() -> Measurement<AllDomain<T>, AllDomain<T>, SymmetricDistance, MaxDivergence<f64>> {
         Measurement::new(
             AllDomain::new(),
             AllDomain::new(),
@@ -366,7 +367,7 @@ mod tests {
     }
 
     // TODO: Find all the places we've duplicated this code and replace with common function.
-    pub fn make_test_transformation<T: Clone>() -> Transformation<AllDomain<T>, AllDomain<T>, SymmetricDistance, SymmetricDistance> {
+    pub fn make_test_transformation<T: Clone + CheckNull>() -> Transformation<AllDomain<T>, AllDomain<T>, SymmetricDistance, SymmetricDistance> {
         trans::make_identity(AllDomain::<T>::new(), SymmetricDistance::default()).unwrap_test()
     }
 

--- a/rust/opendp-ffi/src/meas/gaussian.rs
+++ b/rust/opendp-ffi/src/meas/gaussian.rs
@@ -11,7 +11,7 @@ use crate::any::AnyMeasurement;
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::util::Type;
 use opendp::dom::{AllDomain, VectorDomain};
-use opendp::traits::InfCast;
+use opendp::traits::{InfCast, CheckNull};
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_gaussian(
@@ -20,7 +20,7 @@ pub extern "C" fn opendp_meas__make_base_gaussian(
 ) -> FfiResult<*mut AnyMeasurement> {
     fn monomorphize<D>(scale: *const c_void) -> FfiResult<*mut AnyMeasurement> where
         D: 'static + GaussianDomain,
-        D::Atom: 'static + Clone + SampleGaussian + Float + InfCast<f64> {
+        D::Atom: 'static + Clone + SampleGaussian + Float + InfCast<f64> + CheckNull {
         let scale = *try_as_ref!(scale as *const D::Atom);
         make_base_gaussian::<D>(scale).into_any()
     }

--- a/rust/opendp-ffi/src/meas/geometric.rs
+++ b/rust/opendp-ffi/src/meas/geometric.rs
@@ -11,7 +11,7 @@ use crate::any::{AnyMeasurement, AnyObject, Downcast};
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::util::Type;
 use crate::util;
-use opendp::traits::InfCast;
+use opendp::traits::{InfCast, TotalOrd};
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_geometric(
@@ -23,8 +23,8 @@ pub extern "C" fn opendp_meas__make_base_geometric(
         scale: *const c_void, bounds: *const AnyObject
     ) -> FfiResult<*mut AnyMeasurement>
         where D: 'static + GeometricDomain,
-              D::Atom: 'static + InfCast<QO> + PartialOrd + Clone,
-              QO: 'static + Float + InfCast<D::Atom>,
+              D::Atom: 'static + InfCast<QO> + TotalOrd + Clone,
+              QO: 'static + Float + InfCast<D::Atom> + TotalOrd,
               f64: From<QO> {
         let scale = try_as_ref!(scale as *const QO).clone();
         let bounds = if let Some(bounds) = util::as_ref(bounds) {

--- a/rust/opendp-ffi/src/meas/laplace.rs
+++ b/rust/opendp-ffi/src/meas/laplace.rs
@@ -11,7 +11,7 @@ use crate::any::AnyMeasurement;
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::util::Type;
 use opendp::dom::{VectorDomain, AllDomain};
-use opendp::traits::InfCast;
+use opendp::traits::{InfCast, CheckNull, TotalOrd};
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_laplace(
@@ -20,7 +20,7 @@ pub extern "C" fn opendp_meas__make_base_laplace(
 ) -> FfiResult<*mut AnyMeasurement> {
     fn monomorphize<D>(scale: *const c_void) -> FfiResult<*mut AnyMeasurement>
         where D: 'static + LaplaceDomain,
-              D::Atom: 'static + Clone + SampleLaplace + Float + InfCast<D::Atom> {
+              D::Atom: 'static + Clone + SampleLaplace + Float + InfCast<D::Atom> + CheckNull + TotalOrd {
         let scale = *try_as_ref!(scale as *const D::Atom);
         make_base_laplace::<D>(scale).into_any()
     }

--- a/rust/opendp-ffi/src/meas/stability.rs
+++ b/rust/opendp-ffi/src/meas/stability.rs
@@ -10,7 +10,7 @@ use opendp::dist::{L1Distance, L2Distance};
 use opendp::err;
 use opendp::meas::{BaseStabilityNoise, make_base_stability};
 use opendp::samplers::CastInternalReal;
-use opendp::traits::ExactIntCast;
+use opendp::traits::{ExactIntCast, CheckNull, TotalOrd};
 
 use crate::any::AnyMeasurement;
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
@@ -29,15 +29,15 @@ pub extern "C" fn opendp_meas__make_base_stability(
         n: usize, scale: *const c_void, threshold: *const c_void,
         MI: Type, TIK: Type, TIC: Type,
     ) -> FfiResult<*mut AnyMeasurement>
-        where TIC: 'static + Integer + Zero + One + AddAssign + Clone,
-              TOC: 'static + PartialOrd + Clone + Float + CastInternalReal + ExactIntCast<usize> + ExactIntCast<TIC> {
+        where TIC: 'static + Integer + Zero + One + AddAssign + Clone + CheckNull,
+              TOC: 'static + TotalOrd + Clone + Float + CastInternalReal + ExactIntCast<usize> + ExactIntCast<TIC> + CheckNull {
         fn monomorphize2<MI, TIK, TIC>(
             n: usize, scale: MI::Distance, threshold: MI::Distance,
         ) -> FfiResult<*mut AnyMeasurement>
             where MI: 'static + SensitivityMetric + BaseStabilityNoise,
-                  TIK: 'static + Eq + Hash + Clone,
-                  TIC: 'static + Integer + Zero + One + AddAssign + Clone,
-                  MI::Distance: 'static + Clone + PartialOrd + Float + CastInternalReal + ExactIntCast<usize> + ExactIntCast<TIC> {
+                  TIK: 'static + Eq + Hash + Clone + CheckNull,
+                  TIC: 'static + Integer + Zero + One + AddAssign + Clone + CheckNull,
+                  MI::Distance: 'static + Clone + TotalOrd + Float + CastInternalReal + ExactIntCast<usize> + ExactIntCast<TIC> + CheckNull {
             make_base_stability::<MI, TIK, TIC>(n, scale, threshold).into_any()
         }
         let scale = *try_as_ref!(scale as *const TOC);

--- a/rust/opendp-ffi/src/trans/bootstrap.json
+++ b/rust/opendp-ffi/src/trans/bootstrap.json
@@ -110,7 +110,7 @@
         "ret": {"c_type": "FfiResult<AnyTransformation *>"}
     },
     "make_clamp": {
-        "description": "Make a Transformation that clamps numeric data in Vec<`T`> between `lower` and `upper`. Set DI to AllDomain<T> for clamping aggregated values.",
+        "description": "Make a Transformation that clamps numeric data in Vec<`T`> between `lower` and `upper`.",
         "args": [
             {
                 "name": "lower",
@@ -125,36 +125,16 @@
                 "description": "If datum is greater than upper, let datum be upper."
             },
             {
-                "name": "DI",
-                "c_type": "char *",
-                "is_type": true,
-                "default": "VectorDomain<AllDomain<T>>",
-                "generics": ["T"],
-                "description": "input domain. One of VectorDomain<AllDomain<_>> or AllDomain<_>."
-            },
-            {
-                "name": "M",
-                "c_type": "char *",
-                "is_type": true,
-                "default": "SymmetricDistance",
-                "description": "metric. Set to SymmetricDistance when clamping datasets, or AbsoluteDistance<_> when clamping aggregated scalars"
-            }
-        ],
-        "derived_types": [
-            {
                 "name": "T",
-                "rust_type": {
-                    "function": "get_domain_atom_or_infer",
-                    "params": [
-                        "DI", "lower"
-                    ]
-                }
+                "c_type": "char *",
+                "is_type": true,
+                "description": "atomic data type"
             }
         ],
         "ret": {"c_type": "FfiResult<AnyTransformation *>"}
     },
     "make_unclamp": {
-        "description": "Make a Transformation that unclamps a VectorDomain<IntervalDomain<T>> to a VectorDomain<AllDomain<T>>. Set DI to IntervalDomain<T> to work on scalars.",
+        "description": "Make a Transformation that unclamps a VectorDomain<IntervalDomain<T>> to a VectorDomain<AllDomain<T>>.",
         "args": [
             {
                 "name": "lower",
@@ -172,14 +152,7 @@
                 "name": "T",
                 "c_type": "char *",
                 "is_type": true,
-                "default": "VectorDomain<IntervalDomain<T>>",
-                "description": "domain of data being unclamped"
-            },
-            {
-                "name": "M",
-                "c_type": "char *",
-                "is_type": true,
-                "description": "metric to use on the input and output spaces"
+                "description": "atomic data type"
             }
         ],
         "ret": {"c_type": "FfiResult<AnyTransformation *>"}
@@ -519,8 +492,8 @@
             "c_type": "FfiResult<AnyTransformation *>"
         }
     },
-    "make_resize_constant": {
-        "description": "Make a Transformation that either truncates or imputes records with `constant` in a Vec<`T`> to match a provided `length`.",
+    "make_resize_constant_bounded": {
+        "description": "Make a Transformation that either truncates or imputes records with `constant` in a Vec<`T`> to match a provided `length`.\nWARNING: This function is temporary. It will be replaced by a more general make_resize_constant that accepts domains.",
         "args": [
             {
                 "name": "constant",
@@ -532,6 +505,18 @@
                 "name": "length",
                 "c_type": "unsigned int",
                 "description": "Number of records in output data."
+            },
+            {
+                "name": "lower",
+                "c_type": "void *",
+                "rust_type": "TA",
+                "description": "Lower bound of data in input domain"
+            },
+            {
+                "name": "upper",
+                "c_type": "void *",
+                "rust_type": "TA",
+                "description": "Upper bound of data in input domain"
             },
             {
                 "name": "TA",

--- a/rust/opendp-ffi/src/trans/cast.rs
+++ b/rust/opendp-ffi/src/trans/cast.rs
@@ -22,7 +22,7 @@ pub extern "C" fn opendp_trans__make_cast(
     let TO = try_!(Type::try_from(TO));
 
     fn monomorphize<TI, TO>() -> FfiResult<*mut AnyTransformation>
-        where TI: 'static + Clone,
+        where TI: 'static + Clone + CheckNull,
               TO: 'static + RoundCast<TI> + CheckNull {
         make_cast::<TI, TO>().into_any()
     }
@@ -37,8 +37,8 @@ pub extern "C" fn opendp_trans__make_cast_default(
     let TO = try_!(Type::try_from(TO));
 
     fn monomorphize<TI, TO>() -> FfiResult<*mut AnyTransformation>
-        where TI: 'static + Clone,
-              TO: 'static + RoundCast<TI> + Default {
+        where TI: 'static + Clone + CheckNull,
+              TO: 'static + RoundCast<TI> + Default + CheckNull {
         make_cast_default::<TI, TO>().into_any()
     }
     dispatch!(monomorphize, [(TI, @primitives), (TO, @primitives)], ())
@@ -52,7 +52,7 @@ pub extern "C" fn opendp_trans__make_cast_inherent(
     let TO = try_!(Type::try_from(TO));
 
     fn monomorphize<TI, TO>() -> FfiResult<*mut AnyTransformation>
-        where TI: 'static + Clone,
+        where TI: 'static + Clone + CheckNull,
               TO: 'static + RoundCast<TI> + InherentNull {
         make_cast_inherent::<TI, TO>().into_any()
     }
@@ -74,7 +74,7 @@ pub extern "C" fn opendp_trans__make_cast_metric(
         where MI: 'static + DatasetMetric,
               MO: 'static + DatasetMetric,
               (MI, MO): DatasetMetricCast,
-              T: 'static + Clone {
+              T: 'static + Clone + CheckNull {
         make_cast_metric::<VectorDomain<AllDomain<T>>, MI, MO>(
             VectorDomain::new_all()
         ).into_any()

--- a/rust/opendp-ffi/src/trans/clamp.rs
+++ b/rust/opendp-ffi/src/trans/clamp.rs
@@ -1,127 +1,49 @@
 use std::convert::TryFrom;
-use std::ops::{Bound};
+use std::ops::Bound;
 use std::os::raw::{c_char, c_void};
 
-use num::One;
-
-use opendp::core::{DatasetMetric, Metric};
-use opendp::dist::{SubstituteDistance, SymmetricDistance, AbsoluteDistance, L1Distance, L2Distance, IntDistance};
-use opendp::dom::{AllDomain, VectorDomain, IntervalDomain};
 use opendp::err;
-use opendp::traits::{DistanceConstant, InfCast};
-use opendp::trans::{ClampableDomain, make_clamp, make_unclamp, UnclampableDomain};
+use opendp::traits::{CheckNull, TotalOrd};
+use opendp::trans::{make_clamp, make_unclamp};
 
 use crate::any::AnyTransformation;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
-use crate::util::{MetricClass, Type};
+use crate::util::Type;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_clamp(
     lower: *const c_void, upper: *const c_void,
-    DI: *const c_char, M: *const c_char,
+    T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    let DI = try_!(Type::try_from(DI));
-    let DIA = try_!(DI.get_domain_atom());
-    let M = try_!(Type::try_from(M));
+    let T = try_!(Type::try_from(T));
 
-    match try_!(M.get_metric_class()) {
-        MetricClass::Dataset => {
-            fn monomorphize_dataset<T>(lower: *const c_void, upper: *const c_void) -> FfiResult<*mut AnyTransformation>
-                where VectorDomain<AllDomain<T>>: ClampableDomain<SymmetricDistance, Atom=T>,
-                      T: 'static + Clone + PartialOrd {
-                let lower = try_as_ref!(lower as *const T).clone();
-                let upper = try_as_ref!(upper as *const T).clone();
-                make_clamp::<VectorDomain<AllDomain<T>>, SymmetricDistance>(lower, upper).into_any()
-            }
-            dispatch!(monomorphize_dataset, [
-                (DIA, @numbers)
-            ], (lower, upper))
-        },
-
-        MetricClass::Sensitivity => {
-            fn monomorphize_sensitivity<T, Q>(
-                lower: *const c_void, upper: *const c_void
-            ) -> FfiResult<*mut AnyTransformation>
-                where AllDomain<T>: ClampableDomain<AbsoluteDistance<Q>, Atom=T>,
-                      Q: DistanceConstant<IntDistance> + One,
-                      T: 'static + Clone + PartialOrd,
-                      IntDistance: InfCast<Q> {
-                let lower = try_as_ref!(lower as *const T).clone();
-                let upper = try_as_ref!(upper as *const T).clone();
-                make_clamp::<AllDomain<T>, AbsoluteDistance<Q>>(lower, upper).into_any()
-            }
-            let Q = try_!(M.get_sensitivity_distance());
-            dispatch!(monomorphize_sensitivity, [
-                (DIA, @numbers),
-                (Q, @numbers)
-            ], (lower, upper))
-        }
+    fn monomorphize_dataset<T>(lower: *const c_void, upper: *const c_void) -> FfiResult<*mut AnyTransformation>
+        where T: 'static + Clone + TotalOrd + CheckNull {
+        let lower = try_as_ref!(lower as *const T).clone();
+        let upper = try_as_ref!(upper as *const T).clone();
+        make_clamp::<T>(lower, upper).into_any()
     }
+    dispatch!(monomorphize_dataset, [
+        (T, @numbers)
+    ], (lower, upper))
 }
 
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_unclamp(
     lower: *const c_void, upper: *const c_void,
-    DI: *const c_char, M: *const c_char,
+    T: *const c_char
 ) -> FfiResult<*mut AnyTransformation> {
-    let DI = try_!(Type::try_from(DI));
-    let M = try_!(Type::try_from(M));
-
-    let T = try_!(DI.get_domain_atom());
-
-    match try_!(M.get_metric_class()) {
-        MetricClass::Dataset => {
-            fn monomorphize_dataset<T, M>(lower: *const c_void, upper: *const c_void) -> FfiResult<*mut AnyTransformation>
-                where VectorDomain<IntervalDomain<T>>: UnclampableDomain<Atom=T, Carrier=Vec<T>>,
-                      T: 'static + Clone + PartialOrd,
-                      M: 'static + DatasetMetric {
-                let lower = try_as_ref!(lower as *const T).clone();
-                let upper = try_as_ref!(upper as *const T).clone();
-                make_unclamp::<VectorDomain<IntervalDomain<T>>, M>(
-                    Bound::Included(lower), Bound::Included(upper)
-                ).into_any()
-            }
-            dispatch!(monomorphize_dataset, [
-                (T, @numbers),
-                (M, @dist_dataset)
-            ], (lower, upper))
-        },
-
-        MetricClass::Sensitivity => {
-            fn monomorphize_sensitivity<T, Q>(
-                lower: *const c_void, upper: *const c_void, DI: Type, M: Type
-            ) -> FfiResult<*mut AnyTransformation>
-                where IntervalDomain<T>: UnclampableDomain<Atom=T, Carrier=T>,
-                      Q: DistanceConstant<Q> + One,
-                      T: 'static + Clone + PartialOrd {
-                fn monomorphize_sensitivity_2<DI, M>(
-                    lower: DI::Atom, upper: DI::Atom,
-                ) -> FfiResult<*mut AnyTransformation>
-                    where DI: 'static + UnclampableDomain,
-                          DI::Carrier: Clone,
-                          M: 'static + Metric,
-                          DI::Atom: 'static + Clone + PartialOrd,
-                          M::Distance: DistanceConstant<M::Distance> + One {
-                    make_unclamp::<DI, M>(
-                        Bound::Included(lower), Bound::Included(upper),
-                    ).into_any()
-                }
-                let lower = try_as_ref!(lower as *const T).clone();
-                let upper = try_as_ref!(upper as *const T).clone();
-
-                dispatch!(monomorphize_sensitivity_2, [
-                    (DI, [IntervalDomain<T>]),
-                    (M, [AbsoluteDistance<Q>, L1Distance<Q>, L2Distance<Q>])
-                ], (lower, upper))
-            }
-            let Q = try_!(M.get_sensitivity_distance());
-            dispatch!(monomorphize_sensitivity, [
-                (T, @numbers),
-                (Q, @numbers)
-            ], (lower, upper, DI, M))
-        }
+    let T = try_!(Type::try_from(T));
+    fn monomorphize_dataset<T>(lower: *const c_void, upper: *const c_void) -> FfiResult<*mut AnyTransformation>
+        where T: 'static + Clone + TotalOrd + CheckNull {
+        let lower = try_as_ref!(lower as *const T).clone();
+        let upper = try_as_ref!(upper as *const T).clone();
+        make_unclamp::<T>(Bound::Included(lower), Bound::Included(upper)).into_any()
     }
+    dispatch!(monomorphize_dataset, [
+        (T, @numbers)
+    ], (lower, upper))
 }
 
 
@@ -133,32 +55,16 @@ mod tests {
 
     use crate::any::{AnyObject, Downcast};
     use crate::core;
+    use crate::trans::clamp::opendp_trans__make_clamp;
     use crate::util;
     use crate::util::ToCharP;
-    use crate::trans::clamp::opendp_trans__make_clamp;
-
-    #[test]
-    fn test_make_clamp_sensitivity() -> Fallible<()> {
-        let transformation = Result::from(opendp_trans__make_clamp(
-            util::into_raw(0.0) as *const c_void,
-            util::into_raw(10.0) as *const c_void,
-            "AllDomain<f64>".to_char_p(),
-            "AbsoluteDistance<f64>".to_char_p(),
-        ))?;
-        let arg = AnyObject::new_raw(-1.0);
-        let res = core::opendp_core__transformation_invoke(&transformation, arg);
-        let res: f64 = Fallible::from(res)?.downcast()?;
-        assert_eq!(res, 0.0);
-        Ok(())
-    }
 
     #[test]
     fn test_make_vector_clamp() -> Fallible<()> {
         let transformation = Result::from(opendp_trans__make_clamp(
             util::into_raw(0.0) as *const c_void,
             util::into_raw(10.0) as *const c_void,
-            "VectorDomain<AllDomain<f64>>".to_char_p(),
-            "SymmetricDistance".to_char_p(),
+            "f64".to_char_p(),
         ))?;
         let arg = AnyObject::new_raw(vec![-1.0, 5.0, 11.0]);
         let res = core::opendp_core__transformation_invoke(&transformation, arg);

--- a/rust/opendp-ffi/src/trans/count.rs
+++ b/rust/opendp-ffi/src/trans/count.rs
@@ -8,7 +8,7 @@ use num::traits::FloatConst;
 use opendp::core::{SensitivityMetric};
 use opendp::dist::{L1Distance, L2Distance, IntDistance};
 use opendp::err;
-use opendp::traits::{DistanceConstant, InfCast, ExactIntCast, SaturatingAdd};
+use opendp::traits::{DistanceConstant, InfCast, ExactIntCast, SaturatingAdd, CheckNull};
 use opendp::trans::{CountByConstant, make_count, make_count_by, make_count_by_categories, make_count_distinct};
 
 use crate::any::{AnyObject, AnyTransformation};
@@ -22,8 +22,8 @@ pub extern "C" fn opendp_trans__make_count(
     TO: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<TIA, TO>() -> FfiResult<*mut AnyTransformation>
-        where TIA: 'static,
-              TO: 'static + ExactIntCast<usize> + Bounded + One + DistanceConstant<IntDistance>,
+        where TIA: 'static + CheckNull,
+              TO: 'static + ExactIntCast<usize> + Bounded + One + DistanceConstant<IntDistance> + CheckNull,
               IntDistance: InfCast<TO> {
         make_count::<TIA, TO>().into_any()
     }
@@ -42,8 +42,8 @@ pub extern "C" fn opendp_trans__make_count_distinct(
     TO: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<TIA, TO: 'static>() -> FfiResult<*mut AnyTransformation>
-        where TIA: 'static + Eq + Hash,
-              TO: 'static + ExactIntCast<usize> + Bounded + One + DistanceConstant<IntDistance>,
+        where TIA: 'static + Eq + Hash + CheckNull,
+              TO: 'static + ExactIntCast<usize> + Bounded + One + DistanceConstant<IntDistance> + CheckNull,
               IntDistance: InfCast<TO> {
         make_count_distinct::<TIA, TO>().into_any()
     }
@@ -70,8 +70,8 @@ pub extern "C" fn opendp_trans__make_count_by_categories(
         fn monomorphize2<MO, TI, TO>(categories: *const AnyObject) -> FfiResult<*mut AnyTransformation>
             where MO: 'static + SensitivityMetric + CountByConstant<MO::Distance>,
                   MO::Distance: DistanceConstant<IntDistance> + One,
-                  TI: 'static + Eq + Hash + Clone,
-                  TO: 'static + Integer + Zero + One + SaturatingAdd,
+                  TI: 'static + Eq + Hash + Clone + CheckNull,
+                  TO: 'static + Integer + Zero + One + SaturatingAdd + CheckNull,
                   IntDistance: InfCast<MO::Distance> {
             let categories = try_!(try_as_ref!(categories).downcast_ref::<Vec<TI>>()).clone();
             make_count_by_categories::<MO, TI, TO>(categories).into_any()
@@ -105,8 +105,8 @@ pub extern "C" fn opendp_trans__make_count_by(
         fn monomorphize2<MO, TI, TO>(n: usize) -> FfiResult<*mut AnyTransformation>
             where MO: 'static + SensitivityMetric + CountByConstant<MO::Distance>,
                   MO::Distance: DistanceConstant<IntDistance> + FloatConst + One,
-                  TI: 'static + Eq + Hash + Clone,
-                  TO: 'static + Integer + Zero + One + SaturatingAdd,
+                  TI: 'static + Eq + Hash + Clone + CheckNull,
+                  TO: 'static + Integer + Zero + One + SaturatingAdd + CheckNull,
                   IntDistance: InfCast<MO::Distance> {
             make_count_by::<MO, TI, TO>(n).into_any()
         }

--- a/rust/opendp-ffi/src/trans/dataframe.rs
+++ b/rust/opendp-ffi/src/trans/dataframe.rs
@@ -11,6 +11,7 @@ use crate::any::{AnyObject, AnyTransformation, Downcast};
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::{c_bool, Type};
 use crate::util;
+use opendp::traits::CheckNull;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_split_lines() -> FfiResult<*mut AnyTransformation> {
@@ -30,7 +31,7 @@ pub extern "C" fn opendp_trans__make_create_dataframe(
     col_names: *const AnyObject, K: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<K>(col_names: *const AnyObject) -> FfiResult<*mut AnyTransformation>
-        where K: 'static + Eq + Hash + Clone {
+        where K: 'static + Eq + Hash + Clone + CheckNull {
         let col_names = try_!(try_as_ref!(col_names).downcast_ref::<Vec<K>>()).clone();
         make_create_dataframe::<K>(col_names).into_any()
     }
@@ -44,7 +45,7 @@ pub extern "C" fn opendp_trans__make_split_dataframe(
     K: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<K>(separator: Option<&str>, col_names: *const AnyObject) -> FfiResult<*mut AnyTransformation>
-        where K: 'static + Eq + Hash + Debug + Clone {
+        where K: 'static + Eq + Hash + Debug + Clone + CheckNull {
         let col_names = try_!(try_as_ref!(col_names).downcast_ref::<Vec<K>>()).clone();
         make_split_dataframe::<K>(separator, col_names).into_any()
     }
@@ -60,7 +61,7 @@ pub extern "C" fn opendp_trans__make_parse_column(
     K: *const c_char, T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<K, T>(key: *const AnyObject, impute: bool) -> FfiResult<*mut AnyTransformation> where
-        K: 'static + Hash + Eq + Debug + Clone,
+        K: 'static + Hash + Eq + Debug + Clone + CheckNull,
         T: 'static + Debug + Clone + PartialEq + FromStr + Default,
         T::Err: Debug {
         let key: K = try_!(try_as_ref!(key).downcast_ref::<K>()).clone();
@@ -81,8 +82,8 @@ pub extern "C" fn opendp_trans__make_select_column(
     key: *const AnyObject, K: *const c_char, T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<K, T>(key: *const AnyObject) -> FfiResult<*mut AnyTransformation> where
-        K: 'static + Hash + Eq + Debug + Clone,
-        T: 'static + Debug + Clone + PartialEq {
+        K: 'static + Hash + Eq + Debug + Clone + CheckNull,
+        T: 'static + Debug + Clone + PartialEq + CheckNull {
         let key: K = try_!(try_as_ref!(key).downcast_ref::<K>()).clone();
         make_select_column::<K, T>(key).into_any()
     }

--- a/rust/opendp-ffi/src/trans/impute.rs
+++ b/rust/opendp-ffi/src/trans/impute.rs
@@ -12,6 +12,7 @@ use opendp::trans::{ImputableDomain, make_impute_constant, make_impute_uniform_f
 use crate::any::{AnyTransformation, AnyObject, Downcast};
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::{Type, TypeContents};
+use opendp::traits::CheckNull;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_impute_uniform_float(
@@ -46,8 +47,8 @@ pub extern "C" fn opendp_trans__make_impute_constant(
             fn monomorphize<T>(
                 constant: *const AnyObject
             ) -> FfiResult<*mut AnyTransformation>
-                where OptionNullDomain<AllDomain<T>>: ImputableDomain<NonNull=T>,
-                      T: 'static + Clone {
+                where OptionNullDomain<AllDomain<T>>: ImputableDomain<Imputed=T>,
+                      T: 'static + Clone + CheckNull{
                 let constant: T = try_!(try_as_ref!(constant).downcast_ref::<T>()).clone();
                 make_impute_constant::<OptionNullDomain<AllDomain<T>>>(constant).into_any()
             }
@@ -57,7 +58,7 @@ pub extern "C" fn opendp_trans__make_impute_constant(
             fn monomorphize<T>(
                 constant: *const AnyObject
             ) -> FfiResult<*mut AnyTransformation>
-                where InherentNullDomain<AllDomain<T>>: ImputableDomain<NonNull=T>,
+                where InherentNullDomain<AllDomain<T>>: ImputableDomain<Imputed=T>,
                       T: 'static + InherentNull + Clone {
                 let constant: T = try_!(try_as_ref!(constant).downcast_ref::<T>()).clone();
                 make_impute_constant::<InherentNullDomain<AllDomain<T>>>(constant).into_any()

--- a/rust/opendp-ffi/src/trans/mean.rs
+++ b/rust/opendp-ffi/src/trans/mean.rs
@@ -6,7 +6,7 @@ use std::os::raw::{c_char, c_uint, c_void};
 use num::Float;
 
 use opendp::err;
-use opendp::traits::{DistanceConstant, InfCast, ExactIntCast, CheckedMul};
+use opendp::traits::{DistanceConstant, InfCast, ExactIntCast, CheckedMul, CheckNull};
 use opendp::trans::{make_bounded_mean};
 
 use crate::any::AnyTransformation;
@@ -20,7 +20,7 @@ pub extern "C" fn opendp_trans__make_bounded_mean(
     T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<T>(lower: *const c_void, upper: *const c_void, n: usize) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactIntCast<usize> + CheckedMul,
+        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactIntCast<usize> + CheckedMul + CheckNull,
               for<'a> T: Sum<&'a T>,
               IntDistance: InfCast<T> {
         let lower = *try_as_ref!(lower as *const T);

--- a/rust/opendp-ffi/src/trans/resize.rs
+++ b/rust/opendp-ffi/src/trans/resize.rs
@@ -3,25 +3,35 @@ use std::os::raw::{c_char, c_uint, c_void};
 
 use opendp::err;
 use opendp::trans::make_resize_constant;
-use opendp::traits::CheckNull;
+use opendp::traits::{CheckNull, TotalOrd};
 
 use crate::any::AnyTransformation;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::Type;
+use opendp::dom::IntervalDomain;
+use std::collections::Bound;
 
+// TODO: add FFI functions for creating domains, adjust this to accept an AnyDomain
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_resize_constant(
+pub extern "C" fn opendp_trans__make_resize_constant_bounded(
     constant: *const c_void, length: c_uint,
+    lower: *const c_void, upper: *const c_void,
     TA: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<TA>(constant: *const c_void, length: usize) -> FfiResult<*mut AnyTransformation>
-        where TA: 'static + Clone + CheckNull {
+    fn monomorphize<TA>(
+        constant: *const c_void, length: usize,
+        lower: *const c_void, upper: *const c_void
+    ) -> FfiResult<*mut AnyTransformation>
+        where TA: 'static + Clone + CheckNull + TotalOrd {
         let constant = try_as_ref!(constant as *const TA).clone();
-        make_resize_constant::<TA>(constant, length).into_any()
+        let lower = try_as_ref!(lower as *const TA).clone();
+        let upper = try_as_ref!(upper as *const TA).clone();
+        let atom_domain = try_!(IntervalDomain::new(Bound::Included(lower), Bound::Included(upper)));
+        make_resize_constant::<IntervalDomain<TA>>(atom_domain, constant, length).into_any()
     }
     let length = length as usize;
     let TA = try_!(Type::try_from(TA));
-    dispatch!(monomorphize, [(TA, @primitives)], (constant, length))
+    dispatch!(monomorphize, [(TA, @numbers)], (constant, length, lower, upper))
 }
 
 
@@ -38,9 +48,11 @@ mod tests {
 
     #[test]
     fn test_make_resize() -> Fallible<()> {
-        let transformation = Result::from(opendp_trans__make_resize_constant(
+        let transformation = Result::from(opendp_trans__make_resize_constant_bounded(
             util::into_raw(0i32) as *const c_void,
             4 as c_uint,
+            util::into_raw(0i32) as *const c_void,
+            util::into_raw(10i32) as *const c_void,
             "i32".to_char_p(),
         ))?;
         let arg = AnyObject::new_raw(vec![1, 2, 3]);

--- a/rust/opendp-ffi/src/trans/sum.rs
+++ b/rust/opendp-ffi/src/trans/sum.rs
@@ -4,7 +4,7 @@ use std::ops::Sub;
 use std::os::raw::{c_char, c_uint, c_void};
 
 use opendp::err;
-use opendp::traits::{Abs, DistanceConstant, InfCast, SaturatingAdd, ExactIntCast, CheckedMul};
+use opendp::traits::{Abs, DistanceConstant, InfCast, SaturatingAdd, ExactIntCast, CheckedMul, CheckNull};
 use opendp::trans::{make_bounded_sum, make_bounded_sum_n};
 
 use crate::any::AnyTransformation;
@@ -21,7 +21,7 @@ pub extern "C" fn opendp_trans__make_bounded_sum(
     fn monomorphize<T>(
         lower: *const c_void, upper: *const c_void
     ) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Abs + SaturatingAdd + Zero,
+        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Abs + SaturatingAdd + Zero + CheckNull,
               IntDistance: InfCast<T> {
         let lower = try_as_ref!(lower as *const T).clone();
         let upper = try_as_ref!(upper as *const T).clone();
@@ -39,7 +39,7 @@ pub extern "C" fn opendp_trans__make_bounded_sum_n(
     T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<T>(lower: *const c_void, upper: *const c_void, n: usize) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Sub<Output=T> + ExactIntCast<usize> + CheckedMul,
+        where T: DistanceConstant<IntDistance> + Sub<Output=T> + ExactIntCast<usize> + CheckedMul + CheckNull,
               for<'a> T: Sum<&'a T>,
               IntDistance: InfCast<T> {
         let lower = try_as_ref!(lower as *const T).clone();

--- a/rust/opendp-ffi/src/trans/variance.rs
+++ b/rust/opendp-ffi/src/trans/variance.rs
@@ -6,7 +6,7 @@ use std::os::raw::{c_char, c_uint, c_void};
 use num::{Float, One, Zero};
 
 use opendp::err;
-use opendp::traits::{DistanceConstant, InfCast, ExactIntCast, CheckedMul};
+use opendp::traits::{DistanceConstant, InfCast, ExactIntCast, CheckedMul, CheckNull};
 use opendp::trans::{make_bounded_covariance, make_bounded_variance};
 
 use crate::any::{AnyObject, AnyTransformation, Downcast};
@@ -23,7 +23,7 @@ pub extern "C" fn opendp_trans__make_bounded_variance(
     fn monomorphize2<T>(
         lower: *const c_void, upper: *const c_void, length: usize, ddof: usize,
     ) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Float + for<'a> Sum<&'a T> + Sum<T> + ExactIntCast<usize> + CheckedMul,
+        where T: DistanceConstant<IntDistance> + Float + for<'a> Sum<&'a T> + Sum<T> + ExactIntCast<usize> + CheckedMul + CheckNull,
               for<'a> &'a T: Sub<Output=T> + Add<&'a T, Output=T>,
               IntDistance: InfCast<T> {
         let lower = *try_as_ref!(lower as *const T);
@@ -52,7 +52,7 @@ pub extern "C" fn opendp_trans__make_bounded_covariance(
         upper: *const AnyObject,
         length: usize, ddof: usize,
     ) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Sum<T> + Zero + One + ExactIntCast<usize> + CheckedMul,
+        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Sum<T> + Zero + One + ExactIntCast<usize> + CheckedMul + CheckNull,
               for<'a> T: Div<&'a T, Output=T> + Add<&'a T, Output=T>,
               for<'a> &'a T: Sub<Output=T>,
               IntDistance: InfCast<T> {

--- a/rust/opendp/src/data.rs
+++ b/rust/opendp/src/data.rs
@@ -3,6 +3,7 @@
 use std::any::Any;
 use std::fmt::Debug;
 use crate::error::*;
+use crate::traits::CheckNull;
 
 pub trait IsVec: Debug {
     // Not sure if we need into_any() (which consumes the Form), keeping it for now.
@@ -30,6 +31,9 @@ impl<T> From<Vec<T>> for Column
 
 #[derive(Debug)]
 pub struct Column(Box<dyn IsVec>);
+impl CheckNull for Column {
+    fn is_null(&self) -> bool { false }
+}
 
 impl Column {
     pub fn new<T: 'static + Debug>(form: Vec<T>) -> Self where Vec<T>: IsVec {

--- a/rust/opendp/src/interactive.rs
+++ b/rust/opendp/src/interactive.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use crate::core::{Domain, Function, Measure, Measurement, Metric, PrivacyRelation};
 use crate::dom::AllDomain;
 use crate::error::*;
-use crate::traits::{FallibleSub, MeasureDistance, MetricDistance};
+use crate::traits::{FallibleSub, MeasureDistance, MetricDistance, CheckNull};
 
 /// A structure tracking the state of an interactive measurement queryable.
 /// It's generic over state (S), query (Q), answer (A), so it can be used for any
@@ -45,6 +45,8 @@ impl<S, Q> Queryable<S, Q, Box<dyn Any>> {
         self.eval(query)?.downcast().map_err(|_| err!(FailedCast)).map(|b| *b)
     }
 }
+
+impl<S, Q, A> CheckNull for Queryable<S, Q, A> { fn is_null(&self) -> bool { false } }
 
 pub type InteractiveMeasurement<DI, DO, MI, MO, S, Q> = Measurement<DI, AllDomain<Queryable<S, Q, <DO as Domain>::Carrier>>, MI, MO>;
 
@@ -163,7 +165,7 @@ mod tests {
 
     use super::*;
 
-    fn make_dummy_meas<TO: From<i32>>() -> Measurement<AllDomain<i32>, AllDomain<TO>, AbsoluteDistance<f64>, MaxDivergence<f64>> {
+    fn make_dummy_meas<TO: From<i32> + CheckNull>() -> Measurement<AllDomain<i32>, AllDomain<TO>, AbsoluteDistance<f64>, MaxDivergence<f64>> {
         Measurement::new(
             AllDomain::new(),
             AllDomain::new(),

--- a/rust/opendp/src/lib.rs
+++ b/rust/opendp/src/lib.rs
@@ -57,7 +57,7 @@
 //!     let load_numbers = make_chain_tt(&cast, &split_lines, None)?;
 //!
 //!     // Construct a Measurement to calculate a noisy sum.
-//!     let clamp = make_clamp::<VectorDomain<_>, _>(bounds.0, bounds.1)?;
+//!     let clamp = make_clamp(bounds.0, bounds.1)?;
 //!     let bounded_sum = make_bounded_sum(bounds.0, bounds.1)?;
 //!     let laplace = make_base_laplace(sigma)?;
 //!     let intermediate = make_chain_tt(&bounded_sum, &clamp, None)?;

--- a/rust/opendp/src/meas/gaussian.rs
+++ b/rust/opendp/src/meas/gaussian.rs
@@ -5,7 +5,7 @@ use crate::dist::{L2Distance, SmoothedMaxDivergence, AbsoluteDistance};
 use crate::dom::{AllDomain, VectorDomain};
 use crate::error::*;
 use crate::samplers::SampleGaussian;
-use crate::traits::InfCast;
+use crate::traits::{InfCast, CheckNull};
 
 // const ADDITIVE_GAUSS_CONST: f64 = 8. / 9. + (2. / std::f64::consts::PI).ln();
 const ADDITIVE_GAUSS_CONST: f64 = 0.4373061836;
@@ -42,7 +42,7 @@ pub trait GaussianDomain: Domain {
 
 
 impl<T> GaussianDomain for AllDomain<T>
-    where T: 'static + SampleGaussian + Float {
+    where T: 'static + SampleGaussian + Float + CheckNull {
     type Metric = AbsoluteDistance<T>;
     type Atom = T;
 
@@ -53,7 +53,7 @@ impl<T> GaussianDomain for AllDomain<T>
 }
 
 impl<T> GaussianDomain for VectorDomain<AllDomain<T>>
-    where T: 'static + SampleGaussian + Float {
+    where T: 'static + SampleGaussian + Float + CheckNull {
     type Metric = L2Distance<T>;
     type Atom = T;
 
@@ -68,7 +68,7 @@ impl<T> GaussianDomain for VectorDomain<AllDomain<T>>
 
 pub fn make_base_gaussian<D>(scale: D::Atom) -> Fallible<Measurement<D, D, D::Metric, SmoothedMaxDivergence<D::Atom>>>
     where D: GaussianDomain,
-          D::Atom: 'static + Clone + SampleGaussian + Float + InfCast<f64> {
+          D::Atom: 'static + Clone + SampleGaussian + Float + InfCast<f64> + CheckNull {
     if scale.is_sign_negative() {
         return fallible!(MakeMeasurement, "scale must not be negative")
     }

--- a/rust/opendp/src/meas/geometric.rs
+++ b/rust/opendp/src/meas/geometric.rs
@@ -4,7 +4,7 @@ use crate::dom::{AllDomain, VectorDomain};
 use crate::error::*;
 use crate::samplers::SampleTwoSidedGeometric;
 use num::Float;
-use crate::traits::{DistanceConstant, InfCast};
+use crate::traits::{DistanceConstant, InfCast, CheckNull, TotalOrd};
 
 
 pub trait GeometricDomain: Domain {
@@ -18,7 +18,7 @@ pub trait GeometricDomain: Domain {
 
 
 impl<T> GeometricDomain for AllDomain<T>
-    where T: 'static + Clone + SampleTwoSidedGeometric {
+    where T: 'static + Clone + SampleTwoSidedGeometric + CheckNull {
     type InputMetric = AbsoluteDistance<T>;
     type Atom = T;
 
@@ -30,7 +30,7 @@ impl<T> GeometricDomain for AllDomain<T>
 }
 
 impl<T> GeometricDomain for VectorDomain<AllDomain<T>>
-    where T: 'static + Clone + SampleTwoSidedGeometric {
+    where T: 'static + Clone + SampleTwoSidedGeometric + CheckNull {
     type InputMetric = L1Distance<T>;
     type Atom = T;
 
@@ -46,7 +46,7 @@ pub fn make_base_geometric<D, QO>(
     scale: QO, bounds: Option<(D::Atom, D::Atom)>
 ) -> Fallible<Measurement<D, D, D::InputMetric, MaxDivergence<QO>>>
     where D: 'static + GeometricDomain,
-          D::Atom: 'static + PartialOrd + Clone + InfCast<QO>,
+          D::Atom: 'static + TotalOrd + Clone + InfCast<QO>,
           QO: 'static + Float + DistanceConstant<D::Atom>,
           f64: From<QO> {
     if scale.is_sign_negative() { return fallible!(MakeMeasurement, "scale must not be negative") }

--- a/rust/opendp/src/meas/laplace.rs
+++ b/rust/opendp/src/meas/laplace.rs
@@ -5,7 +5,7 @@ use crate::dist::{L1Distance, MaxDivergence, AbsoluteDistance};
 use crate::dom::{AllDomain, VectorDomain};
 use crate::samplers::{SampleLaplace};
 use crate::error::*;
-use crate::traits::{InfCast};
+use crate::traits::{InfCast, CheckNull, TotalOrd};
 
 pub trait LaplaceDomain: Domain {
     type Metric: SensitivityMetric<Distance=Self::Atom> + Default;
@@ -15,7 +15,7 @@ pub trait LaplaceDomain: Domain {
 }
 
 impl<T> LaplaceDomain for AllDomain<T>
-    where T: 'static + SampleLaplace + Float {
+    where T: 'static + SampleLaplace + Float + CheckNull {
     type Metric = AbsoluteDistance<T>;
     type Atom = Self::Carrier;
 
@@ -26,7 +26,7 @@ impl<T> LaplaceDomain for AllDomain<T>
 }
 
 impl<T> LaplaceDomain for VectorDomain<AllDomain<T>>
-    where T: 'static + SampleLaplace + Float {
+    where T: 'static + SampleLaplace + Float + CheckNull {
     type Metric = L1Distance<T>;
     type Atom = T;
 
@@ -40,7 +40,7 @@ impl<T> LaplaceDomain for VectorDomain<AllDomain<T>>
 
 pub fn make_base_laplace<D>(scale: D::Atom) -> Fallible<Measurement<D, D, D::Metric, MaxDivergence<D::Atom>>>
     where D: LaplaceDomain,
-          D::Atom: 'static + Clone + SampleLaplace + Float + InfCast<D::Atom> {
+          D::Atom: 'static + Clone + SampleLaplace + Float + InfCast<D::Atom> + CheckNull + TotalOrd {
     if scale.is_sign_negative() {
         return fallible!(MakeMeasurement, "scale must not be negative")
     }

--- a/rust/opendp/src/meas/stability.rs
+++ b/rust/opendp/src/meas/stability.rs
@@ -8,7 +8,7 @@ use crate::dist::{L1Distance, L2Distance, SmoothedMaxDivergence};
 use crate::dom::{AllDomain, MapDomain, SizedDomain};
 use crate::samplers::{SampleLaplace, SampleGaussian};
 use crate::error::Fallible;
-use crate::traits::{ExactIntCast, ExactIntBounds};
+use crate::traits::{ExactIntCast, ExactIntBounds, CheckNull, TotalOrd};
 
 // TIK: Type of Input Key
 // TIC: Type of Input Count
@@ -35,9 +35,9 @@ pub fn make_base_stability<MI, TIK, TIC>(
     n: usize, scale: MI::Distance, threshold: MI::Distance
 ) -> Fallible<Measurement<CountDomain<TIK, TIC>, CountDomain<TIK, MI::Distance>, MI, SmoothedMaxDivergence<MI::Distance>>>
     where MI: BaseStabilityNoise,
-          TIK: Eq + Hash + Clone,
-          TIC: Integer + Clone,
-          MI::Distance: 'static + Float + Clone + PartialOrd + ExactIntCast<usize> + ExactIntCast<TIC> {
+          TIK: Eq + Hash + Clone + CheckNull,
+          TIC: Integer + Clone + CheckNull,
+          MI::Distance: 'static + Float + Clone + TotalOrd + ExactIntCast<usize> + ExactIntCast<TIC> + CheckNull {
     if scale.is_sign_negative() {
         return fallible!(MakeMeasurement, "scale must not be negative")
     }

--- a/rust/opendp/src/samplers.rs
+++ b/rust/opendp/src/samplers.rs
@@ -12,6 +12,7 @@ use crate::error::Fallible;
 use statrs::function::erf;
 #[cfg(any(not(feature="use-mpfr"), not(feature="use-openssl")))]
 use rand::Rng;
+use crate::traits::TotalOrd;
 
 #[cfg(feature="use-openssl")]
 pub fn fill_bytes(buffer: &mut [u8]) -> Fallible<()> {
@@ -337,7 +338,7 @@ pub trait SampleTwoSidedGeometric: SampleGeometric {
     ) -> Fallible<Self>;
 }
 
-impl<T: Clone + SampleGeometric + Sub<Output=T> + Bounded + Zero + One + PartialOrd> SampleTwoSidedGeometric for T {
+impl<T: Clone + SampleGeometric + Sub<Output=T> + Bounded + Zero + One + TotalOrd> SampleTwoSidedGeometric for T {
     /// When no bounds are given, there are no protections against timing attacks.
     ///     The bounds are effectively T::MIN and T::MAX and up to T::MAX - T::MIN trials are taken.
     ///     The output of this mechanism is as if samples were taken from the

--- a/rust/opendp/src/traits.rs
+++ b/rust/opendp/src/traits.rs
@@ -4,6 +4,7 @@ use std::ops::{Div, Mul, Sub};
 use num::{NumCast, One, Zero};
 
 use crate::error::Fallible;
+use std::cmp::{Ordering};
 
 /// A type that can be used as a stability or privacy constant to scale a distance.
 /// Encapsulates the necessary traits for the new_from_constant method on relations.
@@ -14,9 +15,9 @@ use crate::error::Fallible;
 /// - QO also clearly needs to support Mul and PartialOrd used in the general form above.
 /// - Div is used for the backward map:
 ///     How do you translate d_out to a d_in that can be used as a hint? |d_out| d_out / c
-pub trait DistanceConstant<TI>: 'static + Clone + InfCast<TI> + Div<Output=Self> + Mul<Output=Self> + PartialOrd
+pub trait DistanceConstant<TI>: 'static + Clone + InfCast<TI> + Div<Output=Self> + Mul<Output=Self> + TotalOrd
     where TI: InfCast<Self> {}
-impl<TI: InfCast<Self>, TO: 'static + Clone + InfCast<TI> + Div<Output=Self> + Mul<Output=Self> + PartialOrd> DistanceConstant<TI> for TO {}
+impl<TI: InfCast<Self>, TO: 'static + Clone + InfCast<TI> + Div<Output=Self> + Mul<Output=Self> + TotalOrd> DistanceConstant<TI> for TO {}
 
 // TODO: Maybe this should be renamed to something more specific to budgeting, and add negative checks? -Mike
 pub trait FallibleSub<Rhs = Self> {
@@ -362,7 +363,7 @@ macro_rules! impl_check_null_for_non_nullable {
         })+
     }
 }
-impl_check_null_for_non_nullable!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, bool, String, &str);
+impl_check_null_for_non_nullable!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, bool, String, &str, char, usize, isize);
 impl<T: CheckNull> CheckNull for Option<T> {
     #[inline]
     fn is_null(&self) -> bool {
@@ -445,3 +446,64 @@ macro_rules! impl_math_float {
     }
 }
 impl_math_float!(f32, f64);
+
+pub fn max_by<T, F: FnOnce(&T, &T) -> Ordering>(v1: T, v2: T, compare: F) -> T {
+    match compare(&v1, &v2) {
+        Ordering::Less | Ordering::Equal => v2,
+        Ordering::Greater => v1,
+    }
+}
+pub fn min_by<T, F: FnOnce(&T, &T) -> Ordering>(v1: T, v2: T, compare: F) -> T {
+    match compare(&v1, &v2) {
+        Ordering::Less | Ordering::Equal => v1,
+        Ordering::Greater => v2,
+    }
+}
+
+/// TotalOrd is well-defined on types that are Ord on their non-null values.
+/// The framework provides a way to ensure values are non-null at runtime.
+/// This trait should only be used when the framework can rely on these assurances.
+pub trait TotalOrd: PartialOrd + Sized {
+    fn total_cmp(&self, other: &Self) -> Ordering;
+    fn total_max(self, other: Self) -> Self { max_by(self, other, TotalOrd::total_cmp) }
+    fn total_min(self, other: Self) -> Self { min_by(self, other, TotalOrd::total_cmp) }
+    fn total_clamp(self, min: Self, max: Self) -> Self {
+        assert!(min <= max);
+        if self < min {
+            min
+        } else if self > max {
+            max
+        } else {
+            self
+        }
+    }
+}
+
+macro_rules! impl_total_ord_for_ord {
+    ($($ty:ty),*) => {$(impl TotalOrd for $ty {
+        fn total_cmp(&self, other: &Self) -> Ordering {Ord::cmp(self, other)}
+    })*}
+}
+impl_total_ord_for_ord!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128);
+
+macro_rules! impl_total_ord_for_float {
+    ($($ty:ty),*) => {
+        $(impl TotalOrd for $ty {
+            fn total_cmp(&self, other: &Self) -> Ordering {
+                PartialOrd::partial_cmp(self, other).expect(concat!(stringify!($ty), " cannot not be null when clamping."))
+            }
+        })*
+    }
+}
+impl_total_ord_for_float!(f64, f32);
+
+impl<T1: TotalOrd, T2: TotalOrd> TotalOrd for (T1, T2) {
+    fn total_cmp(&self, other: &Self) -> Ordering {
+        let cmp = self.0.total_cmp(&other.0);
+        if Ordering::Equal == cmp {
+            self.1.total_cmp(&other.1)
+        } else {
+            cmp
+        }
+    }
+}

--- a/rust/opendp/src/trans/cast.rs
+++ b/rust/opendp/src/trans/cast.rs
@@ -8,7 +8,7 @@ use crate::trans::make_row_by_row;
 /// A [`Transformation`] that casts elements between types
 /// Maps a Vec<TI> -> Vec<Option<TO>>
 pub fn make_cast<TI, TO>() -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<OptionNullDomain<AllDomain<TO>>>, SymmetricDistance, SymmetricDistance>>
-    where TI: 'static + Clone, TO: 'static + RoundCast<TI> + CheckNull {
+    where TI: 'static + Clone + CheckNull, TO: 'static + RoundCast<TI> + CheckNull {
     make_row_by_row(
         AllDomain::new(),
         OptionNullDomain::new(AllDomain::new()),
@@ -19,7 +19,7 @@ pub fn make_cast<TI, TO>() -> Fallible<Transformation<VectorDomain<AllDomain<TI>
 /// A [`Transformation`] that casts elements between types. Fills with TO::default if parsing fails.
 /// Maps a Vec<TI> -> Vec<TO>
 pub fn make_cast_default<TI, TO>() -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<AllDomain<TO>>, SymmetricDistance, SymmetricDistance>>
-    where TI: 'static + Clone, TO: 'static + RoundCast<TI> + Default {
+    where TI: 'static + Clone + CheckNull, TO: 'static + RoundCast<TI> + Default + CheckNull {
     make_row_by_row(
         AllDomain::new(),
         AllDomain::new(),
@@ -30,7 +30,7 @@ pub fn make_cast_default<TI, TO>() -> Fallible<Transformation<VectorDomain<AllDo
 /// Maps a Vec<TI> -> Vec<TO>
 pub fn make_cast_inherent<TI, TO>(
 ) -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<InherentNullDomain<AllDomain<TO>>>, SymmetricDistance, SymmetricDistance>>
-    where TI: 'static + Clone, TO: 'static + RoundCast<TI> + InherentNull {
+    where TI: 'static + Clone + CheckNull, TO: 'static + RoundCast<TI> + InherentNull + CheckNull {
     make_row_by_row(
         AllDomain::new(),
         InherentNullDomain::new(AllDomain::new()),

--- a/rust/opendp/src/trans/clamp.rs
+++ b/rust/opendp/src/trans/clamp.rs
@@ -1,151 +1,40 @@
 use std::collections::Bound;
 
-use num::One;
-
-use crate::core::{Function, Metric, StabilityRelation, Transformation, Domain};
+use crate::core::Transformation;
+use crate::dist::SymmetricDistance;
 use crate::dom::{AllDomain, IntervalDomain, VectorDomain};
 use crate::error::*;
-use crate::traits::{DistanceConstant, InfCast};
-use std::ops::Sub;
-use crate::dist::{AbsoluteDistance, SymmetricDistance};
+use crate::traits::{CheckNull, TotalOrd};
+use crate::trans::make_row_by_row;
 
-
-fn min<T: PartialOrd>(a: T, b: T) -> T { if a < b {a} else {b} }
-fn clamp<'a, T: PartialOrd>(lower: &'a T, upper: &'a T, x: &'a T) -> &'a T {
-    if x < lower { lower } else if x > upper { upper } else { x }
+pub fn make_clamp<T: 'static + Clone + TotalOrd + CheckNull>(
+    lower: T, upper: T,
+) -> Fallible<Transformation<VectorDomain<AllDomain<T>>, VectorDomain<IntervalDomain<T>>, SymmetricDistance, SymmetricDistance>> {
+    make_row_by_row(
+        AllDomain::new(),
+        IntervalDomain::new(Bound::Included(lower.clone()), Bound::Included(upper.clone()))?,
+        move |arg: &T| arg.clone().total_clamp(lower.clone(), upper.clone()))
 }
 
-pub trait ClampableDomain<M>: Domain
-    where M: Metric {
-    type Atom;
-    type OutputDomain: Domain;
-    fn new_input_domain() -> Self;
-    fn new_output_domain(lower: Self::Atom, upper: Self::Atom) -> Fallible<Self::OutputDomain>;
-    fn clamp_function(lower: Self::Atom, upper: Self::Atom) -> Function<Self, Self::OutputDomain>;
-    fn stability_relation(lower: Self::Atom, upper: Self::Atom) -> StabilityRelation<M, M>;
+pub fn make_unclamp<T: 'static + Clone + TotalOrd + CheckNull>(
+    lower: Bound<T>, upper: Bound<T>,
+) -> Fallible<Transformation<VectorDomain<IntervalDomain<T>>, VectorDomain<AllDomain<T>>, SymmetricDistance, SymmetricDistance>> {
+    make_row_by_row(
+        IntervalDomain::new(lower, upper)?,
+        AllDomain::new(),
+        |arg| arg.clone())
 }
-
-impl<T> ClampableDomain<SymmetricDistance> for VectorDomain<AllDomain<T>>
-    where T: 'static + PartialOrd + Clone, {
-    type Atom = T;
-    type OutputDomain = VectorDomain<IntervalDomain<T>>;
-
-    fn new_input_domain() -> Self { VectorDomain::new_all() }
-    fn new_output_domain(lower: Self::Atom, upper: Self::Atom) -> Fallible<Self::OutputDomain> {
-        IntervalDomain::new(Bound::Included(lower.clone()), Bound::Included(upper.clone()))
-            .map(VectorDomain::new)
-    }
-    fn clamp_function(lower: Self::Atom, upper: Self::Atom) -> Function<Self, Self::OutputDomain> {
-        Function::new(move |arg: &Vec<T>| arg.iter().map(|v| clamp(&lower, &upper, v)).cloned().collect())
-    }
-    fn stability_relation(_lower: Self::Atom, _upper: Self::Atom) -> StabilityRelation<SymmetricDistance, SymmetricDistance> {
-        StabilityRelation::new_from_constant(1)
-    }
-}
-
-impl<T, Q> ClampableDomain<AbsoluteDistance<Q>> for AllDomain<T>
-    where Q: DistanceConstant<T> + One,
-          T: 'static + Clone + PartialOrd + Sub<Output=T> + InfCast<Q> {
-    type Atom = T;
-    type OutputDomain = IntervalDomain<T>;
-
-    fn new_input_domain() -> Self { AllDomain::new() }
-    fn new_output_domain(lower: Self::Atom, upper: Self::Atom) -> Fallible<Self::OutputDomain> {
-        IntervalDomain::new(Bound::Included(lower), Bound::Included(upper))
-    }
-    fn clamp_function(lower: Self::Atom, upper: Self::Atom) -> Function<Self, Self::OutputDomain> {
-        Function::new(move |arg: &T| clamp(&lower, &upper, arg).clone())
-    }
-    fn stability_relation(lower: Self::Atom, upper: Self::Atom) -> StabilityRelation<AbsoluteDistance<Q>, AbsoluteDistance<Q>> {
-        // the sensitivity is at most upper - lower
-        StabilityRelation::new_all(
-            // relation
-            enclose!((lower, upper), move |d_in: &Q, d_out: &Q|
-                Ok(d_out.clone() >= min(d_in.clone(), Q::inf_cast(upper.clone() - lower.clone())?))),
-            // forward map
-            Some(move |d_in: &Q|
-                Ok(Box::new(min(d_in.clone(), Q::inf_cast(upper.clone() - lower.clone())?)))),
-            // backward map
-            None::<fn(&_)->_>
-        )
-    }
-}
-
-pub fn make_clamp<DI, M>(lower: DI::Atom, upper: DI::Atom) -> Fallible<Transformation<DI, DI::OutputDomain, M, M>>
-    where DI: ClampableDomain<M>,
-          DI::Atom: Clone + PartialOrd,
-          M: Metric {
-    Ok(Transformation::new(
-        DI::new_input_domain(),
-        DI::new_output_domain(lower.clone(), upper.clone())?,
-        DI::clamp_function(lower.clone(), upper.clone()),
-        M::default(),
-        M::default(),
-        DI::stability_relation(lower, upper)))
-}
-
-
-pub trait UnclampableDomain: Domain {
-    type Atom;
-    type OutputDomain: Domain<Carrier=Self::Carrier>;
-    fn new_input_domain(lower: Bound<Self::Atom>, upper: Bound<Self::Atom>) -> Fallible<Self>;
-    fn new_output_domain() -> Self::OutputDomain;
-}
-
-impl<T> UnclampableDomain for VectorDomain<IntervalDomain<T>>
-    where T: PartialOrd + Clone {
-    type Atom = T;
-    type OutputDomain = VectorDomain<AllDomain<T>>;
-
-    fn new_input_domain(lower: Bound<Self::Atom>, upper: Bound<Self::Atom>) -> Fallible<Self> {
-        IntervalDomain::new(lower, upper).map(VectorDomain::new)
-    }
-    fn new_output_domain() -> Self::OutputDomain {
-        VectorDomain::new_all()
-    }
-}
-
-impl<T> UnclampableDomain for IntervalDomain<T>
-    where T: PartialOrd + Clone, {
-    type Atom = T;
-    type OutputDomain = AllDomain<T>;
-
-    fn new_input_domain(lower: Bound<Self::Atom>, upper: Bound<Self::Atom>) -> Fallible<Self> {
-        IntervalDomain::new(lower, upper)
-    }
-    fn new_output_domain() -> Self::OutputDomain {
-        AllDomain::new()
-    }
-}
-
-pub fn make_unclamp<DI, M>(lower: Bound<DI::Atom>, upper: Bound<DI::Atom>) -> Fallible<Transformation<DI, DI::OutputDomain, M, M>>
-    where DI: UnclampableDomain,
-          DI::Carrier: Clone,
-          M: Metric,
-          DI::Atom: 'static + Clone + PartialOrd,
-          M::Distance: DistanceConstant<M::Distance> + One {
-    Ok(Transformation::new(
-        DI::new_input_domain(lower.clone(), upper.clone())?,
-        DI::new_output_domain(),
-        Function::new(|arg: &DI::Carrier| arg.clone()),
-        M::default(),
-        M::default(),
-        StabilityRelation::new_from_constant(M::Distance::one())
-    ))
-}
-
 
 
 #[cfg(test)]
 mod tests {
+    use crate::trans::{make_clamp, make_unclamp};
 
     use super::*;
-    use crate::dist::{SymmetricDistance};
-    use crate::trans::{make_clamp, make_unclamp};
 
     #[test]
     fn test_make_clamp() {
-        let transformation = make_clamp::<VectorDomain<_>, SymmetricDistance>(0, 10).unwrap_test();
+        let transformation = make_clamp(0, 10).unwrap_test();
         let arg = vec![-10, -5, 0, 5, 10, 20];
         let ret = transformation.function.eval(&arg).unwrap_test();
         let expected = vec![0, 0, 0, 5, 10, 10];
@@ -154,30 +43,11 @@ mod tests {
 
     #[test]
     fn test_make_unclamp() -> Fallible<()> {
-        let clamp = make_clamp::<VectorDomain<_>, SymmetricDistance>(2, 3)?;
+        let clamp = make_clamp(2, 3)?;
         let unclamp = make_unclamp(Bound::Included(2), Bound::Included(3))?;
         let chained = (clamp >> unclamp)?;
         chained.function.eval(&vec![1, 2, 3])?;
         assert!(chained.stability_relation.eval(&1, &1)?);
-        Ok(())
-    }
-
-    #[test]
-    fn test_make_clamp_scalar() -> Fallible<()> {
-        let transformation = make_clamp::<AllDomain<_>, _>(0, 10)?;
-        assert_eq!(transformation.function.eval(&15)?, 10);
-        assert!(!transformation.stability_relation.eval(&15, &9)?);
-        assert!(transformation.stability_relation.eval(&15, &10)?);
-        assert!(!transformation.stability_relation.eval(&5, &4)?);
-        assert!(transformation.stability_relation.eval(&5, &5)?);
-        Ok(())
-    }
-
-    #[test]
-    fn test_make_unclamp_scalar() -> Fallible<()> {
-        let transformation = make_unclamp::<IntervalDomain<_>, AbsoluteDistance<_>>(Bound::Included(0), Bound::Included(10))?;
-        assert_eq!(transformation.function.eval(&15)?, 15);
-        assert!(transformation.stability_relation.eval(&15, &15)?);
         Ok(())
     }
 }

--- a/rust/opendp/src/trans/count.rs
+++ b/rust/opendp/src/trans/count.rs
@@ -8,11 +8,12 @@ use crate::core::{Function, SensitivityMetric, StabilityRelation, Transformation
 use crate::dist::{AbsoluteDistance, SymmetricDistance, LpDistance, IntDistance};
 use crate::dom::{AllDomain, MapDomain, SizedDomain, VectorDomain};
 use crate::error::*;
-use crate::traits::{DistanceConstant, InfCast, ExactIntCast, SaturatingAdd};
+use crate::traits::{DistanceConstant, InfCast, ExactIntCast, SaturatingAdd, CheckNull};
 
 pub fn make_count<TIA, TO>(
 ) -> Fallible<Transformation<VectorDomain<AllDomain<TIA>>, AllDomain<TO>, SymmetricDistance, AbsoluteDistance<TO>>>
-    where TO: ExactIntCast<usize> + One + DistanceConstant<IntDistance>,
+    where TIA: CheckNull,
+          TO: ExactIntCast<usize> + One + DistanceConstant<IntDistance> + CheckNull,
           IntDistance: InfCast<TO> {
     Ok(Transformation::new(
         VectorDomain::new_all(),
@@ -28,8 +29,8 @@ pub fn make_count<TIA, TO>(
 
 pub fn make_count_distinct<TIA, TO>(
 ) -> Fallible<Transformation<VectorDomain<AllDomain<TIA>>, AllDomain<TO>, SymmetricDistance, AbsoluteDistance<TO>>>
-    where TIA: Eq + Hash,
-          TO: ExactIntCast<usize> + One + DistanceConstant<IntDistance>,
+    where TIA: Eq + Hash + CheckNull,
+          TO: ExactIntCast<usize> + One + DistanceConstant<IntDistance> + CheckNull,
           IntDistance: InfCast<TO> {
     Ok(Transformation::new(
         VectorDomain::new_all(),
@@ -56,8 +57,8 @@ pub fn make_count_by_categories<MO, TI, TO>(
 ) -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<AllDomain<TO>>, SymmetricDistance, MO>>
     where MO: CountByConstant<MO::Distance> + SensitivityMetric,
           MO::Distance: DistanceConstant<IntDistance> + One,
-          TI: 'static + Eq + Hash,
-          TO: Integer + Zero + One + SaturatingAdd,
+          TI: 'static + Eq + Hash + CheckNull,
+          TO: Integer + Zero + One + SaturatingAdd + CheckNull,
           IntDistance: InfCast<MO::Distance>{
     let mut uniques = HashSet::new();
     if categories.iter().any(move |x| !uniques.insert(x)) {
@@ -97,8 +98,8 @@ pub fn make_count_by<MO, TI, TO>(
 ) -> Fallible<Transformation<SizedDomain<VectorDomain<AllDomain<TI>>>, SizedDomain<MapDomain<AllDomain<TI>, AllDomain<TO>>>, SymmetricDistance, MO>>
     where MO: CountByConstant<MO::Distance> + SensitivityMetric,
           MO::Distance: DistanceConstant<IntDistance>,
-          TI: 'static + Eq + Hash + Clone,
-          TO: Integer + Zero + One + SaturatingAdd,
+          TI: 'static + Eq + Hash + Clone + CheckNull,
+          TO: Integer + Zero + One + SaturatingAdd + CheckNull,
           IntDistance: InfCast<MO::Distance> {
     Ok(Transformation::new(
         SizedDomain::new(VectorDomain::new_all(), n),

--- a/rust/opendp/src/trans/dataframe.rs
+++ b/rust/opendp/src/trans/dataframe.rs
@@ -10,6 +10,7 @@ use crate::data::Column;
 use crate::dom::{AllDomain, MapDomain, VectorDomain};
 use crate::error::*;
 use crate::dist::SymmetricDistance;
+use crate::traits::CheckNull;
 
 pub type DataFrame<K> = HashMap<K, Column>;
 pub type DataFrameDomain<K> = MapDomain<AllDomain<K>, AllDomain<Column>>;
@@ -38,14 +39,14 @@ fn create_dataframe<K: Eq + Hash>(col_names: Vec<K>, records: &[Vec<&str>]) -> D
         .collect()
 }
 
-fn create_dataframe_domain<K: Eq + Hash>() -> DataFrameDomain<K> {
+fn create_dataframe_domain<K: Eq + Hash + CheckNull>() -> DataFrameDomain<K> {
     MapDomain::new(AllDomain::new(), AllDomain::new())
 }
 
 pub fn make_create_dataframe<K>(
     col_names: Vec<K>
 ) -> Fallible<Transformation<VectorDomain<VectorDomain<AllDomain<String>>>, DataFrameDomain<K>, SymmetricDistance, SymmetricDistance>>
-    where K: 'static + Eq + Hash + Clone {
+    where K: 'static + Eq + Hash + Clone + CheckNull {
     Ok(Transformation::new(
         VectorDomain::new(VectorDomain::new_all()),
         create_dataframe_domain(),
@@ -69,7 +70,7 @@ fn split_dataframe<K: Hash + Eq>(separator: &str, col_names: Vec<K>, s: &str) ->
 pub fn make_split_dataframe<K>(
     separator: Option<&str>, col_names: Vec<K>
 ) -> Fallible<Transformation<AllDomain<String>, DataFrameDomain<K>, SymmetricDistance, SymmetricDistance>>
-    where K: 'static + Hash + Eq + Clone {
+    where K: 'static + Hash + Eq + Clone + CheckNull {
     let separator = separator.unwrap_or(",").to_owned();
     Ok(Transformation::new(
         AllDomain::new(),
@@ -100,7 +101,7 @@ fn parse_column<K, T>(key: &K, impute: bool, df: &DataFrame<K>) -> Fallible<Data
 }
 
 pub fn make_parse_column<K, T>(key: K, impute: bool) -> Fallible<Transformation<DataFrameDomain<K>, DataFrameDomain<K>, SymmetricDistance, SymmetricDistance>>
-    where K: 'static + Hash + Eq + Debug + Clone,
+    where K: 'static + Hash + Eq + Debug + Clone + CheckNull,
           T: 'static + Debug + FromStr + Clone + Default + PartialEq,
           T::Err: Debug {
     Ok(Transformation::new(
@@ -113,8 +114,8 @@ pub fn make_parse_column<K, T>(key: K, impute: bool) -> Fallible<Transformation<
 }
 
 pub fn make_select_column<K, T>(key: K) -> Fallible<Transformation<DataFrameDomain<K>, VectorDomain<AllDomain<T>>, SymmetricDistance, SymmetricDistance>>
-    where K: 'static + Eq + Hash + Debug,
-          T: 'static + Debug + Clone + PartialEq {
+    where K: 'static + Eq + Hash + Debug + CheckNull,
+          T: 'static + Debug + Clone + PartialEq + CheckNull {
     Ok(Transformation::new(
         create_dataframe_domain(),
         VectorDomain::new_all(),

--- a/rust/opendp/src/trans/manipulation.rs
+++ b/rust/opendp/src/trans/manipulation.rs
@@ -63,7 +63,7 @@ pub fn make_identity<D, M>(domain: D, metric: M) -> Fallible<Transformation<D, D
 pub fn make_is_equal<TI>(
     value: TI
 ) -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<AllDomain<bool>>, SymmetricDistance, SymmetricDistance>>
-    where TI: 'static + PartialEq {
+    where TI: 'static + PartialEq + CheckNull {
     make_row_by_row(
         AllDomain::new(),
         AllDomain::new(),

--- a/rust/opendp/src/trans/mean.rs
+++ b/rust/opendp/src/trans/mean.rs
@@ -1,7 +1,7 @@
 use crate::core::{Transformation, Function, StabilityRelation};
 use std::ops::{Sub};
 use std::iter::Sum;
-use crate::traits::{DistanceConstant, ExactIntCast, InfCast, CheckedMul};
+use crate::traits::{DistanceConstant, ExactIntCast, InfCast, CheckedMul, CheckNull};
 use crate::error::Fallible;
 use crate::dom::{VectorDomain, IntervalDomain, AllDomain, SizedDomain};
 use std::collections::Bound;
@@ -11,7 +11,7 @@ use num::{Float};
 pub fn make_bounded_mean<T>(
     lower: T, upper: T, n: usize
 ) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactIntCast<usize>, for <'a> T: Sum<&'a T> + CheckedMul,
+    where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactIntCast<usize>, for <'a> T: Sum<&'a T> + CheckedMul + CheckNull,
           IntDistance: InfCast<T> {
     let _n = T::exact_int_cast(n)?;
     let _2 = T::exact_int_cast(2)?;

--- a/rust/opendp/src/trans/resize.rs
+++ b/rust/opendp/src/trans/resize.rs
@@ -1,20 +1,23 @@
-use crate::core::{Transformation, Function, StabilityRelation};
+use crate::core::{Transformation, Function, StabilityRelation, Domain};
 use crate::error::Fallible;
 use crate::dist::{SymmetricDistance, IntDistance};
-use crate::dom::{VectorDomain, AllDomain, SizedDomain};
+use crate::dom::{VectorDomain, SizedDomain};
 use std::cmp::Ordering;
 use crate::traits::CheckNull;
 
-pub fn make_resize_constant<TA: 'static + Clone + CheckNull>(
-    constant: TA, length: usize
-) -> Fallible<Transformation<VectorDomain<AllDomain<TA>>, SizedDomain<VectorDomain<AllDomain<TA>>>, SymmetricDistance, SymmetricDistance>> {
+pub fn make_resize_constant<DA>(
+    atom_domain: DA,
+    constant: DA::Carrier, length: usize
+) -> Fallible<Transformation<VectorDomain<DA>, SizedDomain<VectorDomain<DA>>, SymmetricDistance, SymmetricDistance>>
+    where DA: 'static + Clone + Domain,
+          DA::Carrier: 'static + Clone + CheckNull {
+    if !atom_domain.member(&constant)? { return fallible!(MakeTransformation, "constant must be a member of DA")}
     if length == 0 { return fallible!(MakeTransformation, "length must be greater than zero") }
-    if constant.is_null() { return fallible!(MakeTransformation, "constant may not be null") }
 
     Ok(Transformation::new(
-        VectorDomain::new_all(),
-        SizedDomain::new(VectorDomain::new_all(), length),
-        Function::new(move |arg: &Vec<TA>| match arg.len().cmp(&length) {
+        VectorDomain::new(atom_domain.clone()),
+        SizedDomain::new(VectorDomain::new(atom_domain), length),
+        Function::new(move |arg: &Vec<DA::Carrier>| match arg.len().cmp(&length) {
             Ordering::Less => arg.iter().chain(vec![&constant; length - arg.len()]).cloned().collect(),
             Ordering::Equal => arg.clone(),
             Ordering::Greater => arg[..length].to_vec()
@@ -28,10 +31,11 @@ pub fn make_resize_constant<TA: 'static + Clone + CheckNull>(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::dom::AllDomain;
 
     #[test]
     fn test() -> Fallible<()> {
-        let trans = make_resize_constant("x", 3)?;
+        let trans = make_resize_constant(AllDomain::new(), "x", 3)?;
         assert_eq!(trans.function.eval(&vec!["A"; 2])?, vec!["A", "A", "x"]);
         assert_eq!(trans.function.eval(&vec!["A"; 3])?, vec!["A"; 3]);
         assert_eq!(trans.function.eval(&vec!["A"; 4])?, vec!["A", "A", "A"]);

--- a/rust/opendp/src/trans/sum.rs
+++ b/rust/opendp/src/trans/sum.rs
@@ -1,4 +1,3 @@
-use std::cmp::Ordering;
 use std::collections::Bound;
 use std::iter::Sum;
 use std::ops::Sub;
@@ -9,16 +8,12 @@ use crate::core::{Function, StabilityRelation, Transformation};
 use crate::dist::{AbsoluteDistance, IntDistance, SymmetricDistance};
 use crate::dom::{AllDomain, IntervalDomain, SizedDomain, VectorDomain};
 use crate::error::*;
-use crate::traits::{Abs, DistanceConstant, InfCast, SaturatingAdd, CheckedMul, ExactIntCast};
-
-fn max<T: PartialOrd>(a: T, b: T) -> Option<T> {
-    a.partial_cmp(&b).map(|o| if let Ordering::Less = o {b} else {a})
-}
+use crate::traits::{Abs, DistanceConstant, InfCast, SaturatingAdd, CheckedMul, ExactIntCast, CheckNull};
 
 pub fn make_bounded_sum<T>(
     lower: T, upper: T
 ) -> Fallible<Transformation<VectorDomain<IntervalDomain<T>>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: DistanceConstant<IntDistance> + Sub<Output=T> + Abs + SaturatingAdd + Zero,
+    where T: DistanceConstant<IntDistance> + Sub<Output=T> + Abs + SaturatingAdd + Zero + CheckNull,
           IntDistance: InfCast<T> {
 
     Ok(Transformation::new(
@@ -28,15 +23,14 @@ pub fn make_bounded_sum<T>(
         Function::new(|arg: &Vec<T>| arg.iter().fold(T::zero(), |sum, v| sum.saturating_add(v))),
         SymmetricDistance::default(),
         AbsoluteDistance::default(),
-        StabilityRelation::new_from_constant(max(lower.abs(), upper.abs())
-            .ok_or_else(|| err!(InvalidDistance, "lower and upper must be comparable"))?)))
+        StabilityRelation::new_from_constant(lower.abs().total_max(upper.abs()))))
 }
 
 
 pub fn make_bounded_sum_n<T>(
     lower: T, upper: T, length: usize
 ) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: DistanceConstant<IntDistance> + Sub<Output=T>, for <'a> T: Sum<&'a T> + ExactIntCast<usize> + CheckedMul,
+    where T: DistanceConstant<IntDistance> + Sub<Output=T>, for <'a> T: Sum<&'a T> + ExactIntCast<usize> + CheckedMul + CheckNull,
           IntDistance: InfCast<T> {
     let length_ = T::exact_int_cast(length)?;
     if lower.checked_mul(&length_).is_none()

--- a/rust/opendp/src/trans/variance.rs
+++ b/rust/opendp/src/trans/variance.rs
@@ -8,13 +8,13 @@ use crate::core::{Function, StabilityRelation, Transformation};
 use crate::dist::{SymmetricDistance, AbsoluteDistance, IntDistance};
 use crate::dom::{AllDomain, IntervalDomain, SizedDomain, VectorDomain};
 use crate::error::Fallible;
-use crate::traits::{DistanceConstant, ExactIntCast, InfCast, CheckedMul};
+use crate::traits::{DistanceConstant, ExactIntCast, InfCast, CheckedMul, CheckNull};
 
 
 pub fn make_bounded_variance<T>(
     lower: T, upper: T, length: usize, ddof: usize
 ) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: DistanceConstant<IntDistance> + Float + One + Sub<Output=T> + Div<Output=T> + Sum<T> + for<'a> Sum<&'a T> + ExactIntCast<usize> + CheckedMul,
+    where T: DistanceConstant<IntDistance> + Float + One + Sub<Output=T> + Div<Output=T> + Sum<T> + for<'a> Sum<&'a T> + ExactIntCast<usize> + CheckedMul + CheckNull,
           for<'a> &'a T: Sub<Output=T> + Add<&'a T, Output=T>,
           IntDistance: InfCast<T> {
     let _length = T::exact_int_cast(length)?;
@@ -52,7 +52,7 @@ pub fn make_bounded_covariance<T>(
     upper: (T, T),
     length: usize, ddof: usize
 ) -> Fallible<Transformation<CovarianceDomain<T>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: ExactIntCast<usize> + DistanceConstant<IntDistance> + Zero + One + Sub<Output=T> + Div<Output=T> + Add<Output=T> + Sum<T> + CheckedMul,
+    where T: ExactIntCast<usize> + DistanceConstant<IntDistance> + Zero + One + Sub<Output=T> + Div<Output=T> + Add<Output=T> + Sum<T> + CheckedMul + CheckNull,
           for <'a> T: Div<&'a T, Output=T> + Add<&'a T, Output=T>,
           for<'a> &'a T: Sub<Output=T>,
           IntDistance: InfCast<T> {


### PR DESCRIPTION
Closes #203 
Adds the trait requirement CheckNull to T in AllDomain<T>. This formalizes that AllDomain does not carry null values.


Also removes the scalar clamper and unclamper, and adjusts the vector (un)clampers to use the row_by_row constructor.
The resize transform has also been made generic wrt the atom domain, and the FFI constructor temporarily assumes the atom domain is IntervalDomain<T>.
