### PR TITLE
fix continuous noise samplers

### DIFF
--- a/rust/opendp-ffi/src/any.rs
+++ b/rust/opendp-ffi/src/any.rs
@@ -400,16 +400,16 @@ fn make_any_relation<QI: 'static, QO: 'static, AQI: Downcast, AQO: Downcast>(rel
     }
 }
 
-fn make_any_map<QI, QO, AQI>(map: &Option<Rc<dyn Fn(&QI) -> Fallible<Box<QO>>>>) -> Option<impl Fn(&AQI) -> Fallible<Box<AnyMetricDistance>>>
+fn make_any_map<QI, QO, AQI>(map: &Option<Rc<dyn Fn(&QI) -> Fallible<QO>>>) -> Option<impl Fn(&AQI) -> Fallible<AnyMetricDistance>>
     where QI: 'static + PartialOrd,
           QO: 'static + PartialOrd + Clone,
           AQI: Downcast {
     map.as_ref().map(|map| {
         let map = map.clone();
-        move |d_in: &AQI| -> Fallible<Box<AnyMetricDistance>> {
+        move |d_in: &AQI| -> Fallible<AnyMetricDistance> {
             let d_in = d_in.downcast_ref()?;
             let d_out = map(d_in);
-            d_out.map(|d| AnyMetricDistance::new(*d)).map(Box::new)
+            d_out.map(|d| AnyMetricDistance::new(d))
         }
     })
 }

--- a/rust/opendp/src/meas/gaussian/mod.rs
+++ b/rust/opendp/src/meas/gaussian/mod.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num::{Float};
 
 use crate::core::{Function, Measurement, PrivacyRelation, Domain, SensitivityMetric};
 use crate::dist::{L2Distance, SmoothedMaxDivergence, AbsoluteDistance};
@@ -28,7 +28,7 @@ fn make_gaussian_privacy_relation<T, MI>(scale: T) -> PrivacyRelation<MI, Smooth
         }
 
         // TODO: should we error if epsilon > 1., or just waste the budget?
-        Ok(eps.min(T::one()) >= (d_in / scale) * (additive_gauss_const + _2 * del.recip().ln()).sqrt())
+        Ok(eps.min(T::one()) * scale >= d_in * (additive_gauss_const + _2 * del.recip().ln()).sqrt())
     })
 }
 

--- a/rust/opendp/src/meas/laplace/mod.rs
+++ b/rust/opendp/src/meas/laplace/mod.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num::{Float};
 
 use crate::core::{Measurement, Function, PrivacyRelation, Domain, SensitivityMetric};
 use crate::dist::{L1Distance, MaxDivergence, AbsoluteDistance};
@@ -50,7 +50,9 @@ pub fn make_base_laplace<D>(scale: D::Atom) -> Fallible<Measurement<D, D, D::Met
         D::noise_function(scale.clone()),
         D::Metric::default(),
         MaxDivergence::default(),
-        PrivacyRelation::new_from_constant(scale.recip())
+        PrivacyRelation::new_all(
+            move |d_in: &D::Atom, d_out: &D::Atom| Ok(d_out.clone() * scale.clone() >= d_in.clone()),
+            Some(move |d_out: &D::Atom| Ok(d_out.clone() * scale.clone())))
     ))
 }
 

--- a/rust/opendp/src/samplers.rs
+++ b/rust/opendp/src/samplers.rs
@@ -457,8 +457,9 @@ impl CastInternalReal for f32 {
 }
 
 #[cfg(feature = "use-mpfr")]
-impl<T: CastInternalReal + SampleRademacher> SampleLaplace for T {
+impl<T: CastInternalReal + SampleRademacher + Zero> SampleLaplace for T {
     fn sample_laplace(shift: Self, scale: Self, constant_time: bool) -> Fallible<Self> {
+        if scale.is_zero() { return Ok(shift) }
         if constant_time {
             return fallible!(FailedFunction, "mpfr samplers do not support constant time execution")
         }
@@ -497,9 +498,10 @@ impl<T: num::Float + rand::distributions::uniform::SampleUniform + SampleRademac
 }
 
 #[cfg(feature = "use-mpfr")]
-impl<T: CastInternalReal> SampleGaussian for T {
+impl<T: CastInternalReal + Zero> SampleGaussian for T {
 
     fn sample_gaussian(shift: Self, scale: Self, constant_time: bool) -> Fallible<Self> {
+        if scale.is_zero() { return Ok(shift) }
         if constant_time {
             return fallible!(FailedFunction, "mpfr samplers do not support constant time execution")
         }

--- a/rust/opendp/src/trans/resize/mod.rs
+++ b/rust/opendp/src/trans/resize/mod.rs
@@ -26,8 +26,8 @@ pub fn make_resize_constant<DA>(
         SymmetricDistance::default(),
         StabilityRelation::new_all(
             move |d_in: &IntDistance, d_out: &IntDistance| Ok(*d_out >= d_in + d_in % 2),
-            Some(|d_in: &IntDistance| Ok(Box::new(d_in + d_in % 2))),
-            Some(|d_out: &IntDistance| Ok(Box::new(*d_out)))
+            Some(|d_in: &IntDistance| Ok(d_in + d_in % 2)),
+            Some(|d_out: &IntDistance| Ok(*d_out))
         )
     ))
 }


### PR DESCRIPTION
Closes #182. It was possible to sample -0 in the non-MPFR laplace sampler and induce a NaN.
Closes #345. With this change, I think the continuous noise samplers are no longer subject to major floating-point attacks. I am not aware of any significant floating point issues in the continuous noise samplers, beyond some minor rounding in preprocessing. We will of course need to do more vetting.

For Laplace noise we have Von-Neumann's exact standard exponential sampler from MPFR, and add a sign non-disruptively with rademacher noise to get standard laplacian noise. The input is divided by scale before adding the standard laplacian noise. We now have a DP release without scaling the noise. Postprocess the DP release back to the original coordinates by multiplying by scale.

For gaussian noise we have Algorithm N from https://arxiv.org/pdf/1303.6257.pdf, implemented in MPFR, which adds rejection sampling to get standard gaussian noise. I apply the same noise addition approach as above.

Closes #140. I needed to add a backward map to Laplace, for zero-scale noise, and the box got in the way.


Lastly, I adjusted `GeneratorOpenSSL` to store a fallible. If OpenSSL throws an error, it no longer panics, it stores the error in the rng struct. The error is propagated manually after the randomized MPFR computations are done.