### PR TITLE
add `make_drop_null` transformation

### DIFF
--- a/docs/source/user/transformation-constructors.rst
+++ b/docs/source/user/transformation-constructors.rst
@@ -128,6 +128,12 @@ so long as you pass the DA (atomic domain) type argument.
    * - :func:`opendp.trans.make_impute_uniform_float`
      - ``VectorDomain<InherentNullDomain<AllDomain<TA>>>``
      - ``VectorDomain<AllDomain<TA>>``
+   * - :func:`opendp.trans.make_drop_null`
+     - ``VectorDomain<OptionNullDomain<AllDomain<TA>>>``
+     - ``VectorDomain<AllDomain<TA>>``
+   * - :func:`opendp.trans.make_drop_null`
+     - ``VectorDomain<InherentNullDomain<AllDomain<TA>>>``
+     - ``VectorDomain<AllDomain<TA>>``
 
 
 Clamping

--- a/python/src/opendp/trans.py
+++ b/python/src/opendp/trans.py
@@ -24,6 +24,7 @@ __all__ = [
     "make_select_column",
     "make_identity",
     "make_impute_constant",
+    "make_drop_null",
     "make_impute_uniform_float",
     "make_sized_bounded_mean",
     "make_resize",
@@ -695,6 +696,35 @@ def make_impute_constant(
     function.restype = FfiResult
     
     return c_to_py(unwrap(function(constant, DA), Transformation))
+
+
+def make_drop_null(
+    DA: RuntimeTypeDescriptor
+) -> Transformation:
+    """Make a Transformation that drops null values.
+    
+    :param DA: domain of data being imputed. This is OptionNullDomain<AllDomain<TA>> or InherentNullDomain<AllDomain<TA>>
+    :type DA: RuntimeTypeDescriptor
+    :return: A drop_null step.
+    :rtype: Transformation
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    assert_features("contrib")
+    
+    # Standardize type arguments.
+    DA = RuntimeType.parse(type_name=DA)
+    
+    # Convert arguments to c types.
+    DA = py_to_c(DA, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_trans__make_drop_null
+    function.argtypes = [ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(DA), Transformation))
 
 
 def make_impute_uniform_float(

--- a/python/test/test_trans.py
+++ b/python/test/test_trans.py
@@ -17,6 +17,18 @@ def test_cast_impute():
     assert caster([float('nan'), 2.]) == [1, 2]
 
 
+def test_cast_drop_null():
+    from opendp.trans import make_cast, make_drop_null, make_cast_inherent
+    caster = make_cast(TIA=str, TOA=int) >> make_drop_null(DA=OptionNullDomain[AllDomain[int]])
+    assert caster(["A", "2", "3"]) == [2, 3]
+
+    caster = make_cast(TIA=float, TOA=int) >> make_drop_null(DA=OptionNullDomain[AllDomain[int]])
+    assert caster([float('nan'), 2.]) == [2]
+
+    caster = make_cast_inherent(TIA=str, TOA=float) >> make_drop_null(DA=InherentNullDomain[AllDomain[float]])
+    assert caster(["a", "2."]) == [2]
+
+
 def test_cast_inherent():
     from opendp.trans import make_cast_inherent
     caster = make_cast_inherent(TIA=int, TOA=float)

--- a/rust/opendp-ffi/src/trans/bootstrap.json
+++ b/rust/opendp-ffi/src/trans/bootstrap.json
@@ -401,6 +401,18 @@
         ],
         "ret": {"c_type": "FfiResult<AnyTransformation *>"}
     },
+    "make_drop_null": {
+        "description": "Make a Transformation that drops null values.",
+        "features": ["contrib"],
+        "args": [
+            {
+                "name": "DA",
+                "is_type": true,
+                "description": "domain of data being imputed. This is OptionNullDomain<AllDomain<TA>> or InherentNullDomain<AllDomain<TA>>"
+            }
+        ],
+        "ret": {"c_type": "FfiResult<AnyTransformation *>"}
+    },
     "make_impute_uniform_float": {
         "description": "Make a Transformation that replaces null/None data in Vec<`TA`> with uniformly distributed floats within `bounds`.",
         "features": ["contrib"],

--- a/rust/opendp-ffi/src/trans/bootstrap.json
+++ b/rust/opendp-ffi/src/trans/bootstrap.json
@@ -408,7 +408,7 @@
             {
                 "name": "DA",
                 "is_type": true,
-                "description": "domain of data being imputed. This is OptionNullDomain<AllDomain<TA>> or InherentNullDomain<AllDomain<TA>>"
+                "description": "atomic domain of input data that contains nulls. This is OptionNullDomain<AllDomain<TA>> or InherentNullDomain<AllDomain<TA>>"
             }
         ],
         "ret": {"c_type": "FfiResult<AnyTransformation *>"}


### PR DESCRIPTION
Closes #347 

Adds a transformation that drops null values (an alternative to constant imputation). Requested by DPCreator.