### PR TITLE
accuracy utilities

### DIFF
--- a/python/src/opendp/accuracy.py
+++ b/python/src/opendp/accuracy.py
@@ -46,7 +46,7 @@ def accuracy_to_laplacian_scale(
     """Convert a desired accuracy into a laplacian noise scale.
     
     :param accuracy: Desired accuracy.
-    :param alpha: Level-alpha, or (1. - alpha)100% confidence. Must be within (0, 1).
+    :param alpha: Statistical significance, level-alpha, or (1. - alpha)100% confidence. Must be within (0, 1).
     :param T: Data type of accuracy and alpha
     :type T: RuntimeTypeDescriptor
     :return: Laplacian noise scale that meets the accuracy requirement at a level-alpha.
@@ -112,7 +112,7 @@ def accuracy_to_gaussian_scale(
     """Convert a desired accuracy into a gaussian noise scale.
     
     :param accuracy: Desired accuracy.
-    :param alpha: Level-alpha, or (1. - alpha)100% confidence. Must be within (0, 1).
+    :param alpha: Statistical significance, level-alpha, or (1. - alpha)100% confidence. Must be within (0, 1).
     :param T: Data type of accuracy and alpha
     :type T: RuntimeTypeDescriptor
     :return: Gaussian noise scale that meets the accuracy requirement at a level-alpha.

--- a/python/src/opendp/accuracy.py
+++ b/python/src/opendp/accuracy.py
@@ -1,0 +1,137 @@
+# Auto-generated. Do not edit.
+from opendp._convert import *
+from opendp._lib import *
+from opendp.mod import *
+from opendp.typing import *
+
+
+def laplacian_scale_to_accuracy(
+    scale,
+    alpha,
+    T: RuntimeTypeDescriptor = None
+) -> Any:
+    """Convert a laplacian scale into an accuracy estimate.
+    
+    :param scale: Laplacian noise scale.
+    :param alpha: Level-alpha, or (1. - alpha)100% confidence. Must be within (0, 1].
+    :param T: Data type of scale and alpha
+    :type T: RuntimeTypeDescriptor
+    :return: Accuracy estimate at a level-alpha.
+    :rtype: Any
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # Standardize type arguments.
+    T = RuntimeType.parse_or_infer(type_name=T, public_example=scale)
+    
+    # Convert arguments to c types.
+    scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=T)
+    alpha = py_to_c(alpha, c_type=ctypes.c_void_p, type_name=T)
+    T = py_to_c(T, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_accuracy__laplacian_scale_to_accuracy
+    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(scale, alpha, T), AnyObjectPtr))
+
+
+def accuracy_to_laplacian_scale(
+    accuracy,
+    alpha,
+    T: RuntimeTypeDescriptor = None
+) -> Any:
+    """Convert a desired accuracy into a laplacian noise scale.
+    
+    :param accuracy: Desired accuracy.
+    :param alpha: Level-alpha, or (1. - alpha)100% confidence. Must be within (0, 1).
+    :param T: Data type of accuracy and alpha
+    :type T: RuntimeTypeDescriptor
+    :return: Laplacian noise scale that meets the accuracy requirement at a level-alpha.
+    :rtype: Any
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # Standardize type arguments.
+    T = RuntimeType.parse_or_infer(type_name=T, public_example=accuracy)
+    
+    # Convert arguments to c types.
+    accuracy = py_to_c(accuracy, c_type=ctypes.c_void_p, type_name=T)
+    alpha = py_to_c(alpha, c_type=ctypes.c_void_p, type_name=T)
+    T = py_to_c(T, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_accuracy__accuracy_to_laplacian_scale
+    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(accuracy, alpha, T), AnyObjectPtr))
+
+
+def gaussian_scale_to_accuracy(
+    scale,
+    alpha,
+    T: RuntimeTypeDescriptor = None
+) -> Any:
+    """Convert a gaussian scale into an accuracy estimate.
+    
+    :param scale: Gaussian noise scale.
+    :param alpha: Level-alpha, or (1. - alpha)100% confidence. Must be within (0, 1].
+    :param T: Data type of scale and alpha
+    :type T: RuntimeTypeDescriptor
+    :return: Accuracy estimate at a level-alpha.
+    :rtype: Any
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # Standardize type arguments.
+    T = RuntimeType.parse_or_infer(type_name=T, public_example=scale)
+    
+    # Convert arguments to c types.
+    scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=T)
+    alpha = py_to_c(alpha, c_type=ctypes.c_void_p, type_name=T)
+    T = py_to_c(T, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_accuracy__gaussian_scale_to_accuracy
+    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(scale, alpha, T), AnyObjectPtr))
+
+
+def accuracy_to_gaussian_scale(
+    accuracy,
+    alpha,
+    T: RuntimeTypeDescriptor = None
+) -> Any:
+    """Convert a desired accuracy into a gaussian noise scale.
+    
+    :param accuracy: Desired accuracy.
+    :param alpha: Level-alpha, or (1. - alpha)100% confidence. Must be within (0, 1).
+    :param T: Data type of accuracy and alpha
+    :type T: RuntimeTypeDescriptor
+    :return: Gaussian noise scale that meets the accuracy requirement at a level-alpha.
+    :rtype: Any
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # Standardize type arguments.
+    T = RuntimeType.parse_or_infer(type_name=T, public_example=accuracy)
+    
+    # Convert arguments to c types.
+    accuracy = py_to_c(accuracy, c_type=ctypes.c_void_p, type_name=T)
+    alpha = py_to_c(alpha, c_type=ctypes.c_void_p, type_name=T)
+    T = py_to_c(T, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_accuracy__accuracy_to_gaussian_scale
+    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(accuracy, alpha, T), AnyObjectPtr))

