### PR TITLE
sequential compositor w/ static distances

### DIFF
--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -17,6 +17,8 @@ ATOM_MAP = {
     'i32': ctypes.c_int32,
     'i64': ctypes.c_int64,
     'bool': ctypes.c_bool,
+    'AnyMeasurementPtr': Measurement,
+    'const AnyTransformation *': Transformation
 }
 
 

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -7,7 +7,9 @@ from typing import Optional, Any
 ATOM_EQUIVALENCE_CLASSES = {
     'i32': ['u8', 'u16', 'u32', 'u64', 'i8', 'i16', 'i32', 'i64'],
     'f64': ['f32', 'f64'],
-    'bool': ['bool']
+    'bool': ['bool'],
+    'AnyMeasurementPtr': ['AnyMeasurementPtr'],
+    'const AnyTransformation *': ['const AnyTransformation *']
 }
 
 lib = None

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -9,7 +9,7 @@ ATOM_EQUIVALENCE_CLASSES = {
     'f64': ['f32', 'f64'],
     'bool': ['bool'],
     'AnyMeasurementPtr': ['AnyMeasurementPtr'],
-    'const AnyTransformation *': ['const AnyTransformation *']
+    'AnyTransformationPtr': ['AnyTransformationPtr'],
 }
 
 lib = None

--- a/python/src/opendp/comb.py
+++ b/python/src/opendp/comb.py
@@ -38,7 +38,7 @@ def make_chain_tt(
     transformation1: Transformation,
     transformation0: Transformation
 ) -> Transformation:
-    """Construct the functional composition (`transformation1` ○ `transformation0`). Returns a Tranformation.
+    """Construct the functional composition (`transformation1` ○ `transformation0`). Returns a Transformation.
     
     :param transformation1: outer transformation
     :type transformation1: Transformation
