### PR TITLE
TotalOrd trait; AllDomain<T: CheckNull>

### DIFF
--- a/python/test/test_trans.py
+++ b/python/test/test_trans.py
@@ -154,12 +154,11 @@ def test_split_dataframe():
     assert query.check(1, 1)
 
 
-def test_vector_clamp():
+def test_clamp():
     from opendp.trans import make_clamp
     query = make_clamp(lower=-1, upper=1)
     assert query([-10, 0, 10]) == [-1, 0, 1]
     assert query.check(1, 1)
-
 
 
 def test_bounded_mean():

--- a/rust/opendp-ffi/src/comb/mod.rs
+++ b/rust/opendp-ffi/src/comb/mod.rs
@@ -42,9 +42,10 @@ mod tests {
     use crate::util;
 
     use super::*;
+    use opendp::traits::CheckNull;
 
     // TODO: Find all the places we've duplicated this code and replace with common function.
-    pub fn make_test_measurement<T: Clone>() -> Measurement<AllDomain<T>, AllDomain<T>, SymmetricDistance, MaxDivergence<f64>> {
+    pub fn make_test_measurement<T: Clone + CheckNull>() -> Measurement<AllDomain<T>, AllDomain<T>, SymmetricDistance, MaxDivergence<f64>> {
         Measurement::new(
             AllDomain::new(),
             AllDomain::new(),
@@ -56,7 +57,7 @@ mod tests {
     }
 
     // TODO: Find all the places we've duplicated this code and replace with common function.
-    pub fn make_test_transformation<T: Clone>() -> Transformation<AllDomain<T>, AllDomain<T>, SymmetricDistance, SymmetricDistance> {
+    pub fn make_test_transformation<T: Clone + CheckNull>() -> Transformation<AllDomain<T>, AllDomain<T>, SymmetricDistance, SymmetricDistance> {
         trans::make_identity(AllDomain::<T>::new(), SymmetricDistance::default()).unwrap_test()
     }
 

--- a/rust/opendp-ffi/src/core/mod.rs
+++ b/rust/opendp-ffi/src/core/mod.rs
@@ -287,6 +287,7 @@ mod tests {
     use crate::util::ToCharP;
 
     use super::*;
+    use opendp::traits::CheckNull;
 
     #[test]
     fn test_ffi_error_from_error() {
@@ -353,7 +354,7 @@ mod tests {
     }
 
     // TODO: Find all the places we've duplicated this code and replace with common function.
-    pub fn make_test_measurement<T: Clone>() -> Measurement<AllDomain<T>, AllDomain<T>, SymmetricDistance, MaxDivergence<f64>> {
+    pub fn make_test_measurement<T: Clone + CheckNull>() -> Measurement<AllDomain<T>, AllDomain<T>, SymmetricDistance, MaxDivergence<f64>> {
         Measurement::new(
             AllDomain::new(),
             AllDomain::new(),
@@ -365,7 +366,7 @@ mod tests {
     }
 
     // TODO: Find all the places we've duplicated this code and replace with common function.
-    pub fn make_test_transformation<T: Clone>() -> Transformation<AllDomain<T>, AllDomain<T>, SymmetricDistance, SymmetricDistance> {
+    pub fn make_test_transformation<T: Clone + CheckNull>() -> Transformation<AllDomain<T>, AllDomain<T>, SymmetricDistance, SymmetricDistance> {
         trans::make_identity(AllDomain::<T>::new(), SymmetricDistance::default()).unwrap_test()
     }
 

--- a/rust/opendp-ffi/src/meas/gaussian.rs
+++ b/rust/opendp-ffi/src/meas/gaussian.rs
@@ -11,7 +11,7 @@ use crate::any::AnyMeasurement;
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::util::Type;
 use opendp::dom::{AllDomain, VectorDomain};
-use opendp::traits::InfCast;
+use opendp::traits::{InfCast, CheckNull};
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_gaussian(
@@ -20,7 +20,7 @@ pub extern "C" fn opendp_meas__make_base_gaussian(
 ) -> FfiResult<*mut AnyMeasurement> {
     fn monomorphize<D>(scale: *const c_void) -> FfiResult<*mut AnyMeasurement> where
         D: 'static + GaussianDomain,
-        D::Atom: 'static + Clone + SampleGaussian + Float + InfCast<f64> {
+        D::Atom: 'static + Clone + SampleGaussian + Float + InfCast<f64> + CheckNull {
         let scale = *try_as_ref!(scale as *const D::Atom);
         make_base_gaussian::<D>(scale).into_any()
     }

--- a/rust/opendp-ffi/src/meas/geometric.rs
+++ b/rust/opendp-ffi/src/meas/geometric.rs
@@ -11,7 +11,7 @@ use crate::any::{AnyMeasurement, AnyObject, Downcast};
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::util::Type;
 use crate::util;
-use opendp::traits::InfCast;
+use opendp::traits::{InfCast, TotalOrd};
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_geometric(
@@ -23,8 +23,8 @@ pub extern "C" fn opendp_meas__make_base_geometric(
         scale: *const c_void, bounds: *const AnyObject
     ) -> FfiResult<*mut AnyMeasurement>
         where D: 'static + GeometricDomain,
-              D::Atom: 'static + InfCast<QO> + PartialOrd + Clone,
-              QO: 'static + Float + InfCast<D::Atom>,
+              D::Atom: 'static + InfCast<QO> + TotalOrd + Clone,
+              QO: 'static + Float + InfCast<D::Atom> + TotalOrd,
               f64: From<QO> {
         let scale = try_as_ref!(scale as *const QO).clone();
         let bounds = if let Some(bounds) = util::as_ref(bounds) {

--- a/rust/opendp-ffi/src/meas/laplace.rs
+++ b/rust/opendp-ffi/src/meas/laplace.rs
@@ -11,7 +11,7 @@ use crate::any::AnyMeasurement;
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::util::Type;
 use opendp::dom::{VectorDomain, AllDomain};
-use opendp::traits::InfCast;
+use opendp::traits::{InfCast, CheckNull, TotalOrd};
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_laplace(
@@ -20,7 +20,7 @@ pub extern "C" fn opendp_meas__make_base_laplace(
 ) -> FfiResult<*mut AnyMeasurement> {
     fn monomorphize<D>(scale: *const c_void) -> FfiResult<*mut AnyMeasurement>
         where D: 'static + LaplaceDomain,
-              D::Atom: 'static + Clone + SampleLaplace + Float + InfCast<D::Atom> {
+              D::Atom: 'static + Clone + SampleLaplace + Float + InfCast<D::Atom> + CheckNull + TotalOrd {
         let scale = *try_as_ref!(scale as *const D::Atom);
         make_base_laplace::<D>(scale).into_any()
     }

--- a/rust/opendp-ffi/src/meas/stability.rs
+++ b/rust/opendp-ffi/src/meas/stability.rs
@@ -10,7 +10,7 @@ use opendp::dist::{L1Distance, L2Distance};
 use opendp::err;
 use opendp::meas::{BaseStabilityNoise, make_base_stability};
 use opendp::samplers::CastInternalReal;
-use opendp::traits::ExactIntCast;
+use opendp::traits::{ExactIntCast, CheckNull, TotalOrd};
 
 use crate::any::AnyMeasurement;
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
@@ -29,15 +29,15 @@ pub extern "C" fn opendp_meas__make_base_stability(
         n: usize, scale: *const c_void, threshold: *const c_void,
         MI: Type, TIK: Type, TIC: Type,
     ) -> FfiResult<*mut AnyMeasurement>
-        where TIC: 'static + Integer + Zero + One + AddAssign + Clone,
-              TOC: 'static + PartialOrd + Clone + Float + CastInternalReal + ExactIntCast<usize> + ExactIntCast<TIC> {
+        where TIC: 'static + Integer + Zero + One + AddAssign + Clone + CheckNull,
+              TOC: 'static + TotalOrd + Clone + Float + CastInternalReal + ExactIntCast<usize> + ExactIntCast<TIC> + CheckNull {
         fn monomorphize2<MI, TIK, TIC>(
             n: usize, scale: MI::Distance, threshold: MI::Distance,
         ) -> FfiResult<*mut AnyMeasurement>
             where MI: 'static + SensitivityMetric + BaseStabilityNoise,
-                  TIK: 'static + Eq + Hash + Clone,
-                  TIC: 'static + Integer + Zero + One + AddAssign + Clone,
-                  MI::Distance: 'static + Clone + PartialOrd + Float + CastInternalReal + ExactIntCast<usize> + ExactIntCast<TIC> {
+                  TIK: 'static + Eq + Hash + Clone + CheckNull,
+                  TIC: 'static + Integer + Zero + One + AddAssign + Clone + CheckNull,
+                  MI::Distance: 'static + Clone + TotalOrd + Float + CastInternalReal + ExactIntCast<usize> + ExactIntCast<TIC> + CheckNull {
             make_base_stability::<MI, TIK, TIC>(n, scale, threshold).into_any()
         }
         let scale = *try_as_ref!(scale as *const TOC);

--- a/rust/opendp-ffi/src/trans/cast.rs
+++ b/rust/opendp-ffi/src/trans/cast.rs
@@ -22,7 +22,7 @@ pub extern "C" fn opendp_trans__make_cast(
     let TO = try_!(Type::try_from(TO));
 
     fn monomorphize<TI, TO>() -> FfiResult<*mut AnyTransformation>
-        where TI: 'static + Clone,
+        where TI: 'static + Clone + CheckNull,
               TO: 'static + RoundCast<TI> + CheckNull {
         make_cast::<TI, TO>().into_any()
     }
@@ -37,8 +37,8 @@ pub extern "C" fn opendp_trans__make_cast_default(
     let TO = try_!(Type::try_from(TO));
 
     fn monomorphize<TI, TO>() -> FfiResult<*mut AnyTransformation>
-        where TI: 'static + Clone,
-              TO: 'static + RoundCast<TI> + Default {
+        where TI: 'static + Clone + CheckNull,
+              TO: 'static + RoundCast<TI> + Default + CheckNull {
         make_cast_default::<TI, TO>().into_any()
     }
     dispatch!(monomorphize, [(TI, @primitives), (TO, @primitives)], ())
@@ -52,7 +52,7 @@ pub extern "C" fn opendp_trans__make_cast_inherent(
     let TO = try_!(Type::try_from(TO));
 
     fn monomorphize<TI, TO>() -> FfiResult<*mut AnyTransformation>
-        where TI: 'static + Clone,
+        where TI: 'static + Clone + CheckNull,
               TO: 'static + RoundCast<TI> + InherentNull {
         make_cast_inherent::<TI, TO>().into_any()
     }
@@ -74,7 +74,7 @@ pub extern "C" fn opendp_trans__make_cast_metric(
         where MI: 'static + DatasetMetric,
               MO: 'static + DatasetMetric,
               (MI, MO): DatasetMetricCast,
-              T: 'static + Clone {
+              T: 'static + Clone + CheckNull {
         make_cast_metric::<VectorDomain<AllDomain<T>>, MI, MO>(
             VectorDomain::new_all()
         ).into_any()

--- a/rust/opendp-ffi/src/trans/clamp.rs
+++ b/rust/opendp-ffi/src/trans/clamp.rs
@@ -3,7 +3,7 @@ use std::ops::Bound;
 use std::os::raw::{c_char, c_void};
 
 use opendp::err;
-use opendp::traits::{CheckNull};
+use opendp::traits::{CheckNull, TotalOrd};
 use opendp::trans::{make_clamp, make_unclamp};
 
 use crate::any::AnyTransformation;
@@ -18,7 +18,7 @@ pub extern "C" fn opendp_trans__make_clamp(
     let T = try_!(Type::try_from(T));
 
     fn monomorphize_dataset<T>(lower: *const c_void, upper: *const c_void) -> FfiResult<*mut AnyTransformation>
-        where T: 'static + Clone + PartialOrd + CheckNull {
+        where T: 'static + Clone + TotalOrd + CheckNull {
         let lower = try_as_ref!(lower as *const T).clone();
         let upper = try_as_ref!(upper as *const T).clone();
         make_clamp::<T>(lower, upper).into_any()
@@ -36,7 +36,7 @@ pub extern "C" fn opendp_trans__make_unclamp(
 ) -> FfiResult<*mut AnyTransformation> {
     let T = try_!(Type::try_from(T));
     fn monomorphize_dataset<T>(lower: *const c_void, upper: *const c_void) -> FfiResult<*mut AnyTransformation>
-        where T: 'static + Clone + PartialOrd + CheckNull {
+        where T: 'static + Clone + TotalOrd + CheckNull {
         let lower = try_as_ref!(lower as *const T).clone();
         let upper = try_as_ref!(upper as *const T).clone();
         make_unclamp::<T>(Bound::Included(lower), Bound::Included(upper)).into_any()

--- a/rust/opendp-ffi/src/trans/count.rs
+++ b/rust/opendp-ffi/src/trans/count.rs
@@ -8,7 +8,7 @@ use num::traits::FloatConst;
 use opendp::core::{SensitivityMetric};
 use opendp::dist::{L1Distance, L2Distance, IntDistance};
 use opendp::err;
-use opendp::traits::{DistanceConstant, InfCast, ExactIntCast, SaturatingAdd};
+use opendp::traits::{DistanceConstant, InfCast, ExactIntCast, SaturatingAdd, CheckNull};
 use opendp::trans::{CountByConstant, make_count, make_count_by, make_count_by_categories, make_count_distinct};
 
 use crate::any::{AnyObject, AnyTransformation};
@@ -22,8 +22,8 @@ pub extern "C" fn opendp_trans__make_count(
     TO: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<TIA, TO>() -> FfiResult<*mut AnyTransformation>
-        where TIA: 'static,
-              TO: 'static + ExactIntCast<usize> + Bounded + One + DistanceConstant<IntDistance>,
+        where TIA: 'static + CheckNull,
+              TO: 'static + ExactIntCast<usize> + Bounded + One + DistanceConstant<IntDistance> + CheckNull,
               IntDistance: InfCast<TO> {
         make_count::<TIA, TO>().into_any()
     }
@@ -42,8 +42,8 @@ pub extern "C" fn opendp_trans__make_count_distinct(
     TO: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<TIA, TO: 'static>() -> FfiResult<*mut AnyTransformation>
-        where TIA: 'static + Eq + Hash,
-              TO: 'static + ExactIntCast<usize> + Bounded + One + DistanceConstant<IntDistance>,
+        where TIA: 'static + Eq + Hash + CheckNull,
+              TO: 'static + ExactIntCast<usize> + Bounded + One + DistanceConstant<IntDistance> + CheckNull,
               IntDistance: InfCast<TO> {
         make_count_distinct::<TIA, TO>().into_any()
     }
@@ -70,8 +70,8 @@ pub extern "C" fn opendp_trans__make_count_by_categories(
         fn monomorphize2<MO, TI, TO>(categories: *const AnyObject) -> FfiResult<*mut AnyTransformation>
             where MO: 'static + SensitivityMetric + CountByConstant<MO::Distance>,
                   MO::Distance: DistanceConstant<IntDistance> + One,
-                  TI: 'static + Eq + Hash + Clone,
-                  TO: 'static + Integer + Zero + One + SaturatingAdd,
+                  TI: 'static + Eq + Hash + Clone + CheckNull,
+                  TO: 'static + Integer + Zero + One + SaturatingAdd + CheckNull,
                   IntDistance: InfCast<MO::Distance> {
             let categories = try_!(try_as_ref!(categories).downcast_ref::<Vec<TI>>()).clone();
             make_count_by_categories::<MO, TI, TO>(categories).into_any()
@@ -105,8 +105,8 @@ pub extern "C" fn opendp_trans__make_count_by(
         fn monomorphize2<MO, TI, TO>(n: usize) -> FfiResult<*mut AnyTransformation>
             where MO: 'static + SensitivityMetric + CountByConstant<MO::Distance>,
                   MO::Distance: DistanceConstant<IntDistance> + FloatConst + One,
-                  TI: 'static + Eq + Hash + Clone,
-                  TO: 'static + Integer + Zero + One + SaturatingAdd,
+                  TI: 'static + Eq + Hash + Clone + CheckNull,
+                  TO: 'static + Integer + Zero + One + SaturatingAdd + CheckNull,
                   IntDistance: InfCast<MO::Distance> {
             make_count_by::<MO, TI, TO>(n).into_any()
         }

--- a/rust/opendp-ffi/src/trans/dataframe.rs
+++ b/rust/opendp-ffi/src/trans/dataframe.rs
@@ -11,6 +11,7 @@ use crate::any::{AnyObject, AnyTransformation, Downcast};
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::{c_bool, Type};
 use crate::util;
+use opendp::traits::CheckNull;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_split_lines() -> FfiResult<*mut AnyTransformation> {
@@ -30,7 +31,7 @@ pub extern "C" fn opendp_trans__make_create_dataframe(
     col_names: *const AnyObject, K: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<K>(col_names: *const AnyObject) -> FfiResult<*mut AnyTransformation>
-        where K: 'static + Eq + Hash + Clone {
+        where K: 'static + Eq + Hash + Clone + CheckNull {
         let col_names = try_!(try_as_ref!(col_names).downcast_ref::<Vec<K>>()).clone();
         make_create_dataframe::<K>(col_names).into_any()
     }
@@ -44,7 +45,7 @@ pub extern "C" fn opendp_trans__make_split_dataframe(
     K: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<K>(separator: Option<&str>, col_names: *const AnyObject) -> FfiResult<*mut AnyTransformation>
-        where K: 'static + Eq + Hash + Debug + Clone {
+        where K: 'static + Eq + Hash + Debug + Clone + CheckNull {
         let col_names = try_!(try_as_ref!(col_names).downcast_ref::<Vec<K>>()).clone();
         make_split_dataframe::<K>(separator, col_names).into_any()
     }
@@ -60,7 +61,7 @@ pub extern "C" fn opendp_trans__make_parse_column(
     K: *const c_char, T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<K, T>(key: *const AnyObject, impute: bool) -> FfiResult<*mut AnyTransformation> where
-        K: 'static + Hash + Eq + Debug + Clone,
+        K: 'static + Hash + Eq + Debug + Clone + CheckNull,
         T: 'static + Debug + Clone + PartialEq + FromStr + Default,
         T::Err: Debug {
         let key: K = try_!(try_as_ref!(key).downcast_ref::<K>()).clone();
@@ -81,8 +82,8 @@ pub extern "C" fn opendp_trans__make_select_column(
     key: *const AnyObject, K: *const c_char, T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<K, T>(key: *const AnyObject) -> FfiResult<*mut AnyTransformation> where
-        K: 'static + Hash + Eq + Debug + Clone,
-        T: 'static + Debug + Clone + PartialEq {
+        K: 'static + Hash + Eq + Debug + Clone + CheckNull,
+        T: 'static + Debug + Clone + PartialEq + CheckNull {
         let key: K = try_!(try_as_ref!(key).downcast_ref::<K>()).clone();
         make_select_column::<K, T>(key).into_any()
     }

--- a/rust/opendp-ffi/src/trans/impute.rs
+++ b/rust/opendp-ffi/src/trans/impute.rs
@@ -12,6 +12,7 @@ use opendp::trans::{ImputableDomain, make_impute_constant, make_impute_uniform_f
 use crate::any::{AnyTransformation, AnyObject, Downcast};
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::{Type, TypeContents};
+use opendp::traits::CheckNull;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_impute_uniform_float(
@@ -46,8 +47,8 @@ pub extern "C" fn opendp_trans__make_impute_constant(
             fn monomorphize<T>(
                 constant: *const AnyObject
             ) -> FfiResult<*mut AnyTransformation>
-                where OptionNullDomain<AllDomain<T>>: ImputableDomain<NonNull=T>,
-                      T: 'static + Clone {
+                where OptionNullDomain<AllDomain<T>>: ImputableDomain<Imputed=T>,
+                      T: 'static + Clone + CheckNull{
                 let constant: T = try_!(try_as_ref!(constant).downcast_ref::<T>()).clone();
                 make_impute_constant::<OptionNullDomain<AllDomain<T>>>(constant).into_any()
             }
@@ -57,7 +58,7 @@ pub extern "C" fn opendp_trans__make_impute_constant(
             fn monomorphize<T>(
                 constant: *const AnyObject
             ) -> FfiResult<*mut AnyTransformation>
-                where InherentNullDomain<AllDomain<T>>: ImputableDomain<NonNull=T>,
+                where InherentNullDomain<AllDomain<T>>: ImputableDomain<Imputed=T>,
                       T: 'static + InherentNull + Clone {
                 let constant: T = try_!(try_as_ref!(constant).downcast_ref::<T>()).clone();
                 make_impute_constant::<InherentNullDomain<AllDomain<T>>>(constant).into_any()

--- a/rust/opendp-ffi/src/trans/mean.rs
+++ b/rust/opendp-ffi/src/trans/mean.rs
@@ -6,7 +6,7 @@ use std::os::raw::{c_char, c_uint, c_void};
 use num::Float;
 
 use opendp::err;
-use opendp::traits::{DistanceConstant, InfCast, ExactIntCast, CheckedMul};
+use opendp::traits::{DistanceConstant, InfCast, ExactIntCast, CheckedMul, CheckNull};
 use opendp::trans::{make_bounded_mean};
 
 use crate::any::AnyTransformation;
@@ -20,7 +20,7 @@ pub extern "C" fn opendp_trans__make_bounded_mean(
     T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<T>(lower: *const c_void, upper: *const c_void, n: usize) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactIntCast<usize> + CheckedMul,
+        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactIntCast<usize> + CheckedMul + CheckNull,
               for<'a> T: Sum<&'a T>,
               IntDistance: InfCast<T> {
         let lower = *try_as_ref!(lower as *const T);

--- a/rust/opendp-ffi/src/trans/resize.rs
+++ b/rust/opendp-ffi/src/trans/resize.rs
@@ -38,11 +38,9 @@ mod tests {
 
     #[test]
     fn test_make_resize() -> Fallible<()> {
-        let transformation = Result::from(opendp_trans__make_resize_constant_bounded(
+        let transformation = Result::from(opendp_trans__make_resize_constant(
             util::into_raw(0i32) as *const c_void,
             4 as c_uint,
-            util::into_raw(0i32) as *const c_void,
-            util::into_raw(10i32) as *const c_void,
             "i32".to_char_p(),
         ))?;
         let arg = AnyObject::new_raw(vec![1, 2, 3]);

--- a/rust/opendp-ffi/src/trans/resize.rs
+++ b/rust/opendp-ffi/src/trans/resize.rs
@@ -38,9 +38,11 @@ mod tests {
 
     #[test]
     fn test_make_resize() -> Fallible<()> {
-        let transformation = Result::from(opendp_trans__make_resize_constant(
+        let transformation = Result::from(opendp_trans__make_resize_constant_bounded(
             util::into_raw(0i32) as *const c_void,
             4 as c_uint,
+            util::into_raw(0i32) as *const c_void,
+            util::into_raw(10i32) as *const c_void,
             "i32".to_char_p(),
         ))?;
         let arg = AnyObject::new_raw(vec![1, 2, 3]);

--- a/rust/opendp-ffi/src/trans/sum.rs
+++ b/rust/opendp-ffi/src/trans/sum.rs
@@ -4,7 +4,7 @@ use std::ops::Sub;
 use std::os::raw::{c_char, c_uint, c_void};
 
 use opendp::err;
-use opendp::traits::{Abs, DistanceConstant, InfCast, SaturatingAdd, ExactIntCast, CheckedMul};
+use opendp::traits::{Abs, DistanceConstant, InfCast, SaturatingAdd, ExactIntCast, CheckedMul, CheckNull};
 use opendp::trans::{make_bounded_sum, make_bounded_sum_n};
 
 use crate::any::AnyTransformation;
@@ -21,7 +21,7 @@ pub extern "C" fn opendp_trans__make_bounded_sum(
     fn monomorphize<T>(
         lower: *const c_void, upper: *const c_void
     ) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Abs + SaturatingAdd + Zero,
+        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Abs + SaturatingAdd + Zero + CheckNull,
               IntDistance: InfCast<T> {
         let lower = try_as_ref!(lower as *const T).clone();
         let upper = try_as_ref!(upper as *const T).clone();
@@ -39,7 +39,7 @@ pub extern "C" fn opendp_trans__make_bounded_sum_n(
     T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<T>(lower: *const c_void, upper: *const c_void, n: usize) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Sub<Output=T> + ExactIntCast<usize> + CheckedMul,
+        where T: DistanceConstant<IntDistance> + Sub<Output=T> + ExactIntCast<usize> + CheckedMul + CheckNull,
               for<'a> T: Sum<&'a T>,
               IntDistance: InfCast<T> {
         let lower = try_as_ref!(lower as *const T).clone();

--- a/rust/opendp-ffi/src/trans/variance.rs
+++ b/rust/opendp-ffi/src/trans/variance.rs
@@ -6,7 +6,7 @@ use std::os::raw::{c_char, c_uint, c_void};
 use num::{Float, One, Zero};
 
 use opendp::err;
-use opendp::traits::{DistanceConstant, InfCast, ExactIntCast, CheckedMul};
+use opendp::traits::{DistanceConstant, InfCast, ExactIntCast, CheckedMul, CheckNull};
 use opendp::trans::{make_bounded_covariance, make_bounded_variance};
 
 use crate::any::{AnyObject, AnyTransformation, Downcast};
@@ -23,7 +23,7 @@ pub extern "C" fn opendp_trans__make_bounded_variance(
     fn monomorphize2<T>(
         lower: *const c_void, upper: *const c_void, length: usize, ddof: usize,
     ) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Float + for<'a> Sum<&'a T> + Sum<T> + ExactIntCast<usize> + CheckedMul,
+        where T: DistanceConstant<IntDistance> + Float + for<'a> Sum<&'a T> + Sum<T> + ExactIntCast<usize> + CheckedMul + CheckNull,
               for<'a> &'a T: Sub<Output=T> + Add<&'a T, Output=T>,
               IntDistance: InfCast<T> {
         let lower = *try_as_ref!(lower as *const T);
@@ -52,7 +52,7 @@ pub extern "C" fn opendp_trans__make_bounded_covariance(
         upper: *const AnyObject,
         length: usize, ddof: usize,
     ) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Sum<T> + Zero + One + ExactIntCast<usize> + CheckedMul,
+        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Sum<T> + Zero + One + ExactIntCast<usize> + CheckedMul + CheckNull,
               for<'a> T: Div<&'a T, Output=T> + Add<&'a T, Output=T>,
               for<'a> &'a T: Sub<Output=T>,
               IntDistance: InfCast<T> {

--- a/rust/opendp/src/data.rs
+++ b/rust/opendp/src/data.rs
@@ -3,6 +3,7 @@
 use std::any::Any;
 use std::fmt::Debug;
 use crate::error::*;
+use crate::traits::CheckNull;
 
 pub trait IsVec: Debug {
     // Not sure if we need into_any() (which consumes the Form), keeping it for now.
@@ -30,6 +31,9 @@ impl<T> From<Vec<T>> for Column
 
 #[derive(Debug)]
 pub struct Column(Box<dyn IsVec>);
+impl CheckNull for Column {
+    fn is_null(&self) -> bool { false }
+}
 
 impl Column {
     pub fn new<T: 'static + Debug>(form: Vec<T>) -> Self where Vec<T>: IsVec {

--- a/rust/opendp/src/interactive.rs
+++ b/rust/opendp/src/interactive.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use crate::core::{Domain, Function, Measure, Measurement, Metric, PrivacyRelation};
 use crate::dom::AllDomain;
 use crate::error::*;
-use crate::traits::{FallibleSub, MeasureDistance, MetricDistance};
+use crate::traits::{FallibleSub, MeasureDistance, MetricDistance, CheckNull};
 
 /// A structure tracking the state of an interactive measurement queryable.
 /// It's generic over state (S), query (Q), answer (A), so it can be used for any
@@ -45,6 +45,8 @@ impl<S, Q> Queryable<S, Q, Box<dyn Any>> {
         self.eval(query)?.downcast().map_err(|_| err!(FailedCast)).map(|b| *b)
     }
 }
+
+impl<S, Q, A> CheckNull for Queryable<S, Q, A> { fn is_null(&self) -> bool { false } }
 
 pub type InteractiveMeasurement<DI, DO, MI, MO, S, Q> = Measurement<DI, AllDomain<Queryable<S, Q, <DO as Domain>::Carrier>>, MI, MO>;
 
@@ -163,7 +165,7 @@ mod tests {
 
     use super::*;
 
-    fn make_dummy_meas<TO: From<i32>>() -> Measurement<AllDomain<i32>, AllDomain<TO>, AbsoluteDistance<f64>, MaxDivergence<f64>> {
+    fn make_dummy_meas<TO: From<i32> + CheckNull>() -> Measurement<AllDomain<i32>, AllDomain<TO>, AbsoluteDistance<f64>, MaxDivergence<f64>> {
         Measurement::new(
             AllDomain::new(),
             AllDomain::new(),

--- a/rust/opendp/src/meas/gaussian/mod.rs
+++ b/rust/opendp/src/meas/gaussian/mod.rs
@@ -5,7 +5,7 @@ use crate::dist::{L2Distance, SmoothedMaxDivergence, AbsoluteDistance};
 use crate::dom::{AllDomain, VectorDomain};
 use crate::error::*;
 use crate::samplers::SampleGaussian;
-use crate::traits::InfCast;
+use crate::traits::{InfCast, CheckNull};
 
 // const ADDITIVE_GAUSS_CONST: f64 = 8. / 9. + (2. / std::f64::consts::PI).ln();
 const ADDITIVE_GAUSS_CONST: f64 = 0.4373061836;
@@ -42,7 +42,7 @@ pub trait GaussianDomain: Domain {
 
 
 impl<T> GaussianDomain for AllDomain<T>
-    where T: 'static + SampleGaussian + Float {
+    where T: 'static + SampleGaussian + Float + CheckNull {
     type Metric = AbsoluteDistance<T>;
     type Atom = T;
 
@@ -53,7 +53,7 @@ impl<T> GaussianDomain for AllDomain<T>
 }
 
 impl<T> GaussianDomain for VectorDomain<AllDomain<T>>
-    where T: 'static + SampleGaussian + Float {
+    where T: 'static + SampleGaussian + Float + CheckNull {
     type Metric = L2Distance<T>;
     type Atom = T;
 
@@ -68,7 +68,7 @@ impl<T> GaussianDomain for VectorDomain<AllDomain<T>>
 
 pub fn make_base_gaussian<D>(scale: D::Atom) -> Fallible<Measurement<D, D, D::Metric, SmoothedMaxDivergence<D::Atom>>>
     where D: GaussianDomain,
-          D::Atom: 'static + Clone + SampleGaussian + Float + InfCast<f64> {
+          D::Atom: 'static + Clone + SampleGaussian + Float + InfCast<f64> + CheckNull {
     if scale.is_sign_negative() {
         return fallible!(MakeMeasurement, "scale must not be negative")
     }

--- a/rust/opendp/src/meas/geometric/mod.rs
+++ b/rust/opendp/src/meas/geometric/mod.rs
@@ -4,7 +4,7 @@ use crate::dom::{AllDomain, VectorDomain};
 use crate::error::*;
 use crate::samplers::SampleTwoSidedGeometric;
 use num::Float;
-use crate::traits::{DistanceConstant, InfCast};
+use crate::traits::{DistanceConstant, InfCast, CheckNull, TotalOrd};
 
 
 pub trait GeometricDomain: Domain {
@@ -18,7 +18,7 @@ pub trait GeometricDomain: Domain {
 
 
 impl<T> GeometricDomain for AllDomain<T>
-    where T: 'static + Clone + SampleTwoSidedGeometric {
+    where T: 'static + Clone + SampleTwoSidedGeometric + CheckNull {
     type InputMetric = AbsoluteDistance<T>;
     type Atom = T;
 
@@ -30,7 +30,7 @@ impl<T> GeometricDomain for AllDomain<T>
 }
 
 impl<T> GeometricDomain for VectorDomain<AllDomain<T>>
-    where T: 'static + Clone + SampleTwoSidedGeometric {
+    where T: 'static + Clone + SampleTwoSidedGeometric + CheckNull {
     type InputMetric = L1Distance<T>;
     type Atom = T;
 
@@ -46,7 +46,7 @@ pub fn make_base_geometric<D, QO>(
     scale: QO, bounds: Option<(D::Atom, D::Atom)>
 ) -> Fallible<Measurement<D, D, D::InputMetric, MaxDivergence<QO>>>
     where D: 'static + GeometricDomain,
-          D::Atom: 'static + PartialOrd + Clone + InfCast<QO>,
+          D::Atom: 'static + TotalOrd + Clone + InfCast<QO>,
           QO: 'static + Float + DistanceConstant<D::Atom>,
           f64: From<QO> {
     if scale.is_sign_negative() { return fallible!(MakeMeasurement, "scale must not be negative") }

--- a/rust/opendp/src/meas/laplace/mod.rs
+++ b/rust/opendp/src/meas/laplace/mod.rs
@@ -5,7 +5,7 @@ use crate::dist::{L1Distance, MaxDivergence, AbsoluteDistance};
 use crate::dom::{AllDomain, VectorDomain};
 use crate::samplers::{SampleLaplace};
 use crate::error::*;
-use crate::traits::{InfCast};
+use crate::traits::{InfCast, CheckNull, TotalOrd};
 
 pub trait LaplaceDomain: Domain {
     type Metric: SensitivityMetric<Distance=Self::Atom> + Default;
@@ -15,7 +15,7 @@ pub trait LaplaceDomain: Domain {
 }
 
 impl<T> LaplaceDomain for AllDomain<T>
-    where T: 'static + SampleLaplace + Float {
+    where T: 'static + SampleLaplace + Float + CheckNull {
     type Metric = AbsoluteDistance<T>;
     type Atom = Self::Carrier;
 
@@ -26,7 +26,7 @@ impl<T> LaplaceDomain for AllDomain<T>
 }
 
 impl<T> LaplaceDomain for VectorDomain<AllDomain<T>>
-    where T: 'static + SampleLaplace + Float {
+    where T: 'static + SampleLaplace + Float + CheckNull {
     type Metric = L1Distance<T>;
     type Atom = T;
 
@@ -40,7 +40,7 @@ impl<T> LaplaceDomain for VectorDomain<AllDomain<T>>
 
 pub fn make_base_laplace<D>(scale: D::Atom) -> Fallible<Measurement<D, D, D::Metric, MaxDivergence<D::Atom>>>
     where D: LaplaceDomain,
-          D::Atom: 'static + Clone + SampleLaplace + Float + InfCast<D::Atom> {
+          D::Atom: 'static + Clone + SampleLaplace + Float + InfCast<D::Atom> + CheckNull + TotalOrd {
     if scale.is_sign_negative() {
         return fallible!(MakeMeasurement, "scale must not be negative")
     }

--- a/rust/opendp/src/meas/stability/mod.rs
+++ b/rust/opendp/src/meas/stability/mod.rs
@@ -8,7 +8,7 @@ use crate::dist::{L1Distance, L2Distance, SmoothedMaxDivergence};
 use crate::dom::{AllDomain, MapDomain, SizedDomain};
 use crate::samplers::{SampleLaplace, SampleGaussian};
 use crate::error::Fallible;
-use crate::traits::{ExactIntCast, ExactIntBounds};
+use crate::traits::{ExactIntCast, ExactIntBounds, CheckNull, TotalOrd};
 
 // TIK: Type of Input Key
 // TIC: Type of Input Count
@@ -35,9 +35,9 @@ pub fn make_base_stability<MI, TIK, TIC>(
     n: usize, scale: MI::Distance, threshold: MI::Distance
 ) -> Fallible<Measurement<CountDomain<TIK, TIC>, CountDomain<TIK, MI::Distance>, MI, SmoothedMaxDivergence<MI::Distance>>>
     where MI: BaseStabilityNoise,
-          TIK: Eq + Hash + Clone,
-          TIC: Integer + Clone,
-          MI::Distance: 'static + Float + Clone + PartialOrd + ExactIntCast<usize> + ExactIntCast<TIC> {
+          TIK: Eq + Hash + Clone + CheckNull,
+          TIC: Integer + Clone + CheckNull,
+          MI::Distance: 'static + Float + Clone + TotalOrd + ExactIntCast<usize> + ExactIntCast<TIC> + CheckNull {
     if scale.is_sign_negative() {
         return fallible!(MakeMeasurement, "scale must not be negative")
     }

--- a/rust/opendp/src/samplers.rs
+++ b/rust/opendp/src/samplers.rs
@@ -12,6 +12,7 @@ use crate::error::Fallible;
 use statrs::function::erf;
 #[cfg(any(not(feature="use-mpfr"), not(feature="use-openssl")))]
 use rand::Rng;
+use crate::traits::TotalOrd;
 
 #[cfg(feature="use-openssl")]
 pub fn fill_bytes(buffer: &mut [u8]) -> Fallible<()> {
@@ -337,7 +338,7 @@ pub trait SampleTwoSidedGeometric: SampleGeometric {
     ) -> Fallible<Self>;
 }
 
-impl<T: Clone + SampleGeometric + Sub<Output=T> + Bounded + Zero + One + PartialOrd> SampleTwoSidedGeometric for T {
+impl<T: Clone + SampleGeometric + Sub<Output=T> + Bounded + Zero + One + TotalOrd> SampleTwoSidedGeometric for T {
     /// When no bounds are given, there are no protections against timing attacks.
     ///     The bounds are effectively T::MIN and T::MAX and up to T::MAX - T::MIN trials are taken.
     ///     The output of this mechanism is as if samples were taken from the

--- a/rust/opendp/src/traits.rs
+++ b/rust/opendp/src/traits.rs
@@ -4,6 +4,7 @@ use std::ops::{Div, Mul, Sub};
 use num::{NumCast, One, Zero};
 
 use crate::error::Fallible;
+use std::cmp::{Ordering};
 
 /// A type that can be used as a stability or privacy constant to scale a distance.
 /// Encapsulates the necessary traits for the new_from_constant method on relations.
@@ -14,9 +15,9 @@ use crate::error::Fallible;
 /// - QO also clearly needs to support Mul and PartialOrd used in the general form above.
 /// - Div is used for the backward map:
 ///     How do you translate d_out to a d_in that can be used as a hint? |d_out| d_out / c
-pub trait DistanceConstant<TI>: 'static + Clone + InfCast<TI> + Div<Output=Self> + Mul<Output=Self> + PartialOrd
+pub trait DistanceConstant<TI>: 'static + Clone + InfCast<TI> + Div<Output=Self> + Mul<Output=Self> + TotalOrd
     where TI: InfCast<Self> {}
-impl<TI: InfCast<Self>, TO: 'static + Clone + InfCast<TI> + Div<Output=Self> + Mul<Output=Self> + PartialOrd> DistanceConstant<TI> for TO {}
+impl<TI: InfCast<Self>, TO: 'static + Clone + InfCast<TI> + Div<Output=Self> + Mul<Output=Self> + TotalOrd> DistanceConstant<TI> for TO {}
 
 // TODO: Maybe this should be renamed to something more specific to budgeting, and add negative checks? -Mike
 pub trait FallibleSub<Rhs = Self> {
@@ -362,7 +363,7 @@ macro_rules! impl_check_null_for_non_nullable {
         })+
     }
 }
-impl_check_null_for_non_nullable!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, bool, String, &str);
+impl_check_null_for_non_nullable!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, bool, String, &str, char, usize, isize);
 impl<T: CheckNull> CheckNull for Option<T> {
     #[inline]
     fn is_null(&self) -> bool {
@@ -445,3 +446,64 @@ macro_rules! impl_math_float {
     }
 }
 impl_math_float!(f32, f64);
+
+pub fn max_by<T, F: FnOnce(&T, &T) -> Ordering>(v1: T, v2: T, compare: F) -> T {
+    match compare(&v1, &v2) {
+        Ordering::Less | Ordering::Equal => v2,
+        Ordering::Greater => v1,
+    }
+}
+pub fn min_by<T, F: FnOnce(&T, &T) -> Ordering>(v1: T, v2: T, compare: F) -> T {
+    match compare(&v1, &v2) {
+        Ordering::Less | Ordering::Equal => v1,
+        Ordering::Greater => v2,
+    }
+}
+
+/// TotalOrd is well-defined on types that are Ord on their non-null values.
+/// The framework provides a way to ensure values are non-null at runtime.
+/// This trait should only be used when the framework can rely on these assurances.
+pub trait TotalOrd: PartialOrd + Sized {
+    fn total_cmp(&self, other: &Self) -> Ordering;
+    fn total_max(self, other: Self) -> Self { max_by(self, other, TotalOrd::total_cmp) }
+    fn total_min(self, other: Self) -> Self { min_by(self, other, TotalOrd::total_cmp) }
+    fn total_clamp(self, min: Self, max: Self) -> Self {
+        assert!(min <= max);
+        if self < min {
+            min
+        } else if self > max {
+            max
+        } else {
+            self
+        }
+    }
+}
+
+macro_rules! impl_total_ord_for_ord {
+    ($($ty:ty),*) => {$(impl TotalOrd for $ty {
+        fn total_cmp(&self, other: &Self) -> Ordering {Ord::cmp(self, other)}
+    })*}
+}
+impl_total_ord_for_ord!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128);
+
+macro_rules! impl_total_ord_for_float {
+    ($($ty:ty),*) => {
+        $(impl TotalOrd for $ty {
+            fn total_cmp(&self, other: &Self) -> Ordering {
+                PartialOrd::partial_cmp(self, other).expect(concat!(stringify!($ty), " cannot not be null when clamping."))
+            }
+        })*
+    }
+}
+impl_total_ord_for_float!(f64, f32);
+
+impl<T1: TotalOrd, T2: TotalOrd> TotalOrd for (T1, T2) {
+    fn total_cmp(&self, other: &Self) -> Ordering {
+        let cmp = self.0.total_cmp(&other.0);
+        if Ordering::Equal == cmp {
+            self.1.total_cmp(&other.1)
+        } else {
+            cmp
+        }
+    }
+}

--- a/rust/opendp/src/trans/cast/mod.rs
+++ b/rust/opendp/src/trans/cast/mod.rs
@@ -8,7 +8,7 @@ use crate::trans::make_row_by_row;
 /// A [`Transformation`] that casts elements between types
 /// Maps a Vec<TI> -> Vec<Option<TO>>
 pub fn make_cast<TI, TO>() -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<OptionNullDomain<AllDomain<TO>>>, SymmetricDistance, SymmetricDistance>>
-    where TI: 'static + Clone, TO: 'static + RoundCast<TI> + CheckNull {
+    where TI: 'static + Clone + CheckNull, TO: 'static + RoundCast<TI> + CheckNull {
     make_row_by_row(
         AllDomain::new(),
         OptionNullDomain::new(AllDomain::new()),
@@ -19,7 +19,7 @@ pub fn make_cast<TI, TO>() -> Fallible<Transformation<VectorDomain<AllDomain<TI>
 /// A [`Transformation`] that casts elements between types. Fills with TO::default if parsing fails.
 /// Maps a Vec<TI> -> Vec<TO>
 pub fn make_cast_default<TI, TO>() -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<AllDomain<TO>>, SymmetricDistance, SymmetricDistance>>
-    where TI: 'static + Clone, TO: 'static + RoundCast<TI> + Default {
+    where TI: 'static + Clone + CheckNull, TO: 'static + RoundCast<TI> + Default + CheckNull {
     make_row_by_row(
         AllDomain::new(),
         AllDomain::new(),
@@ -30,7 +30,7 @@ pub fn make_cast_default<TI, TO>() -> Fallible<Transformation<VectorDomain<AllDo
 /// Maps a Vec<TI> -> Vec<TO>
 pub fn make_cast_inherent<TI, TO>(
 ) -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<InherentNullDomain<AllDomain<TO>>>, SymmetricDistance, SymmetricDistance>>
-    where TI: 'static + Clone, TO: 'static + RoundCast<TI> + InherentNull {
+    where TI: 'static + Clone + CheckNull, TO: 'static + RoundCast<TI> + InherentNull + CheckNull {
     make_row_by_row(
         AllDomain::new(),
         InherentNullDomain::new(AllDomain::new()),

--- a/rust/opendp/src/trans/clamp/mod.rs
+++ b/rust/opendp/src/trans/clamp/mod.rs
@@ -5,15 +5,15 @@ use crate::dist::SymmetricDistance;
 use crate::dom::{AllDomain, IntervalDomain, VectorDomain};
 use crate::error::*;
 use crate::traits::{CheckNull, TotalOrd};
-use crate::trans::make_row_by_row;
+use crate::trans::{make_row_by_row, make_row_by_row_fallible};
 
 pub fn make_clamp<T: 'static + Clone + TotalOrd + CheckNull>(
     lower: T, upper: T,
 ) -> Fallible<Transformation<VectorDomain<AllDomain<T>>, VectorDomain<IntervalDomain<T>>, SymmetricDistance, SymmetricDistance>> {
-    make_row_by_row(
+    make_row_by_row_fallible(
         AllDomain::new(),
         IntervalDomain::new(Bound::Included(lower.clone()), Bound::Included(upper.clone()))?,
-        move |arg: &T| if arg < &lower { lower.clone() } else if arg > &upper { upper.clone() } else { arg.clone() })
+        move |arg: &T| arg.clone().total_clamp(lower.clone(), upper.clone()))
 }
 
 pub fn make_unclamp<T: 'static + Clone + TotalOrd + CheckNull>(

--- a/rust/opendp/src/trans/clamp/mod.rs
+++ b/rust/opendp/src/trans/clamp/mod.rs
@@ -4,10 +4,10 @@ use crate::core::Transformation;
 use crate::dist::SymmetricDistance;
 use crate::dom::{AllDomain, IntervalDomain, VectorDomain};
 use crate::error::*;
-use crate::traits::{CheckNull};
+use crate::traits::{CheckNull, TotalOrd};
 use crate::trans::make_row_by_row;
 
-pub fn make_clamp<T: 'static + Clone + PartialOrd + CheckNull>(
+pub fn make_clamp<T: 'static + Clone + TotalOrd + CheckNull>(
     lower: T, upper: T,
 ) -> Fallible<Transformation<VectorDomain<AllDomain<T>>, VectorDomain<IntervalDomain<T>>, SymmetricDistance, SymmetricDistance>> {
     make_row_by_row(
@@ -16,7 +16,7 @@ pub fn make_clamp<T: 'static + Clone + PartialOrd + CheckNull>(
         move |arg: &T| if arg < &lower { lower.clone() } else if arg > &upper { upper.clone() } else { arg.clone() })
 }
 
-pub fn make_unclamp<T: 'static + Clone + PartialOrd + CheckNull>(
+pub fn make_unclamp<T: 'static + Clone + TotalOrd + CheckNull>(
     lower: Bound<T>, upper: Bound<T>,
 ) -> Fallible<Transformation<VectorDomain<IntervalDomain<T>>, VectorDomain<AllDomain<T>>, SymmetricDistance, SymmetricDistance>> {
     make_row_by_row(

--- a/rust/opendp/src/trans/count/mod.rs
+++ b/rust/opendp/src/trans/count/mod.rs
@@ -8,11 +8,12 @@ use crate::core::{Function, SensitivityMetric, StabilityRelation, Transformation
 use crate::dist::{AbsoluteDistance, SymmetricDistance, LpDistance, IntDistance};
 use crate::dom::{AllDomain, MapDomain, SizedDomain, VectorDomain};
 use crate::error::*;
-use crate::traits::{DistanceConstant, InfCast, ExactIntCast, SaturatingAdd};
+use crate::traits::{DistanceConstant, InfCast, ExactIntCast, SaturatingAdd, CheckNull};
 
 pub fn make_count<TIA, TO>(
 ) -> Fallible<Transformation<VectorDomain<AllDomain<TIA>>, AllDomain<TO>, SymmetricDistance, AbsoluteDistance<TO>>>
-    where TO: ExactIntCast<usize> + One + DistanceConstant<IntDistance>,
+    where TIA: CheckNull,
+          TO: ExactIntCast<usize> + One + DistanceConstant<IntDistance> + CheckNull,
           IntDistance: InfCast<TO> {
     Ok(Transformation::new(
         VectorDomain::new_all(),
@@ -28,8 +29,8 @@ pub fn make_count<TIA, TO>(
 
 pub fn make_count_distinct<TIA, TO>(
 ) -> Fallible<Transformation<VectorDomain<AllDomain<TIA>>, AllDomain<TO>, SymmetricDistance, AbsoluteDistance<TO>>>
-    where TIA: Eq + Hash,
-          TO: ExactIntCast<usize> + One + DistanceConstant<IntDistance>,
+    where TIA: Eq + Hash + CheckNull,
+          TO: ExactIntCast<usize> + One + DistanceConstant<IntDistance> + CheckNull,
           IntDistance: InfCast<TO> {
     Ok(Transformation::new(
         VectorDomain::new_all(),
@@ -56,8 +57,8 @@ pub fn make_count_by_categories<MO, TI, TO>(
 ) -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<AllDomain<TO>>, SymmetricDistance, MO>>
     where MO: CountByConstant<MO::Distance> + SensitivityMetric,
           MO::Distance: DistanceConstant<IntDistance> + One,
-          TI: 'static + Eq + Hash,
-          TO: Integer + Zero + One + SaturatingAdd,
+          TI: 'static + Eq + Hash + CheckNull,
+          TO: Integer + Zero + One + SaturatingAdd + CheckNull,
           IntDistance: InfCast<MO::Distance>{
     let mut uniques = HashSet::new();
     if categories.iter().any(move |x| !uniques.insert(x)) {
@@ -97,8 +98,8 @@ pub fn make_count_by<MO, TI, TO>(
 ) -> Fallible<Transformation<SizedDomain<VectorDomain<AllDomain<TI>>>, SizedDomain<MapDomain<AllDomain<TI>, AllDomain<TO>>>, SymmetricDistance, MO>>
     where MO: CountByConstant<MO::Distance> + SensitivityMetric,
           MO::Distance: DistanceConstant<IntDistance>,
-          TI: 'static + Eq + Hash + Clone,
-          TO: Integer + Zero + One + SaturatingAdd,
+          TI: 'static + Eq + Hash + Clone + CheckNull,
+          TO: Integer + Zero + One + SaturatingAdd + CheckNull,
           IntDistance: InfCast<MO::Distance> {
     Ok(Transformation::new(
         SizedDomain::new(VectorDomain::new_all(), n),

--- a/rust/opendp/src/trans/dataframe/mod.rs
+++ b/rust/opendp/src/trans/dataframe/mod.rs
@@ -10,6 +10,7 @@ use crate::data::Column;
 use crate::dom::{AllDomain, MapDomain, VectorDomain};
 use crate::error::*;
 use crate::dist::SymmetricDistance;
+use crate::traits::CheckNull;
 
 pub type DataFrame<K> = HashMap<K, Column>;
 pub type DataFrameDomain<K> = MapDomain<AllDomain<K>, AllDomain<Column>>;
@@ -38,14 +39,14 @@ fn create_dataframe<K: Eq + Hash>(col_names: Vec<K>, records: &[Vec<&str>]) -> D
         .collect()
 }
 
-fn create_dataframe_domain<K: Eq + Hash>() -> DataFrameDomain<K> {
+fn create_dataframe_domain<K: Eq + Hash + CheckNull>() -> DataFrameDomain<K> {
     MapDomain::new(AllDomain::new(), AllDomain::new())
 }
 
 pub fn make_create_dataframe<K>(
     col_names: Vec<K>
 ) -> Fallible<Transformation<VectorDomain<VectorDomain<AllDomain<String>>>, DataFrameDomain<K>, SymmetricDistance, SymmetricDistance>>
-    where K: 'static + Eq + Hash + Clone {
+    where K: 'static + Eq + Hash + Clone + CheckNull {
     Ok(Transformation::new(
         VectorDomain::new(VectorDomain::new_all()),
         create_dataframe_domain(),
@@ -69,7 +70,7 @@ fn split_dataframe<K: Hash + Eq>(separator: &str, col_names: Vec<K>, s: &str) ->
 pub fn make_split_dataframe<K>(
     separator: Option<&str>, col_names: Vec<K>
 ) -> Fallible<Transformation<AllDomain<String>, DataFrameDomain<K>, SymmetricDistance, SymmetricDistance>>
-    where K: 'static + Hash + Eq + Clone {
+    where K: 'static + Hash + Eq + Clone + CheckNull {
     let separator = separator.unwrap_or(",").to_owned();
     Ok(Transformation::new(
         AllDomain::new(),
@@ -100,7 +101,7 @@ fn parse_column<K, T>(key: &K, impute: bool, df: &DataFrame<K>) -> Fallible<Data
 }
 
 pub fn make_parse_column<K, T>(key: K, impute: bool) -> Fallible<Transformation<DataFrameDomain<K>, DataFrameDomain<K>, SymmetricDistance, SymmetricDistance>>
-    where K: 'static + Hash + Eq + Debug + Clone,
+    where K: 'static + Hash + Eq + Debug + Clone + CheckNull,
           T: 'static + Debug + FromStr + Clone + Default + PartialEq,
           T::Err: Debug {
     Ok(Transformation::new(
@@ -113,8 +114,8 @@ pub fn make_parse_column<K, T>(key: K, impute: bool) -> Fallible<Transformation<
 }
 
 pub fn make_select_column<K, T>(key: K) -> Fallible<Transformation<DataFrameDomain<K>, VectorDomain<AllDomain<T>>, SymmetricDistance, SymmetricDistance>>
-    where K: 'static + Eq + Hash + Debug,
-          T: 'static + Debug + Clone + PartialEq {
+    where K: 'static + Eq + Hash + Debug + CheckNull,
+          T: 'static + Debug + Clone + PartialEq + CheckNull {
     Ok(Transformation::new(
         create_dataframe_domain(),
         VectorDomain::new_all(),

--- a/rust/opendp/src/trans/manipulation/mod.rs
+++ b/rust/opendp/src/trans/manipulation/mod.rs
@@ -63,7 +63,7 @@ pub fn make_identity<D, M>(domain: D, metric: M) -> Fallible<Transformation<D, D
 pub fn make_is_equal<TI>(
     value: TI
 ) -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<AllDomain<bool>>, SymmetricDistance, SymmetricDistance>>
-    where TI: 'static + PartialEq {
+    where TI: 'static + PartialEq + CheckNull {
     make_row_by_row(
         AllDomain::new(),
         AllDomain::new(),

--- a/rust/opendp/src/trans/mean/mod.rs
+++ b/rust/opendp/src/trans/mean/mod.rs
@@ -1,7 +1,7 @@
 use crate::core::{Transformation, Function, StabilityRelation};
 use std::ops::{Sub};
 use std::iter::Sum;
-use crate::traits::{DistanceConstant, ExactIntCast, InfCast, CheckedMul};
+use crate::traits::{DistanceConstant, ExactIntCast, InfCast, CheckedMul, CheckNull};
 use crate::error::Fallible;
 use crate::dom::{VectorDomain, IntervalDomain, AllDomain, SizedDomain};
 use std::collections::Bound;
@@ -11,7 +11,7 @@ use num::{Float};
 pub fn make_bounded_mean<T>(
     lower: T, upper: T, n: usize
 ) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactIntCast<usize>, for <'a> T: Sum<&'a T> + CheckedMul,
+    where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactIntCast<usize>, for <'a> T: Sum<&'a T> + CheckedMul + CheckNull,
           IntDistance: InfCast<T> {
     let _n = T::exact_int_cast(n)?;
     let _2 = T::exact_int_cast(2)?;

--- a/rust/opendp/src/trans/sum/mod.rs
+++ b/rust/opendp/src/trans/sum/mod.rs
@@ -1,4 +1,3 @@
-use std::cmp::Ordering;
 use std::collections::Bound;
 use std::iter::Sum;
 use std::ops::Sub;
@@ -9,16 +8,12 @@ use crate::core::{Function, StabilityRelation, Transformation};
 use crate::dist::{AbsoluteDistance, IntDistance, SymmetricDistance};
 use crate::dom::{AllDomain, IntervalDomain, SizedDomain, VectorDomain};
 use crate::error::*;
-use crate::traits::{Abs, DistanceConstant, InfCast, SaturatingAdd, CheckedMul, ExactIntCast};
-
-fn max<T: PartialOrd>(a: T, b: T) -> Option<T> {
-    a.partial_cmp(&b).map(|o| if let Ordering::Less = o {b} else {a})
-}
+use crate::traits::{Abs, DistanceConstant, InfCast, SaturatingAdd, CheckedMul, ExactIntCast, CheckNull};
 
 pub fn make_bounded_sum<T>(
     lower: T, upper: T
 ) -> Fallible<Transformation<VectorDomain<IntervalDomain<T>>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: DistanceConstant<IntDistance> + Sub<Output=T> + Abs + SaturatingAdd + Zero,
+    where T: DistanceConstant<IntDistance> + Sub<Output=T> + Abs + SaturatingAdd + Zero + CheckNull,
           IntDistance: InfCast<T> {
 
     Ok(Transformation::new(
@@ -28,15 +23,14 @@ pub fn make_bounded_sum<T>(
         Function::new(|arg: &Vec<T>| arg.iter().fold(T::zero(), |sum, v| sum.saturating_add(v))),
         SymmetricDistance::default(),
         AbsoluteDistance::default(),
-        StabilityRelation::new_from_constant(max(lower.abs(), upper.abs())
-            .ok_or_else(|| err!(InvalidDistance, "lower and upper must be comparable"))?)))
+        StabilityRelation::new_from_constant(lower.abs().total_max(upper.abs()))))
 }
 
 
 pub fn make_bounded_sum_n<T>(
     lower: T, upper: T, length: usize
 ) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: DistanceConstant<IntDistance> + Sub<Output=T>, for <'a> T: Sum<&'a T> + ExactIntCast<usize> + CheckedMul,
+    where T: DistanceConstant<IntDistance> + Sub<Output=T>, for <'a> T: Sum<&'a T> + ExactIntCast<usize> + CheckedMul + CheckNull,
           IntDistance: InfCast<T> {
     let length_ = T::exact_int_cast(length)?;
     if lower.checked_mul(&length_).is_none()

--- a/rust/opendp/src/trans/sum/mod.rs
+++ b/rust/opendp/src/trans/sum/mod.rs
@@ -23,7 +23,7 @@ pub fn make_bounded_sum<T>(
         Function::new(|arg: &Vec<T>| arg.iter().fold(T::zero(), |sum, v| sum.saturating_add(v))),
         SymmetricDistance::default(),
         AbsoluteDistance::default(),
-        StabilityRelation::new_from_constant(lower.abs().total_max(upper.abs()))))
+        StabilityRelation::new_from_constant(lower.abs().total_max(upper.abs())?)))
 }
 
 

--- a/rust/opendp/src/trans/variance/mod.rs
+++ b/rust/opendp/src/trans/variance/mod.rs
@@ -8,13 +8,13 @@ use crate::core::{Function, StabilityRelation, Transformation};
 use crate::dist::{SymmetricDistance, AbsoluteDistance, IntDistance};
 use crate::dom::{AllDomain, IntervalDomain, SizedDomain, VectorDomain};
 use crate::error::Fallible;
-use crate::traits::{DistanceConstant, ExactIntCast, InfCast, CheckedMul};
+use crate::traits::{DistanceConstant, ExactIntCast, InfCast, CheckedMul, CheckNull};
 
 
 pub fn make_bounded_variance<T>(
     lower: T, upper: T, length: usize, ddof: usize
 ) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: DistanceConstant<IntDistance> + Float + One + Sub<Output=T> + Div<Output=T> + Sum<T> + for<'a> Sum<&'a T> + ExactIntCast<usize> + CheckedMul,
+    where T: DistanceConstant<IntDistance> + Float + One + Sub<Output=T> + Div<Output=T> + Sum<T> + for<'a> Sum<&'a T> + ExactIntCast<usize> + CheckedMul + CheckNull,
           for<'a> &'a T: Sub<Output=T> + Add<&'a T, Output=T>,
           IntDistance: InfCast<T> {
     let _length = T::exact_int_cast(length)?;
@@ -52,7 +52,7 @@ pub fn make_bounded_covariance<T>(
     upper: (T, T),
     length: usize, ddof: usize
 ) -> Fallible<Transformation<CovarianceDomain<T>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: ExactIntCast<usize> + DistanceConstant<IntDistance> + Zero + One + Sub<Output=T> + Div<Output=T> + Add<Output=T> + Sum<T> + CheckedMul,
+    where T: ExactIntCast<usize> + DistanceConstant<IntDistance> + Zero + One + Sub<Output=T> + Div<Output=T> + Add<Output=T> + Sum<T> + CheckedMul + CheckNull,
           for <'a> T: Div<&'a T, Output=T> + Add<&'a T, Output=T>,
           for<'a> &'a T: Sub<Output=T>,
           IntDistance: InfCast<T> {


### PR DESCRIPTION
Closes #203
Adds the trait requirement CheckNull to T in AllDomain. This formalizes that AllDomain does not carry null values.