--- a/python/test/test_accuracy.py
+++ b/python/test/test_accuracy.py
@@ -1,0 +1,44 @@
+from opendp.accuracy import *
+
+
+def print_statement(dist, scale, accuracy, alpha):
+    perc = round((1 - alpha) * 100)
+    print(f"When the {dist} scale is {scale}, the DP estimate differs from the true value "
+          f"by no more than {accuracy} at a level-alpha of {alpha}, "
+          f"or with (1 - {alpha})100% = {perc}% confidence.")
+
+
+def test_laplacian_scale_to_accuracy():
+    def check_laplacian_scale_to_accuracy(scale, alpha):
+        print_statement("laplacian", scale, laplacian_scale_to_accuracy(scale, alpha), alpha)
+
+    check_laplacian_scale_to_accuracy(scale=1., alpha=0.05)
+    check_laplacian_scale_to_accuracy(scale=2., alpha=0.05)
+    check_laplacian_scale_to_accuracy(scale=0., alpha=0.55)
+
+
+def test_accuracy_to_laplacian_scale():
+    def check_accuracy_to_laplacian_scale(accuracy, alpha):
+        print_statement("laplacian", accuracy_to_laplacian_scale(accuracy, alpha), accuracy, alpha)
+
+    check_accuracy_to_laplacian_scale(accuracy=1., alpha=0.05)
+    check_accuracy_to_laplacian_scale(accuracy=2., alpha=0.05)
+    check_accuracy_to_laplacian_scale(accuracy=0.01, alpha=0.1)
+
+
+def test_gaussian_scale_to_accuracy():
+    def check_gaussian_scale_to_accuracy(scale, alpha):
+        print_statement("gaussian", scale, gaussian_scale_to_accuracy(scale, alpha), alpha)
+
+    check_gaussian_scale_to_accuracy(scale=1., alpha=0.05)
+    check_gaussian_scale_to_accuracy(scale=2., alpha=0.10)
+    check_gaussian_scale_to_accuracy(scale=3., alpha=0.55)
+
+
+def test_accuracy_to_gaussian_scale():
+    def check_accuracy_to_gaussian_scale(accuracy, alpha):
+        print_statement("gaussian", accuracy_to_gaussian_scale(accuracy, alpha), accuracy, alpha)
+
+    check_accuracy_to_gaussian_scale(accuracy=1., alpha=0.05)
+    check_accuracy_to_gaussian_scale(accuracy=2., alpha=0.05)
+    check_accuracy_to_gaussian_scale(accuracy=1.2, alpha=0.1)

