### PR TITLE
capture Debug trait in AnyBoxBase (4) 

### DIFF
--- a/rust/opendp-ffi/src/any.rs
+++ b/rust/opendp-ffi/src/any.rs
@@ -8,6 +8,7 @@
 use std::any;
 use std::any::Any;
 use std::cmp::Ordering;
+use std::fmt::{Debug, Formatter};
 use std::rc::Rc;
 
 use opendp::core::{Domain, Function, Measure, Measurement, Metric, PrivacyRelation, StabilityRelation, Transformation};
@@ -25,34 +26,45 @@ pub trait Downcast {
 }
 
 /// A struct wrapping a Box<dyn Any>, optionally implementing Clone and/or PartialEq.
-pub struct AnyBoxBase<const CLONE: bool, const PARTIALEQ: bool> {
+pub struct AnyBoxBase<const CLONE: bool, const PARTIALEQ: bool, const DEBUG: bool> {
     pub value: Box<dyn Any>,
     clone_glue: Option<Glue<fn(&Self) -> Self>>,
     eq_glue: Option<Glue<fn(&Self, &Self) -> bool>>,
+    debug_glue: Option<Glue<fn(&Self) -> String>>
 }
 
-impl<const CLONE: bool, const PARTIALEQ: bool> AnyBoxBase<CLONE, PARTIALEQ> {
-    fn new_base<T: 'static>(value: T, clone_glue: Option<Glue<fn(&Self) -> Self>>, eq_glue: Option<Glue<fn(&Self, &Self) -> bool>>) -> Self {
-        Self { value: Box::new(value), clone_glue, eq_glue }
+impl<const CLONE: bool, const PARTIALEQ: bool, const DEBUG: bool> AnyBoxBase<CLONE, PARTIALEQ, DEBUG> {
+    fn new_base<T: 'static>(
+        value: T,
+        clone_glue: Option<Glue<fn(&Self) -> Self>>,
+        eq_glue: Option<Glue<fn(&Self, &Self) -> bool>>,
+        debug_glue: Option<Glue<fn(&Self) -> String>>
+    ) -> Self {
+        Self { value: Box::new(value), clone_glue, eq_glue, debug_glue }
     }
-    fn make_clone_glue<T: 'static + Clone>() -> Option<Glue<fn(&Self) -> Self>> {
-        Some(Glue::new(|self_: &Self| {
+    fn make_clone_glue<T: 'static + Clone>() -> Glue<fn(&Self) -> Self> {
+        Glue::new(|self_: &Self| {
             Self::new_base(
                 self_.value.downcast_ref::<T>().unwrap_assert("Failed downcast of AnyBox value").clone(),
                 self_.clone_glue.clone(),
                 self_.eq_glue.clone(),
+                self_.debug_glue.clone()
             )
-        }))
+        })
     }
-    fn make_eq_glue<T: 'static + PartialEq>() -> Option<Glue<fn(&Self, &Self) -> bool>> {
-        Some(Glue::new(|self_: &Self, other: &Self| {
+    fn make_eq_glue<T: 'static + PartialEq>() -> Glue<fn(&Self, &Self) -> bool> {
+        Glue::new(|self_: &Self, other: &Self| {
             // The first downcast will always succeed, so equality check is all that's necessary.
             self_.value.downcast_ref::<T>() == other.value.downcast_ref::<T>()
-        }))
+        })
+    }
+    fn make_debug_glue<T: 'static + Debug>() -> Glue<fn(&Self) -> String> {
+        Glue::new(|self_: &Self| format!("{:?}", self_.value.downcast_ref::<T>()
+            .unwrap_assert("Failed downcast of AnyBox value")))
     }
 }
 
-impl<const CLONE: bool, const PARTIALEQ: bool> Downcast for AnyBoxBase<CLONE, PARTIALEQ> {
+impl<const CLONE: bool, const PARTIALEQ: bool, const DEBUG: bool> Downcast for AnyBoxBase<CLONE, PARTIALEQ, DEBUG> {
     fn downcast<T: 'static>(self) -> Fallible<T> {
         self.value.downcast().map_err(|_| err!(FailedCast, "Failed downcast of AnyBox to {}", any::type_name::<T>())).map(|x| *x)
     }
@@ -61,51 +73,53 @@ impl<const CLONE: bool, const PARTIALEQ: bool> Downcast for AnyBoxBase<CLONE, PA
     }
 }
 
