### PR TITLE
add Resources section #272

### DIFF
--- a/docs/source/more.rst
+++ b/docs/source/more.rst
@@ -8,6 +8,7 @@ More...
 
 .. toctree::
 
+   resources/index
    faq
    developer/index
    opendp-commons/index

--- a/docs/source/resources/index.rst
+++ b/docs/source/resources/index.rst
@@ -1,0 +1,92 @@
+Resources
+=========
+
+.. contents:: |toctitle|
+    :local:
+
+Background
+----------
+
+Differential privacy: A primer for a non-technical audience
+
+https://salil.seas.harvard.edu/publications/differential-privacy-primer-non-technical-audience
+
+The Algorithmic Foundations of Differential Privacy
+
+https://www.cis.upenn.edu/~aaroth/Papers/privacybook.pdf
+
+Learning About Differential Privacy
+-----------------------------------
+
+Courses & Educational Materials from the Harvard University Privacy Tools Project
+
+https://privacytools.seas.harvard.edu/courses-educational-materials
+
+Designing Access with Differential Privacy
+
+https://admindatahandbook.mit.edu/book/latest/diffpriv.html
+
+Programming Differential Privacy
+
+https://programming-dp.com/notebooks/cover.html
+
+Privacy and Confidentiality Protection Overview
+
+https://www2.census.gov/cac/nac/meetings/2019-05/garfinkel-privacy-confidentiality-protection.pdf
+
+Papers
+------
+
+The Complexity of Differential Privacy
+
+https://privacytools.seas.harvard.edu/files/privacytools/files/complexityprivacy_1.pdf
+
+Calibrating Noise to Sensitivity in Private Data Analysis
+
+(Laplace mechanism)
+
+https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf
+
+On Significance of the Least Significant Bits For Differential Privacy
+
+(Snapping mechanism and how floating-point numbers and the laplace mechanism leak)
+
+https://www.microsoft.com/en-us/research/wp-content/uploads/2012/10/lsbs.pdf
+
+Mechanism Design via Differential Privacy
+
+(Exponential mechanism)
+
+https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/mdviadp.pdf
+
+Differential Privacy on Finite Computers
+
+(Geometric mechanism)
+
+https://arxiv.org/pdf/1709.05396.pdf
+
+Privacy-preserving Statistical Estimation with Optimal Convergence Rates
+
+(Sample/aggregate and quantiles)
+
+https://cs-people.bu.edu/ads22/pubs/2011/stoc194-smith.pdf
+
+Deep Learning with Differential Privacy
+
+(Gradient descent)
+
+https://arxiv.org/pdf/1607.00133.pdf
+
+Rényi Differential Privacy
+
+https://arxiv.org/pdf/1702.07476.pdf
+
+Concentrated Differential Privacy: Simplifications, Extensions, and Lower Bounds
+
+(zCDP)
+
+https://arxiv.org/pdf/1605.02065.pdf
+
+U.S. Broadband Coverage Data Set: A Differentially Private Data Release
+
+https://arxiv.org/pdf/2103.14035.pdf

--- a/docs/source/resources/index.rst
+++ b/docs/source/resources/index.rst
@@ -77,16 +77,6 @@ Deep Learning with Differential Privacy
 
 https://arxiv.org/pdf/1607.00133.pdf
 
-Rényi Differential Privacy
-
-https://arxiv.org/pdf/1702.07476.pdf
-
-Concentrated Differential Privacy: Simplifications, Extensions, and Lower Bounds
-
-(zCDP)
-
-https://arxiv.org/pdf/1605.02065.pdf
-
 U.S. Broadband Coverage Data Set: A Differentially Private Data Release
 
 https://arxiv.org/pdf/2103.14035.pdf

--- a/docs/source/resources/index.rst
+++ b/docs/source/resources/index.rst
@@ -7,76 +7,36 @@ Resources
 Background
 ----------
 
-Differential privacy: A primer for a non-technical audience
+`Differential privacy: A primer for a non-technical audience <https://salil.seas.harvard.edu/publications/differential-privacy-primer-non-technical-audience>`_
 
-https://salil.seas.harvard.edu/publications/differential-privacy-primer-non-technical-audience
-
-The Algorithmic Foundations of Differential Privacy
-
-https://www.cis.upenn.edu/~aaroth/Papers/privacybook.pdf
+`The Algorithmic Foundations of Differential Privacy <https://www.cis.upenn.edu/~aaroth/Papers/privacybook.pdf>`_
 
 Learning About Differential Privacy
 -----------------------------------
 