--- a/rust/opendp-ffi/build/main.rs
+++ b/rust/opendp-ffi/build/main.rs
@@ -112,7 +112,7 @@ fn main() {
     // only build the bindings if you're in dev mode
     if env::var("CARGO_PKG_VERSION").unwrap().as_str() != "0.0.0-development" { return }
 
-    let module_names = vec!["comb", "meas", "trans", "data", "core"];
+    let module_names = vec!["comb", "meas", "trans", "data", "core", "accuracy"];
 
     let get_bootstrap_path = |val: &str|
         Path::new("src").join(val).join("bootstrap.json");

--- a/rust/opendp-ffi/build/python.rs
+++ b/rust/opendp-ffi/build/python.rs
@@ -1,4 +1,3 @@
-
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;

--- a/rust/opendp-ffi/src/accuracy/bootstrap.json
+++ b/rust/opendp-ffi/src/accuracy/bootstrap.json
@@ -12,7 +12,7 @@
                 "name": "alpha",
                 "c_type": "void *",
                 "rust_type": "T",
-                "description": "Level-alpha, or (1. - alpha)100% confidence. Must be within (0, 1]."
+                "description": "Statistical significance, level-alpha, or (1. - alpha)100% confidence. Must be within (0, 1]."
             },
             {
                 "name": "T",

--- a/rust/opendp-ffi/src/accuracy/bootstrap.json
+++ b/rust/opendp-ffi/src/accuracy/bootstrap.json
@@ -1,0 +1,110 @@
+{
+    "laplacian_scale_to_accuracy": {
+        "description": "Convert a laplacian scale into an accuracy estimate.",
+        "args": [
+            {
+                "name": "scale",
+                "c_type": "void *",
+                "rust_type": "T",
+                "description": "Laplacian noise scale."
+            },
+            {
+                "name": "alpha",
+                "c_type": "void *",
+                "rust_type": "T",
+                "description": "Level-alpha, or (1. - alpha)100% confidence. Must be within (0, 1]."
+            },
+            {
+                "name": "T",
+                "is_type": true,
+                "description": "Data type of scale and alpha"
+            }
+        ],
+        "ret": {
+            "c_type": "FfiResult<AnyObject *>",
+            "rust_type": "T",
+            "description": "Accuracy estimate at a level-alpha."
+        }
+    },
+    "accuracy_to_laplacian_scale": {
+        "description": "Convert a desired accuracy into a laplacian noise scale.",
+        "args": [
+            {
+                "name": "accuracy",
+                "c_type": "void *",
+                "rust_type": "T",
+                "description": "Desired accuracy."
+            },
+            {
+                "name": "alpha",
+                "c_type": "void *",
+                "rust_type": "T",
+                "description": "Level-alpha, or (1. - alpha)100% confidence. Must be within (0, 1)."
+            },
+            {
+                "name": "T",
+                "is_type": true,
+                "description": "Data type of accuracy and alpha"
+            }
+        ],
+        "ret": {
+            "c_type": "FfiResult<AnyObject *>",
+            "rust_type": "T",
+            "description": "Laplacian noise scale that meets the accuracy requirement at a level-alpha."
+        }
+    },
+    "gaussian_scale_to_accuracy": {
+        "description": "Convert a gaussian scale into an accuracy estimate.",
+        "args": [
+            {
+                "name": "scale",
+                "c_type": "void *",
+                "rust_type": "T",
+                "description": "Gaussian noise scale."
+            },
+            {
+                "name": "alpha",
+                "c_type": "void *",
+                "rust_type": "T",
+                "description": "Level-alpha, or (1. - alpha)100% confidence. Must be within (0, 1]."
+            },
+            {
+                "name": "T",
+                "is_type": true,
+                "description": "Data type of scale and alpha"
+            }
+        ],
+        "ret": {
+            "c_type": "FfiResult<AnyObject *>",
+            "rust_type": "T",
+            "description": "Accuracy estimate at a level-alpha."
+        }
+    },
+    "accuracy_to_gaussian_scale": {
+        "description": "Convert a desired accuracy into a gaussian noise scale.",
+        "args": [
+            {
+                "name": "accuracy",
+                "c_type": "void *",
+                "rust_type": "T",
+                "description": "Desired accuracy."
+            },
+            {
+                "name": "alpha",
+                "c_type": "void *",
+                "rust_type": "T",
+                "description": "Level-alpha, or (1. - alpha)100% confidence. Must be within (0, 1)."
+            },
+            {
+                "name": "T",
+                "is_type": true,
+                "description": "Data type of accuracy and alpha"
+            }
+        ],
+        "ret": {
+            "c_type": "FfiResult<AnyObject *>",
+            "rust_type": "T",
+            "description": "Gaussian noise scale that meets the accuracy requirement at a level-alpha."
+        }
+    }
+}

--- a/rust/opendp-ffi/src/accuracy/bootstrap.json
+++ b/rust/opendp-ffi/src/accuracy/bootstrap.json
@@ -66,7 +66,7 @@
                 "name": "alpha",
                 "c_type": "void *",
                 "rust_type": "T",
-                "description": "Level-alpha, or (1. - alpha)100% confidence. Must be within (0, 1]."
+                "description": "Statistical significance, level-alpha, or (1. - alpha)100% confidence. Must be within (0, 1]."
             },
             {
                 "name": "T",

--- a/rust/opendp-ffi/src/accuracy/bootstrap.json
+++ b/rust/opendp-ffi/src/accuracy/bootstrap.json
@@ -39,7 +39,7 @@
                 "name": "alpha",
                 "c_type": "void *",
                 "rust_type": "T",
-                "description": "Level-alpha, or (1. - alpha)100% confidence. Must be within (0, 1)."
+                "description": "Statistical significance, level-alpha, or (1. - alpha)100% confidence. Must be within (0, 1)."
             },
             {
                 "name": "T",
@@ -93,7 +93,7 @@
                 "name": "alpha",
                 "c_type": "void *",
                 "rust_type": "T",
-                "description": "Level-alpha, or (1. - alpha)100% confidence. Must be within (0, 1)."
+                "description": "Statistical significance, level-alpha, or (1. - alpha)100% confidence. Must be within (0, 1)."
             },
             {
                 "name": "T",

--- a/rust/opendp-ffi/src/accuracy/mod.rs
+++ b/rust/opendp-ffi/src/accuracy/mod.rs
@@ -1,0 +1,47 @@
+use std::convert::TryFrom;
+use std::os::raw::{c_char, c_void};
+use std::fmt::Debug;
+
+use num::{Float, One, Zero};
+
+use opendp::accuracy::*;
+use opendp::err;
+use opendp::traits::InfCast;
+
+use crate::core::{FfiError, FfiResult};
+use crate::util;
+use crate::util::Type;
+use crate::any::AnyObject;
+
+macro_rules! build_extern_accuracy {
+    ($arg:ident, $ffi_func:ident, $func:ident) => {
+        #[no_mangle]
+        pub extern "C" fn $ffi_func(
+            $arg: *const c_void,
+            alpha: *const c_void,
+            T: *const c_char,
+        ) -> FfiResult<*mut AnyObject> {
+            fn monomorphize<T>(
+                $arg: *const c_void, alpha: *const c_void
+            ) -> FfiResult<*mut AnyObject> where
+                T: 'static + Float + One + Zero + Debug + InfCast<f64>,
+                f64: InfCast<T> {
+                let $arg = *try_as_ref!($arg as *const T);
+                let alpha = *try_as_ref!(alpha as *const T);
+
+                $func($arg, alpha).map_or_else(
+                    |e| FfiResult::Err(util::into_raw(FfiError::from(e))),
+                    |v| FfiResult::Ok(util::into_raw(AnyObject::new(v))))
+            }
+            let T = try_!(Type::try_from(T));
+            dispatch!(monomorphize, [
+                (T, @floats)
+            ], ($arg, alpha))
+        }
+    }
+}
+
+build_extern_accuracy!(accuracy, opendp_accuracy__accuracy_to_laplacian_scale, accuracy_to_laplacian_scale);
+build_extern_accuracy!(scale, opendp_accuracy__laplacian_scale_to_accuracy, laplacian_scale_to_accuracy);
+build_extern_accuracy!(accuracy, opendp_accuracy__accuracy_to_gaussian_scale, accuracy_to_gaussian_scale);
+build_extern_accuracy!(scale, opendp_accuracy__gaussian_scale_to_accuracy, gaussian_scale_to_accuracy);

--- a/rust/opendp-ffi/src/accuracy/mod.rs
+++ b/rust/opendp-ffi/src/accuracy/mod.rs
@@ -41,7 +41,7 @@ macro_rules! build_extern_accuracy {
     }
 }
 