-impl<const PARTIALEQ: bool> Clone for AnyBoxBase<true, PARTIALEQ> {
+impl<const PARTIALEQ: bool, const DEBUG: bool> Clone for AnyBoxBase<true, PARTIALEQ, DEBUG> {
     fn clone(&self) -> Self {
-        (self.clone_glue.as_ref().unwrap_assert("No clone_glue for AnyBox"))(&self)
+        (self.clone_glue.as_ref().unwrap_assert("clone_glue always exists for CLONE=true AnyBoxBase"))(&self)
     }
 }
 
-impl<const CLONE: bool> PartialEq for AnyBoxBase<CLONE, true> {
+impl<const CLONE: bool, const DEBUG: bool> PartialEq for AnyBoxBase<CLONE, true, DEBUG> {
     fn eq(&self, other: &Self) -> bool {
-        (self.eq_glue.as_ref().unwrap_assert("No eq_glue for AnyBox"))(self, other)
+        (self.eq_glue.as_ref().unwrap_assert("eq_glue always exists for PARTIALEQ=true AnyBoxBase"))(self, other)
+    }
+}
+impl<const CLONE: bool, const PARTIALEQ: bool> Debug for AnyBoxBase<CLONE, PARTIALEQ, true> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "{}", (self.debug_glue.as_ref().unwrap_assert("debug_glue always exists for DEBUG=true AnyBoxBase"))(self))
     }
 }
 
 /// An AnyBox not implementing optional traits.
-pub type AnyBox = AnyBoxBase<false, false>;
+pub type AnyBox = AnyBoxBase<false, false, false>;
 
 impl AnyBox {
     pub fn new<T: 'static>(value: T) -> Self {
-        Self::new_base(value, None, None)
-    }
-}
-
-/// An AnyBox implementing Clone.
-pub type AnyBoxClone = AnyBoxBase<true, false>;
-
-impl AnyBoxClone {
-    pub fn new_clone<T: 'static + Clone>(value: T) -> Self {
-        Self::new_base(value, Self::make_clone_glue::<T>(), None)
-    }
-}
-
-/// An AnyBox implementing PartialEq.
-pub type AnyBoxPartialEq = AnyBoxBase<false, true>;
-
-impl AnyBoxPartialEq {
-    pub fn new_partial_eq<T: 'static + PartialEq>(value: T) -> Self {
-        Self::new_base(value, None, Self::make_eq_glue::<T>())
+        Self::new_base(value, None, None, None)
     }
 }
 
 /// An AnyBox implementing Clone + PartialEq.
-pub type AnyBoxClonePartialEq = AnyBoxBase<true, true>;
+pub type AnyBoxClonePartialEq = AnyBoxBase<true, true, false>;
 
 impl AnyBoxClonePartialEq {
     pub fn new_clone_partial_eq<T: 'static + Clone + PartialEq>(value: T) -> Self {
-        Self::new_base(value, Self::make_clone_glue::<T>(), Self::make_eq_glue::<T>())
+        Self::new_base(
+            value,
+            Some(Self::make_clone_glue::<T>()),
+            Some(Self::make_eq_glue::<T>()),
+            None)
+    }
+}
+pub type AnyBoxClonePartialEqDebug = AnyBoxBase<true, true, true>;
+
+impl AnyBoxClonePartialEqDebug {
+    pub fn new_clone_partial_eq_debug<T: 'static + Clone + PartialEq + Debug>(value: T) -> Self {
+        Self::new_base(
+            value,
+            Some(Self::make_clone_glue::<T>()),
+            Some(Self::make_eq_glue::<T>()),
+            Some(Self::make_debug_glue::<T>()))
     }
 }
 
