### PR TITLE
capture Debug trait in AnyBoxBase

### DIFF
--- a/python/example/test.py
+++ b/python/example/test.py
@@ -24,7 +24,7 @@ def main():
     # Noisy sum, col 1
     noisy_sum_1 = (
         make_select_column(key="B", T=int) >>
-        # make_clamp(lower=0, upper=10) >>
+        make_clamp(lower=0, upper=10) >>
         make_bounded_sum(lower=0, upper=10) >>
         make_base_geometric(scale=1.0)
     )

--- a/python/example/test.py
+++ b/python/example/test.py
@@ -24,7 +24,7 @@ def main():
     # Noisy sum, col 1
     noisy_sum_1 = (
         make_select_column(key="B", T=int) >>
-        make_clamp(lower=0, upper=10) >>
+        # make_clamp(lower=0, upper=10) >>
         make_bounded_sum(lower=0, upper=10) >>
         make_base_geometric(scale=1.0)
     )

--- a/python/src/opendp/comb.py
+++ b/python/src/opendp/comb.py
@@ -90,3 +90,43 @@ def make_basic_composition(
     function.restype = FfiResult
     
     return c_to_py(unwrap(function(measurement0, measurement1), Measurement))
+
+
+def make_population_amplification(
+    measurement: Measurement,
+    n_population: int,
+    DIA: RuntimeTypeDescriptor,
+    MO: RuntimeTypeDescriptor
+) -> Measurement:
+    """Construct an amplified measurement from a `measurement` with privacy amplification by subsampling.
+    
+    :param measurement: The measurement to amplify.
+    :type measurement: Measurement
+    :param n_population: Number of records in population.
+    :type n_population: int
+    :param DIA: atomic input domain
+    :type DIA: RuntimeTypeDescriptor
+    :param MO: output measure
+    :type MO: RuntimeTypeDescriptor
+    :return: New measurement with the same function, but an adjusted privacy relation.
+    :rtype: Measurement
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # Standardize type arguments.
+    DIA = RuntimeType.parse(type_name=DIA)
+    MO = RuntimeType.parse(type_name=MO)
+    
+    # Convert arguments to c types.
+    measurement = py_to_c(measurement, c_type=Measurement)
+    n_population = py_to_c(n_population, c_type=ctypes.c_uint)
+    DIA = py_to_c(DIA, c_type=ctypes.c_char_p)
+    MO = py_to_c(MO, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_comb__make_population_amplification
+    function.argtypes = [Measurement, ctypes.c_uint, ctypes.c_char_p, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(measurement, n_population, DIA, MO), Measurement))

--- a/python/src/opendp/trans.py
+++ b/python/src/opendp/trans.py
@@ -766,11 +766,11 @@ def make_resize(
     # Convert arguments to c types.
     constant = py_to_c(constant, c_type=AnyObjectPtr, type_name=TA)
     length = py_to_c(length, c_type=ctypes.c_uint)
-    TA = py_to_c(TA, c_type=ctypes.c_void_p)
+    TA = py_to_c(TA, c_type=ctypes.c_char_p)
     
     # Call library function.
     function = lib.opendp_trans__make_resize
-    function.argtypes = [AnyObjectPtr, ctypes.c_uint, ctypes.c_void_p]
+    function.argtypes = [AnyObjectPtr, ctypes.c_uint, ctypes.c_char_p]
     function.restype = FfiResult
     
     return c_to_py(unwrap(function(constant, length, TA), Transformation))

--- a/python/src/opendp/trans.py
+++ b/python/src/opendp/trans.py
@@ -741,16 +741,20 @@ def make_bounded_mean(
     return c_to_py(unwrap(function(lower, upper, n, T), Transformation))
 
 
-def make_resize_constant(
+def make_resize_constant_bounded(
     constant,
     length: int,
+    lower,
+    upper,
     TA: RuntimeTypeDescriptor = None
 ) -> Transformation:
-    """Make a Transformation that either truncates or imputes records with `constant` in a Vec<`T`> to match a provided `length`.
+    """Make a Transformation that either truncates or imputes records with `constant` in a Vec<`T`> to match a provided `length`.\nWARNING: This function is temporary. It will be replaced by a more general make_resize_constant that accepts domains
     
     :param constant: Value to impute with.
     :param length: Number of records in output data.
     :type length: int
+    :param lower: Lower bound of data in input domain
+    :param upper: Upper bound of data in input domain
     :param TA: Atomic type.
     :type TA: RuntimeTypeDescriptor
     :return: A vector of the same type `TA`, but with the provided `length`.
@@ -765,14 +769,16 @@ def make_resize_constant(
     # Convert arguments to c types.
     constant = py_to_c(constant, c_type=ctypes.c_void_p, type_name=TA)
     length = py_to_c(length, c_type=ctypes.c_uint)
+    lower = py_to_c(lower, c_type=ctypes.c_void_p, type_name=TA)
+    upper = py_to_c(upper, c_type=ctypes.c_void_p, type_name=TA)
     TA = py_to_c(TA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_trans__make_resize_constant
-    function.argtypes = [ctypes.c_void_p, ctypes.c_uint, ctypes.c_char_p]
+    function = lib.opendp_trans__make_resize_constant_bounded
+    function.argtypes = [ctypes.c_void_p, ctypes.c_uint, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(constant, length, TA), Transformation))
+    return c_to_py(unwrap(function(constant, length, lower, upper, TA), Transformation))
 
 
 def make_bounded_sum(

--- a/python/test/test_comb.py
+++ b/python/test/test_comb.py
@@ -1,0 +1,19 @@
+from opendp.mod import enable_features
+from opendp.typing import *
+
+enable_features("floating-point")
+
+
+def test_amplification():
+    from opendp.trans import make_bounded_mean
+    from opendp.meas import make_base_laplace
+    from opendp.comb import make_population_amplification
+
+    meas = make_bounded_mean(0., 10., 10) >> make_base_laplace(scale=0.5)
+
+    amplified = make_population_amplification(meas, n_population=100, DIA=IntervalDomain[float], MO=MaxDivergence[float])
+    print("amplified base laplace:", amplified([1.] * 10))
+    assert meas.check(1, 1.)
+    assert not meas.check(1, 0.999)
+    assert amplified.check(1, 0.159)
+    assert not amplified.check(1, 0.158)

--- a/python/test/test_trans.py
+++ b/python/test/test_trans.py
@@ -236,8 +236,15 @@ def test_count_by_categories():
 
 
 def test_resize():
-    from opendp.trans import make_resize_constant_bounded
-    query = make_resize_constant_bounded(constant=0, length=4, lower=0, upper=10)
+    from opendp.trans import make_resize_bounded
+    query = make_resize_bounded(constant=0, length=4, lower=0, upper=10)
+    assert query([-1, 2, 5]) == [-1, 2, 5, 0]
+    assert not query.check(1, 1)
+    assert query.check(1, 2)
+    assert query.check(2, 2)
+
+    from opendp.trans import make_resize
+    query = make_resize(constant=0, length=4)
     assert query([-1, 2, 5]) == [-1, 2, 5, 0]
     assert not query.check(1, 1)
     assert query.check(1, 2)

--- a/python/test/test_trans.py
+++ b/python/test/test_trans.py
@@ -236,9 +236,9 @@ def test_count_by_categories():
 
 
 def test_resize():
-    from opendp.trans import make_resize_constant
-    query = make_resize_constant(True, 4)
-    assert query([True, True, False]) == [True, True, False, True]
+    from opendp.trans import make_resize_constant_bounded
+    query = make_resize_constant_bounded(constant=0, length=4, lower=0, upper=10)
+    assert query([-1, 2, 5]) == [-1, 2, 5, 0]
     assert not query.check(1, 1)
     assert query.check(1, 2)
     assert query.check(2, 2)

--- a/rust/opendp-ffi/build/main.rs
+++ b/rust/opendp-ffi/build/main.rs
@@ -74,6 +74,10 @@ impl Argument {
         self.name.clone().expect("unknown name when parsing argument")
     }
     fn c_type(&self) -> String {
+        if self.is_type {
+            if self.c_type.is_some() { panic!("c_type should not be specified when is_type") }
+            return "char *".to_string()
+        }
         self.c_type.clone().expect("unknown c_type when parsing argument")
     }
     fn c_type_origin(&self) -> String {

--- a/rust/opendp-ffi/src/any.rs
+++ b/rust/opendp-ffi/src/any.rs
@@ -552,14 +552,13 @@ mod tests {
     fn test_any_domain() -> Fallible<()> {
         let domain1 = IntervalDomain::new(Bound::Included(0), Bound::Included(1))?;
         let domain2 = IntervalDomain::new(Bound::Included(0), Bound::Included(1))?;
-        // TODO: Add Debug to Domain so we can use assert_eq!.
-        assert!(domain1 == domain2);
+        assert_eq!(domain1, domain2);
 
         let domain1 = AnyDomain::new(IntervalDomain::new(Bound::Included(0), Bound::Included(1))?);
         let domain2 = AnyDomain::new(IntervalDomain::new(Bound::Included(0), Bound::Included(1))?);
         let domain3 = AnyDomain::new(AllDomain::<i32>::new());
-        assert!(domain1 == domain2);
-        assert!(domain1 != domain3);
+        assert_eq!(domain1, domain2);
+        assert_ne!(domain1, domain3);
 
         let _domain1: IntervalDomain<i32> = domain1.downcast()?;
         let domain3: Fallible<IntervalDomain<i32>> = domain3.downcast();
@@ -572,13 +571,13 @@ mod tests {
         let metric1 = SymmetricDistance::default();
         let metric2 = SymmetricDistance::default();
         // TODO: Add Debug to Metric so we can use assert_eq!.
-        assert!(metric1 == metric2);
+        assert_eq!(metric1, metric2);
 
         let metric1 = AnyMetric::new(SymmetricDistance::default());
         let metric2 = AnyMetric::new(SymmetricDistance::default());
         let metric3 = AnyMetric::new(SubstituteDistance::default());
-        assert!(metric1 == metric2);
-        assert!(metric1 != metric3);
+        assert_eq!(metric1, metric2);
+        assert_ne!(metric1, metric3);
 
         let _metric1: SymmetricDistance = metric1.downcast()?;
         let metric3: Fallible<SymmetricDistance> = metric3.downcast();
@@ -590,14 +589,13 @@ mod tests {
     fn test_any_measure() -> Fallible<()> {
         let measure1 = MaxDivergence::<f64>::default();
         let measure2 = MaxDivergence::<f64>::default();
-        // TODO: Add Debug to Measure so we can use assert_eq!.
-        assert!(measure1 == measure2);
+        assert_eq!(measure1, measure2);
 
         let measure1 = AnyMeasure::new(MaxDivergence::<f64>::default());
         let measure2 = AnyMeasure::new(MaxDivergence::<f64>::default());
         let measure3 = AnyMeasure::new(SmoothedMaxDivergence::<f64>::default());
-        assert!(measure1 == measure2);
-        assert!(measure1 != measure3);
+        assert_eq!(measure1, measure2);
+        assert_ne!(measure1, measure3);
 
         let _measure1: MaxDivergence<f64> = measure1.downcast()?;
         let measure3: Fallible<MaxDivergence<f64>> = measure3.downcast();

--- a/rust/opendp-ffi/src/any.rs
+++ b/rust/opendp-ffi/src/any.rs
@@ -138,7 +138,7 @@ impl Downcast for AnyObject {
 #[derive(Clone, PartialEq)]
 pub struct AnyDomain {
     pub carrier_type: Type,
-    domain: AnyBoxClonePartialEq,
+    pub domain: AnyBoxClonePartialEq,
     member_glue: Glue<fn(&Self, &<Self as Domain>::Carrier) -> Fallible<bool>>,
 }
 

--- a/rust/opendp-ffi/src/any.rs
+++ b/rust/opendp-ffi/src/any.rs
@@ -570,7 +570,6 @@ mod tests {
     fn test_any_metric() -> Fallible<()> {
         let metric1 = SymmetricDistance::default();
         let metric2 = SymmetricDistance::default();
-        // TODO: Add Debug to Metric so we can use assert_eq!.
         assert_eq!(metric1, metric2);
 
         let metric1 = AnyMetric::new(SymmetricDistance::default());

--- a/rust/opendp-ffi/src/any.rs
+++ b/rust/opendp-ffi/src/any.rs
@@ -138,7 +138,7 @@ impl AnyObject {
     }
 
     #[cfg(test)]
-    pub fn new_raw<T: 'static>(value: T) -> *mut Self {
+    pub fn new_raw<T: 'static + Debug>(value: T) -> *mut Self {
         crate::util::into_raw(Self::new(value))
     }
 }

--- a/rust/opendp-ffi/src/comb/bootstrap.json
+++ b/rust/opendp-ffi/src/comb/bootstrap.json
@@ -55,5 +55,35 @@
             "c_type": "FfiResult<AnyMeasurement *>",
             "description": "Measurement representing the composed transformations."
         }
+    },
+    "make_population_amplification": {
+        "description": "Construct an amplified measurement from a `measurement` with privacy amplification by subsampling.",
+        "args": [
+            {
+                "name": "measurement",
+                "c_type": "const AnyMeasurement *",
+                "description": "The measurement to amplify."
+            },
+            {
+                "name": "n_population",
+                "c_type": "unsigned int",
+                "description": "Number of records in population."
+            },
+            {
+                "name": "DIA",
+                "is_type": true,
+                "description": "atomic input domain"
+            },
+            {
+                "name": "MO",
+                "is_type": true,
+                "description": "output measure"
+            }
+        ],
+        "ret": {
+            "c_type": "FfiResult<AnyMeasurement *>",
+            "description": "New measurement with the same function, but an adjusted privacy relation."
+        }
+
     }
 }

--- a/rust/opendp-ffi/src/comb/mod.rs
+++ b/rust/opendp-ffi/src/comb/mod.rs
@@ -13,6 +13,7 @@ use crate::any::{AnyMeasurement, AnyTransformation, IntoAnyMeasurementOutExt, An
 use crate::core::FfiResult;
 use crate::util::Type;
 use num::Float;
+use std::fmt::Debug;
 
 #[no_mangle]
 pub extern "C" fn opendp_comb__make_chain_mt(measurement1: *const AnyMeasurement, transformation0: *const AnyTransformation) -> FfiResult<*mut AnyMeasurement> {
@@ -55,7 +56,7 @@ pub extern "C" fn opendp_comb__make_population_amplification(
         measurement: &AnyMeasurement, n_population: usize,
         DIA: Type, MO: Type,
     ) -> FfiResult<*mut AnyMeasurement>
-        where TIA: 'static + Clone + TotalOrd + CheckNull,
+        where TIA: 'static + Clone + TotalOrd + CheckNull + Debug,
               QO: 'static + ExactIntCast<usize> + Div<Output=QO> + Clone + Float + ExactIntCast<usize> + MeasureDistance + for<'a> Sub<&'a QO, Output=QO> {
         fn monomorphize2<DIA: Domain, MO: Measure>(
             measurement: &AnyMeasurement, n_population: usize,

--- a/rust/opendp-ffi/src/comb/mod.rs
+++ b/rust/opendp-ffi/src/comb/mod.rs
@@ -9,7 +9,7 @@ use opendp::dist::{MaxDivergence, SmoothedMaxDivergence};
 use opendp::dom::{AllDomain, IntervalDomain, SizedDomain, VectorDomain};
 use opendp::traits::{ExactIntCast, CheckNull, TotalOrd, MeasureDistance};
 
-use crate::any::{AnyMeasurement, AnyObject, AnyTransformation, IntoAnyMeasurementOutExt, AnyMetricDistance, AnyMeasureDistance, Downcast};
+use crate::any::{AnyMeasurement, AnyTransformation, IntoAnyMeasurementOutExt, AnyMetricDistance, AnyMeasureDistance, Downcast};
 use crate::core::FfiResult;
 use crate::util::Type;
 use num::Float;
@@ -72,12 +72,7 @@ pub extern "C" fn opendp_comb__make_population_amplification(
                     .downcast_ref::<SizedDomain<VectorDomain<DIA>>>()
                     .ok_or_else(|| err!(FFI, "failed to downcast AnyDomain to SizedDomain<VectorDomain<{}>>", Type::of::<DIA>().to_string()))).clone(),
                 measurement.output_domain.clone(),
-                {
-                    let function = measurement.function.clone();
-                    Function::new_fallible(
-                        move |arg: &Vec<DIA::Carrier>|
-                            function.eval(&AnyObject::new(arg.clone())))
-                },
+                Function::new(|_| unreachable!()),
                 measurement.input_metric.clone(),
                 try_!(measurement.output_measure.measure.value
                     .downcast_ref::<MO>()

--- a/rust/opendp-ffi/src/comb/mod.rs
+++ b/rust/opendp-ffi/src/comb/mod.rs
@@ -121,7 +121,7 @@ mod tests {
     use super::*;
 
     // TODO: Find all the places we've duplicated this code and replace with common function.
-    pub fn make_test_measurement<T: Clone + CheckNull>() -> Measurement<AllDomain<T>, AllDomain<T>, SymmetricDistance, MaxDivergence<f64>> {
+    pub fn make_test_measurement<T: Clone + CheckNull + Debug>() -> Measurement<AllDomain<T>, AllDomain<T>, SymmetricDistance, MaxDivergence<f64>> {
         Measurement::new(
             AllDomain::new(),
             AllDomain::new(),
@@ -133,7 +133,7 @@ mod tests {
     }
 
     // TODO: Find all the places we've duplicated this code and replace with common function.
-    pub fn make_test_transformation<T: Clone + CheckNull>() -> Transformation<AllDomain<T>, AllDomain<T>, SymmetricDistance, SymmetricDistance> {
+    pub fn make_test_transformation<T: Clone + CheckNull + Debug>() -> Transformation<AllDomain<T>, AllDomain<T>, SymmetricDistance, SymmetricDistance> {
         trans::make_identity(AllDomain::<T>::new(), SymmetricDistance::default()).unwrap_test()
     }
 

--- a/rust/opendp-ffi/src/core/mod.rs
+++ b/rust/opendp-ffi/src/core/mod.rs
@@ -354,7 +354,7 @@ mod tests {
     }
 
     // TODO: Find all the places we've duplicated this code and replace with common function.
-    pub fn make_test_measurement<T: Clone + CheckNull>() -> Measurement<AllDomain<T>, AllDomain<T>, SymmetricDistance, MaxDivergence<f64>> {
+    pub fn make_test_measurement<T: Clone + CheckNull + Debug>() -> Measurement<AllDomain<T>, AllDomain<T>, SymmetricDistance, MaxDivergence<f64>> {
         Measurement::new(
             AllDomain::new(),
             AllDomain::new(),
@@ -366,7 +366,7 @@ mod tests {
     }
 
     // TODO: Find all the places we've duplicated this code and replace with common function.
-    pub fn make_test_transformation<T: Clone + CheckNull>() -> Transformation<AllDomain<T>, AllDomain<T>, SymmetricDistance, SymmetricDistance> {
+    pub fn make_test_transformation<T: Clone + CheckNull + Debug>() -> Transformation<AllDomain<T>, AllDomain<T>, SymmetricDistance, SymmetricDistance> {
         trans::make_identity(AllDomain::<T>::new(), SymmetricDistance::default()).unwrap_test()
     }
 

--- a/rust/opendp-ffi/src/data/bootstrap.json
+++ b/rust/opendp-ffi/src/data/bootstrap.json
@@ -13,7 +13,7 @@
         "description": "Internal function. Load data from a `slice` into an AnyObject",
         "args": [
             {"name": "slice", "c_type": "const FfiSlice *", "rust_type": "T", "hint": "FfiSlicePtr"},
-            {"name": "T",  "c_type": "char *", "is_type": true}
+            {"name": "T", "is_type": true}
         ],
         "ret": {
             "c_type": "FfiResult<const AnyObject *>",
@@ -25,7 +25,7 @@
         "description": "Internal function. Load data from a `slice` into an AnyMetricDistance",
         "args": [
             {"name": "slice", "c_type": "const FfiSlice *", "rust_type": "T", "hint": "FfiSlicePtr"},
-            {"name": "T",  "c_type": "char *", "is_type": true}
+            {"name": "T", "is_type": true}
         ],
         "ret": {
             "c_type": "FfiResult<const AnyMetricDistance *>",
@@ -37,7 +37,7 @@
         "description": "Internal function. Load data from a `slice` into an AnyMeasureDistance",
         "args": [
             {"name": "slice", "c_type": "const FfiSlice *", "rust_type": "T", "hint": "FfiSlicePtr"},
-            {"name": "T",  "c_type": "char *", "is_type": true}
+            {"name": "T", "is_type": true}
         ],
         "ret": {
             "c_type": "FfiResult<const AnyMeasureDistance *>",

--- a/rust/opendp-ffi/src/meas/bootstrap.json
+++ b/rust/opendp-ffi/src/meas/bootstrap.json
@@ -12,7 +12,6 @@
             },
             {
                 "name": "D",
-                "c_type": "char *",
                 "default": "AllDomain<T>",
                 "generics": ["T"],
                 "description": "Domain of the data type to be privatized. Valid values are VectorDomain<AllDomain<T>> or AllDomain<T>",
@@ -44,7 +43,6 @@
             },
             {
                 "name": "D",
-                "c_type": "char *",
                 "default": "AllDomain<T>",
                 "generics": ["T"],
                 "description": "Domain of the data type to be privatized. Valid values are VectorDomain<AllDomain<T>> or AllDomain<T>",
@@ -84,14 +82,12 @@
             },
             {
                 "name": "D",
-                "c_type": "char *",
                 "default": "AllDomain<i32>",
                 "description": "Domain of the data type to be privatized. Valid values are VectorDomain<AllDomain<T>> or AllDomain<T>",
                 "is_type": true
             },
             {
                 "name": "QO",
-                "c_type": "char *",
                 "description": "Data type of the sensitivity, scale, and budget.",
                 "is_type": true
             }
@@ -147,20 +143,17 @@
             },
             {
                 "name": "MI",
-                "c_type": "char *",
                 "description": "Input metric.",
                 "is_type": true,
                 "hint": "SensitivityMetric"
             },
             {
                 "name": "TIK",
-                "c_type": "char *",
                 "description": "Data type of input key- must be hashable/categorical.",
                 "is_type": true
             },
             {
                 "name": "TIC",
-                "c_type": "char *",
                 "description": "Data type of input count- must be integral.",
                 "is_type": true,
                 "default": "i32"

--- a/rust/opendp-ffi/src/meas/gaussian.rs
+++ b/rust/opendp-ffi/src/meas/gaussian.rs
@@ -12,6 +12,7 @@ use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::util::Type;
 use opendp::dom::{AllDomain, VectorDomain};
 use opendp::traits::{InfCast, CheckNull};
+use std::fmt::Debug;
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_gaussian(
@@ -20,7 +21,7 @@ pub extern "C" fn opendp_meas__make_base_gaussian(
 ) -> FfiResult<*mut AnyMeasurement> {
     fn monomorphize<D>(scale: *const c_void) -> FfiResult<*mut AnyMeasurement> where
         D: 'static + GaussianDomain,
-        D::Atom: 'static + Clone + SampleGaussian + Float + InfCast<f64> + CheckNull {
+        D::Atom: 'static + Clone + SampleGaussian + Float + InfCast<f64> + CheckNull + Debug {
         let scale = *try_as_ref!(scale as *const D::Atom);
         make_base_gaussian::<D>(scale).into_any()
     }

--- a/rust/opendp-ffi/src/meas/geometric.rs
+++ b/rust/opendp-ffi/src/meas/geometric.rs
@@ -12,6 +12,7 @@ use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::util::Type;
 use crate::util;
 use opendp::traits::{InfCast, TotalOrd};
+use std::fmt::Debug;
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_geometric(
@@ -24,7 +25,7 @@ pub extern "C" fn opendp_meas__make_base_geometric(
     ) -> FfiResult<*mut AnyMeasurement>
         where D: 'static + GeometricDomain,
               D::Atom: 'static + InfCast<QO> + TotalOrd + Clone,
-              QO: 'static + Float + InfCast<D::Atom> + TotalOrd,
+              QO: 'static + Float + InfCast<D::Atom> + TotalOrd + Debug,
               f64: From<QO> {
         let scale = try_as_ref!(scale as *const QO).clone();
         let bounds = if let Some(bounds) = util::as_ref(bounds) {

--- a/rust/opendp-ffi/src/meas/laplace.rs
+++ b/rust/opendp-ffi/src/meas/laplace.rs
@@ -12,6 +12,7 @@ use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::util::Type;
 use opendp::dom::{VectorDomain, AllDomain};
 use opendp::traits::{InfCast, CheckNull, TotalOrd};
+use std::fmt::Debug;
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_laplace(
@@ -20,7 +21,7 @@ pub extern "C" fn opendp_meas__make_base_laplace(
 ) -> FfiResult<*mut AnyMeasurement> {
     fn monomorphize<D>(scale: *const c_void) -> FfiResult<*mut AnyMeasurement>
         where D: 'static + LaplaceDomain,
-              D::Atom: 'static + Clone + SampleLaplace + Float + InfCast<D::Atom> + CheckNull + TotalOrd {
+              D::Atom: 'static + Clone + SampleLaplace + Float + InfCast<D::Atom> + CheckNull + TotalOrd + Debug {
         let scale = *try_as_ref!(scale as *const D::Atom);
         make_base_laplace::<D>(scale).into_any()
     }

--- a/rust/opendp-ffi/src/meas/stability.rs
+++ b/rust/opendp-ffi/src/meas/stability.rs
@@ -52,7 +52,7 @@ pub extern "C" fn opendp_meas__make_base_stability(
     let TIK = try_!(Type::try_from(TIK));
     let TIC = try_!(Type::try_from(TIC));
 
-    let TOC = try_!(MI.get_sensitivity_distance());
+    let TOC = try_!(MI.get_atom());
     dispatch!(monomorphize, [
         (TIC, @integers),
         (TOC, @floats)

--- a/rust/opendp-ffi/src/meas/stability.rs
+++ b/rust/opendp-ffi/src/meas/stability.rs
@@ -14,7 +14,7 @@ use opendp::traits::{ExactIntCast, CheckNull, TotalOrd};
 
 use crate::any::AnyMeasurement;
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
-use crate::util::Type;
+use crate::util::Type;use std::fmt::Debug;
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_stability(
@@ -29,15 +29,15 @@ pub extern "C" fn opendp_meas__make_base_stability(
         n: usize, scale: *const c_void, threshold: *const c_void,
         MI: Type, TIK: Type, TIC: Type,
     ) -> FfiResult<*mut AnyMeasurement>
-        where TIC: 'static + Integer + Zero + One + AddAssign + Clone + CheckNull,
-              TOC: 'static + TotalOrd + Clone + Float + CastInternalReal + ExactIntCast<usize> + ExactIntCast<TIC> + CheckNull {
+        where TIC: 'static + Integer + Zero + One + AddAssign + Clone + CheckNull + Debug,
+              TOC: 'static + TotalOrd + Clone + Float + CastInternalReal + ExactIntCast<usize> + ExactIntCast<TIC> + CheckNull + Debug {
         fn monomorphize2<MI, TIK, TIC>(
             n: usize, scale: MI::Distance, threshold: MI::Distance,
         ) -> FfiResult<*mut AnyMeasurement>
             where MI: 'static + SensitivityMetric + BaseStabilityNoise,
-                  TIK: 'static + Eq + Hash + Clone + CheckNull,
-                  TIC: 'static + Integer + Zero + One + AddAssign + Clone + CheckNull,
-                  MI::Distance: 'static + Clone + TotalOrd + Float + CastInternalReal + ExactIntCast<usize> + ExactIntCast<TIC> + CheckNull {
+                  TIK: 'static + Eq + Hash + Clone + CheckNull + Debug,
+                  TIC: 'static + Integer + Zero + One + AddAssign + Clone + CheckNull + Debug,
+                  MI::Distance: 'static + Clone + TotalOrd + Float + CastInternalReal + ExactIntCast<usize> + ExactIntCast<TIC> + CheckNull + Debug {
             make_base_stability::<MI, TIK, TIC>(n, scale, threshold).into_any()
         }
         let scale = *try_as_ref!(scale as *const TOC);

--- a/rust/opendp-ffi/src/trans/bootstrap.json
+++ b/rust/opendp-ffi/src/trans/bootstrap.json
@@ -492,8 +492,8 @@
             "c_type": "FfiResult<AnyTransformation *>"
         }
     },
-    "make_resize_constant": {
-        "description": "Make a Transformation that either truncates or imputes records with `constant` in a Vec<`T`> to match a provided `length`.",
+    "make_resize_constant_bounded": {
+        "description": "Make a Transformation that either truncates or imputes records with `constant` in a Vec<`T`> to match a provided `length`.\\nWARNING: This function is temporary. It will be replaced by a more general make_resize_constant that accepts domains",
         "args": [
             {
                 "name": "constant",
@@ -505,6 +505,18 @@
                 "name": "length",
                 "c_type": "unsigned int",
                 "description": "Number of records in output data."
+            },
+            {
+                "name": "lower",
+                "c_type": "void *",
+                "rust_type": "TA",
+                "description": "Lower bound of data in input domain"
+            },
+            {
+                "name": "upper",
+                "c_type": "void *",
+                "rust_type": "TA",
+                "description": "Upper bound of data in input domain"
             },
             {
                 "name": "TA",

--- a/rust/opendp-ffi/src/trans/bootstrap.json
+++ b/rust/opendp-ffi/src/trans/bootstrap.json
@@ -492,7 +492,33 @@
             "c_type": "FfiResult<AnyTransformation *>"
         }
     },
-    "make_resize_constant_bounded": {
+    "make_resize": {
+        "description": "Make a Transformation that either truncates or imputes records with `constant` in a Vec<`T`> to match a provided `length`.\\nWARNING: This function is temporary. It will be replaced by a more general make_resize that accepts domains",
+        "args": [
+            {
+                "name": "constant",
+                "c_type": "AnyObject *",
+                "rust_type": "TA",
+                "description": "Value to impute with."
+            },
+            {
+                "name": "length",
+                "c_type": "unsigned int",
+                "description": "Number of records in output data."
+            },
+            {
+                "name": "TA",
+                "c_type": "void *",
+                "is_type": true,
+                "description": "Atomic type."
+            }
+        ],
+        "ret": {
+            "c_type": "FfiResult<AnyTransformation *>",
+            "description": "A vector of the same type `TA`, but with the provided `length`."
+        }
+    },
+    "make_resize_bounded": {
         "description": "Make a Transformation that either truncates or imputes records with `constant` in a Vec<`T`> to match a provided `length`.\\nWARNING: This function is temporary. It will be replaced by a more general make_resize_constant that accepts domains",
         "args": [
             {

--- a/rust/opendp-ffi/src/trans/bootstrap.json
+++ b/rust/opendp-ffi/src/trans/bootstrap.json
@@ -4,13 +4,11 @@
         "args": [
             {
                 "name": "TI",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "input data type to cast from"
             },
             {
                 "name": "TO",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "data type to cast into"
             }
@@ -22,13 +20,11 @@
         "args": [
             {
                 "name": "TI",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "input data type to cast from"
             },
             {
                 "name": "TO",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "data type to cast into"
             }
@@ -46,7 +42,6 @@
             },
             {
                 "name": "TI",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "input data type"
             }
@@ -58,7 +53,6 @@
         "args": [
             {
                 "name": "DIA",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "atomic input domain"
             }
@@ -70,13 +64,11 @@
         "args": [
             {
                 "name": "TI",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "input data type to cast from"
             },
             {
                 "name": "TO",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "data type to cast into"
             }
@@ -88,21 +80,18 @@
         "args": [
             {
                 "name": "MI",
-                "c_type": "char *",
                 "hint": "DatasetMetric",
                 "is_type": true,
                 "description": "input dataset metric"
             },
             {
                 "name": "MO",
-                "c_type": "char *",
                 "hint": "DatasetMetric",
                 "is_type": true,
                 "description": "output dataset metric"
             },
             {
                 "name": "T",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "atomic type of data"
             }
@@ -126,7 +115,6 @@
             },
             {
                 "name": "T",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "atomic data type"
             }
@@ -150,7 +138,6 @@
             },
             {
                 "name": "T",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "atomic data type"
             }
@@ -162,13 +149,11 @@
         "args": [
             {
                 "name": "TIA",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "Atomic Input Type. Input data is expected to be of the form Vec<TIA>."
             },
             {
                 "name": "TO",
-                "c_type": "char *",
                 "default": "i32",
                 "is_type": true,
                 "description": "type of output integer"
@@ -181,13 +166,11 @@
         "args": [
             {
                 "name": "TIA",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "Atomic Input Type. Input data is expected to be of the form Vec<TIA>."
             },
             {
                 "name": "TO",
-                "c_type": "char *",
                 "default": "i32",
                 "is_type": true,
                 "description": "Output Type. integer"
@@ -205,20 +188,17 @@
             },
             {
                 "name": "MO",
-                "c_type": "char *",
                 "hint": "SensitivityMetric",
                 "is_type": true,
                 "description": "Output Metric."
             },
             {
                 "name": "TI",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "Input Type. Categorical/hashable input data type. Input data must be Vec<TI>."
             },
             {
                 "name": "TO",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "Output Type. express counts in terms of this integral type",
                 "default": "i32"
@@ -243,20 +223,17 @@
             },
             {
                 "name": "MO",
-                "c_type": "char *",
                 "hint": "SensitivityMetric",
                 "is_type": true,
                 "description": "output sensitivity metric"
             },
             {
                 "name": "TI",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "categorical/hashable input data type. Input data must be Vec<TI>."
             },
             {
                 "name": "TO",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "express counts in terms of this integral type",
                 "default": "i32"
@@ -296,7 +273,6 @@
             },
             {
                 "name": "K",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "categorical/hashable data type of column names"
             }
@@ -322,7 +298,6 @@
             },
             {
                 "name": "K",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "categorical/hashable data type of column names"
             }
@@ -348,13 +323,11 @@
             },
             {
                 "name": "K",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "categorical/hashable data type of the key/column name"
             },
             {
                 "name": "T",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "data type to parse into"
             }
@@ -372,13 +345,11 @@
             },
             {
                 "name": "K",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "data type of the key"
             },
             {
                 "name": "T",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "data type to downcast to"
             }
@@ -390,14 +361,12 @@
         "args": [
             {
                 "name": "M",
-                "c_type": "char *",
                 "hint": "DatasetMetric",
                 "description": "dataset metric",
                 "is_type": true
             },
             {
                 "name": "T",
-                "c_type": "char *",
                 "description": "Type of data passed to the identity function.",
                 "is_type": true
             }
@@ -417,7 +386,6 @@
             },
             {
                 "name": "DA",
-                "c_type": "char *",
                 "is_type": true,
                 "default": "OptionNullDomain<AllDomain<T>>",
                 "generics": ["T"],
@@ -454,7 +422,6 @@
             },
             {
                 "name": "T",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "type of data being imputed"
             }
@@ -483,7 +450,6 @@
             },
             {
                 "name": "T",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "atomic data type"
             }
@@ -508,7 +474,6 @@
             },
             {
                 "name": "TA",
-                "c_type": "void *",
                 "is_type": true,
                 "description": "Atomic type."
             }
@@ -546,7 +511,6 @@
             },
             {
                 "name": "TA",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "Atomic type."
             }
@@ -573,7 +537,6 @@
             },
             {
                 "name": "T",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "atomic type of data"
             }
@@ -604,7 +567,6 @@
             },
             {
                 "name": "T",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "atomic type of data"
             }
@@ -641,7 +603,6 @@
             },
             {
                 "name": "T",
-                "c_type": "char *",
                 "is_type": true,
                 "description": "atomic data type"
             }

--- a/rust/opendp-ffi/src/trans/cast.rs
+++ b/rust/opendp-ffi/src/trans/cast.rs
@@ -11,7 +11,7 @@ use opendp::trans::{make_cast, make_cast_default, make_cast_inherent, make_cast_
 use crate::any::AnyTransformation;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::{Type};
-
+use std::fmt::Debug;
 
 
 #[no_mangle]
@@ -22,8 +22,8 @@ pub extern "C" fn opendp_trans__make_cast(
     let TO = try_!(Type::try_from(TO));
 
     fn monomorphize<TI, TO>() -> FfiResult<*mut AnyTransformation>
-        where TI: 'static + Clone + CheckNull,
-              TO: 'static + RoundCast<TI> + CheckNull {
+        where TI: 'static + Clone + CheckNull + Debug,
+              TO: 'static + RoundCast<TI> + CheckNull + Debug {
         make_cast::<TI, TO>().into_any()
     }
     dispatch!(monomorphize, [(TI, @primitives), (TO, @primitives)], ())
@@ -37,8 +37,8 @@ pub extern "C" fn opendp_trans__make_cast_default(
     let TO = try_!(Type::try_from(TO));
 
     fn monomorphize<TI, TO>() -> FfiResult<*mut AnyTransformation>
-        where TI: 'static + Clone + CheckNull,
-              TO: 'static + RoundCast<TI> + Default + CheckNull {
+        where TI: 'static + Clone + CheckNull + Debug,
+              TO: 'static + RoundCast<TI> + Default + CheckNull + Debug {
         make_cast_default::<TI, TO>().into_any()
     }
     dispatch!(monomorphize, [(TI, @primitives), (TO, @primitives)], ())
@@ -52,8 +52,8 @@ pub extern "C" fn opendp_trans__make_cast_inherent(
     let TO = try_!(Type::try_from(TO));
 
     fn monomorphize<TI, TO>() -> FfiResult<*mut AnyTransformation>
-        where TI: 'static + Clone + CheckNull,
-              TO: 'static + RoundCast<TI> + InherentNull {
+        where TI: 'static + Clone + CheckNull + Debug,
+              TO: 'static + RoundCast<TI> + InherentNull + Debug {
         make_cast_inherent::<TI, TO>().into_any()
     }
     dispatch!(monomorphize, [(TI, @primitives), (TO, @floats)], ())
@@ -74,7 +74,7 @@ pub extern "C" fn opendp_trans__make_cast_metric(
         where MI: 'static + DatasetMetric,
               MO: 'static + DatasetMetric,
               (MI, MO): DatasetMetricCast,
-              T: 'static + Clone + CheckNull {
+              T: 'static + Clone + CheckNull + Debug {
         make_cast_metric::<VectorDomain<AllDomain<T>>, MI, MO>(
             VectorDomain::new_all()
         ).into_any()

--- a/rust/opendp-ffi/src/trans/clamp.rs
+++ b/rust/opendp-ffi/src/trans/clamp.rs
@@ -9,6 +9,7 @@ use opendp::trans::{make_clamp, make_unclamp};
 use crate::any::AnyTransformation;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::Type;
+use std::fmt::Debug;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_clamp(
@@ -18,7 +19,7 @@ pub extern "C" fn opendp_trans__make_clamp(
     let T = try_!(Type::try_from(T));
 
     fn monomorphize_dataset<T>(lower: *const c_void, upper: *const c_void) -> FfiResult<*mut AnyTransformation>
-        where T: 'static + Clone + TotalOrd + CheckNull {
+        where T: 'static + Clone + TotalOrd + CheckNull + Debug {
         let lower = try_as_ref!(lower as *const T).clone();
         let upper = try_as_ref!(upper as *const T).clone();
         make_clamp::<T>(lower, upper).into_any()
@@ -36,7 +37,7 @@ pub extern "C" fn opendp_trans__make_unclamp(
 ) -> FfiResult<*mut AnyTransformation> {
     let T = try_!(Type::try_from(T));
     fn monomorphize_dataset<T>(lower: *const c_void, upper: *const c_void) -> FfiResult<*mut AnyTransformation>
-        where T: 'static + Clone + TotalOrd + CheckNull {
+        where T: 'static + Clone + TotalOrd + CheckNull + Debug {
         let lower = try_as_ref!(lower as *const T).clone();
         let upper = try_as_ref!(upper as *const T).clone();
         make_unclamp::<T>(Bound::Included(lower), Bound::Included(upper)).into_any()

--- a/rust/opendp-ffi/src/trans/count.rs
+++ b/rust/opendp-ffi/src/trans/count.rs
@@ -14,7 +14,7 @@ use opendp::trans::{CountByConstant, make_count, make_count_by, make_count_by_ca
 use crate::any::{AnyObject, AnyTransformation};
 use crate::any::Downcast;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
-use crate::util::Type;
+use crate::util::Type;use std::fmt::Debug;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_count(
@@ -22,8 +22,8 @@ pub extern "C" fn opendp_trans__make_count(
     TO: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<TIA, TO>() -> FfiResult<*mut AnyTransformation>
-        where TIA: 'static + CheckNull,
-              TO: 'static + ExactIntCast<usize> + Bounded + One + DistanceConstant<IntDistance> + CheckNull,
+        where TIA: 'static + CheckNull + Debug,
+              TO: 'static + ExactIntCast<usize> + Bounded + One + DistanceConstant<IntDistance> + CheckNull + Debug,
               IntDistance: InfCast<TO> {
         make_count::<TIA, TO>().into_any()
     }
@@ -42,8 +42,8 @@ pub extern "C" fn opendp_trans__make_count_distinct(
     TO: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<TIA, TO: 'static>() -> FfiResult<*mut AnyTransformation>
-        where TIA: 'static + Eq + Hash + CheckNull,
-              TO: 'static + ExactIntCast<usize> + Bounded + One + DistanceConstant<IntDistance> + CheckNull,
+        where TIA: 'static + Eq + Hash + CheckNull + Debug,
+              TO: 'static + ExactIntCast<usize> + Bounded + One + DistanceConstant<IntDistance> + CheckNull + Debug,
               IntDistance: InfCast<TO> {
         make_count_distinct::<TIA, TO>().into_any()
     }
@@ -65,13 +65,13 @@ pub extern "C" fn opendp_trans__make_count_by_categories(
         categories: *const AnyObject,
         MO: Type, TI: Type, TO: Type,
     ) -> FfiResult<*mut AnyTransformation>
-        where QO: DistanceConstant<IntDistance> + FloatConst + One,
+        where QO: DistanceConstant<IntDistance> + FloatConst + One + Debug,
               IntDistance: InfCast<QO> {
         fn monomorphize2<MO, TI, TO>(categories: *const AnyObject) -> FfiResult<*mut AnyTransformation>
             where MO: 'static + SensitivityMetric + CountByConstant<MO::Distance>,
                   MO::Distance: DistanceConstant<IntDistance> + One,
-                  TI: 'static + Eq + Hash + Clone + CheckNull,
-                  TO: 'static + Integer + Zero + One + SaturatingAdd + CheckNull,
+                  TI: 'static + Eq + Hash + Clone + CheckNull + Debug,
+                  TO: 'static + Integer + Zero + One + SaturatingAdd + CheckNull + Debug,
                   IntDistance: InfCast<MO::Distance> {
             let categories = try_!(try_as_ref!(categories).downcast_ref::<Vec<TI>>()).clone();
             make_count_by_categories::<MO, TI, TO>(categories).into_any()
@@ -100,13 +100,13 @@ pub extern "C" fn opendp_trans__make_count_by(
     fn monomorphize<QO>(
         n: usize, MO: Type, TI: Type, TO: Type,
     ) -> FfiResult<*mut AnyTransformation>
-        where QO: DistanceConstant<IntDistance> + FloatConst + One,
+        where QO: DistanceConstant<IntDistance> + FloatConst + One + Debug,
               IntDistance: InfCast<QO> {
         fn monomorphize2<MO, TI, TO>(n: usize) -> FfiResult<*mut AnyTransformation>
             where MO: 'static + SensitivityMetric + CountByConstant<MO::Distance>,
                   MO::Distance: DistanceConstant<IntDistance> + FloatConst + One,
-                  TI: 'static + Eq + Hash + Clone + CheckNull,
-                  TO: 'static + Integer + Zero + One + SaturatingAdd + CheckNull,
+                  TI: 'static + Eq + Hash + Clone + CheckNull + Debug,
+                  TO: 'static + Integer + Zero + One + SaturatingAdd + CheckNull + Debug,
                   IntDistance: InfCast<MO::Distance> {
             make_count_by::<MO, TI, TO>(n).into_any()
         }

--- a/rust/opendp-ffi/src/trans/count.rs
+++ b/rust/opendp-ffi/src/trans/count.rs
@@ -86,7 +86,7 @@ pub extern "C" fn opendp_trans__make_count_by_categories(
     let TI = try_!(Type::try_from(TI));
     let TO = try_!(Type::try_from(TO));
 
-    let QO = try_!(MO.get_sensitivity_distance());
+    let QO = try_!(MO.get_atom());
     dispatch!(monomorphize, [
         (QO, @floats)
     ], (categories, MO, TI, TO))
@@ -121,6 +121,6 @@ pub extern "C" fn opendp_trans__make_count_by(
     let TI = try_!(Type::try_from(TI));
     let TO = try_!(Type::try_from(TO));
 
-    let QO = try_!(MO.get_sensitivity_distance());
+    let QO = try_!(MO.get_atom());
     dispatch!(monomorphize, [(QO, @floats)], (n, MO, TI, TO))
 }

--- a/rust/opendp-ffi/src/trans/dataframe.rs
+++ b/rust/opendp-ffi/src/trans/dataframe.rs
@@ -31,7 +31,7 @@ pub extern "C" fn opendp_trans__make_create_dataframe(
     col_names: *const AnyObject, K: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<K>(col_names: *const AnyObject) -> FfiResult<*mut AnyTransformation>
-        where K: 'static + Eq + Hash + Clone + CheckNull {
+        where K: 'static + Eq + Hash + Clone + CheckNull + Debug {
         let col_names = try_!(try_as_ref!(col_names).downcast_ref::<Vec<K>>()).clone();
         make_create_dataframe::<K>(col_names).into_any()
     }

--- a/rust/opendp-ffi/src/trans/impute.rs
+++ b/rust/opendp-ffi/src/trans/impute.rs
@@ -40,7 +40,7 @@ pub extern "C" fn opendp_trans__make_impute_constant(
     DA: *const c_char
 ) -> FfiResult<*mut AnyTransformation> {
     let DA = try_!(Type::try_from(DA));
-    let T = try_!(DA.get_domain_atom());
+    let T = try_!(DA.get_atom());
 
     match &DA.contents {
         TypeContents::GENERIC {name, ..} if name == &"OptionNullDomain" => {

--- a/rust/opendp-ffi/src/trans/impute.rs
+++ b/rust/opendp-ffi/src/trans/impute.rs
@@ -13,6 +13,7 @@ use crate::any::{AnyTransformation, AnyObject, Downcast};
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::{Type, TypeContents};
 use opendp::traits::CheckNull;
+use std::fmt::Debug;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_impute_uniform_float(
@@ -24,7 +25,7 @@ pub extern "C" fn opendp_trans__make_impute_uniform_float(
     fn monomorphize<T>(
         lower: *const c_void, upper: *const c_void,
     ) -> FfiResult<*mut AnyTransformation>
-        where for<'a> T: 'static + Float + SampleUniform + Clone + Sub<Output=T> + Mul<&'a T, Output=T> + Add<&'a T, Output=T> + InherentNull {
+        where for<'a> T: 'static + Float + SampleUniform + Clone + Sub<Output=T> + Mul<&'a T, Output=T> + Add<&'a T, Output=T> + InherentNull + Debug {
         let lower = try_as_ref!(lower as *const T).clone();
         let upper = try_as_ref!(upper as *const T).clone();
         make_impute_uniform_float::<T>(
@@ -48,7 +49,7 @@ pub extern "C" fn opendp_trans__make_impute_constant(
                 constant: *const AnyObject
             ) -> FfiResult<*mut AnyTransformation>
                 where OptionNullDomain<AllDomain<T>>: ImputableDomain<Imputed=T>,
-                      T: 'static + Clone + CheckNull{
+                      T: 'static + Clone + CheckNull + Debug {
                 let constant: T = try_!(try_as_ref!(constant).downcast_ref::<T>()).clone();
                 make_impute_constant::<OptionNullDomain<AllDomain<T>>>(constant).into_any()
             }
@@ -59,7 +60,7 @@ pub extern "C" fn opendp_trans__make_impute_constant(
                 constant: *const AnyObject
             ) -> FfiResult<*mut AnyTransformation>
                 where InherentNullDomain<AllDomain<T>>: ImputableDomain<Imputed=T>,
-                      T: 'static + InherentNull + Clone {
+                      T: 'static + InherentNull + Clone + Debug {
                 let constant: T = try_!(try_as_ref!(constant).downcast_ref::<T>()).clone();
                 make_impute_constant::<InherentNullDomain<AllDomain<T>>>(constant).into_any()
             }

--- a/rust/opendp-ffi/src/trans/manipulation.rs
+++ b/rust/opendp-ffi/src/trans/manipulation.rs
@@ -60,7 +60,7 @@ pub extern "C" fn opendp_trans__make_is_null(
     DIA: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     let DIA = try_!(Type::try_from(DIA));
-    let T = try_!(DIA.get_domain_atom());
+    let T = try_!(DIA.get_atom());
 
     match &DIA.contents {
         TypeContents::GENERIC { name, .. } if name == &"OptionNullDomain" => {

--- a/rust/opendp-ffi/src/trans/manipulation.rs
+++ b/rust/opendp-ffi/src/trans/manipulation.rs
@@ -11,6 +11,7 @@ use crate::any::{AnyTransformation, AnyObject, Downcast};
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::{Type, TypeContents};
 use opendp::traits::CheckNull;
+use std::fmt::Debug;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_identity(
@@ -18,12 +19,12 @@ pub extern "C" fn opendp_trans__make_identity(
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize_scalar<M, T>() -> FfiResult<*mut AnyTransformation>
         where M: 'static + DatasetMetric,
-              T: 'static + Clone + CheckNull {
+              T: 'static + Clone + CheckNull + Debug {
         make_identity::<AllDomain<T>, M>(AllDomain::<T>::new(), M::default()).into_any()
     }
     fn monomorphize_vec<M, T>() -> FfiResult<*mut AnyTransformation>
         where M: 'static + DatasetMetric,
-              T: 'static + Clone + CheckNull {
+              T: 'static + Clone + CheckNull + Debug {
         make_identity::<VectorDomain<AllDomain<T>>, M>(VectorDomain::new(AllDomain::<T>::new()), M::default()).into_any()
     }
     let M = try_!(Type::try_from(M));
@@ -48,7 +49,7 @@ pub extern "C" fn opendp_trans__make_is_equal(
     let TI = try_!(Type::try_from(TI));
 
     fn monomorphize<TI>(value: *const AnyObject) -> FfiResult<*mut AnyTransformation> where
-        TI: 'static + Clone + PartialEq + CheckNull {
+        TI: 'static + Clone + PartialEq + CheckNull + Debug {
         let value: TI = try_!(try_as_ref!(value).downcast_ref::<TI>()).clone();
         make_is_equal::<TI>(value).into_any()
     }
@@ -65,14 +66,14 @@ pub extern "C" fn opendp_trans__make_is_null(
     match &DIA.contents {
         TypeContents::GENERIC { name, .. } if name == &"OptionNullDomain" => {
             fn monomorphize<T>() -> FfiResult<*mut AnyTransformation>
-                where T: 'static + CheckNull {
+                where T: 'static + CheckNull + Debug {
                 make_is_null::<OptionNullDomain<AllDomain<T>>>().into_any()
             }
             dispatch!(monomorphize, [(T, @primitives)], ())
         }
         TypeContents::GENERIC { name, .. } if name == &"InherentNullDomain" => {
             fn monomorphize<T>() -> FfiResult<*mut AnyTransformation>
-                where T: 'static + InherentNull {
+                where T: 'static + InherentNull + Debug {
                 make_is_null::<InherentNullDomain<AllDomain<T>>>().into_any()
             }
             dispatch!(monomorphize, [(T, [f64, f32])], ())

--- a/rust/opendp-ffi/src/trans/mean.rs
+++ b/rust/opendp-ffi/src/trans/mean.rs
@@ -13,6 +13,7 @@ use crate::any::AnyTransformation;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::Type;
 use opendp::dist::IntDistance;
+use std::fmt::Debug;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_bounded_mean(
@@ -20,7 +21,7 @@ pub extern "C" fn opendp_trans__make_bounded_mean(
     T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<T>(lower: *const c_void, upper: *const c_void, n: usize) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactIntCast<usize> + CheckedMul + CheckNull,
+        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactIntCast<usize> + CheckedMul + CheckNull + Debug,
               for<'a> T: Sum<&'a T>,
               IntDistance: InfCast<T> {
         let lower = *try_as_ref!(lower as *const T);

--- a/rust/opendp-ffi/src/trans/resize.rs
+++ b/rust/opendp-ffi/src/trans/resize.rs
@@ -1,25 +1,26 @@
 use std::convert::TryFrom;
+use std::ops::Bound;
 use std::os::raw::{c_char, c_uint, c_void};
 
+use opendp::dom::{AllDomain, IntervalDomain};
 use opendp::err;
-use opendp::trans::make_resize_constant;
 use opendp::traits::{CheckNull, TotalOrd};
+use opendp::trans::make_resize_constant;
 
-use crate::any::AnyTransformation;
+use crate::any::{AnyObject, AnyTransformation};
+use crate::any::Downcast;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::Type;
-use opendp::dom::IntervalDomain;
-use std::ops::Bound;
 
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_resize_constant_bounded(
+pub extern "C" fn opendp_trans__make_resize_bounded(
     constant: *const c_void, length: c_uint,
     lower: *const c_void, upper: *const c_void,
     TA: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<TA>(
         constant: *const c_void, length: usize,
-        lower: *const c_void, upper: *const c_void
+        lower: *const c_void, upper: *const c_void,
     ) -> FfiResult<*mut AnyTransformation>
         where TA: 'static + Clone + CheckNull + TotalOrd {
         let constant = try_as_ref!(constant as *const TA).clone();
@@ -31,6 +32,23 @@ pub extern "C" fn opendp_trans__make_resize_constant_bounded(
     let length = length as usize;
     let TA = try_!(Type::try_from(TA));
     dispatch!(monomorphize, [(TA, @numbers)], (constant, length, lower, upper))
+}
+
+#[no_mangle]
+pub extern "C" fn opendp_trans__make_resize(
+    constant: *const AnyObject, length: c_uint,
+    TA: *const c_char,
+) -> FfiResult<*mut AnyTransformation> {
+    fn monomorphize<TA>(
+        constant: *const AnyObject, length: usize,
+    ) -> FfiResult<*mut AnyTransformation>
+        where TA: 'static + Clone + CheckNull + TotalOrd {
+        let constant = try_!(try_as_ref!(constant).downcast_ref::<TA>()).clone();
+        make_resize_constant::<AllDomain<TA>>(AllDomain::new(), constant, length).into_any()
+    }
+    let length = length as usize;
+    let TA = try_!(Type::try_from(TA));
+    dispatch!(monomorphize, [(TA, @numbers)], (constant, length))
 }
 
 
@@ -47,7 +65,22 @@ mod tests {
 
     #[test]
     fn test_make_resize() -> Fallible<()> {
-        let transformation = Result::from(opendp_trans__make_resize_constant_bounded(
+        let transformation = Result::from(opendp_trans__make_resize(
+            AnyObject::new_raw(0i32),
+            4 as c_uint,
+            "i32".to_char_p(),
+        ))?;
+        let arg = AnyObject::new_raw(vec![1, 2, 3]);
+        let res = opendp_core__transformation_invoke(&transformation, arg);
+        let res: Vec<i32> = Fallible::from(res)?.downcast()?;
+        assert_eq!(res, vec![1, 2, 3, 0]);
+        Ok(())
+    }
+
+
+    #[test]
+    fn test_make_resize_bounded() -> Fallible<()> {
+        let transformation = Result::from(opendp_trans__make_resize_bounded(
             util::into_raw(0i32) as *const c_void,
             4 as c_uint,
             util::into_raw(0i32) as *const c_void,

--- a/rust/opendp-ffi/src/trans/resize.rs
+++ b/rust/opendp-ffi/src/trans/resize.rs
@@ -3,25 +3,34 @@ use std::os::raw::{c_char, c_uint, c_void};
 
 use opendp::err;
 use opendp::trans::make_resize_constant;
-use opendp::traits::CheckNull;
+use opendp::traits::{CheckNull, TotalOrd};
 
 use crate::any::AnyTransformation;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::Type;
+use opendp::dom::IntervalDomain;
+use std::ops::Bound;
 
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_resize_constant(
+pub extern "C" fn opendp_trans__make_resize_constant_bounded(
     constant: *const c_void, length: c_uint,
+    lower: *const c_void, upper: *const c_void,
     TA: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<TA>(constant: *const c_void, length: usize) -> FfiResult<*mut AnyTransformation>
-        where TA: 'static + Clone + CheckNull {
+    fn monomorphize<TA>(
+        constant: *const c_void, length: usize,
+        lower: *const c_void, upper: *const c_void
+    ) -> FfiResult<*mut AnyTransformation>
+        where TA: 'static + Clone + CheckNull + TotalOrd {
         let constant = try_as_ref!(constant as *const TA).clone();
-        make_resize_constant::<TA>(constant, length).into_any()
+        let lower = try_as_ref!(lower as *const TA).clone();
+        let upper = try_as_ref!(upper as *const TA).clone();
+        let atom_domain = try_!(IntervalDomain::new(Bound::Included(lower), Bound::Included(upper)));
+        make_resize_constant::<IntervalDomain<TA>>(atom_domain, constant, length).into_any()
     }
     let length = length as usize;
     let TA = try_!(Type::try_from(TA));
-    dispatch!(monomorphize, [(TA, @primitives)], (constant, length))
+    dispatch!(monomorphize, [(TA, @numbers)], (constant, length, lower, upper))
 }
 
 
@@ -38,9 +47,11 @@ mod tests {
 
     #[test]
     fn test_make_resize() -> Fallible<()> {
-        let transformation = Result::from(opendp_trans__make_resize_constant(
+        let transformation = Result::from(opendp_trans__make_resize_constant_bounded(
             util::into_raw(0i32) as *const c_void,
             4 as c_uint,
+            util::into_raw(0i32) as *const c_void,
+            util::into_raw(10i32) as *const c_void,
             "i32".to_char_p(),
         ))?;
         let arg = AnyObject::new_raw(vec![1, 2, 3]);

--- a/rust/opendp-ffi/src/trans/resize.rs
+++ b/rust/opendp-ffi/src/trans/resize.rs
@@ -11,6 +11,7 @@ use crate::any::{AnyObject, AnyTransformation};
 use crate::any::Downcast;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::Type;
+use std::fmt::Debug;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_resize_bounded(
@@ -22,7 +23,7 @@ pub extern "C" fn opendp_trans__make_resize_bounded(
         constant: *const c_void, length: usize,
         lower: *const c_void, upper: *const c_void,
     ) -> FfiResult<*mut AnyTransformation>
-        where TA: 'static + Clone + CheckNull + TotalOrd {
+        where TA: 'static + Clone + CheckNull + TotalOrd + Debug {
         let constant = try_as_ref!(constant as *const TA).clone();
         let lower = try_as_ref!(lower as *const TA).clone();
         let upper = try_as_ref!(upper as *const TA).clone();
@@ -42,7 +43,7 @@ pub extern "C" fn opendp_trans__make_resize(
     fn monomorphize<TA>(
         constant: *const AnyObject, length: usize,
     ) -> FfiResult<*mut AnyTransformation>
-        where TA: 'static + Clone + CheckNull + TotalOrd {
+        where TA: 'static + Clone + CheckNull + TotalOrd + Debug {
         let constant = try_!(try_as_ref!(constant).downcast_ref::<TA>()).clone();
         make_resize_constant::<AllDomain<TA>>(AllDomain::new(), constant, length).into_any()
     }

--- a/rust/opendp-ffi/src/trans/sum.rs
+++ b/rust/opendp-ffi/src/trans/sum.rs
@@ -12,6 +12,7 @@ use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::Type;
 use num::Zero;
 use opendp::dist::IntDistance;
+use std::fmt::Debug;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_bounded_sum(
@@ -21,7 +22,7 @@ pub extern "C" fn opendp_trans__make_bounded_sum(
     fn monomorphize<T>(
         lower: *const c_void, upper: *const c_void
     ) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Abs + SaturatingAdd + Zero + CheckNull,
+        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Abs + SaturatingAdd + Zero + CheckNull + Debug,
               IntDistance: InfCast<T> {
         let lower = try_as_ref!(lower as *const T).clone();
         let upper = try_as_ref!(upper as *const T).clone();
@@ -39,7 +40,7 @@ pub extern "C" fn opendp_trans__make_bounded_sum_n(
     T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<T>(lower: *const c_void, upper: *const c_void, n: usize) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Sub<Output=T> + ExactIntCast<usize> + CheckedMul + CheckNull,
+        where T: DistanceConstant<IntDistance> + Sub<Output=T> + ExactIntCast<usize> + CheckedMul + CheckNull + Debug,
               for<'a> T: Sum<&'a T>,
               IntDistance: InfCast<T> {
         let lower = try_as_ref!(lower as *const T).clone();

--- a/rust/opendp-ffi/src/trans/variance.rs
+++ b/rust/opendp-ffi/src/trans/variance.rs
@@ -13,6 +13,7 @@ use crate::any::{AnyObject, AnyTransformation, Downcast};
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::util::Type;
 use opendp::dist::IntDistance;
+use std::fmt::Debug;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_bounded_variance(
@@ -23,7 +24,7 @@ pub extern "C" fn opendp_trans__make_bounded_variance(
     fn monomorphize2<T>(
         lower: *const c_void, upper: *const c_void, length: usize, ddof: usize,
     ) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Float + for<'a> Sum<&'a T> + Sum<T> + ExactIntCast<usize> + CheckedMul + CheckNull,
+        where T: DistanceConstant<IntDistance> + Float + for<'a> Sum<&'a T> + Sum<T> + ExactIntCast<usize> + CheckedMul + CheckNull + Debug,
               for<'a> &'a T: Sub<Output=T> + Add<&'a T, Output=T>,
               IntDistance: InfCast<T> {
         let lower = *try_as_ref!(lower as *const T);
@@ -52,7 +53,7 @@ pub extern "C" fn opendp_trans__make_bounded_covariance(
         upper: *const AnyObject,
         length: usize, ddof: usize,
     ) -> FfiResult<*mut AnyTransformation>
-        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Sum<T> + Zero + One + ExactIntCast<usize> + CheckedMul + CheckNull,
+        where T: DistanceConstant<IntDistance> + Sub<Output=T> + Sum<T> + Zero + One + ExactIntCast<usize> + CheckedMul + CheckNull + Debug,
               for<'a> T: Div<&'a T, Output=T> + Add<&'a T, Output=T>,
               for<'a> &'a T: Sub<Output=T>,
               IntDistance: InfCast<T> {

--- a/rust/opendp-ffi/src/util.rs
+++ b/rust/opendp-ffi/src/util.rs
@@ -8,7 +8,7 @@ use std::os::raw::c_char;
 use std::str::Utf8Error;
 
 use opendp::{err, fallible};
-use opendp::dist::{SubstituteDistance, L1Distance, L2Distance, SymmetricDistance, AbsoluteDistance};
+use opendp::dist::{SubstituteDistance, L1Distance, L2Distance, SymmetricDistance, AbsoluteDistance, MaxDivergence, SmoothedMaxDivergence};
 use opendp::error::*;
 use crate::any::AnyObject;
 use opendp::dom::{VectorDomain, AllDomain, IntervalDomain, InherentNullDomain, OptionNullDomain, SizedDomain};
@@ -74,48 +74,36 @@ impl Type {
     }
 }
 
-pub enum MetricClass { Dataset, Sensitivity }
-
 impl Type {
-    pub fn get_domain_atom(&self) -> Fallible<Type> {
+    pub fn get_atom(&self) -> Fallible<Type> {
         match &self.contents {
             TypeContents::PLAIN(_) => Ok(self.clone()),
-            TypeContents::GENERIC { name, args } => {
-                if !name.ends_with("Domain") {
-                    return fallible!(TypeParse, "Failed to extract atomic type: {:?} is not a domain", name)
-                }
+            TypeContents::GENERIC { args, .. } => {
                 if args.len() != 1 {
-                    return fallible!(TypeParse, "Failed to extract atomic type: expected one argument, got {:?} generic arguments", args.len())
+                    return fallible!(TypeParse, "Failed to extract atom type: expected one argument, got {:?} arguments", args.len())
                 }
-                Type::of_id(&args[0])?.get_domain_atom()
+                Type::of_id(&args[0])?.get_atom()
             }
-            _ => fallible!(TypeParse, "Failed to extract atomic type: not a domain")
+            _ => fallible!(TypeParse, "Failed to extract atom type: not a generic")
         }
     }
-    pub fn get_sensitivity_distance(&self) -> Fallible<Type> {
-        if let TypeContents::GENERIC {args, name} = &self.contents {
-            if !vec!["L1Distance", "L2Distance", "AbsoluteDistance"].contains(name) {
-                return fallible!(TypeParse, "Expected a sensitivity type name, received {:?}", name)
-            }
-            if args.len() != 1 {
-                return fallible!(TypeParse, "Sensitivity must have one generic argument")
-            }
-            Type::of_id(&args[0])
-        } else {
-            fallible!(TypeParse, "Expected a sensitivity type that is generic with respect to one distance type- for example, AbsoluteDistance<u32>")
-        }
-    }
-    pub fn get_metric_class(&self) -> Fallible<MetricClass> {
-        if self == &Type::of::<SubstituteDistance>() || self == &Type::of::<SymmetricDistance>() {
-            Ok(MetricClass::Dataset)
-        } else if let TypeContents::GENERIC { name, .. } = &self.contents {
-            if vec!["L1Distance", "L2Distance", "AbsoluteDistance"].contains(name) {
-                Ok(MetricClass::Sensitivity)
-            } else {
-                return fallible!(TypeParse, "Expected a metric type name, received {:?}", name)
-            }
-        } else {
-            fallible!(TypeParse, "Expected a metric type.")
+}
+impl ToString for Type {
+    fn to_string(&self) -> String {
+        let get_id_str = |type_id: &TypeId| Type::of_id(type_id)
+            .as_ref().map(ToString::to_string)
+            .unwrap_or_else(|_| "?".to_string());
+
+        match &self.contents {
+            TypeContents::PLAIN(v) => v.to_string(),
+            TypeContents::TUPLE(args) => format!("({})", args.iter()
+                .map(get_id_str).collect::<Vec<_>>().join(", ")),
+            TypeContents::ARRAY { element_id, len } =>
+                format!("[{}; {}]", get_id_str(element_id), len),
+            TypeContents::SLICE(type_id) => format!("&[{}]", get_id_str(type_id)),
+            TypeContents::GENERIC { name, args } => format!("{}<{}>", name, args.iter()
+                .map(get_id_str).collect::<Vec<_>>().join(", ")),
+            TypeContents::VEC(v) => format!("Vec<{}>", get_id_str(v))
         }
     }
 }
@@ -255,6 +243,10 @@ lazy_static! {
             type_vec![AbsoluteDistance, <u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64>],
             type_vec![L1Distance, <u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64>],
             type_vec![L2Distance, <u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64>],
+
+            // measures
+            type_vec![MaxDivergence, <u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64>],
+            type_vec![SmoothedMaxDivergence, <u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64>],
         ].into_iter().flatten().collect();
         let descriptors: HashSet<_> = types.iter().map(|e| &e.descriptor).collect();
         assert_eq!(descriptors.len(), types.len());

--- a/rust/opendp/src/comb/amplify/mod.rs
+++ b/rust/opendp/src/comb/amplify/mod.rs
@@ -5,19 +5,20 @@ use crate::error::Fallible;
 use num::Float;
 use crate::traits::ExactIntCast;
 use std::ops::Div;
+use std::fmt::Debug;
 
 pub trait AmplifiableMeasure: Measure {
     type Atom;
     fn amplify(budget: Self::Distance, sampling_rate: Self::Atom) -> Self::Distance;
 }
 
-impl<Q: Float> AmplifiableMeasure for MaxDivergence<Q> {
+impl<Q: Float + Debug> AmplifiableMeasure for MaxDivergence<Q> {
     type Atom = Q;
     fn amplify(epsilon: Q, sampling_rate: Q) -> Q {
         (epsilon.exp_m1() / sampling_rate).ln_1p()
     }
 }
-impl<Q: Float> AmplifiableMeasure for SmoothedMaxDivergence<Q> {
+impl<Q: Float + Debug> AmplifiableMeasure for SmoothedMaxDivergence<Q> {
     type Atom = Q;
     fn amplify((epsilon, delta): (Q, Q), sampling_rate: Q) -> (Q, Q) {
         ((epsilon.exp_m1() / sampling_rate).ln_1p(), delta / sampling_rate)

--- a/rust/opendp/src/comb/amplify/mod.rs
+++ b/rust/opendp/src/comb/amplify/mod.rs
@@ -1,0 +1,69 @@
+use crate::core::{Domain, Measurement, Metric, PrivacyRelation, Measure};
+use crate::dist::{SmoothedMaxDivergence, MaxDivergence};
+use crate::dom::SizedDomain;
+use crate::error::Fallible;
+use num::Float;
+use crate::traits::ExactIntCast;
+use std::ops::Div;
+
+pub trait AmplifiableMeasure: Measure {
+    type Atom;
+    fn amplify(budget: Self::Distance, sampling_rate: Self::Atom) -> Self::Distance;
+}
+
+impl<Q: Float> AmplifiableMeasure for MaxDivergence<Q> {
+    type Atom = Q;
+    fn amplify(epsilon: Q, sampling_rate: Q) -> Q {
+        (epsilon.exp_m1() / sampling_rate).ln_1p()
+    }
+}
+impl<Q: Float> AmplifiableMeasure for SmoothedMaxDivergence<Q> {
+    type Atom = Q;
+    fn amplify((epsilon, delta): (Q, Q), sampling_rate: Q) -> (Q, Q) {
+        ((epsilon.exp_m1() / sampling_rate).ln_1p(), delta / sampling_rate)
+    }
+}
+
+pub fn make_population_amplification<DIA, DO, MI, MO>(
+    measurement: &Measurement<SizedDomain<DIA>, DO, MI, MO>,
+    n_population: usize,
+) -> Fallible<Measurement<SizedDomain<DIA>, DO, MI, MO>>
+    where DIA: Domain,
+          DO: Domain,
+          MI: 'static + Metric,
+          MO: 'static + Measure + AmplifiableMeasure,
+          MO::Atom: ExactIntCast<usize> + Div<Output=MO::Atom> + Clone,
+          MO::Distance: Clone {
+    let mut measurement = measurement.clone();
+    let n_sample = measurement.input_domain.length;
+    if n_population < n_sample { return fallible!(MakeMeasurement, "population size cannot be less than sample size") }
+
+    let privacy_relation = measurement.privacy_relation;
+    let sampling_rate = MO::Atom::exact_int_cast(n_sample)? / MO::Atom::exact_int_cast(n_population)?;
+
+    measurement.privacy_relation = PrivacyRelation::new_fallible(
+        move |d_in, d_out: &MO::Distance| privacy_relation.eval(
+            d_in, &MO::amplify(d_out.clone(), sampling_rate.clone())));
+
+    Ok(measurement)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::error::Fallible;
+    use crate::trans::make_bounded_mean;
+    use crate::meas::make_base_laplace;
+    use crate::comb::make_population_amplification;
+
+    #[test]
+    fn test_amplifier() -> Fallible<()> {
+        let meas = (make_bounded_mean(0., 10., 10)? >> make_base_laplace(0.5)?)?;
+        let amp = make_population_amplification(&meas, 100)?;
+        amp.function.eval(&vec![1.; 10])?;
+        assert!(meas.privacy_relation.eval(&1, &1.)?);
+        assert!(!meas.privacy_relation.eval(&1, &0.999)?);
+        assert!(amp.privacy_relation.eval(&1, &0.159)?);
+        assert!(!amp.privacy_relation.eval(&1, &0.158)?);
+        Ok(())
+    }
+}

--- a/rust/opendp/src/comb/chain/mod.rs
+++ b/rust/opendp/src/comb/chain/mod.rs
@@ -16,9 +16,9 @@ pub fn make_chain_mt<DI, DX, DO, MI, MX, MO>(
           MX: 'static + Metric,
           MO: 'static + Measure {
     if transformation0.output_domain != measurement1.input_domain {
-        return fallible!(DomainMismatch, "Intermediate domain mismatch");
+        return fallible!(DomainMismatch, "Intermediate domain mismatch: {:?} != {:?}", transformation0.output_domain, measurement1.input_domain);
     } else if transformation0.output_metric != measurement1.input_metric {
-        return fallible!(MetricMismatch, "Intermediate metric mismatch");
+        return fallible!(MetricMismatch, "Intermediate metric mismatch: {:?} != {:?}", transformation0.output_metric, measurement1.input_metric);
     }
 
     Ok(Measurement::new(
@@ -43,9 +43,9 @@ pub fn make_chain_tt<DI, DX, DO, MI, MX, MO>(
           MX: 'static + Metric,
           MO: 'static + Metric {
     if transformation0.output_domain != transformation1.input_domain {
-        return fallible!(DomainMismatch, "Intermediate domain mismatch");
+        return fallible!(DomainMismatch, "Intermediate domain mismatch: {:?} != {:?}", transformation0.output_domain, transformation1.input_domain);
     } else if transformation0.output_metric != transformation1.input_metric {
-        return fallible!(MetricMismatch, "Intermediate metric mismatch");
+        return fallible!(MetricMismatch, "Intermediate metric mismatch: {:?} != {:?}", transformation0.output_metric, transformation1.input_metric);
     }
 
     Ok(Transformation::new(

--- a/rust/opendp/src/comb/mod.rs
+++ b/rust/opendp/src/comb/mod.rs
@@ -1,3 +1,6 @@
 
 pub mod chain;
+pub mod amplify;
+
 pub use crate::comb::chain::*;
+pub use crate::comb::amplify::*;

--- a/rust/opendp/src/core.rs
+++ b/rust/opendp/src/core.rs
@@ -37,9 +37,13 @@ pub trait Domain: Clone + PartialEq {
 }
 
 /// A mathematical function which maps values from an input [`Domain`] to an output [`Domain`].
-#[derive(Clone)]
 pub struct Function<DI: Domain, DO: Domain> {
     pub function: Rc<dyn Fn(&DI::Carrier) -> Fallible<DO::Carrier>>,
+}
+impl<DI: Domain, DO: Domain> Clone for Function<DI, DO> {
+    fn clone(&self) -> Self {
+        Function {function: self.function.clone()}
+    }
 }
 
 impl<DI: Domain, DO: Domain> Function<DI, DO> {
@@ -123,10 +127,18 @@ impl<MI: Metric, MO: Metric, MX: Metric> HintTt<MI, MO, MX> {
 ///
 /// A `PrivacyRelation` is implemented as a function that takes an input [`Metric::Distance`] and output [`Measure::Distance`],
 /// and returns a boolean indicating if the relation holds.
-#[derive(Clone)]
 pub struct PrivacyRelation<MI: Metric, MO: Measure> {
     pub relation: Rc<dyn Fn(&MI::Distance, &MO::Distance) -> Fallible<bool>>,
     pub backward_map: Option<Rc<dyn Fn(&MO::Distance) -> Fallible<Box<MI::Distance>>>>,
+}
+
+impl<MI: Metric, MO: Measure> Clone for PrivacyRelation<MI, MO> {
+    fn clone(&self) -> Self {
+        PrivacyRelation {
+            relation: self.relation.clone(),
+            backward_map: self.backward_map.clone()
+        }
+    }
 }
 
 impl<MI: Metric, MO: Measure> PrivacyRelation<MI, MO> {
@@ -235,11 +247,20 @@ impl<MI: 'static + Metric, MO: 'static + Measure> PrivacyRelation<MI, MO> {
 ///
 /// A `StabilityRelation` is implemented as a function that takes an input and output [`Metric::Distance`],
 /// and returns a boolean indicating if the relation holds.
-#[derive(Clone)]
 pub struct StabilityRelation<MI: Metric, MO: Metric> {
     pub relation: Rc<dyn Fn(&MI::Distance, &MO::Distance) -> Fallible<bool>>,
     pub forward_map: Option<Rc<dyn Fn(&MI::Distance) -> Fallible<Box<MO::Distance>>>>,
     pub backward_map: Option<Rc<dyn Fn(&MO::Distance) -> Fallible<Box<MI::Distance>>>>,
+}
+
+impl<MI: Metric, MO: Metric> Clone for StabilityRelation<MI, MO> {
+    fn clone(&self) -> Self {
+        StabilityRelation {
+            relation: self.relation.clone(),
+            forward_map: self.forward_map.clone(),
+            backward_map: self.backward_map.clone()
+        }
+    }
 }
 
 impl<MI: Metric, MO: Metric> StabilityRelation<MI, MO> {
@@ -336,6 +357,7 @@ impl<MI: 'static + Metric, MO: 'static + Metric> StabilityRelation<MI, MO> {
 
 
 /// A randomized mechanism with certain privacy characteristics.
+#[derive(Clone)]
 pub struct Measurement<DI: Domain, DO: Domain, MI: Metric, MO: Measure> {
     pub input_domain: DI,
     pub output_domain: DO,
@@ -366,6 +388,7 @@ impl<DI: Domain, DO: Domain, MI: Metric, MO: Measure> Measurement<DI, DO, MI, MO
 }
 
 /// A data transformation with certain stability characteristics.
+#[derive(Clone)]
 pub struct Transformation<DI: Domain, DO: Domain, MI: Metric, MO: Metric> {
     pub input_domain: DI,
     pub output_domain: DO,

--- a/rust/opendp/src/dist.rs
+++ b/rust/opendp/src/dist.rs
@@ -3,12 +3,13 @@
 use std::marker::PhantomData;
 
 use crate::core::{DatasetMetric, Measure, Metric, SensitivityMetric};
+use std::fmt::Debug;
 
 // default type for distances between datasets
 pub type IntDistance = u32;
 
 /// Measures
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MaxDivergence<Q>(PhantomData<Q>);
 impl<Q> Default for MaxDivergence<Q> {
     fn default() -> Self { MaxDivergence(PhantomData) }
@@ -18,11 +19,11 @@ impl<Q> PartialEq for MaxDivergence<Q> {
     fn eq(&self, _other: &Self) -> bool { true }
 }
 
-impl<Q: Clone> Measure for MaxDivergence<Q> {
+impl<Q: Clone + Debug> Measure for MaxDivergence<Q> {
     type Distance = Q;
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SmoothedMaxDivergence<Q>(PhantomData<Q>);
 
 impl<Q> Default for SmoothedMaxDivergence<Q> {
@@ -33,12 +34,12 @@ impl<Q> PartialEq for SmoothedMaxDivergence<Q> {
     fn eq(&self, _other: &Self) -> bool { true }
 }
 
-impl<Q: Clone> Measure for SmoothedMaxDivergence<Q> {
+impl<Q: Clone + Debug> Measure for SmoothedMaxDivergence<Q> {
     type Distance = (Q, Q);
 }
 
 /// Metrics
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SymmetricDistance;
 
 impl Default for SymmetricDistance {
@@ -54,7 +55,7 @@ impl Metric for SymmetricDistance {
 
 impl DatasetMetric for SymmetricDistance {}
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SubstituteDistance;
 
 impl Default for SubstituteDistance {
@@ -72,6 +73,7 @@ impl Metric for SubstituteDistance {
 impl DatasetMetric for SubstituteDistance {}
 
 // Sensitivity in P-space
+#[derive(Debug)]
 pub struct LpDistance<Q, const P: usize>(PhantomData<Q>);
 impl<Q, const P: usize> Default for LpDistance<Q, P> {
     fn default() -> Self { LpDistance(PhantomData) }
@@ -83,15 +85,16 @@ impl<Q, const P: usize> Clone for LpDistance<Q, P> {
 impl<Q, const P: usize> PartialEq for LpDistance<Q, P> {
     fn eq(&self, _other: &Self) -> bool { true }
 }
-impl<Q, const P: usize> Metric for LpDistance<Q, P> {
+impl<Q: Debug, const P: usize> Metric for LpDistance<Q, P> {
     type Distance = Q;
 }
-impl<Q, const P: usize> SensitivityMetric for LpDistance<Q, P> {}
+impl<Q: Debug, const P: usize> SensitivityMetric for LpDistance<Q, P> {}
 
 pub type L1Distance<Q> = LpDistance<Q, 1>;
 pub type L2Distance<Q> = LpDistance<Q, 2>;
 
 
+#[derive(Debug)]
 pub struct AbsoluteDistance<Q>(PhantomData<Q>);
 impl<Q> Default for AbsoluteDistance<Q> {
     fn default() -> Self { AbsoluteDistance(PhantomData) }
@@ -103,7 +106,7 @@ impl<Q> Clone for AbsoluteDistance<Q> {
 impl<Q> PartialEq for AbsoluteDistance<Q> {
     fn eq(&self, _other: &Self) -> bool { true }
 }
-impl<Q> Metric for AbsoluteDistance<Q> {
+impl<Q: Debug> Metric for AbsoluteDistance<Q> {
     type Distance = Q;
 }
-impl<Q> SensitivityMetric for AbsoluteDistance<Q> {}
+impl<Q: Debug> SensitivityMetric for AbsoluteDistance<Q> {}

--- a/rust/opendp/src/dom.rs
+++ b/rust/opendp/src/dom.rs
@@ -13,8 +13,10 @@ use std::ops::Bound;
 use crate::core::Domain;
 use crate::error::Fallible;
 use crate::traits::{CheckNull, TotalOrd};
+use std::fmt::Debug;
 
 /// A Domain that contains all non-null members of the carrier type.
+#[derive(Debug)]
 pub struct AllDomain<T> {
     _marker: PhantomData<T>,
 }
@@ -34,14 +36,14 @@ impl<T> Clone for AllDomain<T> {
 impl<T> PartialEq for AllDomain<T> {
     fn eq(&self, _other: &Self) -> bool { true }
 }
-impl<T: CheckNull> Domain for AllDomain<T> {
+impl<T: CheckNull + Debug> Domain for AllDomain<T> {
     type Carrier = T;
     fn member(&self, val: &Self::Carrier) -> Fallible<bool> { Ok(!val.is_null()) }
 }
 
 
 /// A Domain that carries an underlying Domain in a Box.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct BoxDomain<D: Domain> {
     element_domain: Box<D>
 }
@@ -59,7 +61,7 @@ impl<D: Domain> Domain for BoxDomain<D> {
 
 
 /// A Domain that unwraps a Data wrapper.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct DataDomain<D: Domain> {
     pub form_domain: D,
 }
@@ -80,7 +82,7 @@ impl<D: Domain> Domain for DataDomain<D> where
 
 
 /// A Domain that contains all the values in an interval.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct IntervalDomain<T> {
     lower: Bound<T>,
     upper: Bound<T>,
@@ -111,7 +113,7 @@ impl<T: TotalOrd> IntervalDomain<T> {
         Ok(IntervalDomain { lower, upper })
     }
 }
-impl<T: Clone + TotalOrd> Domain for IntervalDomain<T> {
+impl<T: Clone + TotalOrd + Debug> Domain for IntervalDomain<T> {
     type Carrier = T;
     fn member(&self, val: &Self::Carrier) -> Fallible<bool> {
         Ok(match &self.lower {
@@ -128,7 +130,7 @@ impl<T: Clone + TotalOrd> Domain for IntervalDomain<T> {
 
 
 /// A Domain that contains pairs of values.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct PairDomain<D0: Domain, D1: Domain>(pub D0, pub D1);
 impl<D0: Domain, D1: Domain> PairDomain<D0, D1> {
     pub fn new(element_domain0: D0, element_domain1: D1) -> Self {
@@ -144,7 +146,7 @@ impl<D0: Domain, D1: Domain> Domain for PairDomain<D0, D1> {
 
 
 /// A Domain that contains maps of (homogeneous) values.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct MapDomain<DK: Domain, DV: Domain> where DK::Carrier: Eq + Hash {
     pub key_domain: DK,
     pub value_domain: DV
@@ -154,7 +156,7 @@ impl<DK: Domain, DV: Domain> MapDomain<DK, DV> where DK::Carrier: Eq + Hash {
         MapDomain { key_domain, value_domain: element_domain }
     }
 }
-impl<K: CheckNull, V: CheckNull> MapDomain<AllDomain<K>, AllDomain<V>> where K: Eq + Hash {
+impl<K: CheckNull + Debug, V: CheckNull + Debug> MapDomain<AllDomain<K>, AllDomain<V>> where K: Eq + Hash {
     pub fn new_all() -> Self {
         Self::new(AllDomain::<K>::new(), AllDomain::<V>::new())
     }
@@ -173,7 +175,7 @@ impl<DK: Domain, DV: Domain> Domain for MapDomain<DK, DV> where DK::Carrier: Eq 
 
 
 /// A Domain that contains vectors of (homogeneous) values.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct VectorDomain<D: Domain> {
     pub element_domain: D,
 }
@@ -185,7 +187,7 @@ impl<D: Domain> VectorDomain<D> {
         VectorDomain { element_domain }
     }
 }
-impl<T: CheckNull> VectorDomain<AllDomain<T>> {
+impl<T: CheckNull + Debug> VectorDomain<AllDomain<T>> {
     pub fn new_all() -> Self {
         Self::new(AllDomain::<T>::new())
     }
@@ -201,7 +203,7 @@ impl<D: Domain> Domain for VectorDomain<D> {
 }
 
 /// A Domain that specifies the length of the enclosed domain
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct SizedDomain<D: Domain> {
     pub element_domain: D,
     pub length: usize
@@ -219,7 +221,7 @@ impl<D: Domain> Domain for SizedDomain<D> {
 }
 
 /// A domain with a built-in representation of nullity, that may take on null values at runtime
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct InherentNullDomain<D: Domain>
     where D::Carrier: InherentNull {
     pub element_domain: D,
@@ -254,7 +256,7 @@ impl_inherent_null_float!(f64, f32);
 /// The value inside is non-null by definition.
 /// Transformations should not emit data that can take on null-values at runtime.
 /// For example, it is fine to have an OptionDomain<AllDomain<f64>>, but the f64 should never be nan
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct OptionNullDomain<D: Domain> {
     pub element_domain: D,
 }

--- a/rust/opendp/src/interactive.rs
+++ b/rust/opendp/src/interactive.rs
@@ -5,6 +5,7 @@ use crate::core::{Domain, Function, Measure, Measurement, Metric, PrivacyRelatio
 use crate::dom::AllDomain;
 use crate::error::*;
 use crate::traits::{FallibleSub, MeasureDistance, MetricDistance, CheckNull};
+use std::fmt::{Formatter, Debug};
 
 /// A structure tracking the state of an interactive measurement queryable.
 /// It's generic over state (S), query (Q), answer (A), so it can be used for any
@@ -16,6 +17,11 @@ pub struct Queryable<S, Q, A> {
     /// The transition function of the Queryable. Takes the current state and a query, returns
     /// the new state and the answer.
     transition: Rc<dyn Fn(S, &Q) -> Fallible<(S, A)>>,
+}
+impl<S, Q, A> Debug for Queryable<S, Q, A> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "Queryable {{state, transition}}")
+    }
 }
 
 impl<S, Q, A> Queryable<S, Q, A> {
@@ -51,6 +57,7 @@ impl<S, Q, A> CheckNull for Queryable<S, Q, A> { fn is_null(&self) -> bool { fal
 pub type InteractiveMeasurement<DI, DO, MI, MO, S, Q> = Measurement<DI, AllDomain<Queryable<S, Q, <DO as Domain>::Carrier>>, MI, MO>;
 
 /// The state of an adaptive composition Queryable.
+#[derive(Debug)]
 pub struct AcState<DI: Domain, DO: Domain, MI: Metric, MO: Measure> {
     input_domain: DI,
     output_domain: DO,

--- a/rust/opendp/src/interactive.rs
+++ b/rust/opendp/src/interactive.rs
@@ -172,7 +172,7 @@ mod tests {
 
     use super::*;
 
-    fn make_dummy_meas<TO: From<i32> + CheckNull>() -> Measurement<AllDomain<i32>, AllDomain<TO>, AbsoluteDistance<f64>, MaxDivergence<f64>> {
+    fn make_dummy_meas<TO: From<i32> + CheckNull + Debug>() -> Measurement<AllDomain<i32>, AllDomain<TO>, AbsoluteDistance<f64>, MaxDivergence<f64>> {
         Measurement::new(
             AllDomain::new(),
             AllDomain::new(),

--- a/rust/opendp/src/meas/gaussian/mod.rs
+++ b/rust/opendp/src/meas/gaussian/mod.rs
@@ -6,12 +6,13 @@ use crate::dom::{AllDomain, VectorDomain};
 use crate::error::*;
 use crate::samplers::SampleGaussian;
 use crate::traits::{InfCast, CheckNull};
+use std::fmt::Debug;
 
 // const ADDITIVE_GAUSS_CONST: f64 = 8. / 9. + (2. / std::f64::consts::PI).ln();
 const ADDITIVE_GAUSS_CONST: f64 = 0.4373061836;
 
 fn make_gaussian_privacy_relation<T, MI>(scale: T) -> PrivacyRelation<MI, SmoothedMaxDivergence<T>>
-    where T: 'static + Clone + SampleGaussian + Float + InfCast<f64>,
+    where T: 'static + Clone + SampleGaussian + Float + InfCast<f64> + Debug,
           MI: SensitivityMetric<Distance=T> {
     PrivacyRelation::new_fallible(move |&d_in: &T, &(eps, del): &(T, T)| {
         let _2 = T::inf_cast(2.)?;
@@ -42,7 +43,7 @@ pub trait GaussianDomain: Domain {
 
 
 impl<T> GaussianDomain for AllDomain<T>
-    where T: 'static + SampleGaussian + Float + CheckNull {
+    where T: 'static + SampleGaussian + Float + CheckNull + Debug {
     type Metric = AbsoluteDistance<T>;
     type Atom = T;
 
@@ -53,7 +54,7 @@ impl<T> GaussianDomain for AllDomain<T>
 }
 
 impl<T> GaussianDomain for VectorDomain<AllDomain<T>>
-    where T: 'static + SampleGaussian + Float + CheckNull {
+    where T: 'static + SampleGaussian + Float + CheckNull + Debug {
     type Metric = L2Distance<T>;
     type Atom = T;
 
@@ -68,7 +69,7 @@ impl<T> GaussianDomain for VectorDomain<AllDomain<T>>
 
 pub fn make_base_gaussian<D>(scale: D::Atom) -> Fallible<Measurement<D, D, D::Metric, SmoothedMaxDivergence<D::Atom>>>
     where D: GaussianDomain,
-          D::Atom: 'static + Clone + SampleGaussian + Float + InfCast<f64> + CheckNull {
+          D::Atom: 'static + Clone + SampleGaussian + Float + InfCast<f64> + CheckNull + Debug {
     if scale.is_sign_negative() {
         return fallible!(MakeMeasurement, "scale must not be negative")
     }

--- a/rust/opendp/src/meas/geometric/mod.rs
+++ b/rust/opendp/src/meas/geometric/mod.rs
@@ -5,6 +5,7 @@ use crate::error::*;
 use crate::samplers::SampleTwoSidedGeometric;
 use num::Float;
 use crate::traits::{DistanceConstant, InfCast, CheckNull, TotalOrd};
+use std::fmt::Debug;
 
 
 pub trait GeometricDomain: Domain {
@@ -18,7 +19,7 @@ pub trait GeometricDomain: Domain {
 
 
 impl<T> GeometricDomain for AllDomain<T>
-    where T: 'static + Clone + SampleTwoSidedGeometric + CheckNull {
+    where T: 'static + Clone + SampleTwoSidedGeometric + CheckNull + Debug {
     type InputMetric = AbsoluteDistance<T>;
     type Atom = T;
 
@@ -30,7 +31,7 @@ impl<T> GeometricDomain for AllDomain<T>
 }
 
 impl<T> GeometricDomain for VectorDomain<AllDomain<T>>
-    where T: 'static + Clone + SampleTwoSidedGeometric + CheckNull {
+    where T: 'static + Clone + SampleTwoSidedGeometric + CheckNull + Debug {
     type InputMetric = L1Distance<T>;
     type Atom = T;
 
@@ -47,7 +48,7 @@ pub fn make_base_geometric<D, QO>(
 ) -> Fallible<Measurement<D, D, D::InputMetric, MaxDivergence<QO>>>
     where D: 'static + GeometricDomain,
           D::Atom: 'static + TotalOrd + Clone + InfCast<QO>,
-          QO: 'static + Float + DistanceConstant<D::Atom>,
+          QO: 'static + Float + DistanceConstant<D::Atom> + Debug,
           f64: From<QO> {
     if scale.is_sign_negative() { return fallible!(MakeMeasurement, "scale must not be negative") }
     if bounds.as_ref().map(|(lower, upper)| lower > upper).unwrap_or(false) {

--- a/rust/opendp/src/meas/laplace/mod.rs
+++ b/rust/opendp/src/meas/laplace/mod.rs
@@ -6,6 +6,7 @@ use crate::dom::{AllDomain, VectorDomain};
 use crate::samplers::{SampleLaplace};
 use crate::error::*;
 use crate::traits::{InfCast, CheckNull, TotalOrd};
+use std::fmt::Debug;
 
 pub trait LaplaceDomain: Domain {
     type Metric: SensitivityMetric<Distance=Self::Atom> + Default;
@@ -15,7 +16,7 @@ pub trait LaplaceDomain: Domain {
 }
 
 impl<T> LaplaceDomain for AllDomain<T>
-    where T: 'static + SampleLaplace + Float + CheckNull {
+    where T: 'static + SampleLaplace + Float + CheckNull + Debug {
     type Metric = AbsoluteDistance<T>;
     type Atom = Self::Carrier;
 
@@ -26,7 +27,7 @@ impl<T> LaplaceDomain for AllDomain<T>
 }
 
 impl<T> LaplaceDomain for VectorDomain<AllDomain<T>>
-    where T: 'static + SampleLaplace + Float + CheckNull {
+    where T: 'static + SampleLaplace + Float + CheckNull + Debug {
     type Metric = L1Distance<T>;
     type Atom = T;
 
@@ -40,7 +41,7 @@ impl<T> LaplaceDomain for VectorDomain<AllDomain<T>>
 
 pub fn make_base_laplace<D>(scale: D::Atom) -> Fallible<Measurement<D, D, D::Metric, MaxDivergence<D::Atom>>>
     where D: LaplaceDomain,
-          D::Atom: 'static + Clone + SampleLaplace + Float + InfCast<D::Atom> + CheckNull + TotalOrd {
+          D::Atom: 'static + Clone + SampleLaplace + Float + InfCast<D::Atom> + CheckNull + TotalOrd + Debug {
     if scale.is_sign_negative() {
         return fallible!(MakeMeasurement, "scale must not be negative")
     }

--- a/rust/opendp/src/meas/stability/mod.rs
+++ b/rust/opendp/src/meas/stability/mod.rs
@@ -9,6 +9,7 @@ use crate::dom::{AllDomain, MapDomain, SizedDomain};
 use crate::samplers::{SampleLaplace, SampleGaussian};
 use crate::error::Fallible;
 use crate::traits::{ExactIntCast, ExactIntBounds, CheckNull, TotalOrd};
+use std::fmt::Debug;
 
 // TIK: Type of Input Key
 // TIC: Type of Input Count
@@ -20,12 +21,12 @@ pub type CountDomain<TIK, TIC> = SizedDomain<MapDomain<AllDomain<TIK>, AllDomain
 pub trait BaseStabilityNoise: SensitivityMetric {
     fn noise(shift: Self::Distance, scale: Self::Distance, constant_time: bool) -> Fallible<Self::Distance>;
 }
-impl<TOC: SampleLaplace> BaseStabilityNoise for L1Distance<TOC> {
+impl<TOC: SampleLaplace + Debug> BaseStabilityNoise for L1Distance<TOC> {
     fn noise(shift: Self::Distance, scale: Self::Distance, constant_time: bool) -> Fallible<Self::Distance> {
         Self::Distance::sample_laplace(shift, scale, constant_time)
     }
 }
-impl<TOC: SampleGaussian> BaseStabilityNoise for L2Distance<TOC> {
+impl<TOC: SampleGaussian + Debug> BaseStabilityNoise for L2Distance<TOC> {
     fn noise(shift: Self::Distance, scale: Self::Distance, constant_time: bool) -> Fallible<Self::Distance> {
         Self::Distance::sample_gaussian(shift, scale, constant_time)
     }
@@ -35,8 +36,8 @@ pub fn make_base_stability<MI, TIK, TIC>(
     n: usize, scale: MI::Distance, threshold: MI::Distance
 ) -> Fallible<Measurement<CountDomain<TIK, TIC>, CountDomain<TIK, MI::Distance>, MI, SmoothedMaxDivergence<MI::Distance>>>
     where MI: BaseStabilityNoise,
-          TIK: Eq + Hash + Clone + CheckNull,
-          TIC: Integer + Clone + CheckNull,
+          TIK: Eq + Hash + Clone + CheckNull + Debug,
+          TIC: Integer + Clone + CheckNull + Debug,
           MI::Distance: 'static + Float + Clone + TotalOrd + ExactIntCast<usize> + ExactIntCast<TIC> + CheckNull {
     if scale.is_sign_negative() {
         return fallible!(MakeMeasurement, "scale must not be negative")

--- a/rust/opendp/src/poly.rs
+++ b/rust/opendp/src/poly.rs
@@ -5,7 +5,7 @@ use crate::core::{Domain, Function, Measure, Measurement, Metric, Transformation
 use crate::error::*;
 
 /// A polymorphic Domain. This admits any value of any type (represented as a Box<dyn Any>).
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct PolyDomain {}
 
 impl PolyDomain {

--- a/rust/opendp/src/traits.rs
+++ b/rust/opendp/src/traits.rs
@@ -33,6 +33,12 @@ macro_rules! impl_fallible_sub {
                 Ok(self - rhs)
             }
         }
+        // impl<'a, Rhs> FallibleSub<&'a Rhs> for &'a $ty where &'a $ty: Sub<&'a Rhs, Output=$ty> {
+        //     type Output = $ty;
+        //     fn sub(self, rhs: &'a Rhs) -> Fallible<Self::Output> {
+        //         Ok(self - rhs)
+        //     }
+        // }
     )+)
 }
 impl_fallible_sub!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64);

--- a/rust/opendp/src/traits.rs
+++ b/rust/opendp/src/traits.rs
@@ -5,6 +5,7 @@ use num::{NumCast, One, Zero};
 
 use crate::error::Fallible;
 use std::cmp::{Ordering};
+use std::fmt::Debug;
 
 /// A type that can be used as a stability or privacy constant to scale a distance.
 /// Encapsulates the necessary traits for the new_from_constant method on relations.
@@ -58,12 +59,12 @@ impl<'a, T0, T1, Rhs0, Rhs1> FallibleSub<&'a (Rhs0, Rhs1)> for (T0, T1) where T0
 }
 
 /// A type that can be used as a measure distance.
-pub trait MeasureDistance: PartialOrd + for<'a> FallibleSub<&'a Self, Output=Self> {}
-impl<T> MeasureDistance for T where T: PartialOrd + for<'a> FallibleSub<&'a Self, Output=Self> {}
+pub trait MeasureDistance: PartialOrd + for<'a> FallibleSub<&'a Self, Output=Self> + Debug {}
+impl<T> MeasureDistance for T where T: PartialOrd + for<'a> FallibleSub<&'a Self, Output=Self> + Debug {}
 
 /// A type that can be used as a metric distance.
-pub trait MetricDistance: PartialOrd {}
-impl<T> MetricDistance for T where T: PartialOrd {}
+pub trait MetricDistance: PartialOrd + Debug {}
+impl<T> MetricDistance for T where T: PartialOrd + Debug {}
 
 
 pub trait Abs { fn abs(self) -> Self; }

--- a/rust/opendp/src/trans/cast/mod.rs
+++ b/rust/opendp/src/trans/cast/mod.rs
@@ -4,11 +4,13 @@ use crate::dom::{AllDomain, InherentNull, InherentNullDomain, OptionNullDomain, 
 use crate::error::Fallible;
 use crate::traits::{RoundCast, CheckNull};
 use crate::trans::make_row_by_row;
+use std::fmt::Debug;
 
 /// A [`Transformation`] that casts elements between types
 /// Maps a Vec<TI> -> Vec<Option<TO>>
 pub fn make_cast<TI, TO>() -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<OptionNullDomain<AllDomain<TO>>>, SymmetricDistance, SymmetricDistance>>
-    where TI: 'static + Clone + CheckNull, TO: 'static + RoundCast<TI> + CheckNull {
+    where TI: 'static + Clone + CheckNull + Debug,
+          TO: 'static + RoundCast<TI> + CheckNull + Debug {
     make_row_by_row(
         AllDomain::new(),
         OptionNullDomain::new(AllDomain::new()),
@@ -19,7 +21,8 @@ pub fn make_cast<TI, TO>() -> Fallible<Transformation<VectorDomain<AllDomain<TI>
 /// A [`Transformation`] that casts elements between types. Fills with TO::default if parsing fails.
 /// Maps a Vec<TI> -> Vec<TO>
 pub fn make_cast_default<TI, TO>() -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<AllDomain<TO>>, SymmetricDistance, SymmetricDistance>>
-    where TI: 'static + Clone + CheckNull, TO: 'static + RoundCast<TI> + Default + CheckNull {
+    where TI: 'static + Clone + CheckNull + Debug,
+          TO: 'static + RoundCast<TI> + Default + CheckNull + Debug {
     make_row_by_row(
         AllDomain::new(),
         AllDomain::new(),
@@ -30,7 +33,8 @@ pub fn make_cast_default<TI, TO>() -> Fallible<Transformation<VectorDomain<AllDo
 /// Maps a Vec<TI> -> Vec<TO>
 pub fn make_cast_inherent<TI, TO>(
 ) -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<InherentNullDomain<AllDomain<TO>>>, SymmetricDistance, SymmetricDistance>>
-    where TI: 'static + Clone + CheckNull, TO: 'static + RoundCast<TI> + InherentNull + CheckNull {
+    where TI: 'static + Clone + CheckNull + Debug,
+          TO: 'static + RoundCast<TI> + InherentNull + CheckNull + Debug {
     make_row_by_row(
         AllDomain::new(),
         InherentNullDomain::new(AllDomain::new()),

--- a/rust/opendp/src/trans/clamp/mod.rs
+++ b/rust/opendp/src/trans/clamp/mod.rs
@@ -6,8 +6,9 @@ use crate::dom::{AllDomain, IntervalDomain, VectorDomain};
 use crate::error::*;
 use crate::traits::{CheckNull, TotalOrd};
 use crate::trans::{make_row_by_row, make_row_by_row_fallible};
+use std::fmt::Debug;
 
-pub fn make_clamp<T: 'static + Clone + TotalOrd + CheckNull>(
+pub fn make_clamp<T: 'static + Clone + TotalOrd + CheckNull + Debug>(
     lower: T, upper: T,
 ) -> Fallible<Transformation<VectorDomain<AllDomain<T>>, VectorDomain<IntervalDomain<T>>, SymmetricDistance, SymmetricDistance>> {
     make_row_by_row_fallible(
@@ -16,7 +17,7 @@ pub fn make_clamp<T: 'static + Clone + TotalOrd + CheckNull>(
         move |arg: &T| arg.clone().total_clamp(lower.clone(), upper.clone()))
 }
 
-pub fn make_unclamp<T: 'static + Clone + TotalOrd + CheckNull>(
+pub fn make_unclamp<T: 'static + Clone + TotalOrd + CheckNull + Debug>(
     lower: Bound<T>, upper: Bound<T>,
 ) -> Fallible<Transformation<VectorDomain<IntervalDomain<T>>, VectorDomain<AllDomain<T>>, SymmetricDistance, SymmetricDistance>> {
     make_row_by_row(

--- a/rust/opendp/src/trans/count/mod.rs
+++ b/rust/opendp/src/trans/count/mod.rs
@@ -9,11 +9,12 @@ use crate::dist::{AbsoluteDistance, SymmetricDistance, LpDistance, IntDistance};
 use crate::dom::{AllDomain, MapDomain, SizedDomain, VectorDomain};
 use crate::error::*;
 use crate::traits::{DistanceConstant, InfCast, ExactIntCast, SaturatingAdd, CheckNull};
+use std::fmt::Debug;
 
 pub fn make_count<TIA, TO>(
 ) -> Fallible<Transformation<VectorDomain<AllDomain<TIA>>, AllDomain<TO>, SymmetricDistance, AbsoluteDistance<TO>>>
-    where TIA: CheckNull,
-          TO: ExactIntCast<usize> + One + DistanceConstant<IntDistance> + CheckNull,
+    where TIA: CheckNull + Debug,
+          TO: ExactIntCast<usize> + One + DistanceConstant<IntDistance> + CheckNull + Debug,
           IntDistance: InfCast<TO> {
     Ok(Transformation::new(
         VectorDomain::new_all(),
@@ -29,8 +30,8 @@ pub fn make_count<TIA, TO>(
 
 pub fn make_count_distinct<TIA, TO>(
 ) -> Fallible<Transformation<VectorDomain<AllDomain<TIA>>, AllDomain<TO>, SymmetricDistance, AbsoluteDistance<TO>>>
-    where TIA: Eq + Hash + CheckNull,
-          TO: ExactIntCast<usize> + One + DistanceConstant<IntDistance> + CheckNull,
+    where TIA: Eq + Hash + CheckNull + Debug,
+          TO: ExactIntCast<usize> + One + DistanceConstant<IntDistance> + CheckNull + Debug,
           IntDistance: InfCast<TO> {
     Ok(Transformation::new(
         VectorDomain::new_all(),
@@ -57,8 +58,8 @@ pub fn make_count_by_categories<MO, TI, TO>(
 ) -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<AllDomain<TO>>, SymmetricDistance, MO>>
     where MO: CountByConstant<MO::Distance> + SensitivityMetric,
           MO::Distance: DistanceConstant<IntDistance> + One,
-          TI: 'static + Eq + Hash + CheckNull,
-          TO: Integer + Zero + One + SaturatingAdd + CheckNull,
+          TI: 'static + Eq + Hash + CheckNull + Debug,
+          TO: Integer + Zero + One + SaturatingAdd + CheckNull + Debug,
           IntDistance: InfCast<MO::Distance>{
     let mut uniques = HashSet::new();
     if categories.iter().any(move |x| !uniques.insert(x)) {
@@ -98,8 +99,8 @@ pub fn make_count_by<MO, TI, TO>(
 ) -> Fallible<Transformation<SizedDomain<VectorDomain<AllDomain<TI>>>, SizedDomain<MapDomain<AllDomain<TI>, AllDomain<TO>>>, SymmetricDistance, MO>>
     where MO: CountByConstant<MO::Distance> + SensitivityMetric,
           MO::Distance: DistanceConstant<IntDistance>,
-          TI: 'static + Eq + Hash + Clone + CheckNull,
-          TO: Integer + Zero + One + SaturatingAdd + CheckNull,
+          TI: 'static + Eq + Hash + Clone + CheckNull + Debug,
+          TO: Integer + Zero + One + SaturatingAdd + CheckNull + Debug,
           IntDistance: InfCast<MO::Distance> {
     Ok(Transformation::new(
         SizedDomain::new(VectorDomain::new_all(), n),

--- a/rust/opendp/src/trans/dataframe/mod.rs
+++ b/rust/opendp/src/trans/dataframe/mod.rs
@@ -39,14 +39,14 @@ fn create_dataframe<K: Eq + Hash>(col_names: Vec<K>, records: &[Vec<&str>]) -> D
         .collect()
 }
 
-fn create_dataframe_domain<K: Eq + Hash + CheckNull>() -> DataFrameDomain<K> {
+fn create_dataframe_domain<K: Eq + Hash + CheckNull + Debug>() -> DataFrameDomain<K> {
     MapDomain::new(AllDomain::new(), AllDomain::new())
 }
 
 pub fn make_create_dataframe<K>(
     col_names: Vec<K>
 ) -> Fallible<Transformation<VectorDomain<VectorDomain<AllDomain<String>>>, DataFrameDomain<K>, SymmetricDistance, SymmetricDistance>>
-    where K: 'static + Eq + Hash + Clone + CheckNull {
+    where K: 'static + Eq + Hash + Clone + CheckNull + Debug {
     Ok(Transformation::new(
         VectorDomain::new(VectorDomain::new_all()),
         create_dataframe_domain(),
@@ -70,7 +70,7 @@ fn split_dataframe<K: Hash + Eq>(separator: &str, col_names: Vec<K>, s: &str) ->
 pub fn make_split_dataframe<K>(
     separator: Option<&str>, col_names: Vec<K>
 ) -> Fallible<Transformation<AllDomain<String>, DataFrameDomain<K>, SymmetricDistance, SymmetricDistance>>
-    where K: 'static + Hash + Eq + Clone + CheckNull {
+    where K: 'static + Hash + Eq + Clone + CheckNull + Debug {
     let separator = separator.unwrap_or(",").to_owned();
     Ok(Transformation::new(
         AllDomain::new(),

--- a/rust/opendp/src/trans/manipulation/mod.rs
+++ b/rust/opendp/src/trans/manipulation/mod.rs
@@ -5,6 +5,7 @@ use crate::error::*;
 use crate::traits::{DistanceConstant, CheckNull};
 use crate::dom::{VectorDomain, AllDomain};
 use crate::dist::SymmetricDistance;
+use std::fmt::Debug;
 
 
 /// Constructs a [`Transformation`] representing an arbitrary row-by-row transformation.
@@ -63,7 +64,7 @@ pub fn make_identity<D, M>(domain: D, metric: M) -> Fallible<Transformation<D, D
 pub fn make_is_equal<TI>(
     value: TI
 ) -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<AllDomain<bool>>, SymmetricDistance, SymmetricDistance>>
-    where TI: 'static + PartialEq + CheckNull {
+    where TI: 'static + PartialEq + CheckNull + Debug {
     make_row_by_row(
         AllDomain::new(),
         AllDomain::new(),

--- a/rust/opendp/src/trans/mean/mod.rs
+++ b/rust/opendp/src/trans/mean/mod.rs
@@ -7,11 +7,12 @@ use crate::dom::{VectorDomain, IntervalDomain, AllDomain, SizedDomain};
 use std::collections::Bound;
 use crate::dist::{SymmetricDistance, AbsoluteDistance, IntDistance};
 use num::{Float};
+use std::fmt::Debug;
 
 pub fn make_bounded_mean<T>(
     lower: T, upper: T, n: usize
 ) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactIntCast<usize>, for <'a> T: Sum<&'a T> + CheckedMul + CheckNull,
+    where T: DistanceConstant<IntDistance> + Sub<Output=T> + Float + ExactIntCast<usize>, for <'a> T: Sum<&'a T> + CheckedMul + CheckNull + Debug,
           IntDistance: InfCast<T> {
     let _n = T::exact_int_cast(n)?;
     let _2 = T::exact_int_cast(2)?;

--- a/rust/opendp/src/trans/resize/mod.rs
+++ b/rust/opendp/src/trans/resize/mod.rs
@@ -1,20 +1,23 @@
-use crate::core::{Transformation, Function, StabilityRelation};
+use crate::core::{Transformation, Function, StabilityRelation, Domain};
 use crate::error::Fallible;
 use crate::dist::{SymmetricDistance, IntDistance};
-use crate::dom::{VectorDomain, AllDomain, SizedDomain};
+use crate::dom::{VectorDomain, SizedDomain};
 use std::cmp::Ordering;
 use crate::traits::CheckNull;
 
-pub fn make_resize_constant<TA: 'static + Clone + CheckNull>(
-    constant: TA, length: usize
-) -> Fallible<Transformation<VectorDomain<AllDomain<TA>>, SizedDomain<VectorDomain<AllDomain<TA>>>, SymmetricDistance, SymmetricDistance>> {
+pub fn make_resize_constant<DA>(
+    atom_domain: DA,
+    constant: DA::Carrier, length: usize
+) -> Fallible<Transformation<VectorDomain<DA>, SizedDomain<VectorDomain<DA>>, SymmetricDistance, SymmetricDistance>>
+    where DA: 'static + Clone + Domain,
+          DA::Carrier: 'static + Clone + CheckNull {
+    if !atom_domain.member(&constant)? { return fallible!(MakeTransformation, "constant must be a member of DA")}
     if length == 0 { return fallible!(MakeTransformation, "length must be greater than zero") }
-    if constant.is_null() { return fallible!(MakeTransformation, "constant may not be null") }
 
     Ok(Transformation::new(
-        VectorDomain::new_all(),
-        SizedDomain::new(VectorDomain::new_all(), length),
-        Function::new(move |arg: &Vec<TA>| match arg.len().cmp(&length) {
+        VectorDomain::new(atom_domain.clone()),
+        SizedDomain::new(VectorDomain::new(atom_domain), length),
+        Function::new(move |arg: &Vec<DA::Carrier>| match arg.len().cmp(&length) {
             Ordering::Less => arg.iter().chain(vec![&constant; length - arg.len()]).cloned().collect(),
             Ordering::Equal => arg.clone(),
             Ordering::Greater => arg[..length].to_vec()
@@ -28,10 +31,11 @@ pub fn make_resize_constant<TA: 'static + Clone + CheckNull>(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::dom::AllDomain;
 
     #[test]
     fn test() -> Fallible<()> {
-        let trans = make_resize_constant("x", 3)?;
+        let trans = make_resize_constant(AllDomain::new(),"x", 3)?;
         assert_eq!(trans.function.eval(&vec!["A"; 2])?, vec!["A", "A", "x"]);
         assert_eq!(trans.function.eval(&vec!["A"; 3])?, vec!["A"; 3]);
         assert_eq!(trans.function.eval(&vec!["A"; 4])?, vec!["A", "A", "A"]);

--- a/rust/opendp/src/trans/sum/mod.rs
+++ b/rust/opendp/src/trans/sum/mod.rs
@@ -9,11 +9,12 @@ use crate::dist::{AbsoluteDistance, IntDistance, SymmetricDistance};
 use crate::dom::{AllDomain, IntervalDomain, SizedDomain, VectorDomain};
 use crate::error::*;
 use crate::traits::{Abs, DistanceConstant, InfCast, SaturatingAdd, CheckedMul, ExactIntCast, CheckNull};
+use std::fmt::Debug;
 
 pub fn make_bounded_sum<T>(
     lower: T, upper: T
 ) -> Fallible<Transformation<VectorDomain<IntervalDomain<T>>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: DistanceConstant<IntDistance> + Sub<Output=T> + Abs + SaturatingAdd + Zero + CheckNull,
+    where T: DistanceConstant<IntDistance> + Sub<Output=T> + Abs + SaturatingAdd + Zero + CheckNull + Debug,
           IntDistance: InfCast<T> {
 
     Ok(Transformation::new(
@@ -30,7 +31,7 @@ pub fn make_bounded_sum<T>(
 pub fn make_bounded_sum_n<T>(
     lower: T, upper: T, length: usize
 ) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: DistanceConstant<IntDistance> + Sub<Output=T>, for <'a> T: Sum<&'a T> + ExactIntCast<usize> + CheckedMul + CheckNull,
+    where T: DistanceConstant<IntDistance> + Sub<Output=T>, for <'a> T: Sum<&'a T> + ExactIntCast<usize> + CheckedMul + CheckNull + Debug,
           IntDistance: InfCast<T> {
     let length_ = T::exact_int_cast(length)?;
     if lower.checked_mul(&length_).is_none()

--- a/rust/opendp/src/trans/variance/mod.rs
+++ b/rust/opendp/src/trans/variance/mod.rs
@@ -9,12 +9,13 @@ use crate::dist::{SymmetricDistance, AbsoluteDistance, IntDistance};
 use crate::dom::{AllDomain, IntervalDomain, SizedDomain, VectorDomain};
 use crate::error::Fallible;
 use crate::traits::{DistanceConstant, ExactIntCast, InfCast, CheckedMul, CheckNull};
+use std::fmt::Debug;
 
 
 pub fn make_bounded_variance<T>(
     lower: T, upper: T, length: usize, ddof: usize
 ) -> Fallible<Transformation<SizedDomain<VectorDomain<IntervalDomain<T>>>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: DistanceConstant<IntDistance> + Float + One + Sub<Output=T> + Div<Output=T> + Sum<T> + for<'a> Sum<&'a T> + ExactIntCast<usize> + CheckedMul + CheckNull,
+    where T: DistanceConstant<IntDistance> + Float + One + Sub<Output=T> + Div<Output=T> + Sum<T> + for<'a> Sum<&'a T> + ExactIntCast<usize> + CheckedMul + CheckNull + Debug,
           for<'a> &'a T: Sub<Output=T> + Add<&'a T, Output=T>,
           IntDistance: InfCast<T> {
     let _length = T::exact_int_cast(length)?;
@@ -52,7 +53,7 @@ pub fn make_bounded_covariance<T>(
     upper: (T, T),
     length: usize, ddof: usize
 ) -> Fallible<Transformation<CovarianceDomain<T>, AllDomain<T>, SymmetricDistance, AbsoluteDistance<T>>>
-    where T: ExactIntCast<usize> + DistanceConstant<IntDistance> + Zero + One + Sub<Output=T> + Div<Output=T> + Add<Output=T> + Sum<T> + CheckedMul + CheckNull,
+    where T: ExactIntCast<usize> + DistanceConstant<IntDistance> + Zero + One + Sub<Output=T> + Div<Output=T> + Add<Output=T> + Sum<T> + CheckedMul + CheckNull + Debug,
           for <'a> T: Div<&'a T, Output=T> + Add<&'a T, Output=T>,
           for<'a> &'a T: Sub<Output=T>,
           IntDistance: InfCast<T> {


### PR DESCRIPTION
Closes #201.
This adds Debug trait bounds... everywhere, which can be pretty annoying.
But now when you attempt to chain incompatible measurements or operations, you can see how the domains or metrics differ. This doesn't capture type information in the output, unfortunately. I've added more comments about this limitation in the linked issue.

`git rebase --onto main 6609ec5 201-anybox-debug`