### PR TITLE
add contrib feature flag to FFI

### DIFF
--- a/rust/opendp-ffi/src/lib.rs
+++ b/rust/opendp-ffi/src/lib.rs
@@ -125,5 +125,6 @@ mod glue;
 mod meas;
 mod trans;
 pub(crate) mod util;
+#[cfg(feature="contrib")]
 mod comb;
 mod accuracy;

--- a/rust/opendp-ffi/src/meas/mod.rs
+++ b/rust/opendp-ffi/src/meas/mod.rs
@@ -1,7 +1,8 @@
-#[cfg(feature="floating-point")]
+#[cfg(all(feature="floating-point", feature="contrib"))]
 pub mod gaussian;
+#[cfg(feature="contrib")]
 pub mod geometric;
-#[cfg(feature="floating-point")]
+#[cfg(all(feature="floating-point", feature="contrib"))]
 pub mod laplace;
-#[cfg(feature="floating-point")]
+#[cfg(all(feature="floating-point", feature="contrib"))]
 pub mod stability;

--- a/rust/opendp-ffi/src/trans/mod.rs
+++ b/rust/opendp-ffi/src/trans/mod.rs
@@ -1,11 +1,21 @@
+#[cfg(feature="contrib")]
 pub mod dataframe;
+#[cfg(feature="contrib")]
 pub mod manipulation;
+#[cfg(feature="contrib")]
 pub mod sum;
+#[cfg(feature="contrib")]
 pub mod count;
+#[cfg(feature="contrib")]
 pub mod mean;
+#[cfg(feature="contrib")]
 pub mod resize;
+#[cfg(feature="contrib")]
 pub mod variance;
+#[cfg(feature="contrib")]
 pub mod impute;
+#[cfg(feature="contrib")]
 pub mod clamp;
+#[cfg(feature="contrib")]
 pub mod cast;
 


### PR DESCRIPTION
The FFI layer is expecting the existence of functions that have been cfg'ed! This missed testing because all of our builds used the "contrib" feature implicitly. The "contrib" feature is enabled by default for debug builds via the dev-dependencies.

Finishes #306.