-Courses & Educational Materials from the Harvard University Privacy Tools Project
+`Courses & Educational Materials from the Harvard University Privacy Tools Project <https://privacytools.seas.harvard.edu/courses-educational-materials>`_
 
-https://privacytools.seas.harvard.edu/courses-educational-materials
+`Designing Access with Differential Privacy <https://admindatahandbook.mit.edu/book/latest/diffpriv.html>`_
 
-Designing Access with Differential Privacy
+`Programming Differential Privacy <https://programming-dp.com/notebooks/cover.html>`_
 
-https://admindatahandbook.mit.edu/book/latest/diffpriv.html
-
-Programming Differential Privacy
-
-https://programming-dp.com/notebooks/cover.html
-
-Privacy and Confidentiality Protection Overview
-
-https://www2.census.gov/cac/nac/meetings/2019-05/garfinkel-privacy-confidentiality-protection.pdf
+`Privacy and Confidentiality Protection Overview <https://www2.census.gov/cac/nac/meetings/2019-05/garfinkel-privacy-confidentiality-protection.pdf>`_
 
 Papers
 ------
 
-The Complexity of Differential Privacy
+`The Complexity of Differential Privacy <https://privacytools.seas.harvard.edu/files/privacytools/files/complexityprivacy_1.pdf>`_
 
-https://privacytools.seas.harvard.edu/files/privacytools/files/complexityprivacy_1.pdf
+`Calibrating Noise to Sensitivity in Private Data Analysis <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>`_ (Laplace mechanism)
 
-Calibrating Noise to Sensitivity in Private Data Analysis
+`On Significance of the Least Significant Bits For Differential Privacy <https://www.microsoft.com/en-us/research/wp-content/uploads/2012/10/lsbs.pdf>`_ (Snapping mechanism and how floating-point numbers and the laplace mechanism leak)
 
-(Laplace mechanism)
+`Mechanism Design via Differential Privacy <https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/mdviadp.pdf>`_ (Exponential mechanism)
 
-https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf
+`Differential Privacy on Finite Computers <https://arxiv.org/pdf/1709.05396.pdf>`_ (Geometric mechanism)
 
-On Significance of the Least Significant Bits For Differential Privacy
+`Privacy-preserving Statistical Estimation with Optimal Convergence Rates <https://cs-people.bu.edu/ads22/pubs/2011/stoc194-smith.pdf>`_ (Sample/aggregate and quantiles)
 
-(Snapping mechanism and how floating-point numbers and the laplace mechanism leak)
+`Deep Learning with Differential Privacy <https://arxiv.org/pdf/1607.00133.pdf>`_ (Gradient descent)
 
-https://www.microsoft.com/en-us/research/wp-content/uploads/2012/10/lsbs.pdf
-
-Mechanism Design via Differential Privacy
-
-(Exponential mechanism)
-
-https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/mdviadp.pdf
-
-Differential Privacy on Finite Computers
-
-(Geometric mechanism)
-
-https://arxiv.org/pdf/1709.05396.pdf
-
-Privacy-preserving Statistical Estimation with Optimal Convergence Rates
-
-(Sample/aggregate and quantiles)
-
-https://cs-people.bu.edu/ads22/pubs/2011/stoc194-smith.pdf
-
-Deep Learning with Differential Privacy
-
-(Gradient descent)
-
-https://arxiv.org/pdf/1607.00133.pdf
-
-U.S. Broadband Coverage Data Set: A Differentially Private Data Release
-
-https://arxiv.org/pdf/2103.14035.pdf
+`U.S. Broadband Coverage Data Set: A Differentially Private Data Release <https://arxiv.org/pdf/2103.14035.pdf>`_


### PR DESCRIPTION
closes #272

I took a quick swing at at least putting links to papers, etc. onto a Resources page. The formatting is extremely minimal and looks like this right now:

![Screen Shot 2021-09-09 at 4 12 17 PM](https://user-images.githubusercontent.com/21006/132757271-a32e244b-0250-4a79-bd71-39133e518586.png)

I'm not sure how fancy we should get. At minimum, we should probably link the titles to the papers like they do at https://differentialprivacy.org/resources/ (they also link the author names, which would be more work):

![Screen Shot 2021-09-09 at 4 09 44 PM](https://user-images.githubusercontent.com/21006/132757273-e76a465c-7751-4694-bb59-1a2dec045052.png)

We could also try to use full on citations and a Sphinx extension where we keep all these in Bibtex format. Probably overkill, I'd say.

Under the "Papers" section I left comments from @Shoeboxam in parentheses. We can take these out or otherwise rework them.