-build_extern_accuracy!(accuracy, opendp_accuracy__accuracy_to_laplacian_scale, accuracy_to_laplacian_scale);
 build_extern_accuracy!(scale, opendp_accuracy__laplacian_scale_to_accuracy, laplacian_scale_to_accuracy);
-build_extern_accuracy!(accuracy, opendp_accuracy__accuracy_to_gaussian_scale, accuracy_to_gaussian_scale);
+build_extern_accuracy!(accuracy, opendp_accuracy__accuracy_to_laplacian_scale, accuracy_to_laplacian_scale);
 build_extern_accuracy!(scale, opendp_accuracy__gaussian_scale_to_accuracy, gaussian_scale_to_accuracy);
+build_extern_accuracy!(accuracy, opendp_accuracy__accuracy_to_gaussian_scale, accuracy_to_gaussian_scale);

--- a/rust/opendp-ffi/src/lib.rs
+++ b/rust/opendp-ffi/src/lib.rs
@@ -126,3 +126,4 @@ mod meas;
 mod trans;
 pub(crate) mod util;
 mod comb;
+mod accuracy;

--- a/rust/opendp/src/accuracy.rs
+++ b/rust/opendp/src/accuracy.rs
@@ -1,0 +1,117 @@
+use std::f64::consts::SQRT_2;
+
+use num::{Float, One, Zero};
+use statrs::function::erf::erf_inv;
+
+use crate::error::Fallible;
+use crate::traits::InfCast;
+use std::fmt::Debug;
+
+pub fn laplacian_scale_to_accuracy<T: Float + Zero + One + Debug>(scale: T, alpha: T) -> Fallible<T> {
+    if scale.is_sign_negative() {
+        return fallible!(InvalidDistance, "scale may not be negative")
+    }
+    if alpha <= T::zero() || T::one() < alpha {
+        return fallible!(InvalidDistance, "alpha ({:?}) must be in (0, 1]")
+    }
+    Ok(scale * alpha.recip().ln())
+}
+
+pub fn accuracy_to_laplacian_scale<T: Float + Zero + One + Debug>(accuracy: T, alpha: T) -> Fallible<T> {
+    if accuracy.is_sign_negative() {
+        return fallible!(InvalidDistance, "accuracy may not be negative")
+    }
+    if alpha <= T::zero() || T::one() <= alpha {
+        return fallible!(InvalidDistance, "alpha ({:?}) must be in (0, 1)")
+    }
+    Ok(accuracy / alpha.recip().ln())
+}
+
+pub fn gaussian_scale_to_accuracy<T>(scale: T, alpha: T) -> Fallible<T>
+    where f64: InfCast<T>, T: InfCast<f64> {
+    let scale = f64::inf_cast(scale)?;
+    let alpha = f64::inf_cast(alpha)?;
+    if scale.is_sign_negative() {
+        return fallible!(InvalidDistance, "scale may not be negative")
+    }
+    if alpha <= 0. || 1. < alpha {
+        return fallible!(InvalidDistance, "alpha ({:?}) must be in (0, 1]")
+    }
+    T::inf_cast(scale * SQRT_2 * erf_inv(1. - alpha))
+}
+
+pub fn accuracy_to_gaussian_scale<T>(accuracy: T, alpha: T) -> Fallible<T>
+    where f64: InfCast<T>, T: InfCast<f64> {
+    let accuracy = f64::inf_cast(accuracy)?;
+    let alpha = f64::inf_cast(alpha)?;
+    if accuracy.is_sign_negative() {
+        return fallible!(InvalidDistance, "accuracy may not be negative")
+    }
+    if alpha <= 0. || 1. <= alpha {
+        return fallible!(InvalidDistance, "alpha ({:?}) must be in (0, 1)")
+    }
+    T::inf_cast(accuracy / SQRT_2 * erf_inv(1. - alpha))
+}
+
+
+#[cfg(test)]
+pub mod test {
+    use std::fmt::Debug;
+    use std::ops::{Mul, Sub};
+
+    use super::*;
+
+    fn print_statement<T: Copy + Debug + One + From<i8> + Sub<Output=T> + Mul<Output=T>>(dist: &str, scale: T, accuracy: T, alpha: T) {
+        let _100 = T::from(100);
+        println!("When the {dist} scale is {scale:?}, the DP estimate differs from the true value \
+                    by no more than {accuracy:?} at a level-alpha of {alpha:?}, \
+                    or with (1 - {alpha:?})100% = {perc:.2?}% confidence.",
+                 dist = dist, scale = scale,
+                 accuracy = accuracy, alpha = alpha, perc = (T::one() - alpha) * _100);
+    }
+
+    #[test]
+    fn test_laplacian_scale_to_accuracy() -> Fallible<()> {
+        macro_rules! check_laplacian_scale_to_accuracy {(scale=$scale:literal, alpha=$alpha:literal) =>
+            (print_statement("laplacian", $scale, laplacian_scale_to_accuracy($scale, $alpha)?, $alpha))
+        }
+        check_laplacian_scale_to_accuracy!(scale=1., alpha=0.05);
+        check_laplacian_scale_to_accuracy!(scale=2., alpha=0.05);
+        check_laplacian_scale_to_accuracy!(scale=0., alpha=0.55);
+        Ok(())
+    }
+
+    #[test]
+    pub fn test_accuracy_to_laplacian_scale() -> Fallible<()> {
+        macro_rules! check_accuracy_to_laplacian_scale {(accuracy=$accuracy:literal, alpha=$alpha:literal) =>
+            (print_statement("laplacian", accuracy_to_laplacian_scale($accuracy, $alpha)?, $accuracy, $alpha))
+        }
+        check_accuracy_to_laplacian_scale!(accuracy=1., alpha=0.05);
+        check_accuracy_to_laplacian_scale!(accuracy=2., alpha=0.05);
+        check_accuracy_to_laplacian_scale!(accuracy=0.01, alpha=0.1);
+        Ok(())
+    }
+
+    #[test]
+    pub fn test_gaussian_scale_to_accuracy() -> Fallible<()> {
+        macro_rules! check_gaussian_scale_to_accuracy {(scale=$scale:literal, alpha=$alpha:literal) =>
+            (print_statement("gaussian", $scale, gaussian_scale_to_accuracy($scale, $alpha)?, $alpha))
+        }
+
+        check_gaussian_scale_to_accuracy!(scale=1., alpha=0.05);
+        check_gaussian_scale_to_accuracy!(scale=2., alpha=0.10);
+        check_gaussian_scale_to_accuracy!(scale=3., alpha=0.55);
+        Ok(())
+    }
+
+    #[test]
+    pub fn test_accuracy_to_gaussian_scale() -> Fallible<()> {
+        macro_rules! check_accuracy_to_gaussian_scale {(accuracy=$accuracy:literal, alpha=$alpha:literal) =>
+            (print_statement("gaussian", accuracy_to_gaussian_scale($accuracy, $alpha)?, $accuracy, $alpha))
+        }
+        check_accuracy_to_gaussian_scale!(accuracy=1., alpha=0.05);
+        check_accuracy_to_gaussian_scale!(accuracy=2., alpha=0.05);
+        check_accuracy_to_gaussian_scale!(accuracy=1.2, alpha=0.1);
+        Ok(())
+    }
+}