@@ -138,7 +152,7 @@ impl Downcast for AnyObject {
 #[derive(Clone, PartialEq)]
 pub struct AnyDomain {
     pub carrier_type: Type,
-    domain: AnyBoxClonePartialEq,
+    domain: AnyBoxClonePartialEqDebug,
     member_glue: Glue<fn(&Self, &<Self as Domain>::Carrier) -> Fallible<bool>>,
 }
 
@@ -146,7 +160,7 @@ impl AnyDomain {
     pub fn new<D: 'static + Domain>(domain: D) -> Self {
         Self {
             carrier_type: Type::of::<D::Carrier>(),
-            domain: AnyBoxClonePartialEq::new_clone_partial_eq(domain),
+            domain: AnyBoxClonePartialEqDebug::new_clone_partial_eq_debug(domain),
             member_glue: Glue::new(|self_: &Self, val: &<Self as Domain>::Carrier| {
                 let self_ = self_.downcast_ref::<D>()
                     .unwrap_assert("downcast of AnyDomain to constructed type will always work");
@@ -169,6 +183,12 @@ impl Domain for AnyDomain {
     type Carrier = AnyObject;
     fn member(&self, val: &Self::Carrier) -> Fallible<bool> {
         (self.member_glue)(self, val)
+    }
+}
+
+impl Debug for AnyDomain {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        self.domain.fmt(f)
     }
 }
 
@@ -261,14 +281,14 @@ impl PartialOrd for AnyMetricDistance {
 
 #[derive(Clone, PartialEq)]
 pub struct AnyMeasure {
-    pub measure: AnyBoxClonePartialEq,
+    pub measure: AnyBoxClonePartialEqDebug,
     pub distance_type: Type
 }
 
 impl AnyMeasure {
     pub fn new<M: 'static + Measure>(measure: M) -> Self {
         Self {
-            measure: AnyBoxClonePartialEq::new_clone_partial_eq(measure),
+            measure: AnyBoxClonePartialEqDebug::new_clone_partial_eq_debug(measure),
             distance_type: Type::of::<M::Distance>()
         }
     }
@@ -290,17 +310,22 @@ impl Default for AnyMeasure {
 impl Measure for AnyMeasure {
     type Distance = AnyMeasureDistance;
 }
+impl Debug for AnyMeasure {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        self.measure.fmt(f)
+    }
+}
 
 #[derive(Clone, PartialEq)]
 pub struct AnyMetric {
-    pub metric: AnyBoxClonePartialEq,
+    pub metric: AnyBoxClonePartialEqDebug,
     pub distance_type: Type
 }
 
 impl AnyMetric {
     pub fn new<M: 'static + Metric>(metric: M) -> Self {
         Self {
-            metric: AnyBoxClonePartialEq::new_clone_partial_eq(metric),
+            metric: AnyBoxClonePartialEqDebug::new_clone_partial_eq_debug(metric),
             distance_type: Type::of::<M::Distance>()
         }
     }
@@ -321,6 +346,12 @@ impl Default for AnyMetric {
 
 impl Metric for AnyMetric {
     type Distance = AnyMetricDistance;
+}
+
+impl Debug for AnyMetric {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        self.metric.fmt(f)
+    }
 }
 
 type AnyFunction = Function<AnyDomain, AnyDomain>;
@@ -494,7 +525,7 @@ impl<DI: 'static + Domain, DO: 'static + Domain, MI: 'static + Metric, MO: 'stat
 
 #[cfg(test)]
 mod tests {
-    use opendp::dist::{SubstituteDistance, MaxDivergence, SmoothedMaxDivergence, SymmetricDistance};
+    use opendp::dist::{MaxDivergence, SmoothedMaxDivergence, SubstituteDistance, SymmetricDistance};
     use opendp::dom::{AllDomain, BoundedDomain};
     use opendp::error::*;
     use opendp::meas;
@@ -506,14 +537,13 @@ mod tests {
     fn test_any_domain() -> Fallible<()> {
         let domain1 = BoundedDomain::new_closed((0, 1))?;
         let domain2 = BoundedDomain::new_closed((0, 1))?;
-        // TODO: Add Debug to Domain so we can use assert_eq!.
-        assert!(domain1 == domain2);
+        assert_eq!(domain1, domain2);
 
         let domain1 = AnyDomain::new(BoundedDomain::new_closed((0, 1))?);
         let domain2 = AnyDomain::new(BoundedDomain::new_closed((0, 1))?);
         let domain3 = AnyDomain::new(AllDomain::<i32>::new());
-        assert!(domain1 == domain2);
-        assert!(domain1 != domain3);
+        assert_eq!(domain1, domain2);
+        assert_ne!(domain1, domain3);
 
         let _domain1: BoundedDomain<i32> = domain1.downcast()?;
         let domain3: Fallible<BoundedDomain<i32>> = domain3.downcast();
@@ -525,14 +555,13 @@ mod tests {
     fn test_any_metric() -> Fallible<()> {
         let metric1 = SymmetricDistance::default();
         let metric2 = SymmetricDistance::default();
-        // TODO: Add Debug to Metric so we can use assert_eq!.
-        assert!(metric1 == metric2);
+        assert_eq!(metric1, metric2);
 
         let metric1 = AnyMetric::new(SymmetricDistance::default());
         let metric2 = AnyMetric::new(SymmetricDistance::default());
         let metric3 = AnyMetric::new(SubstituteDistance::default());
-        assert!(metric1 == metric2);
-        assert!(metric1 != metric3);
+        assert_eq!(metric1, metric2);
+        assert_ne!(metric1, metric3);
 
         let _metric1: SymmetricDistance = metric1.downcast()?;
         let metric3: Fallible<SymmetricDistance> = metric3.downcast();
@@ -544,14 +573,13 @@ mod tests {
     fn test_any_measure() -> Fallible<()> {
         let measure1 = MaxDivergence::<f64>::default();
         let measure2 = MaxDivergence::<f64>::default();
-        // TODO: Add Debug to Measure so we can use assert_eq!.
-        assert!(measure1 == measure2);
+        assert_eq!(measure1, measure2);
 
         let measure1 = AnyMeasure::new(MaxDivergence::<f64>::default());
         let measure2 = AnyMeasure::new(MaxDivergence::<f64>::default());
         let measure3 = AnyMeasure::new(SmoothedMaxDivergence::<f64>::default());
-        assert!(measure1 == measure2);
-        assert!(measure1 != measure3);
+        assert_eq!(measure1, measure2);
+        assert_ne!(measure1, measure3);
 
         let _measure1: MaxDivergence<f64> = measure1.downcast()?;
         let measure3: Fallible<MaxDivergence<f64>> = measure3.downcast();

--- a/rust/opendp/src/comb/chain/mod.rs
+++ b/rust/opendp/src/comb/chain/mod.rs
@@ -9,7 +9,7 @@ fn mismatch_message<T1: Debug, T2: Debug>(mode: &str, struct1: &T1, struct2: &T2
     let str1 = format!("{:?}", struct1);
     let str2 = format!("{:?}", struct2);
     let explanation = if str1 == str2 {
-        format!("\n    The structure of the intermediate {mode}s are the same, but the types or parameters differ.\n    shared_{mode}: {str1}", mode=mode, str1=str1)
+        format!("\n    The structure of the intermediate {mode}s are the same, but the types or parameters differ.\n    shared_{mode}: {str1}\n", mode=mode, str1=str1)
     } else {
         format!("\n    output_{mode}: {struct1}\n    input_{mode}:  {struct2}\n", mode=mode, struct1=str1, struct2=str2)
     };

--- a/rust/opendp/src/core.rs
+++ b/rust/opendp/src/core.rs
@@ -26,10 +26,12 @@ use crate::dom::PairDomain;
 use crate::error::*;
 use crate::traits::{DistanceConstant, InfCast};
 use crate::dist::IntDistance;
+use std::fmt::Debug;
+
 /// A set which constrains the input or output of a [`Function`].
 ///
 /// Domains capture the notion of what values are allowed to be the input or output of a `Function`.
-pub trait Domain: Clone + PartialEq {
+pub trait Domain: Clone + PartialEq + Debug {
     /// The underlying type that the Domain specializes.
     type Carrier;
     /// Predicate to test an element for membership in the domain.
@@ -73,12 +75,12 @@ impl<DI: 'static + Domain, DO0: 'static + Domain, DO1: 'static + Domain> Functio
 }
 
 /// A representation of the distance between two elements in a set.
-pub trait Metric: Default + Clone + PartialEq {
+pub trait Metric: Default + Clone + PartialEq + Debug {
     type Distance;
 }
 
 /// A representation of the distance between two distributions.
-pub trait Measure: Default + Clone + PartialEq {
+pub trait Measure: Default + Clone + PartialEq + Debug {
     type Distance;
 }
 

--- a/rust/opendp/src/dist.rs
+++ b/rust/opendp/src/dist.rs
@@ -3,6 +3,7 @@
 use std::marker::PhantomData;
 
 use crate::core::{DatasetMetric, Measure, Metric, SensitivityMetric};
+use std::fmt::{Debug, Formatter};
 
 // default type for distances between datasets
 pub type IntDistance = u32;
@@ -16,6 +17,12 @@ impl<Q> Default for MaxDivergence<Q> {
 
 impl<Q> PartialEq for MaxDivergence<Q> {
     fn eq(&self, _other: &Self) -> bool { true }
+}
+
+impl<Q> Debug for MaxDivergence<Q> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "MaxDivergence()")
+    }
 }
 
 impl<Q: Clone> Measure for MaxDivergence<Q> {
@@ -32,7 +39,11 @@ impl<Q> Default for SmoothedMaxDivergence<Q> {
 impl<Q> PartialEq for SmoothedMaxDivergence<Q> {
     fn eq(&self, _other: &Self) -> bool { true }
 }
-
+impl<Q> Debug for SmoothedMaxDivergence<Q> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "SmoothedMaxDivergence()")
+    }
+}
 impl<Q: Clone> Measure for SmoothedMaxDivergence<Q> {
     type Distance = (Q, Q);
 }
@@ -47,6 +58,11 @@ impl Default for SymmetricDistance {
 
 impl PartialEq for SymmetricDistance {
     fn eq(&self, _other: &Self) -> bool { true }
+}
+impl Debug for SymmetricDistance {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "SymmetricDistance()")
+    }
 }
 impl Metric for SymmetricDistance {
     type Distance = IntDistance;
@@ -64,7 +80,11 @@ impl Default for SubstituteDistance {
 impl PartialEq for SubstituteDistance {
     fn eq(&self, _other: &Self) -> bool { true }
 }
-
+impl Debug for SubstituteDistance {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "SubstituteDistance()")
+    }
+}
 impl Metric for SubstituteDistance {
     type Distance = IntDistance;
 }
@@ -82,6 +102,11 @@ impl<Q, const P: usize> Clone for LpDistance<Q, P> {
 }
 impl<Q, const P: usize> PartialEq for LpDistance<Q, P> {
     fn eq(&self, _other: &Self) -> bool { true }
+}
+impl<Q, const P: usize> Debug for LpDistance<Q, P> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "L{}Distance()", P)
+    }
 }
 impl<Q, const P: usize> Metric for LpDistance<Q, P> {
     type Distance = Q;
@@ -102,6 +127,11 @@ impl<Q> Clone for AbsoluteDistance<Q> {
 }
 impl<Q> PartialEq for AbsoluteDistance<Q> {
     fn eq(&self, _other: &Self) -> bool { true }
+}
+impl<Q> Debug for AbsoluteDistance<Q> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "AbsoluteDistance()")
+    }
 }
 impl<Q> Metric for AbsoluteDistance<Q> {
     type Distance = Q;

--- a/rust/opendp/src/dom.rs
+++ b/rust/opendp/src/dom.rs
@@ -13,10 +13,16 @@ use std::ops::Bound;
 use crate::core::Domain;
 use crate::error::Fallible;
 use crate::traits::{CheckNull, TotalOrd};
+use std::fmt::{Debug, Formatter};
 
 /// A Domain that contains all non-null members of the carrier type.
 pub struct AllDomain<T> {
     _marker: PhantomData<T>,
+}
+impl<T> Debug for AllDomain<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "AllDomain()")
+    }
 }
 impl<T> Default for AllDomain<T> {
     fn default() -> Self { Self::new() }
@@ -41,7 +47,7 @@ impl<T: CheckNull> Domain for AllDomain<T> {
 
 
 /// A Domain that carries an underlying Domain in a Box.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct BoxDomain<D: Domain> {
     element_domain: Box<D>
 }
@@ -59,7 +65,7 @@ impl<D: Domain> Domain for BoxDomain<D> {
 
 
 /// A Domain that unwraps a Data wrapper.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct DataDomain<D: Domain> {
     pub form_domain: D,
 }
@@ -115,6 +121,11 @@ impl<T: TotalOrd> BoundedDomain<T> {
         Ok(BoundedDomain { lower, upper })
     }
 }
+impl<T> Debug for BoundedDomain<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "BoundedDomain()")
+    }
+}
 impl<T: Clone + TotalOrd> Domain for BoundedDomain<T> {
     type Carrier = T;
     fn member(&self, val: &Self::Carrier) -> Fallible<bool> {
@@ -132,7 +143,7 @@ impl<T: Clone + TotalOrd> Domain for BoundedDomain<T> {
 
 
 /// A Domain that contains pairs of values.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct PairDomain<D0: Domain, D1: Domain>(pub D0, pub D1);
 impl<D0: Domain, D1: Domain> PairDomain<D0, D1> {
     pub fn new(element_domain0: D0, element_domain1: D1) -> Self {
@@ -148,7 +159,7 @@ impl<D0: Domain, D1: Domain> Domain for PairDomain<D0, D1> {
 
 
 /// A Domain that contains maps of (homogeneous) values.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct MapDomain<DK: Domain, DV: Domain> where DK::Carrier: Eq + Hash {
     pub key_domain: DK,
     pub value_domain: DV
@@ -180,6 +191,11 @@ impl<DK: Domain, DV: Domain> Domain for MapDomain<DK, DV> where DK::Carrier: Eq 
 #[derive(Clone, PartialEq)]
 pub struct VectorDomain<D: Domain> {
     pub element_domain: D,
+}
+impl<D: Domain> Debug for VectorDomain<D> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "VectorDomain({:?})", self.element_domain)
+    }
 }
 impl<D: Domain + Default> Default for VectorDomain<D> {
     fn default() -> Self { Self::new(D::default()) }
@@ -215,6 +231,11 @@ impl<D: Domain> SizedDomain<D> {
         SizedDomain { element_domain: member_domain, size }
     }
 }
+impl<D: Domain> Debug for SizedDomain<D> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "SizedDomain({:?}, size={})", self.element_domain, self.size)
+    }
+}
 impl<D: Domain> Domain for SizedDomain<D> {
     type Carrier = D::Carrier;
     fn member(&self, val: &Self::Carrier) -> Fallible<bool> {
@@ -235,6 +256,11 @@ impl<D: Domain + Default> Default for InherentNullDomain<D>
 impl<D: Domain> InherentNullDomain<D> where D::Carrier: InherentNull {
     pub fn new(member_domain: D) -> Self {
         InherentNullDomain { element_domain: member_domain }
+    }
+}
+impl<D: Domain> Debug for InherentNullDomain<D> where D::Carrier: InherentNull {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "InherentNullDomain({:?})", self.element_domain)
     }
 }
 impl<D: Domain> Domain for InherentNullDomain<D> where D::Carrier: InherentNull {
@@ -268,6 +294,11 @@ impl<D: Domain + Default> Default for OptionNullDomain<D> {
 impl<D: Domain> OptionNullDomain<D> {
     pub fn new(member_domain: D) -> Self {
         OptionNullDomain { element_domain: member_domain }
+    }
+}
+impl<D: Domain> Debug for OptionNullDomain<D> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "OptionNullDomain({:?})", self.element_domain)
     }
 }
 impl<D: Domain> Domain for OptionNullDomain<D> {

--- a/rust/opendp/src/poly.rs
+++ b/rust/opendp/src/poly.rs
@@ -3,6 +3,7 @@ use std::any::Any;
 
 use crate::core::{Domain, Function, Measure, Measurement, Metric, Transformation};
 use crate::error::*;
+use std::fmt::{Formatter, Debug};
 
 /// A polymorphic Domain. This admits any value of any type (represented as a Box<dyn Any>).
 #[derive(PartialEq, Clone)]
@@ -11,7 +12,11 @@ pub struct PolyDomain {}
 impl PolyDomain {
     pub fn new() -> Self { PolyDomain {} }
 }
-
+impl Debug for PolyDomain {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "PolyDomain()")
+    }
+}
 impl Domain for PolyDomain {
     type Carrier = Box<dyn Any>;
     fn member(&self, _val: &Self::Carrier) -> Fallible<bool> { Ok(true) }


### PR DESCRIPTION
Closes #201.
Continuation of #263.
This adds Debug trait bounds to domains, metrics and measures. When you attempt to chain incompatible measurements or operations, you can see how they differ. This doesn't capture type information or parameters contained within the domain. This PR differs from the previous one in that it omits parameters in the errors, which avoids requiring debug on all downstream types (everything is downstream).

Sample errors:

When you fail to clamp.
```
opendp.mod.OpenDPException: DomainMismatch("Intermediate domains don't match.
    output_domain: VectorDomain(AllDomain())
    input_domain:  VectorDomain(BoundedDomain())
")
```

When you fail to resize.
```
opendp.mod.OpenDPException: DomainMismatch("Intermediate domains don't match.
    output_domain: SizedDomain(VectorDomain(BoundedDomain()), size=10)
    input_domain:  VectorDomain(BoundedDomain())
")
```

When the input and output domain strings are equivalent (like a missing cast)
```
opendp.mod.OpenDPException: DomainMismatch("Intermediate domains don't match.
    The structure of the intermediate domains are the same, but the types or parameters differ.
    shared_domain:  VectorDomain(BoundedDomain())
")
```
