### PR TITLE
Docs version list sorting

### DIFF
--- a/docs/source/_templates/versioning.html
+++ b/docs/source/_templates/versioning.html
@@ -7,10 +7,15 @@
 </ul>
 {% endif %}
 {% if versions.tags %}
-<h6>{{ _('Tags') }}</h6>
+<h6>{{ _('Releases') }}</h6>
 <ul>
-  {%- for item in versions.tags %}
-  <li><a href="{{ item.url }}">{{ item.name }}</a></li>
+  {%- set ns = namespace(items=[]) %}
+  {%- for tag in versions.tags %}
+    {%- set extended_name = tag.name if "-rc" in tag.name else tag.name + "-rc.~" %}
+    {%- set ns.items = ns.items + [{"extended_name": extended_name, "tag": tag}] %}
+  {%- endfor %}
+  {%- for item in ns.items|sort(attribute="extended_name", reverse=True) %}
+  <li><a href="{{ item.tag.url }}">{{ item.tag.name }}</a></li>
   {%- endfor %}
 </ul>
 {% endif %}


### PR DESCRIPTION
Closes #311.

* Hacked Jinja template to fix sorting for RC versions

TADA!

At the same time, I feel some shame for this hack. Will break when numbers get above 10.

Screenshot:

<img width="177" alt="image" src="https://user-images.githubusercontent.com/6577271/134246160-b5abe96e-5f44-433e-a1ba-3753a14320b8.png">
