### PR TITLE
clean up notebook example link, add Binder link #285

### DIFF
--- a/docs/source/examples/notebooks.rst
+++ b/docs/source/examples/notebooks.rst
@@ -4,4 +4,10 @@ Notebooks
 .. contents:: |toctitle|
 	:local:
 
-For now, see https://github.com/opendp/opendp/tree/main/python/example
+Example notebooks can be found in `python/example`_ in the OpenDP library source tree.
+
+.. _python/example: https://github.com/opendp/opendp/tree/main/python/example
+
+You can open and run these notebooks online in Binder_ (navigate to ``python/example``).
+
+.. _Binder: https://mybinder.org/v2/gh/opendp/opendp/HEAD


### PR DESCRIPTION
Instead of a raw link to GitHub, I added some surrounding text so it looks nicer.

More importantly, I also linked to Binder so people can try the notebooks from their browser.

For now, the Binder link doesn't have a branch specified so it'll default to "main" (the default) but as discussed in #285 once we cut a release, we can specify "stable" as the branch.