### PR TITLE
Binary search utilities

### DIFF
--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -307,7 +307,6 @@ def binary_search_chain(
     >>> )
     >>> # Find a value in `bounds` that produces a (`d_in`, `d_out`)-chain within `tolerance` of the decision boundary.
     >>> # `make_chain` returns the complete computation chain when given a single numeric parameter.
-    >>> # The function `binary_search_chain` returns the parameterized computation chain.
     >>> chain = binary_search_chain(
     >>>     make_chain=lambda s: pre >> make_base_laplace(scale=s),
     >>>     bounds=(0., 10.), d_in=1, d_out=1.)
@@ -342,7 +341,6 @@ def binary_search_param(
     >>>
     >>> # Find a value in `bounds` that produces a (`d_in`, `d_out`)-chain within `tolerance` of the decision boundary.
     >>> # `make_chain` returns the complete computation chain when given a single numeric parameter
-    >>> # The function `binary_search_param` returns the discovered parameter.
     >>> scale = binary_search_param(
     >>>     make_chain=lambda s: make_base_laplace(scale=s),
     >>>     bounds=(0., 10.), d_in=0.1, d_out=1.)

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -336,31 +336,25 @@ def binary_search(
     assert maximize != minimize, "the decision point of the predicate is outside the bounds"
 
     if isinstance(lower, int):
-        while upper != lower:
-            mid = lower + (upper - lower) // 2
-
-            if predicate(mid) == minimize:
-                upper = mid
-            else:
-                lower = mid + 1
-
-        # make sure the search terminates on a successful predicate
-        if not predicate(lower):
-            lower += 1 if minimize else -1
-        return lower
+        half = lambda x: x // 2
+        done = lambda: lower + 1 == upper
+        post = lambda: lower + (0 if predicate(lower) else 1)
 
     elif isinstance(lower, float):
-        assert isinstance(tolerance, float), 'tolerance must be a float'
-        while upper - lower > tolerance:
-            mid = lower + (upper - lower) / 2.
-
-            if predicate(mid) == minimize:
-                upper = mid
-            else:
-                lower = mid
-
-        # make sure the search terminates on a successful predicate
-        return upper if minimize else lower
+        half = lambda x: x / 2.
+        done = lambda: upper - lower <= tolerance
+        post = lambda: upper if minimize else lower
 
     else:
         raise ValueError("bounds must be either float or int")
+
+    while not done():
+        mid = lower + half(upper - lower)
+
+        if predicate(mid) == minimize:
+            upper = mid
+        else:
+            lower = mid
+
+    # make sure the search terminates on a successful predicate
+    return post()

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -295,7 +295,7 @@ def binary_search_chain(
 
     :example:
 
-    >>> from opendp.mod import binary_search_chain, binary_search_param
+    >>> from opendp.mod import binary_search_chain
     >>> from opendp.trans import make_clamp, make_resize_bounded, make_bounded_mean
     >>> from opendp.meas import make_base_laplace
     >>>
@@ -305,7 +305,7 @@ def binary_search_chain(
     >>>     make_resize_bounded(constant=0., length=10, lower=0., upper=1.) >>
     >>>     make_bounded_mean(lower=0., upper=1., n=10)
     >>> )
-    >>> # Find a value in `bounds` that produces a (`d_in`, `d_out`)-chain within `tolerance` of the decision boundary
+    >>> # Find a value in `bounds` that produces a (`d_in`, `d_out`)-chain within `tolerance` of the decision boundary.
     >>> # `make_chain` returns the complete computation chain when given a single numeric parameter.
     >>> # The function `binary_search_chain` returns the parameterized computation chain.
     >>> chain = binary_search_chain(
@@ -313,7 +313,6 @@ def binary_search_chain(
     >>>     bounds=(0., 10.), d_in=1, d_out=1.)
     >>> # We can double-check that the resulting computation chain obeys the provided `d_in`, `d_out`.
     >>> assert chain.check(1, 1.)
-    >>> chain([5.] * 10)
 
 
     :param make_chain: a unary function that maps from a number to a Transformation or Measurement
@@ -338,23 +337,15 @@ def binary_search_param(
 
     :example:
 
-    >>> from opendp.mod import binary_search_chain, binary_search_param
-    >>> from opendp.trans import make_clamp, make_resize_bounded, make_bounded_mean
+    >>> from opendp.mod import binary_search_param
     >>> from opendp.meas import make_base_laplace
     >>>
-    >>> # The majority of the chain only needs to be defined once
-    >>> pre = (
-    >>>     make_clamp(lower=0., upper=1.) >>
-    >>>     make_resize_bounded(constant=0., length=10, lower=0., upper=1.) >>
-    >>>     make_bounded_mean(lower=0., upper=1., n=10)
-    >>> )
-    >>>
-    >>> # Find a value in `bounds` that produces a (`d_in`, `d_out`)-chain within `tolerance` of the decision boundary
+    >>> # Find a value in `bounds` that produces a (`d_in`, `d_out`)-chain within `tolerance` of the decision boundary.
     >>> # `make_chain` returns the complete computation chain when given a single numeric parameter
     >>> # The function `binary_search_param` returns the discovered parameter.
     >>> scale = binary_search_param(
-    >>>     make_chain=lambda s: pre >> make_base_laplace(scale=s),
-    >>>     bounds=(0., 10.), d_in=1, d_out=1.)
+    >>>     make_chain=lambda s: make_base_laplace(scale=s),
+    >>>     bounds=(0., 10.), d_in=0.1, d_out=1.)
     >>> # The discovered scale differs by at most `tolerance` from the ideal scale (0.1).
     >>> assert scale - 0.1 < 1e-8
 

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -310,7 +310,7 @@ def binary_search_chain(
     >>> chain = binary_search_chain(
     >>>     lambda s: pre >> make_base_laplace(scale=s),
     >>>     bounds=(0., 10.), d_in=1, d_out=1.)
-    >>> # We can double-check that the resulting computation chain obeys the provided `d_in`, `d_out`.
+    >>> # The resulting computation chain is always (`d_in`, `d_out`)-close, but we can still double-check:
     >>> assert chain.check(1, 1.)
 
 
@@ -346,6 +346,8 @@ def binary_search_param(
     >>>     bounds=(0., 10.), d_in=0.1, d_out=1.)
     >>> # The discovered scale differs by at most `tolerance` from the ideal scale (0.1).
     >>> assert scale - 0.1 < 1e-8
+    >>> # Constructing the same chain with the discovered parameter will always be (0.1, 1.)-close.
+    >>> assert make_base_laplace(scale).check(0.1, 1.)
 
     :param make_chain: a unary function that maps from a number to a Transformation or Measurement
     :param bounds: a 2-tuple of the lower and upper bounds to the input of `make_chain`

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -309,7 +309,7 @@ def binary_search_chain(
     >>> # `make_chain` returns the complete computation chain when given a single numeric parameter.
     >>> # The function `binary_search_chain` returns the parameterized computation chain.
     >>> chain = binary_search_chain(
-    >>>     lambda s: pre >> make_base_laplace(scale=s),
+    >>>     make_chain=lambda s: pre >> make_base_laplace(scale=s),
     >>>     bounds=(0., 10.), d_in=1, d_out=1.)
     >>> # We can double-check that the resulting computation chain obeys the provided `d_in`, `d_out`.
     >>> assert chain.check(1, 1.)

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -321,8 +321,8 @@ def binary_search(
         tolerance=1e-8):
     """Find the closest value to the `predicate`'s decision point within float or integer `bounds`.
 
-    :param predicate: a function with one parameter that returns a boolean
-    :param bounds: the parameter's lower and upper bounds
+    :param predicate: a monotonic unary function over numbers that returns a boolean
+    :param bounds: lower and upper bounds on the argument to the predicate
     :param tolerance: the discovered float parameter differs by at most `tolerance` from the ideal float parameter
     :return: the discovered parameter within the bounds
     """

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -289,7 +289,7 @@ def binary_search_chain(
     """Optimizes a parameterized chain `make_chain` within float or integer `bounds`,
     subject to the chained relation being (`d_in`, `d_out`)-close.
 
-    `bounds` defaults to (0., 1.0e8).
+    `bounds` defaults to (0., MAX_FINITE_FLOAT).
     If `bounds` are float, `tolerance` defaults to 1e-8.
 
     See `binary_search_param` to retrieve the discovered parameter instead of the complete computation chain.
@@ -332,7 +332,7 @@ def binary_search_param(
     """Optimizes a parameterized chain `make_chain` within float or integer `bounds`,
     subject to the chained relation being (`d_in`, `d_out`)-close.
 
-    `bounds` defaults to (0., 1.0e8).
+    `bounds` defaults to (0., MAX_FINITE_FLOAT).
     If `bounds` are float, `tolerance` defaults to 1e-8.
 
     :example:
@@ -358,7 +358,8 @@ def binary_search_param(
     :raises AssertionError: if the arguments are ill-formed (type issues, decision boundary not within `bounds`)
     """
     if bounds is None:
-        bounds = (0., 1e8)
+        import sys
+        bounds = (0., sys.float_info.max)
     return binary_search(lambda param: make_chain(param).check(d_in, d_out), bounds, tolerance)
 
 
@@ -394,7 +395,7 @@ def binary_search(
     assert maximize != minimize, "the decision boundary of the predicate is outside the bounds"
 
     if isinstance(lower, float):
-        tolerance = 1e-8 if tolerance is None else tolerance
+        tolerance = 1.0e-8 if tolerance is None else tolerance
         half = lambda x: x / 2.
     elif isinstance(lower, int):
         tolerance = tolerance or 1  # the lower and upper bounds never meet due to int truncation

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -1,5 +1,5 @@
 import ctypes
-from typing import Union, Tuple, Any, Callable
+from typing import Union, Tuple, Callable
 
 from opendp._lib import AnyMeasurement, AnyTransformation
 
@@ -312,7 +312,6 @@ def binary_search_chain(
     >>>     lambda s: pre >> make_base_laplace(scale=s),
     >>>     bounds=(0., 10.), d_in=1, d_out=1.)
     >>> # We can double-check that the resulting computation chain obeys the provided `d_in`, `d_out`.
-    >>> # The chain passes at a parameter within `tolerance` of the ideal parameter.
     >>> assert chain.check(1, 1.)
     >>> chain([5.] * 10)
 

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -337,7 +337,7 @@ def binary_search(
 
     if isinstance(lower, int):
         while upper != lower:
-            mid = (lower + upper) // 2
+            mid = lower + (upper - lower) // 2
 
             if predicate(mid) == minimize:
                 upper = mid
@@ -352,7 +352,7 @@ def binary_search(
     elif isinstance(lower, float):
         assert isinstance(tolerance, float), 'tolerance must be a float'
         while upper - lower > tolerance:
-            mid = (lower + upper) / 2.
+            mid = lower + (upper - lower) / 2.
 
             if predicate(mid) == minimize:
                 upper = mid

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -306,9 +306,9 @@ def binary_search_chain(
     >>>     make_bounded_mean(lower=0., upper=1., n=10)
     >>> )
     >>> # Find a value in `bounds` that produces a (`d_in`, `d_out`)-chain within `tolerance` of the decision boundary.
-    >>> # `make_chain` returns the complete computation chain when given a single numeric parameter.
+    >>> # The lambda function returns the complete computation chain when given a single numeric parameter.
     >>> chain = binary_search_chain(
-    >>>     make_chain=lambda s: pre >> make_base_laplace(scale=s),
+    >>>     lambda s: pre >> make_base_laplace(scale=s),
     >>>     bounds=(0., 10.), d_in=1, d_out=1.)
     >>> # We can double-check that the resulting computation chain obeys the provided `d_in`, `d_out`.
     >>> assert chain.check(1, 1.)

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -288,8 +288,10 @@ def binary_search_chain(
     """Optimizes a parameterized chain `make_chain` within float or integer `bounds`,
     subject to the chained relation being (`d_in`, `d_out`)-close.
 
-    If bounds are float, `tolerance` defaults to 1e-8.
-    If bounds are int, `tolerance` must be None.
+    If `bounds` are float, `tolerance` defaults to 1e-8.
+    If `bounds` are int, `tolerance` must be None.
+
+    See `binary_search_param` to retrieve the discovered parameter instead of the complete computation chain.
 
     :example:
 
@@ -303,9 +305,9 @@ def binary_search_chain(
     >>>     make_resize_bounded(constant=0., length=10, lower=0., upper=1.) >>
     >>>     make_bounded_mean(lower=0., upper=1., n=10)
     >>> )
-    >>> # Find a value in `bounds` that produces a (`d_in`, `d_out`)-chain within `tolerance` of the acceptance boundary
+    >>> # Find a value in `bounds` that produces a (`d_in`, `d_out`)-chain within `tolerance` of the decision boundary
     >>> # `make_chain` returns the complete computation chain when given a single numeric parameter.
-    >>> # `binary_search_chain` returns the parameterized computation chain.
+    >>> # The function `binary_search_chain` returns the parameterized computation chain.
     >>> chain = binary_search_chain(
     >>>     lambda s: pre >> make_base_laplace(scale=s),
     >>>     bounds=(0., 10.), d_in=1, d_out=1.)
@@ -332,8 +334,8 @@ def binary_search_param(
     """Optimizes a parameterized chain `make_chain` within float or integer `bounds`,
     subject to the chained relation being (`d_in`, `d_out`)-close.
 
-    If bounds are float, `tolerance` defaults to 1e-8.
-    If bounds are int, `tolerance` must be None.
+    If `bounds` are float, `tolerance` defaults to 1e-8.
+    If `bounds` are int, `tolerance` must be None.
 
     :example:
 
@@ -348,9 +350,9 @@ def binary_search_param(
     >>>     make_bounded_mean(lower=0., upper=1., n=10)
     >>> )
     >>>
-    >>> # Find a value in `bounds` that produces a (`d_in`, `d_out`)-chain within `tolerance` of the acceptance boundary
+    >>> # Find a value in `bounds` that produces a (`d_in`, `d_out`)-chain within `tolerance` of the decision boundary
     >>> # `make_chain` returns the complete computation chain when given a single numeric parameter
-    >>> # `binary_search_param` returns the discovered parameter.
+    >>> # The function `binary_search_param` returns the discovered parameter.
     >>> scale = binary_search_param(
     >>>     make_chain=lambda s: pre >> make_base_laplace(scale=s),
     >>>     bounds=(0., 10.), d_in=1, d_out=1.)
@@ -371,10 +373,10 @@ def binary_search(
         predicate: Callable[[Union[float, int]], bool],
         bounds: Union[Tuple[float, float], Tuple[int, int]],
         tolerance=None):
-    """Find the closest value to `predicate` acceptance boundary within float or integer `bounds`.
+    """Find the closest passing value to `predicate`'s decision boundary within float or integer `bounds`.
 
-    If bounds are float, `tolerance` defaults to 1e-8.
-    If bounds are int, `tolerance` must be None.
+    If `bounds` are float, `tolerance` defaults to 1e-8.
+    If `bounds` are int, `tolerance` must be None.
 
     :example:
 
@@ -397,8 +399,7 @@ def binary_search(
 
     maximize = predicate(lower)  # if the lower bound passes, we should maximize
     minimize = predicate(upper)  # if the upper bound passes, we should minimize
-
-    assert maximize != minimize, "the decision point of the predicate is outside the bounds"
+    assert maximize != minimize, "the decision boundary of the predicate is outside the bounds"
 
     if isinstance(lower, int):
         assert tolerance is None, "integer binary search does not accept a tolerance"
@@ -420,5 +421,5 @@ def binary_search(
         else:
             lower = mid
 
-    # make sure the search terminates on a successful predicate
+    # ensure the search terminates on a successful predicate
     return post()

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -289,7 +289,6 @@ def binary_search_chain(
     subject to the chained relation being (`d_in`, `d_out`)-close.
 
     If `bounds` are float, `tolerance` defaults to 1e-8.
-    If `bounds` are int, `tolerance` must be None.
 
     See `binary_search_param` to retrieve the discovered parameter instead of the complete computation chain.
 
@@ -318,7 +317,7 @@ def binary_search_chain(
     :param bounds: a 2-tuple of the lower and upper bounds to the input of `make_chain`
     :param d_in: desired input distance of the computation chain
     :param d_out: desired output distance of the computation chain
-    :param tolerance: if float bounds, the discovered parameter differs by at most `tolerance` from the ideal parameter
+    :param tolerance: the discovered parameter differs by at most `tolerance` from the ideal parameter
     :return: a chain parameterized at the nearest passing value to the decision point of the relation
     :raises AssertionError: if the arguments are ill-formed (type issues, decision boundary not within `bounds`)
     """
@@ -333,7 +332,6 @@ def binary_search_param(
     subject to the chained relation being (`d_in`, `d_out`)-close.
 
     If `bounds` are float, `tolerance` defaults to 1e-8.
-    If `bounds` are int, `tolerance` must be None.
 
     :example:
 
@@ -353,7 +351,7 @@ def binary_search_param(
     :param bounds: a 2-tuple of the lower and upper bounds to the input of `make_chain`
     :param d_in: desired input distance of the computation chain
     :param d_out: desired output distance of the computation chain
-    :param tolerance: if float bounds, the discovered parameter differs by at most `tolerance` from the ideal parameter
+    :param tolerance: the discovered parameter differs by at most `tolerance` from the ideal parameter
     :return: the nearest passing value to the decision point of the relation
     :raises AssertionError: if the arguments are ill-formed (type issues, decision boundary not within `bounds`)
     """
@@ -367,7 +365,6 @@ def binary_search(
     """Find the closest passing value to the decision boundary of `predicate` within float or integer `bounds`.
 
     If `bounds` are float, `tolerance` defaults to 1e-8.
-    If `bounds` are int, `tolerance` must be None.
 
     :example:
 
@@ -381,7 +378,7 @@ def binary_search(
 
     :param predicate: a monotonic unary function from a number to a boolean
     :param bounds: a 2-tuple of the lower and upper bounds to the input of `predicate`
-    :param tolerance: if float bounds, the discovered parameter differs by at most `tolerance` from the ideal parameter
+    :param tolerance: the discovered parameter differs by at most `tolerance` from the ideal parameter
     :return: the discovered parameter within the bounds
     :raises AssertionError: if the arguments are ill-formed (type issues, decision boundary not within `bounds`)
     """
@@ -395,15 +392,13 @@ def binary_search(
     if isinstance(lower, float):
         tolerance = 1e-8 if tolerance is None else tolerance
         half = lambda x: x / 2.
-        done = lambda: upper - lower <= tolerance
     elif isinstance(lower, int):
-        assert tolerance is None, "integer binary search does not accept a tolerance"
+        tolerance = tolerance or 1  # the lower and upper bounds never meet due to int truncation
         half = lambda x: x // 2
-        done = lambda: lower + 1 == upper  # the lower and upper bounds never meet due to int truncation
     else:
         raise AssertionError("bounds must be either float or int")
 
-    while not done():
+    while upper - lower > tolerance:
         mid = lower + half(upper - lower)  # avoid overflow
         if predicate(mid) == minimize:
             upper = mid

--- a/python/test/test_core.py
+++ b/python/test/test_core.py
@@ -1,4 +1,7 @@
+import pytest
+
 from opendp.mod import enable_features
+enable_features('floating-point')
 
 
 def test_type_getters():
@@ -36,12 +39,48 @@ def test_chain():
     print("evaluate chain:", chain(data))
 
 
-def test_binary_search():
+def test_bisect():
     from opendp.mod import binary_search
 
     for i in range(100):
         assert binary_search(lambda x: x < i + 1, (0, 100)) == i
         assert binary_search(lambda x: x > i, (0, 100)) == i + 1
 
-        assert -(binary_search(lambda x: x < i, (0, 100)) - i) < 1e-8
-        assert binary_search(lambda x: x > i, (0, 100)) - i < 1e-8
+        assert -(binary_search(lambda x: x < i + 1, (0., 100.)) - (i + 1)) < 1e-8
+        assert binary_search(lambda x: x > i, (0., 100.)) - i < 1e-8
+
+
+def test_bisect_edge():
+    from opendp.mod import binary_search
+    with pytest.raises(ValueError):
+        binary_search(lambda x: x > 5., (0., 5.))
+
+
+def test_bisect_chain():
+    from opendp.mod import binary_search, binary_search_chain, binary_search_param
+    from opendp.trans import make_clamp, make_resize_bounded, make_bounded_mean
+    from opendp.meas import make_base_laplace
+    pre = (
+        # make_clamp(lower=0., upper=1.) >>
+        make_resize_bounded(constant=0., length=10, lower=0., upper=1.) >>
+        make_bounded_mean(lower=0., upper=1., n=10)
+    )
+    # chain = bisect_chain(
+    #     lambda s: pre >> make_base_laplace(scale=s),
+    #     bounds=(0., 10.), d_in=1, d_out=1.)
+    # assert chain.check(1, 1.)
+
+    # scale = bisect_param(
+    #     lambda s: pre >> make_base_laplace(scale=s),
+    #     bounds=(0., 10.), d_in=1, d_out=1.)
+
+    print(binary_search(lambda s: (pre >> make_base_laplace(scale=s)).check(1, 1.), (0., 10.)))
+    print((pre >> make_base_laplace(scale=1.25)).check(1, 1.))
+    print((pre >> make_base_laplace(scale=0.1)).check(1, 1.))
+
+    # print((pre >> make_base_laplace(scale=0.1)).check(2, 1.))
+    # print(scale)
+
+
+# test_bisect_chain()
+test_bisect()

--- a/python/test/test_core.py
+++ b/python/test/test_core.py
@@ -65,22 +65,29 @@ def test_bisect_chain():
         make_resize_bounded(constant=0., length=10, lower=0., upper=1.) >>
         make_bounded_mean(lower=0., upper=1., n=10)
     )
-    # chain = bisect_chain(
-    #     lambda s: pre >> make_base_laplace(scale=s),
-    #     bounds=(0., 10.), d_in=1, d_out=1.)
-    # assert chain.check(1, 1.)
+    chain = binary_search_chain(
+        lambda s: pre >> make_base_laplace(scale=s),
+        bounds=(0., 10.), d_in=1, d_out=1.)
+    assert chain.check(1, 1.)
 
-    # scale = bisect_param(
-    #     lambda s: pre >> make_base_laplace(scale=s),
-    #     bounds=(0., 10.), d_in=1, d_out=1.)
+    scale = binary_search_param(
+        lambda s: pre >> make_base_laplace(scale=s),
+        bounds=(0., 10.), d_in=1, d_out=1.)
+    print(scale)
 
     print(binary_search(lambda s: (pre >> make_base_laplace(scale=s)).check(1, 1.), (0., 10.)))
     print((pre >> make_base_laplace(scale=1.25)).check(1, 1.))
     print((pre >> make_base_laplace(scale=0.1)).check(1, 1.))
+    # OH NO!
+    print((pre >> make_base_laplace(scale=0.11)).check(1, 1.))
 
-    # print((pre >> make_base_laplace(scale=0.1)).check(2, 1.))
-    # print(scale)
+
+def test_check():
+    from opendp.meas import make_base_laplace
+    print((make_base_laplace(scale=0.1)).check(0.1, 1.))
+    print((make_base_laplace(scale=0.61)).check(0.1, 1.))
 
 
-# test_bisect_chain()
-test_bisect()
+test_bisect_chain()
+# test_bisect()
+# test_check()

--- a/python/test/test_core.py
+++ b/python/test/test_core.py
@@ -34,3 +34,14 @@ def test_chain():
     print("chained measurement check:", chain.check(d_in=1, d_out=1000., debug=True))
 
     print("evaluate chain:", chain(data))
+
+
+def test_binary_search():
+    from opendp.mod import binary_search
+
+    for i in range(100):
+        assert binary_search(lambda x: x < i + 1, (0, 100)) == i
+        assert binary_search(lambda x: x > i, (0, 100)) == i + 1
+
+        assert -(binary_search(lambda x: x < i, (0, 100)) - i) < 1e-8
+        assert binary_search(lambda x: x > i, (0, 100)) - i < 1e-8

--- a/python/test/test_core.py
+++ b/python/test/test_core.py
@@ -74,12 +74,8 @@ def test_bisect_chain():
         make_resize_bounded(constant=0., length=10, lower=0., upper=1.) >>
         make_bounded_mean(lower=0., upper=1., n=10)
     )
-    chain = binary_search_chain(
-        lambda s: pre >> make_base_laplace(scale=s),
-        bounds=(0., 10.), d_in=1, d_out=1.)
+    chain = binary_search_chain(lambda s: pre >> make_base_laplace(scale=s), d_in=1, d_out=1.)
     assert chain.check(1, 1.)
 
-    scale = binary_search_param(
-        lambda s: pre >> make_base_laplace(scale=s),
-        bounds=(0., 10.), d_in=1, d_out=1.)
+    scale = binary_search_param(lambda s: pre >> make_base_laplace(scale=s), d_in=1, d_out=1.)
     assert scale - 0.1 < 1e-8

--- a/python/test/test_core.py
+++ b/python/test/test_core.py
@@ -59,9 +59,14 @@ def test_bisect_edge():
     with pytest.raises(AssertionError):
         binary_search(lambda x: x < 1, (0, 0))
 
+    assert binary_search(lambda x: x > 5, bounds=(0, 10)) == 6
+    assert binary_search(lambda x: x < 5, bounds=(0, 10)) == 4
+    assert binary_search(lambda x: x > 5., bounds=(0., 10.)) - 5. < 1e-8
+    assert binary_search(lambda x: x > 5., bounds=(0., 10.)) - 5. > -1e-8
+
 
 def test_bisect_chain():
-    from opendp.mod import binary_search, binary_search_chain, binary_search_param
+    from opendp.mod import binary_search_chain, binary_search_param
     from opendp.trans import make_clamp, make_resize_bounded, make_bounded_mean
     from opendp.meas import make_base_laplace
     pre = (

--- a/python/test/test_core.py
+++ b/python/test/test_core.py
@@ -52,8 +52,12 @@ def test_bisect():
 
 def test_bisect_edge():
     from opendp.mod import binary_search
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         binary_search(lambda x: x > 5., (0., 5.))
+    assert binary_search(lambda x: x > 0, (0, 1)) == 1
+    assert binary_search(lambda x: x < 1, (0, 1)) == 0
+    with pytest.raises(AssertionError):
+        binary_search(lambda x: x < 1, (0, 0))
 
 
 def test_bisect_chain():
@@ -61,7 +65,7 @@ def test_bisect_chain():
     from opendp.trans import make_clamp, make_resize_bounded, make_bounded_mean
     from opendp.meas import make_base_laplace
     pre = (
-        # make_clamp(lower=0., upper=1.) >>
+        make_clamp(lower=0., upper=1.) >>
         make_resize_bounded(constant=0., length=10, lower=0., upper=1.) >>
         make_bounded_mean(lower=0., upper=1., n=10)
     )
@@ -73,21 +77,4 @@ def test_bisect_chain():
     scale = binary_search_param(
         lambda s: pre >> make_base_laplace(scale=s),
         bounds=(0., 10.), d_in=1, d_out=1.)
-    print(scale)
-
-    print(binary_search(lambda s: (pre >> make_base_laplace(scale=s)).check(1, 1.), (0., 10.)))
-    print((pre >> make_base_laplace(scale=1.25)).check(1, 1.))
-    print((pre >> make_base_laplace(scale=0.1)).check(1, 1.))
-    # OH NO!
-    print((pre >> make_base_laplace(scale=0.11)).check(1, 1.))
-
-
-def test_check():
-    from opendp.meas import make_base_laplace
-    print((make_base_laplace(scale=0.1)).check(0.1, 1.))
-    print((make_base_laplace(scale=0.61)).check(0.1, 1.))
-
-
-test_bisect_chain()
-# test_bisect()
-# test_check()
+    assert scale - 0.1 < 1e-8

--- a/rust/opendp-ffi/src/dispatch.rs
+++ b/rust/opendp-ffi/src/dispatch.rs
@@ -127,7 +127,7 @@ macro_rules! disp_expand {
     ($function:ident, ($rt_type:expr, [$($dispatch_type:ty),+]), $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
         match $rt_type.id {
             $(x if x == std::any::TypeId::of::<$dispatch_type>() => disp_1!($function, $rt_dispatch_types, $type_args, $dispatch_type, $args)),+,
-            _ => opendp::err!(FFI, "No match for concrete type {} ({:?})", $rt_type.descriptor, $rt_type.id).into()
+            _ => opendp::err!(FFI, "No match for concrete type {} ({:?}). You've got a debug binary! You may want to run `cargo build --release` and set `OPENDP_TEST_RELEASE=1` before importing opendp.", $rt_type.descriptor, $rt_type.id).into()
         }
     };
 }

--- a/rust/opendp/src/trans/resize/mod.rs
+++ b/rust/opendp/src/trans/resize/mod.rs
@@ -24,7 +24,11 @@ pub fn make_resize_constant<DA>(
         }),
         SymmetricDistance::default(),
         SymmetricDistance::default(),
-        StabilityRelation::new(move |d_in: &IntDistance, d_out: &IntDistance| *d_out >= d_in + d_in % 2)
+        StabilityRelation::new_all(
+            move |d_in: &IntDistance, d_out: &IntDistance| Ok(*d_out >= d_in + d_in % 2),
+            Some(|d_in: &IntDistance| Ok(Box::new(d_in + d_in % 2))),
+            Some(|d_out: &IntDistance| Ok(Box::new(*d_out)))
+        )
     ))
 }
 


### PR DESCRIPTION
Closes #237 
Adds a general binary search algorithm to python to solve for free parameters in computation chains.
Adds distance maps to the resize transformation. The library was finding a very strange loosening.
Allows _free to fail when the interpreter is shutting down at the end of the program. 