### PR TITLE
sampler correctness checks

### DIFF
--- a/rust/opendp/Cargo.toml
+++ b/rust/opendp/Cargo.toml
@@ -20,6 +20,8 @@ rug = { version = "1.9.0", default-features = false, features = ["integer", "flo
 gmp-mpfr-sys = { version = "=1.2.4", default-features = false, features = ["mpfr"], optional = true }
 openssl = { version = "0.10.29", features = ["vendored"], optional = true }
 
+vega_lite_4 = { version = "0.6.0", optional = true }
+
 [features]
 default = ["use-openssl", "use-mpfr"]
 
@@ -31,6 +33,9 @@ use-openssl = ["openssl"]
 use-mpfr = ["gmp-mpfr-sys", "rug"]
 # re-export use-system-libs from mpfr
 use-system-libs = ["use-mpfr", "gmp-mpfr-sys/use-system-libs"]
+
+# for plotting in unit tests
+test-plot = ["vega_lite_4"]
 
 [lib]
 

--- a/rust/opendp/src/error.rs
+++ b/rust/opendp/src/error.rs
@@ -95,6 +95,14 @@ impl fmt::Display for Error {
     }
 }
 
+// simplify error creation from vega_lite_4
+#[cfg(all(test, feature="test-plot"))]
+impl From<String> for Error {
+    fn from(v: String) -> Self {
+        err!(FailedFunction, v)
+    }
+}
+
 impl From<ErrorVariant> for Error {
     fn from(variant: ErrorVariant) -> Self {
         Self { variant, message: None, backtrace: _Backtrace::new() }


### PR DESCRIPTION
Related to #74.
Based on #75.

Adds a test for the biased bernoulli sampler.
Adds some plots to visualize common probability distributions.