@@ -61,6 +61,31 @@ def make_chain_tt(
     function.restype = FfiResult
     
     return c_to_py(unwrap(function(transformation1, transformation0), Transformation))
+
+
+def make_basic_composition_multi(
+    measurements: Any
+) -> Measurement:
+    """Construct the DP composition [`measurement0`, `measurement1`, ...]. Returns a Measurement.
+    
+    :param measurements: A list of measurements to compose.
+    :type measurements: Any
+    :return: Measurement representing the composed transformations.
+    :rtype: Measurement
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # No type arguments to standardize.
+    # Convert arguments to c types.
+    measurements = py_to_c(measurements, c_type=AnyObjectPtr, type_name="Vec<AnyMeasurementPtr>")
+    
+    # Call library function.
+    function = lib.opendp_comb__make_basic_composition_multi
+    function.argtypes = [AnyObjectPtr]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(measurements), Measurement))
 
 
 def make_basic_composition(

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -3,8 +3,8 @@ import typing
 from collections.abc import Hashable
 from typing import Union, Any, Type, List
 
-from opendp.mod import UnknownTypeException
-from opendp._lib import ATOM_EQUIVALENCE_CLASSES
+from opendp.v1.mod import UnknownTypeException, Measurement, Transformation
+from opendp.v1._lib import ATOM_EQUIVALENCE_CLASSES
 
 if sys.version_info >= (3, 7):
     from typing import _GenericAlias
@@ -183,6 +183,12 @@ class RuntimeType(object):
                 cls.infer(next(iter(public_example.keys()))),
                 cls.infer(next(iter(public_example.values())))
             ])
+
+        if isinstance(public_example, Measurement):
+            return "AnyMeasurementPtr"
+
+        if isinstance(public_example, Transformation):
+            return "AnyTransformationPtr"
 
         if public_example is None:
             return RuntimeType('Option', [UnknownType("Constructed Option from a None variant")])

--- a/python/test/test_meas.py
+++ b/python/test/test_meas.py
@@ -67,3 +67,16 @@ def test_base_stability():
     )
     print("base stability:", meas(["CAT_A"] * 4 + ["CAT_B"] * 6))
     assert meas.check(1, (2.3, .000001))
+
+
+def test_basic_composition_multi():
+    from opendp.comb import make_basic_composition_multi
+    from opendp.meas import make_base_geometric
+    composed = make_basic_composition_multi([
+        make_base_geometric(scale=2.),
+        make_base_geometric(scale=2.)
+    ])
+
+    print(composed.check(1, 2.))
+
+test_basic_composition_multi()

--- a/rust/opendp-ffi/src/comb/bootstrap.json
+++ b/rust/opendp-ffi/src/comb/bootstrap.json
@@ -19,7 +19,7 @@
         }
     },
     "make_chain_tt": {
-        "description": "Construct the functional composition (`transformation1` ○ `transformation0`). Returns a Tranformation.",
+        "description": "Construct the functional composition (`transformation1` ○ `transformation0`). Returns a Transformation.",
         "args": [
             {
                 "name": "transformation1",
@@ -35,6 +35,21 @@
         "ret": {
             "c_type": "FfiResult<AnyTransformation *>",
             "description": "Transformation representing the chained computation."
+        }
+    },
+    "make_basic_composition_multi": {
+        "description": "Construct the DP composition [`measurement0`, `measurement1`, ...]. Returns a Measurement.",
+        "args": [
+            {
+                "name": "measurements",
+                "rust_type": "\"Vec<AnyMeasurementPtr>\"",
+                "c_type": "const AnyObject *",
+                "description": "A list of measurements to compose."
+            }
+        ],
+        "ret": {
+            "c_type": "FfiResult<AnyMeasurement *>",
+            "description": "Measurement representing the composed transformations."
         }
     },
     "make_basic_composition": {

--- a/rust/opendp-ffi/src/data/mod.rs
+++ b/rust/opendp-ffi/src/data/mod.rs
@@ -11,7 +11,7 @@ use opendp::error::Fallible;
 use crate::any::{AnyObject, Downcast, AnyMeasureDistance, AnyMetricDistance};
 use crate::core::{FfiError, FfiResult, FfiSlice};
 use crate::util;
-use crate::util::{c_bool, Type, TypeContents};
+use crate::util::{c_bool, Type, TypeContents, AnyMeasurementPtr, AnyTransformationPtr};
 use opendp::traits::{MeasureDistance, MetricDistance};
 use std::fmt::Formatter;
 use std::hash::Hash;
@@ -147,10 +147,11 @@ pub extern "C" fn opendp_data___slice_as_object(raw: *const FfiSlice, T: *const 
         }
         TypeContents::VEC(element_id) => {
             let element = try_!(Type::of_id(&element_id));
-            if element.descriptor == "String" {
-                raw_to_vec_string(raw)
-            } else {
-                dispatch!(raw_to_vec, [(element, @primitives)], (raw))
+            match element.descriptor.as_str() {
+                "String" => raw_to_vec_string(raw),
+                "AnyMeasurementPtr" => raw_to_vec::<AnyMeasurementPtr>(raw),
+                "AnyTransformationPtr" => raw_to_vec::<AnyTransformationPtr>(raw),
+                _ => dispatch!(raw_to_vec, [(element, @primitives)], (raw))
             }
         }
         TypeContents::TUPLE(ref element_ids) => {

--- a/rust/opendp-ffi/src/meas/gaussian.rs
+++ b/rust/opendp-ffi/src/meas/gaussian.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 use std::os::raw::{c_char, c_void};
 
-use num::Float;
+use num::{Float, Zero};
 
 use opendp::err;
 use opendp::meas::{make_base_gaussian, GaussianDomain};
@@ -11,7 +11,10 @@ use crate::any::AnyMeasurement;
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::util::Type;
 use opendp::dom::{AllDomain, VectorDomain};
-use opendp::traits::{InfCast, CheckNull};
+use opendp::traits::{InfCast, CheckNull, MeasureDistance, CheckedAdd};
+use opendp::dist::SmoothedMaxDivergence;
+use opendp::comb::ComposableMeasure;
+use opendp::core::Measure;
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_gaussian(
@@ -20,7 +23,9 @@ pub extern "C" fn opendp_meas__make_base_gaussian(
 ) -> FfiResult<*mut AnyMeasurement> {
     fn monomorphize<D>(scale: *const c_void) -> FfiResult<*mut AnyMeasurement> where
         D: 'static + GaussianDomain,
-        D::Atom: 'static + Clone + SampleGaussian + Float + InfCast<f64> + CheckNull {
+        D::Atom: 'static + Clone + SampleGaussian + Float + InfCast<f64> + CheckNull + CheckedAdd + Zero,
+        SmoothedMaxDivergence<D::Atom>: ComposableMeasure,
+        <SmoothedMaxDivergence<D::Atom> as Measure>::Distance: Clone + MeasureDistance {
         let scale = *try_as_ref!(scale as *const D::Atom);
         make_base_gaussian::<D>(scale).into_any()
     }

--- a/rust/opendp-ffi/src/meas/geometric.rs
+++ b/rust/opendp-ffi/src/meas/geometric.rs
@@ -11,7 +11,10 @@ use crate::any::{AnyMeasurement, AnyObject, Downcast};
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::util::Type;
 use crate::util;
-use opendp::traits::{InfCast, TotalOrd};
+use opendp::traits::{InfCast, TotalOrd, MeasureDistance};
+use opendp::dist::MaxDivergence;
+use opendp::comb::ComposableMeasure;
+use opendp::core::Measure;
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_geometric(
@@ -25,7 +28,9 @@ pub extern "C" fn opendp_meas__make_base_geometric(
         where D: 'static + GeometricDomain,
               D::Atom: 'static + InfCast<QO> + TotalOrd + Clone,
               QO: 'static + Float + InfCast<D::Atom> + TotalOrd,
-              f64: From<QO> {
+              f64: From<QO>,
+              MaxDivergence<QO>: ComposableMeasure,
+              <MaxDivergence<QO> as Measure>::Distance: Clone + MeasureDistance {
         let scale = try_as_ref!(scale as *const QO).clone();
         let bounds = if let Some(bounds) = util::as_ref(bounds) {
             Some(try_!(bounds.downcast_ref::<(D::Atom, D::Atom)>()).clone())

--- a/rust/opendp-ffi/src/meas/laplace.rs
+++ b/rust/opendp-ffi/src/meas/laplace.rs
@@ -11,7 +11,10 @@ use crate::any::AnyMeasurement;
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::util::Type;
 use opendp::dom::{VectorDomain, AllDomain};
-use opendp::traits::{InfCast, CheckNull, TotalOrd};
+use opendp::traits::{InfCast, CheckNull, TotalOrd, MeasureDistance};
+use opendp::comb::ComposableMeasure;
+use opendp::dist::MaxDivergence;
+use opendp::core::Measure;
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_laplace(
@@ -20,7 +23,9 @@ pub extern "C" fn opendp_meas__make_base_laplace(
 ) -> FfiResult<*mut AnyMeasurement> {
     fn monomorphize<D>(scale: *const c_void) -> FfiResult<*mut AnyMeasurement>
         where D: 'static + LaplaceDomain,
-              D::Atom: 'static + Clone + SampleLaplace + Float + InfCast<D::Atom> + CheckNull + TotalOrd {
+              D::Atom: 'static + Clone + SampleLaplace + Float + InfCast<D::Atom> + CheckNull + TotalOrd,
+              MaxDivergence<D::Atom>: ComposableMeasure,
+              <MaxDivergence<D::Atom> as Measure>::Distance: Clone + MeasureDistance {
         let scale = *try_as_ref!(scale as *const D::Atom);
         make_base_laplace::<D>(scale).into_any()
     }

--- a/rust/opendp-ffi/src/meas/stability.rs
+++ b/rust/opendp-ffi/src/meas/stability.rs
@@ -1,20 +1,21 @@
 use std::convert::TryFrom;
 use std::hash::Hash;
-use std::ops::AddAssign;
+use std::ops::{AddAssign, Sub};
 use std::os::raw::{c_char, c_void};
 
 use num::{Float, Integer, One, Zero};
 
-use opendp::core::SensitivityMetric;
-use opendp::dist::{L1Distance, L2Distance};
+use opendp::core::{SensitivityMetric, Measure};
+use opendp::dist::{L1Distance, L2Distance, SmoothedMaxDivergence};
 use opendp::err;
 use opendp::meas::{BaseStabilityNoise, make_base_stability};
 use opendp::samplers::CastInternalReal;
-use opendp::traits::{ExactIntCast, CheckNull, TotalOrd};
+use opendp::traits::{ExactIntCast, CheckNull, TotalOrd, MeasureDistance, CheckedAdd};
 
 use crate::any::AnyMeasurement;
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::util::Type;
+use opendp::comb::ComposableMeasure;
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_stability(
@@ -30,14 +31,16 @@ pub extern "C" fn opendp_meas__make_base_stability(
         MI: Type, TIK: Type, TIC: Type,
     ) -> FfiResult<*mut AnyMeasurement>
         where TIC: 'static + Integer + Zero + One + AddAssign + Clone + CheckNull,
-              TOC: 'static + TotalOrd + Clone + Float + CastInternalReal + ExactIntCast<usize> + ExactIntCast<TIC> + CheckNull {
+              TOC: 'static + TotalOrd + Clone + Float + CastInternalReal + ExactIntCast<usize> + ExactIntCast<TIC> + CheckNull + CheckedAdd + for<'a> Sub<&'a TOC, Output=TOC> {
         fn monomorphize2<MI, TIK, TIC>(
             n: usize, scale: MI::Distance, threshold: MI::Distance,
         ) -> FfiResult<*mut AnyMeasurement>
             where MI: 'static + SensitivityMetric + BaseStabilityNoise,
                   TIK: 'static + Eq + Hash + Clone + CheckNull,
                   TIC: 'static + Integer + Zero + One + AddAssign + Clone + CheckNull,
-                  MI::Distance: 'static + Clone + TotalOrd + Float + CastInternalReal + ExactIntCast<usize> + ExactIntCast<TIC> + CheckNull {
+                  MI::Distance: 'static + Clone + TotalOrd + Float + CastInternalReal + ExactIntCast<usize> + ExactIntCast<TIC> + CheckNull,
+                  SmoothedMaxDivergence<MI::Distance>: ComposableMeasure,
+                  <SmoothedMaxDivergence<MI::Distance> as Measure>::Distance: Clone + MeasureDistance {
             make_base_stability::<MI, TIK, TIC>(n, scale, threshold).into_any()
         }
         let scale = *try_as_ref!(scale as *const TOC);

--- a/rust/opendp-ffi/src/util.rs
+++ b/rust/opendp-ffi/src/util.rs
@@ -10,7 +10,7 @@ use std::str::Utf8Error;
 use opendp::{err, fallible};
 use opendp::dist::{SubstituteDistance, L1Distance, L2Distance, SymmetricDistance, AbsoluteDistance};
 use opendp::error::*;
-use crate::any::AnyObject;
+use crate::any::{AnyObject, AnyTransformation, AnyMeasurement};
 use opendp::dom::{VectorDomain, AllDomain, IntervalDomain, InherentNullDomain, OptionNullDomain, SizedDomain};
 
 #[derive(Debug, PartialEq, Clone)]
@@ -224,6 +224,9 @@ macro_rules! type_vec {
     ($($names:ty),*) => { vec![$(t!($names)),*] };
 }
 
+pub type AnyMeasurementPtr = *const AnyMeasurement;
+pub type AnyTransformationPtr = *const AnyTransformation;
+
 lazy_static! {
     /// The set of registered types. We don't need everything here, just the ones that will be looked up by descriptor
     /// (i.e., the ones that appear in FFI function generic args).
@@ -239,6 +242,8 @@ lazy_static! {
             type_vec![HashMap, <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, String>, <bool, char, u8, u16, u32, i16, i32, i64, i128, f32, f64, String, AnyObject>],
             // OptionNullDomain<AllDomain<_>>::Carrier
             type_vec![[Vec Option], <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String, AnyObject>],
+            type_vec![AnyMeasurementPtr, AnyTransformationPtr],
+            type_vec![Vec, <AnyMeasurementPtr, AnyTransformationPtr>],
 
             // domains
             type_vec![AllDomain, <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String>],

--- a/rust/opendp/src/comb/chain/mod.rs
+++ b/rust/opendp/src/comb/chain/mod.rs
@@ -1,8 +1,12 @@
 use std::ops::Shr;
 
+use num::Zero;
+
 use crate::core::{Domain, Function, HintMt, HintTt, Measure, Measurement, Metric, PrivacyRelation, StabilityRelation, Transformation};
-use crate::dom::PairDomain;
+use crate::dist::{MaxDivergence, SmoothedMaxDivergence};
+use crate::dom::{PairDomain, VectorDomain};
 use crate::error::Fallible;
+use crate::traits::CheckedAdd;
 
 pub fn make_chain_mt<DI, DX, DO, MI, MX, MO>(
     measurement1: &Measurement<DX, DO, MX, MO>,
@@ -58,6 +62,87 @@ pub fn make_chain_tt<DI, DX, DO, MI, MX, MO>(
     ))
 }
 
+pub trait ComposableMeasure: Measure {
+    fn compose(&self, d_i: &Vec<Self::Distance>) -> Fallible<Self::Distance>;
+}
+
+impl<Q: CheckedAdd + Zero + Clone> ComposableMeasure for MaxDivergence<Q> {
+    fn compose(&self, d_i: &Vec<Self::Distance>) -> Fallible<Self::Distance> {
+        d_i.iter().try_fold(
+            Q::zero(),
+            |sum, d_i| sum.checked_add(d_i))
+            .ok_or_else(|| err!(MakeMeasurement, "detected overflow when composing distances"))
+    }
+}
+
+impl<Q: CheckedAdd + Zero + Clone> ComposableMeasure for SmoothedMaxDivergence<Q> {
+    fn compose(&self, d_i: &Vec<Self::Distance>) -> Fallible<Self::Distance> {
+        d_i.iter().try_fold(
+            (Q::zero(), Q::zero()),
+            |(e1, d1), (e2, d2)| e1.checked_add(e2).zip(d1.checked_add(d2)))
+            .ok_or_else(|| err!(MakeMeasurement, "detected overflow when composing distances"))
+    }
+}
+
+pub fn make_sequential_composition_static_distances<DI, DO, MI, MO>(
+    d_in: MI::Distance,
+    measurement_pairs: Vec<(&Measurement<DI, DO, MI, MO>, MO::Distance)>
+) -> Fallible<Measurement<DI, VectorDomain<DO>, MI, MO>>
+    where DI: 'static + Domain,
+          DO: 'static + Domain,
+          MI: 'static + Metric,
+          MI::Distance: 'static + PartialOrd,
+          MO: 'static + ComposableMeasure,
+          MO::Distance: 'static + PartialOrd {
+
+    if measurement_pairs.is_empty() {
+        return fallible!(MakeMeasurement, "Must have at least one measurement")
+    }
+
+    for (measurement, d_mid) in &measurement_pairs {
+        if !measurement.privacy_relation.eval(&d_in, d_mid)? {
+            return fallible!(MakeMeasurement, "one of the relations does not pass with its respective d_mid");
+        }
+    }
+
+    let (measurements, d_mids): (Vec<_>, Vec<_>) =
+        measurement_pairs.into_iter().unzip();
+
+    let input_domain = measurements[0].input_domain.clone();
+    let output_domain = measurements[0].output_domain.clone();
+    let input_metric = measurements[0].input_metric.clone();
+    let output_measure = measurements[0].output_measure.clone();
+
+    if !measurements.iter().all(|v| input_domain == v.input_domain) {
+        return fallible!(DomainMismatch, "All input domains must be the same");
+    }
+    if !measurements.iter().all(|v| output_domain == v.output_domain) {
+        return fallible!(DomainMismatch, "All output domains must be the same");
+    }
+    if !measurements.iter().all(|v| input_metric == v.input_metric) {
+        return fallible!(MetricMismatch, "All input metrics must be the same");
+    }
+    if !measurements.iter().all(|v| output_measure == v.output_measure) {
+        return fallible!(MetricMismatch, "All output measures must be the same");
+    }
+
+    let functions = measurements.iter()
+        .map(|m| m.function.clone()).collect::<Vec<_>>();
+    let d_out = output_measure.compose(&d_mids)?;
+
+    Ok(Measurement::new(
+        input_domain,
+        VectorDomain::new(output_domain),
+        Function::new_fallible(move |arg: &DI::Carrier|
+            functions.iter().map(|f| f.eval(arg)).collect()),
+        input_metric,
+        output_measure.clone(),
+        PrivacyRelation::new(move |d_in_prime: &MI::Distance, d_out_prime: &MO::Distance|
+            d_in_prime <= &d_in && &d_out <= d_out_prime)
+    ))
+}
+
+
 pub fn make_basic_composition<DI, DO0, DO1, MI, MO>(measurement0: &Measurement<DI, DO0, MI, MO>, measurement1: &Measurement<DI, DO1, MI, MO>) -> Fallible<Measurement<DI, PairDomain<DO0, DO1>, MI, MO>>
     where DI: 'static + Domain,
           DO0: 'static + Domain,
@@ -91,6 +176,7 @@ mod tests {
     use crate::dist::{L1Distance, MaxDivergence};
     use crate::dom::AllDomain;
     use crate::error::ExplainUnwrap;
+    use crate::meas::make_base_laplace;
 
     use super::*;
 
@@ -158,6 +244,25 @@ mod tests {
         let arg = 99;
         let ret = composition.function.eval(&arg).unwrap_test();
         assert_eq!(ret, (100_f32, 98_f64));
+    }
+
+    #[test]
+    fn test_make_sequential_composition_static_distances() -> Fallible<()> {
+        let laplace = make_base_laplace::<AllDomain<_>>(1.)?;
+        let measurements = vec![
+            (&laplace, 1.),
+            (&laplace, 1.),
+        ];
+        let composition = make_sequential_composition_static_distances(1., &measurements)?;
+        let arg = 99.;
+        let ret = composition.function.eval(&arg)?;
+
+        assert_eq!(ret.len(), 2);
+
+        assert!(composition.privacy_relation.eval(&1., &2.)?);
+        assert!(composition.privacy_relation.eval(&1., &2.0001)?);
+        assert!(!composition.privacy_relation.eval(&1., &1.999)?);
+        Ok(())
     }
 }
 

--- a/rust/opendp/src/comb/chain/mod.rs
+++ b/rust/opendp/src/comb/chain/mod.rs
@@ -63,7 +63,8 @@ pub fn make_chain_tt<DI, DX, DO, MI, MX, MO>(
 }
 
 pub trait ComposableMeasure: Measure {
-    fn compose(&self, d_i: &Vec<Self::Distance>) -> Fallible<Self::Distance>;
+    fn compose(&self, d_i: &Vec<Self::Distance>)
+        -> Fallible<Self::Distance>;
 }
 
 impl<Q: CheckedAdd + Zero + Clone> ComposableMeasure for MaxDivergence<Q> {

--- a/rust/opendp/src/core.rs
+++ b/rust/opendp/src/core.rs
@@ -37,9 +37,14 @@ pub trait Domain: Clone + PartialEq {
 }
 
 /// A mathematical function which maps values from an input [`Domain`] to an output [`Domain`].
-#[derive(Clone)]
+// #[derive(Clone)]
 pub struct Function<DI: Domain, DO: Domain> {
     pub function: Rc<dyn Fn(&DI::Carrier) -> Fallible<DO::Carrier>>,
+}
+impl<DI: Domain, DO: Domain> Clone for Function<DI, DO> {
+    fn clone(&self) -> Self {
+        Function { function: self.function.clone() }
+    }
 }
 
 impl<DI: Domain, DO: Domain> Function<DI, DO> {


### PR DESCRIPTION
Closes #7
This PR replaces the basic composition PR based on a suggestion from Salil. The internals are simpler, because the shared behavior captured in the AnyMeasure is just a function to sum distances.

- Removed the EpsilonDelta struct, Midpoint/Tolerance traits, and binary search.
- Replaced `basic_composition` with `sequential_composition_with_static_distances`