--- a/rust/opendp/src/accuracy.rs
+++ b/rust/opendp/src/accuracy.rs
@@ -60,7 +60,7 @@ pub mod test {
     use std::ops::{Mul, Sub};
 
     use super::*;
-    use crate::meas::{make_base_laplace, make_base_gaussian};
+    use crate::meas::{make_base_laplace, make_base_gaussian, make_base_geometric};
     use crate::error::ExplainUnwrap;
     use crate::dom::AllDomain;
 
@@ -216,6 +216,25 @@ pub mod test {
             .count() as f64 / n as f64;
 
         println!("Gaussian significance levels/alpha");
+        println!("Theoretical: {:?}", theoretical_alpha);
+        println!("Empirical:   {:?}", empirical_alpha);
+        assert!((empirical_alpha - theoretical_alpha).abs() < 1e-2);
+        Ok(())
+    }
+
+    #[test]
+    pub fn test_empirical_geometric_accuracy() -> Fallible<()> {
+        let accuracy = 25;
+        let theoretical_alpha = 0.05;
+        let scale = accuracy_to_laplacian_scale(accuracy as f64, theoretical_alpha)?;
+        println!("scale: {}", scale);
+        let base_geometric = make_base_geometric::<AllDomain<i8>, f64>(scale, None)?;
+        let n = 50_000;
+        let empirical_alpha = (0..n)
+            .filter(|_| base_geometric.function.eval(&0).unwrap_test().abs() >= accuracy)
+            .count() as f64 / n as f64;
+
+        println!("Geometric significance levels/alpha");
         println!("Theoretical: {:?}", theoretical_alpha);
         println!("Empirical:   {:?}", empirical_alpha);
         assert!((empirical_alpha - theoretical_alpha).abs() < 1e-2);

--- a/rust/opendp/src/accuracy.rs
+++ b/rust/opendp/src/accuracy.rs
@@ -221,4 +221,16 @@ pub mod test {
         assert!((empirical_alpha - theoretical_alpha).abs() < 1e-2);
         Ok(())
     }
+
+    #[test]
+    pub fn test_roundtrip() -> Fallible<()> {
+        let accuracy = 1.;
+        let alpha = 0.05;
+        let accuracy_2 = gaussian_scale_to_accuracy(accuracy_to_gaussian_scale(accuracy, alpha)?, alpha)?;
+        assert!((accuracy - accuracy_2).abs() < 1e-8);
+
+        let accuracy_2 = laplacian_scale_to_accuracy(accuracy_to_laplacian_scale(accuracy, alpha)?, alpha)?;
+        assert!((accuracy - accuracy_2).abs() < 1e-8);
+        Ok(())
+    }
 }

--- a/rust/opendp/src/lib.rs
+++ b/rust/opendp/src/lib.rs
@@ -153,3 +153,4 @@ pub mod samplers;
 pub mod traits;
 pub mod trans;
 pub mod comb;
+pub mod accuracy;


### PR DESCRIPTION
Closes #274 
Adds utilities for converting between accuracy estimates and noise scales for laplacian and gaussian noise.

The laplacian noise estimate can also be used for the geometric distribution.
We might want to think about renaming `make_base_geometric` to `make_base_discrete_laplace` at some point to make this more obvious.
One could make the argument that you should take the ceil of the geometric accuracy, because the support is discrete ...but on the other hand, the probabilities are still approximately continuous, so I don't think this is necessary. Due to this, I have dropped the ceil when porting from Smartnoise-Core.