### PR TITLE
atomic domain in resize transform

### DIFF
--- a/python/src/opendp/trans.py
+++ b/python/src/opendp/trans.py
@@ -766,11 +766,11 @@ def make_resize(
     # Convert arguments to c types.
     constant = py_to_c(constant, c_type=AnyObjectPtr, type_name=TA)
     length = py_to_c(length, c_type=ctypes.c_uint)
-    TA = py_to_c(TA, c_type=ctypes.c_void_p)
+    TA = py_to_c(TA, c_type=ctypes.c_char_p)
     
     # Call library function.
     function = lib.opendp_trans__make_resize
-    function.argtypes = [AnyObjectPtr, ctypes.c_uint, ctypes.c_void_p]
+    function.argtypes = [AnyObjectPtr, ctypes.c_uint, ctypes.c_char_p]
     function.restype = FfiResult
     
     return c_to_py(unwrap(function(constant, length, TA), Transformation))

--- a/python/src/opendp/trans.py
+++ b/python/src/opendp/trans.py
@@ -741,16 +741,20 @@ def make_bounded_mean(
     return c_to_py(unwrap(function(lower, upper, n, T), Transformation))
 
 
-def make_resize_constant(
+def make_resize_constant_bounded(
     constant,
     length: int,
+    lower,
+    upper,
     TA: RuntimeTypeDescriptor = None
 ) -> Transformation:
-    """Make a Transformation that either truncates or imputes records with `constant` in a Vec<`T`> to match a provided `length`.
+    """Make a Transformation that either truncates or imputes records with `constant` in a Vec<`T`> to match a provided `length`.\nWARNING: This function is temporary. It will be replaced by a more general make_resize_constant that accepts domains
     
     :param constant: Value to impute with.
     :param length: Number of records in output data.
     :type length: int
+    :param lower: Lower bound of data in input domain
+    :param upper: Upper bound of data in input domain
     :param TA: Atomic type.
     :type TA: RuntimeTypeDescriptor
     :return: A vector of the same type `TA`, but with the provided `length`.
@@ -765,14 +769,16 @@ def make_resize_constant(
     # Convert arguments to c types.
     constant = py_to_c(constant, c_type=ctypes.c_void_p, type_name=TA)
     length = py_to_c(length, c_type=ctypes.c_uint)
+    lower = py_to_c(lower, c_type=ctypes.c_void_p, type_name=TA)
+    upper = py_to_c(upper, c_type=ctypes.c_void_p, type_name=TA)
     TA = py_to_c(TA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_trans__make_resize_constant
-    function.argtypes = [ctypes.c_void_p, ctypes.c_uint, ctypes.c_char_p]
+    function = lib.opendp_trans__make_resize_constant_bounded
+    function.argtypes = [ctypes.c_void_p, ctypes.c_uint, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(constant, length, TA), Transformation))
+    return c_to_py(unwrap(function(constant, length, lower, upper, TA), Transformation))
 
 
 def make_bounded_sum(

--- a/python/test/test_trans.py
+++ b/python/test/test_trans.py
@@ -236,8 +236,15 @@ def test_count_by_categories():
 
 
 def test_resize():
-    from opendp.trans import make_resize_constant_bounded
-    query = make_resize_constant_bounded(constant=0, length=4, lower=0, upper=10)
+    from opendp.trans import make_resize_bounded
+    query = make_resize_bounded(constant=0, length=4, lower=0, upper=10)
+    assert query([-1, 2, 5]) == [-1, 2, 5, 0]
+    assert not query.check(1, 1)
+    assert query.check(1, 2)
+    assert query.check(2, 2)
+
+    from opendp.trans import make_resize
+    query = make_resize(constant=0, length=4)
     assert query([-1, 2, 5]) == [-1, 2, 5, 0]
     assert not query.check(1, 1)
     assert query.check(1, 2)

--- a/python/test/test_trans.py
+++ b/python/test/test_trans.py
@@ -236,9 +236,9 @@ def test_count_by_categories():
 
 
 def test_resize():
-    from opendp.trans import make_resize_constant
-    query = make_resize_constant(True, 4)
-    assert query([True, True, False]) == [True, True, False, True]
+    from opendp.trans import make_resize_constant_bounded
+    query = make_resize_constant_bounded(constant=0, length=4, lower=0, upper=10)
+    assert query([-1, 2, 5]) == [-1, 2, 5, 0]
     assert not query.check(1, 1)
     assert query.check(1, 2)
     assert query.check(2, 2)

--- a/rust/opendp-ffi/build/main.rs
+++ b/rust/opendp-ffi/build/main.rs
@@ -74,6 +74,10 @@ impl Argument {
         self.name.clone().expect("unknown name when parsing argument")
     }
     fn c_type(&self) -> String {
+        if self.is_type {
+            if self.c_type.is_some() { panic!("c_type should not be specified when is_type") }
+            return "char *".to_string()
+        }
         self.c_type.clone().expect("unknown c_type when parsing argument")
     }
     fn c_type_origin(&self) -> String {

--- a/rust/opendp-ffi/src/data/bootstrap.json
+++ b/rust/opendp-ffi/src/data/bootstrap.json
@@ -13,7 +13,7 @@
         "description": "Internal function. Load data from a `slice` into an AnyObject",
         "args": [
             {"name": "slice", "c_type": "const FfiSlice *", "rust_type": "T", "hint": "FfiSlicePtr"},
-            {"name": "T",  "c_type": "char *", "is_type": true}
+            {"name": "T", "is_type": true}
         ],
         "ret": {
             "c_type": "FfiResult<const AnyObject *>",
@@ -25,7 +25,7 @@
         "description": "Internal function. Load data from a `slice` into an AnyMetricDistance",
         "args": [
             {"name": "slice", "c_type": "const FfiSlice *", "rust_type": "T", "hint": "FfiSlicePtr"},
-            {"name": "T",  "c_type": "char *", "is_type": true}
+            {"name": "T", "is_type": true}
         ],
         "ret": {
             "c_type": "FfiResult<const AnyMetricDistance *>",
@@ -37,7 +37,7 @@
         "description": "Internal function. Load data from a `slice` into an AnyMeasureDistance",
         "args": [
             {"name": "slice", "c_type": "const FfiSlice *", "rust_type": "T", "hint": "FfiSlicePtr"},
-            {"name": "T",  "c_type": "char *", "is_type": true}
+            {"name": "T", "is_type": true}
         ],
         "ret": {
             "c_type": "FfiResult<const AnyMeasureDistance *>",

--- a/rust/opendp-ffi/src/meas/bootstrap.json
+++ b/rust/opendp-ffi/src/meas/bootstrap.json
@@ -12,7 +12,6 @@
             },
             {
                 "name": "D",
-                "c_type": "char *",
                 "default": "AllDomain<T>",
                 "generics": ["T"],
                 "description": "Domain of the data type to be privatized. Valid values are VectorDomain<AllDomain<T>> or AllDomain<T>",
@@ -44,7 +43,6 @@
             },
             {
                 "name": "D",
-                "c_type": "char *",
                 "default": "AllDomain<T>",
                 "generics": ["T"],
                 "description": "Domain of the data type to be privatized. Valid values are VectorDomain<AllDomain<T>> or AllDomain<T>",
@@ -84,14 +82,12 @@
             },
             {
                 "name": "D",
-                "c_type": "char *",
                 "default": "AllDomain<i32>",
                 "description": "Domain of the data type to be privatized. Valid values are VectorDomain<AllDomain<T>> or AllDomain<T>",
                 "is_type": true
             },
             {
                 "name": "QO",
-                "c_type": "char *",
                 "description": "Data type of the sensitivity, scale, and budget.",
                 "is_type": true
             }
@@ -147,20 +143,17 @@
             },
             {
                 "name": "MI",
-                "c_type": "char *",
                 "description": "Input metric.",
                 "is_type": true,
                 "hint": "SensitivityMetric"
             },
             {
                 "name": "TIK",
-                "c_type": "char *",
                 "description": "Data type of input key- must be hashable/categorical.",
                 "is_type": true
             },
             {
                 "name": "TIC",
-                "c_type": "char *",
                 "description": "Data type of input count- must be integral.",
                 "is_type": true,
                 "default": "i32"

--- a/rust/opendp-ffi/src/trans/bootstrap.json
+++ b/rust/opendp-ffi/src/trans/bootstrap.json
@@ -492,8 +492,8 @@
             "c_type": "FfiResult<AnyTransformation *>"
         }
     },
-    "make_resize_constant": {
-        "description": "Make a Transformation that either truncates or imputes records with `constant` in a Vec<`T`> to match a provided `length`.",
+    "make_resize_constant_bounded": {
+        "description": "Make a Transformation that either truncates or imputes records with `constant` in a Vec<`T`> to match a provided `length`.\\nWARNING: This function is temporary. It will be replaced by a more general make_resize_constant that accepts domains",
         "args": [
             {
                 "name": "constant",
@@ -505,6 +505,18 @@
                 "name": "length",
                 "c_type": "unsigned int",
                 "description": "Number of records in output data."
+            },
+            {
+                "name": "lower",
+                "c_type": "void *",
+                "rust_type": "TA",
+                "description": "Lower bound of data in input domain"
+            },
+            {
+                "name": "upper",
+                "c_type": "void *",
+                "rust_type": "TA",
+                "description": "Upper bound of data in input domain"
             },
             {
                 "name": "TA",

--- a/rust/opendp-ffi/src/trans/bootstrap.json
+++ b/rust/opendp-ffi/src/trans/bootstrap.json
@@ -492,7 +492,33 @@
             "c_type": "FfiResult<AnyTransformation *>"
         }
     },
-    "make_resize_constant_bounded": {
+    "make_resize": {
+        "description": "Make a Transformation that either truncates or imputes records with `constant` in a Vec<`T`> to match a provided `length`.\\nWARNING: This function is temporary. It will be replaced by a more general make_resize that accepts domains",
+        "args": [
+            {
+                "name": "constant",
+                "c_type": "AnyObject *",
+                "rust_type": "TA",
+                "description": "Value to impute with."
+            },
+            {
+                "name": "length",
+                "c_type": "unsigned int",
+                "description": "Number of records in output data."
+            },
+            {
+                "name": "TA",
+                "c_type": "void *",
+                "is_type": true,
+                "description": "Atomic type."
+            }
+        ],
+        "ret": {
+            "c_type": "FfiResult<AnyTransformation *>",
+            "description": "A vector of the same type `TA`, but with the provided `length`."
+        }
+    },
+    "make_resize_bounded": {
         "description": "Make a Transformation that either truncates or imputes records with `constant` in a Vec<`T`> to match a provided `length`.\\nWARNING: This function is temporary. It will be replaced by a more general make_resize_constant that accepts domains",
         "args": [
             {

--- a/rust/opendp-ffi/src/trans/bootstrap.json
+++ b/rust/opendp-ffi/src/trans/bootstrap.json
@@ -4,13 +4,11 @@
         "args": [
             {
                 "name": "TI",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "input data type to cast from"
             },
             {
                 "name": "TO",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "data type to cast into"
             }
@@ -22,13 +20,11 @@
         "args": [
             {
                 "name": "TI",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "input data type to cast from"
             },
             {
                 "name": "TO",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "data type to cast into"
             }
@@ -46,7 +42,6 @@
             },
             {
                 "name": "TI",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "input data type"
             }
@@ -58,7 +53,6 @@
         "args": [
             {
                 "name": "DIA",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "atomic input domain"
             }
@@ -70,13 +64,11 @@
         "args": [
             {
                 "name": "TI",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "input data type to cast from"
             },
             {
                 "name": "TO",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "data type to cast into"
             }
@@ -88,21 +80,18 @@
         "args": [
             {
                 "name": "MI",
-                "c_type": "char *",
                 "hint": "DatasetMetric",
                 "is_type": true,
                 "description": "input dataset metric"
             },
             {
                 "name": "MO",
-                "c_type": "char *",
                 "hint": "DatasetMetric",
                 "is_type": true,
                 "description": "output dataset metric"
             },
             {
                 "name": "T",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "atomic type of data"
             }
@@ -126,7 +115,6 @@
             },
             {
                 "name": "T",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "atomic data type"
             }
@@ -150,7 +138,6 @@
             },
             {
                 "name": "T",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "atomic data type"
             }
@@ -162,13 +149,11 @@
         "args": [
             {
                 "name": "TIA",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "Atomic Input Type. Input data is expected to be of the form Vec<TIA>."
             },
             {
                 "name": "TO",
-                "c_type": "char *",
                 "default": "i32",
                 "is_type": true,
                 "description": "type of output integer"
@@ -181,13 +166,11 @@
         "args": [
             {
                 "name": "TIA",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "Atomic Input Type. Input data is expected to be of the form Vec<TIA>."
             },
             {
                 "name": "TO",
-                "c_type": "char *",
                 "default": "i32",
                 "is_type": true,
                 "description": "Output Type. integer"
@@ -205,20 +188,17 @@
             },
             {
                 "name": "MO",
-                "c_type": "char *",
                 "hint": "SensitivityMetric",
                 "is_type": true,
                 "description": "Output Metric."
             },
             {
                 "name": "TI",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "Input Type. Categorical/hashable input data type. Input data must be Vec<TI>."
             },
             {
                 "name": "TO",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "Output Type. express counts in terms of this integral type",
                 "default": "i32"
@@ -243,20 +223,17 @@
             },
             {
                 "name": "MO",
-                "c_type": "char *",
                 "hint": "SensitivityMetric",
                 "is_type": true,
                 "description": "output sensitivity metric"
             },
             {
                 "name": "TI",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "categorical/hashable input data type. Input data must be Vec<TI>."
             },
             {
                 "name": "TO",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "express counts in terms of this integral type",
                 "default": "i32"
@@ -296,7 +273,6 @@
             },
             {
                 "name": "K",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "categorical/hashable data type of column names"
             }
@@ -322,7 +298,6 @@
             },
             {
                 "name": "K",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "categorical/hashable data type of column names"
             }
@@ -348,13 +323,11 @@
             },
             {
                 "name": "K",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "categorical/hashable data type of the key/column name"
             },
             {
                 "name": "T",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "data type to parse into"
             }
@@ -372,13 +345,11 @@
             },
             {
                 "name": "K",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "data type of the key"
             },
             {
                 "name": "T",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "data type to downcast to"
             }
@@ -390,14 +361,12 @@
         "args": [
             {
                 "name": "M",
-                "c_type": "char *",
                 "hint": "DatasetMetric",
                 "description": "dataset metric",
                 "is_type": true
             },
             {
                 "name": "T",
-                "c_type": "char *",
                 "description": "Type of data passed to the identity function.",
                 "is_type": true
             }
@@ -417,7 +386,6 @@
             },
             {
                 "name": "DA",
-                "c_type": "char *",
                 "is_type": true,
                 "default": "OptionNullDomain<AllDomain<T>>",
                 "generics": ["T"],
@@ -454,7 +422,6 @@
             },
             {
                 "name": "T",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "type of data being imputed"
             }
@@ -483,7 +450,6 @@
             },
             {
                 "name": "T",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "atomic data type"
             }
@@ -508,7 +474,6 @@
             },
             {
                 "name": "TA",
-                "c_type": "void *",
                 "is_type": true,
                 "description": "Atomic type."
             }
@@ -546,7 +511,6 @@
             },
             {
                 "name": "TA",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "Atomic type."
             }
@@ -573,7 +537,6 @@
             },
             {
                 "name": "T",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "atomic type of data"
             }
@@ -604,7 +567,6 @@
             },
             {
                 "name": "T",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "atomic type of data"
             }
@@ -641,7 +603,6 @@
             },
             {
                 "name": "T",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "atomic data type"
             }

--- a/rust/opendp-ffi/src/trans/resize.rs
+++ b/rust/opendp-ffi/src/trans/resize.rs
@@ -1,25 +1,26 @@
 use std::convert::TryFrom;
+use std::ops::Bound;
 use std::os::raw::{c_char, c_uint, c_void};
 
+use opendp::dom::{AllDomain, IntervalDomain};
 use opendp::err;
-use opendp::trans::make_resize_constant;
 use opendp::traits::{CheckNull, TotalOrd};
+use opendp::trans::make_resize_constant;
 
-use crate::any::AnyTransformation;
+use crate::any::{AnyObject, AnyTransformation};
+use crate::any::Downcast;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::Type;
-use opendp::dom::IntervalDomain;
-use std::ops::Bound;
 
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_resize_constant_bounded(
+pub extern "C" fn opendp_trans__make_resize_bounded(
     constant: *const c_void, length: c_uint,
     lower: *const c_void, upper: *const c_void,
     TA: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<TA>(
         constant: *const c_void, length: usize,
-        lower: *const c_void, upper: *const c_void
+        lower: *const c_void, upper: *const c_void,
     ) -> FfiResult<*mut AnyTransformation>
         where TA: 'static + Clone + CheckNull + TotalOrd {
         let constant = try_as_ref!(constant as *const TA).clone();
@@ -31,6 +32,23 @@ pub extern "C" fn opendp_trans__make_resize_constant_bounded(
     let length = length as usize;
     let TA = try_!(Type::try_from(TA));
     dispatch!(monomorphize, [(TA, @numbers)], (constant, length, lower, upper))
+}
+
+#[no_mangle]
+pub extern "C" fn opendp_trans__make_resize(
+    constant: *const AnyObject, length: c_uint,
+    TA: *const c_char,
+) -> FfiResult<*mut AnyTransformation> {
+    fn monomorphize<TA>(
+        constant: *const AnyObject, length: usize,
+    ) -> FfiResult<*mut AnyTransformation>
+        where TA: 'static + Clone + CheckNull + TotalOrd {
+        let constant = try_!(try_as_ref!(constant).downcast_ref::<TA>()).clone();
+        make_resize_constant::<AllDomain<TA>>(AllDomain::new(), constant, length).into_any()
+    }
+    let length = length as usize;
+    let TA = try_!(Type::try_from(TA));
+    dispatch!(monomorphize, [(TA, @numbers)], (constant, length))
 }
 
 
@@ -47,7 +65,22 @@ mod tests {
 
     #[test]
     fn test_make_resize() -> Fallible<()> {
-        let transformation = Result::from(opendp_trans__make_resize_constant_bounded(
+        let transformation = Result::from(opendp_trans__make_resize(
+            AnyObject::new_raw(0i32),
+            4 as c_uint,
+            "i32".to_char_p(),
+        ))?;
+        let arg = AnyObject::new_raw(vec![1, 2, 3]);
+        let res = opendp_core__transformation_invoke(&transformation, arg);
+        let res: Vec<i32> = Fallible::from(res)?.downcast()?;
+        assert_eq!(res, vec![1, 2, 3, 0]);
+        Ok(())
+    }
+
+
+    #[test]
+    fn test_make_resize_bounded() -> Fallible<()> {
+        let transformation = Result::from(opendp_trans__make_resize_bounded(
             util::into_raw(0i32) as *const c_void,
             4 as c_uint,
             util::into_raw(0i32) as *const c_void,

--- a/rust/opendp-ffi/src/trans/resize.rs
+++ b/rust/opendp-ffi/src/trans/resize.rs
@@ -3,25 +3,34 @@ use std::os::raw::{c_char, c_uint, c_void};
 
 use opendp::err;
 use opendp::trans::make_resize_constant;
-use opendp::traits::CheckNull;
+use opendp::traits::{CheckNull, TotalOrd};
 
 use crate::any::AnyTransformation;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::Type;
+use opendp::dom::IntervalDomain;
+use std::ops::Bound;
 
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_resize_constant(
+pub extern "C" fn opendp_trans__make_resize_constant_bounded(
     constant: *const c_void, length: c_uint,
+    lower: *const c_void, upper: *const c_void,
     TA: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<TA>(constant: *const c_void, length: usize) -> FfiResult<*mut AnyTransformation>
-        where TA: 'static + Clone + CheckNull {
+    fn monomorphize<TA>(
+        constant: *const c_void, length: usize,
+        lower: *const c_void, upper: *const c_void
+    ) -> FfiResult<*mut AnyTransformation>
+        where TA: 'static + Clone + CheckNull + TotalOrd {
         let constant = try_as_ref!(constant as *const TA).clone();
-        make_resize_constant::<TA>(constant, length).into_any()
+        let lower = try_as_ref!(lower as *const TA).clone();
+        let upper = try_as_ref!(upper as *const TA).clone();
+        let atom_domain = try_!(IntervalDomain::new(Bound::Included(lower), Bound::Included(upper)));
+        make_resize_constant::<IntervalDomain<TA>>(atom_domain, constant, length).into_any()
     }
     let length = length as usize;
     let TA = try_!(Type::try_from(TA));
-    dispatch!(monomorphize, [(TA, @primitives)], (constant, length))
+    dispatch!(monomorphize, [(TA, @numbers)], (constant, length, lower, upper))
 }
 
 
@@ -38,9 +47,11 @@ mod tests {
 
     #[test]
     fn test_make_resize() -> Fallible<()> {
-        let transformation = Result::from(opendp_trans__make_resize_constant(
+        let transformation = Result::from(opendp_trans__make_resize_constant_bounded(
             util::into_raw(0i32) as *const c_void,
             4 as c_uint,
+            util::into_raw(0i32) as *const c_void,
+            util::into_raw(10i32) as *const c_void,
             "i32".to_char_p(),
         ))?;
         let arg = AnyObject::new_raw(vec![1, 2, 3]);

--- a/rust/opendp/src/trans/resize/mod.rs
+++ b/rust/opendp/src/trans/resize/mod.rs
@@ -1,20 +1,23 @@
-use crate::core::{Transformation, Function, StabilityRelation};
+use crate::core::{Transformation, Function, StabilityRelation, Domain};
 use crate::error::Fallible;
 use crate::dist::{SymmetricDistance, IntDistance};
-use crate::dom::{VectorDomain, AllDomain, SizedDomain};
+use crate::dom::{VectorDomain, SizedDomain};
 use std::cmp::Ordering;
 use crate::traits::CheckNull;
 
-pub fn make_resize_constant<TA: 'static + Clone + CheckNull>(
-    constant: TA, length: usize
-) -> Fallible<Transformation<VectorDomain<AllDomain<TA>>, SizedDomain<VectorDomain<AllDomain<TA>>>, SymmetricDistance, SymmetricDistance>> {
+pub fn make_resize_constant<DA>(
+    atom_domain: DA,
+    constant: DA::Carrier, length: usize
+) -> Fallible<Transformation<VectorDomain<DA>, SizedDomain<VectorDomain<DA>>, SymmetricDistance, SymmetricDistance>>
+    where DA: 'static + Clone + Domain,
+          DA::Carrier: 'static + Clone + CheckNull {
+    if !atom_domain.member(&constant)? { return fallible!(MakeTransformation, "constant must be a member of DA")}
     if length == 0 { return fallible!(MakeTransformation, "length must be greater than zero") }
-    if constant.is_null() { return fallible!(MakeTransformation, "constant may not be null") }
 
     Ok(Transformation::new(
-        VectorDomain::new_all(),
-        SizedDomain::new(VectorDomain::new_all(), length),
-        Function::new(move |arg: &Vec<TA>| match arg.len().cmp(&length) {
+        VectorDomain::new(atom_domain.clone()),
+        SizedDomain::new(VectorDomain::new(atom_domain), length),
+        Function::new(move |arg: &Vec<DA::Carrier>| match arg.len().cmp(&length) {
             Ordering::Less => arg.iter().chain(vec![&constant; length - arg.len()]).cloned().collect(),
             Ordering::Equal => arg.clone(),
             Ordering::Greater => arg[..length].to_vec()
@@ -28,10 +31,11 @@ pub fn make_resize_constant<TA: 'static + Clone + CheckNull>(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::dom::AllDomain;
 
     #[test]
     fn test() -> Fallible<()> {
-        let trans = make_resize_constant("x", 3)?;
+        let trans = make_resize_constant(AllDomain::new(),"x", 3)?;
         assert_eq!(trans.function.eval(&vec!["A"; 2])?, vec!["A", "A", "x"]);
         assert_eq!(trans.function.eval(&vec!["A"; 3])?, vec!["A"; 3]);
         assert_eq!(trans.function.eval(&vec!["A"; 4])?, vec!["A", "A", "A"]);


### PR DESCRIPTION
Closes #230 

I made the resize transform generic in the library core, but can only provide an interface for a single domain at a time from FFI. A next step would be adding FFI functions for constructing domains themselves. A user could then pass these domains into the resize constructor as an AnyDomain. See https://github.com/opendp/opendp/issues/232