### PR TITLE
relabeling, binning, indexing

### DIFF
--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -16,6 +16,7 @@ ATOM_MAP = {
     'i16': ctypes.c_int16,
     'i32': ctypes.c_int32,
     'i64': ctypes.c_int64,
+    'usize': ctypes.c_size_t,
     'bool': ctypes.c_bool,
 }
 

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -5,7 +5,7 @@ from typing import Optional, Any
 
 # list all acceptable alternative types for each default type
 ATOM_EQUIVALENCE_CLASSES = {
-    'i32': ['u8', 'u16', 'u32', 'u64', 'i8', 'i16', 'i32', 'i64'],
+    'i32': ['u8', 'u16', 'u32', 'u64', 'i8', 'i16', 'i32', 'i64', 'usize'],
     'f64': ['f32', 'f64'],
     'bool': ['bool']
 }

--- a/python/src/opendp/trans.py
+++ b/python/src/opendp/trans.py
@@ -769,7 +769,7 @@ def make_find(
 ) -> Transformation:
     """Find the index of a data value in a set of categories.
     
-    :param categories: The set of categories to compute counts for.
+    :param categories: The set of categories to find indexes from.
     :type categories: Any
     :param TIA: categorical/hashable input type. Input data must be Vec<TIA>.
     :type TIA: RuntimeTypeDescriptor
@@ -804,7 +804,7 @@ def make_find_bin(
     
     :param edges: The set of edges to split bins by.
     :type edges: Any
-    :param TIA: categorical/hashable input type. Input data must be Vec<TIA>.
+    :param TIA: numerical input type. Input data must be Vec<TIA>.
     :type TIA: RuntimeTypeDescriptor
     :return: A find_bin step.
     :rtype: Transformation
@@ -840,7 +840,7 @@ def make_index(
     :type categories: Any
     :param null: Category to return if the index is out-of-range of the category set.
     :type null: Any
-    :param TOA: categorical/hashable output type. Output data will be Vec<TIA>.
+    :param TOA: atomic output type. Output data will be Vec<TIA>.
     :type TOA: RuntimeTypeDescriptor
     :return: A index step.
     :rtype: Transformation

--- a/python/src/opendp/trans.py
+++ b/python/src/opendp/trans.py
@@ -26,6 +26,9 @@ __all__ = [
     "make_impute_constant",
     "make_drop_null",
     "make_impute_uniform_float",
+    "make_find",
+    "make_find_bin",
+    "make_index",
     "make_sized_bounded_mean",
     "make_resize",
     "make_bounded_resize",
@@ -758,6 +761,109 @@ def make_impute_uniform_float(
     function.restype = FfiResult
     
     return c_to_py(unwrap(function(bounds, TA), Transformation))
+
+
+def make_find(
+    categories: Any,
+    TIA: RuntimeTypeDescriptor = None
+) -> Transformation:
+    """Find the index of a data value in a set of categories.
+    
+    :param categories: The set of categories to compute counts for.
+    :type categories: Any
+    :param TIA: categorical/hashable input type. Input data must be Vec<TIA>.
+    :type TIA: RuntimeTypeDescriptor
+    :return: A find step.
+    :rtype: Transformation
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    assert_features("contrib")
+    
+    # Standardize type arguments.
+    TIA = RuntimeType.parse_or_infer(type_name=TIA, public_example=next(iter(categories), None))
+    
+    # Convert arguments to c types.
+    categories = py_to_c(categories, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[TIA]))
+    TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_trans__make_find
+    function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(categories, TIA), Transformation))
+
+
+def make_find_bin(
+    edges: Any,
+    TIA: RuntimeTypeDescriptor = None
+) -> Transformation:
+    """Find the bin index from a monotonically increasing vector of edges.
+    
+    :param edges: The set of edges to split bins by.
+    :type edges: Any
+    :param TIA: categorical/hashable input type. Input data must be Vec<TIA>.
+    :type TIA: RuntimeTypeDescriptor
+    :return: A find_bin step.
+    :rtype: Transformation
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    assert_features("contrib")
+    
+    # Standardize type arguments.
+    TIA = RuntimeType.parse_or_infer(type_name=TIA, public_example=next(iter(edges), None))
+    
+    # Convert arguments to c types.
+    edges = py_to_c(edges, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[TIA]))
+    TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_trans__make_find_bin
+    function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(edges, TIA), Transformation))
+
+
+def make_index(
+    categories: Any,
+    null: Any,
+    TOA: RuntimeTypeDescriptor = None
+) -> Transformation:
+    """Index into a vector of categories.
+    
+    :param categories: The set of categories to index into.
+    :type categories: Any
+    :param null: Category to return if the index is out-of-range of the category set.
+    :type null: Any
+    :param TOA: categorical/hashable output type. Output data will be Vec<TIA>.
+    :type TOA: RuntimeTypeDescriptor
+    :return: A index step.
+    :rtype: Transformation
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    assert_features("contrib")
+    
+    # Standardize type arguments.
+    TOA = RuntimeType.parse_or_infer(type_name=TOA, public_example=next(iter(categories), None))
+    
+    # Convert arguments to c types.
+    categories = py_to_c(categories, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[TOA]))
+    null = py_to_c(null, c_type=AnyObjectPtr, type_name=TOA)
+    TOA = py_to_c(TOA, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_trans__make_index
+    function.argtypes = [AnyObjectPtr, AnyObjectPtr, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(categories, null, TOA), Transformation))
 
 
 def make_sized_bounded_mean(

--- a/python/test/test_trans.py
+++ b/python/test/test_trans.py
@@ -270,3 +270,20 @@ def test_count_by_categories_str():
     query = make_count_by_categories(categories=["1", "3", "4"], MO=L1Distance[int])
     assert query(STR_DATA) == [1, 1, 1, 6]
     assert query.check(1, 1)
+
+
+def test_indexing():
+    from opendp.trans import make_find, make_find_bin, make_index
+
+    find = make_find(categories=["1", "3", "4"])
+    assert find(STR_DATA) == [0, 3, 1, 2, 3, 3, 3, 3, 3]
+    assert find.check(1, 1)
+
+    binner = make_find_bin(edges=[2, 3, 5])
+    assert binner(INT_DATA) == [0, 1, 2, 2, 3, 3, 3, 3, 3]
+
+    indexer = make_index(categories=["A", "B", "C"], null="NA")
+    assert indexer([0, 1, 3, 1, 5]) == ['A', 'B', 'NA', 'B', 'NA']
+
+    assert (find >> indexer)(STR_DATA) == ['A', 'NA', 'B', 'C', 'NA', 'NA', 'NA', 'NA', 'NA']
+    assert (binner >> indexer)(INT_DATA) == ['A', 'B', 'C', 'C', 'NA', 'NA', 'NA', 'NA', 'NA']

--- a/python/test/test_trans.py
+++ b/python/test/test_trans.py
@@ -273,9 +273,9 @@ def test_count_by_categories_str():
 
 
 def test_indexing():
-    from opendp.trans import make_find, make_find_bin, make_index
+    from opendp.trans import make_find, make_impute_constant, make_find_bin, make_index
 
-    find = make_find(categories=["1", "3", "4"])
+    find = make_find(categories=["1", "3", "4"]) >> make_impute_constant(3, DA=OptionNullDomain[AllDomain["usize"]])
     assert find(STR_DATA) == [0, 3, 1, 2, 3, 3, 3, 3, 3]
     assert find.check(1, 1)
 

--- a/rust/opendp-ffi/build/python_typemap.json
+++ b/rust/opendp-ffi/build/python_typemap.json
@@ -14,6 +14,7 @@
     "uint64_t": "ctypes.c_uint64",
     "float": "ctypes.c_float",
     "double": "ctypes.c_double",
+    "size_t": "ctypes.c_size_t",
     "char *": "ctypes.c_char_p",
     "const char *": "ctypes.c_char_p",
     "bool": "ctypes.c_bool",

--- a/rust/opendp-ffi/build/type_hierarchy.json
+++ b/rust/opendp-ffi/build/type_hierarchy.json
@@ -1,5 +1,5 @@
 {
-    "integer": ["int", "int8_t", "int16_t", "int32_t", "int64_t", "unsigned int", "uint8_t", "uint16_t", "uint32_t", "uint64_t"],
+    "integer": ["int", "int8_t", "int16_t", "int32_t", "int64_t", "unsigned int", "uint8_t", "uint16_t", "uint32_t", "uint64_t", "size_t"],
     "float": ["float", "double"],
     "string": ["char *", "const char *"],
     "bool": ["bool"]

--- a/rust/opendp-ffi/src/dispatch.rs
+++ b/rust/opendp-ffi/src/dispatch.rs
@@ -73,22 +73,22 @@ macro_rules! disp {
 #[cfg(not(debug_assertions))]
 macro_rules! disp_expand {
     ($function:ident, ($rt_type:expr, @primitives),              $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
-        disp_expand!($function, ($rt_type, [u8, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, bool, String]), $rt_dispatch_types, $type_args, $args)
+        disp_expand!($function, ($rt_type, [u8, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, bool, String]), $rt_dispatch_types, $type_args, $args)
     };
     ($function:ident, ($rt_type:expr, @primitives_plus),         $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
-        disp_expand!($function, ($rt_type, [u8, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, bool, String, AnyObject]), $rt_dispatch_types, $type_args, $args)
+        disp_expand!($function, ($rt_type, [u8, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, bool, String, AnyObject]), $rt_dispatch_types, $type_args, $args)
     };
     ($function:ident, ($rt_type:expr, @numbers),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
-        disp_expand!($function, ($rt_type, [u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64]), $rt_dispatch_types, $type_args, $args)
+        disp_expand!($function, ($rt_type, [u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64]), $rt_dispatch_types, $type_args, $args)
     };
     ($function:ident, ($rt_type:expr, @hashable),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
-        disp_expand!($function, ($rt_type, [u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, bool, String]), $rt_dispatch_types, $type_args, $args)
+        disp_expand!($function, ($rt_type, [u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, bool, String]), $rt_dispatch_types, $type_args, $args)
     };
     ($function:ident, ($rt_type:expr, @floats),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
         disp_expand!($function, ($rt_type, [f32, f64]), $rt_dispatch_types, $type_args, $args)
     };
     ($function:ident, ($rt_type:expr, @integers),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
-        disp_expand!($function, ($rt_type, [u8, u16, u32, u64, u128, i8, i16, i32, i64, i128]), $rt_dispatch_types, $type_args, $args)
+        disp_expand!($function, ($rt_type, [u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize]), $rt_dispatch_types, $type_args, $args)
     };
     ($function:ident, ($rt_type:expr, @dist_dataset),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
         disp_expand!($function, ($rt_type, [SubstituteDistance, SymmetricDistance]), $rt_dispatch_types, $type_args, $args)
@@ -104,10 +104,10 @@ macro_rules! disp_expand {
 #[cfg(debug_assertions)]
 macro_rules! disp_expand {
     ($function:ident, ($rt_type:expr, @primitives),              $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
-        disp_expand!($function, ($rt_type, [bool, i32, f64, String]), $rt_dispatch_types, $type_args, $args)
+        disp_expand!($function, ($rt_type, [bool, i32, f64, String, usize]), $rt_dispatch_types, $type_args, $args)
     };
     ($function:ident, ($rt_type:expr, @primitives_plus),         $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
-        disp_expand!($function, ($rt_type, [i32, f64, String, AnyObject]), $rt_dispatch_types, $type_args, $args)
+        disp_expand!($function, ($rt_type, [i32, f64, String, usize, AnyObject]), $rt_dispatch_types, $type_args, $args)
     };
     ($function:ident, ($rt_type:expr, @numbers),                 $rt_dispatch_types:tt, $type_args:tt, $args:tt) => {
         disp_expand!($function, ($rt_type, [u32, i32, f64]), $rt_dispatch_types, $type_args, $args)

--- a/rust/opendp-ffi/src/trans/bootstrap.json
+++ b/rust/opendp-ffi/src/trans/bootstrap.json
@@ -450,7 +450,7 @@
                     "origin": "Vec",
                     "args": ["TIA"]
                 },
-                "description": "The set of categories to compute counts for."
+                "description": "The set of categories to find indexes from."
             },
             {
                 "name": "TIA",
@@ -476,7 +476,7 @@
             {
                 "name": "TIA",
                 "is_type": true,
-                "description": "categorical/hashable input type. Input data must be Vec<TIA>."
+                "description": "numerical input type. Input data must be Vec<TIA>."
             }
         ],
         "ret": {"c_type": "FfiResult<AnyTransformation *>"}
@@ -503,7 +503,7 @@
             {
                 "name": "TOA",
                 "is_type": true,
-                "description": "categorical/hashable output type. Output data will be Vec<TIA>."
+                "description": "atomic output type. Output data will be Vec<TIA>."
             }
         ],
         "ret": {"c_type": "FfiResult<AnyTransformation *>"}

--- a/rust/opendp-ffi/src/trans/bootstrap.json
+++ b/rust/opendp-ffi/src/trans/bootstrap.json
@@ -439,6 +439,75 @@
         ],
         "ret": {"c_type": "FfiResult<AnyTransformation *>"}
     },
+    "make_find": {
+        "description": "Find the index of a data value in a set of categories.",
+        "features": ["contrib"],
+        "args": [
+            {
+                "name": "categories",
+                "c_type": "AnyObject *",
+                "rust_type": {
+                    "origin": "Vec",
+                    "args": ["TIA"]
+                },
+                "description": "The set of categories to compute counts for."
+            },
+            {
+                "name": "TIA",
+                "is_type": true,
+                "description": "categorical/hashable input type. Input data must be Vec<TIA>."
+            }
+        ],
+        "ret": {"c_type": "FfiResult<AnyTransformation *>"}
+    },
+    "make_find_bin": {
+        "description": "Find the bin index from a monotonically increasing vector of edges.",
+        "features": ["contrib"],
+        "args": [
+            {
+                "name": "edges",
+                "c_type": "AnyObject *",
+                "rust_type": {
+                    "origin": "Vec",
+                    "args": ["TIA"]
+                },
+                "description": "The set of edges to split bins by."
+            },
+            {
+                "name": "TIA",
+                "is_type": true,
+                "description": "categorical/hashable input type. Input data must be Vec<TIA>."
+            }
+        ],
+        "ret": {"c_type": "FfiResult<AnyTransformation *>"}
+    },
+    "make_index": {
+        "description": "Index into a vector of categories.",
+        "features": ["contrib"],
+        "args": [
+            {
+                "name": "categories",
+                "c_type": "AnyObject *",
+                "rust_type": {
+                    "origin": "Vec",
+                    "args": ["TOA"]
+                },
+                "description": "The set of categories to index into."
+            },
+            {
+                "name": "null",
+                "c_type": "AnyObject *",
+                "rust_type": "TOA",
+                "description": "Category to return if the index is out-of-range of the category set."
+            },
+            {
+                "name": "TOA",
+                "is_type": true,
+                "description": "categorical/hashable output type. Output data will be Vec<TIA>."
+            }
+        ],
+        "ret": {"c_type": "FfiResult<AnyTransformation *>"}
+    },
     "make_sized_bounded_mean": {
         "description": "Make a Transformation that computes the mean of bounded data. \nThis uses a restricted-sensitivity proof that takes advantage of known dataset size. \nUse `make_clamp` to bound data and `make_bounded_resize` to establish dataset size.",
         "features": ["contrib"],

--- a/rust/opendp-ffi/src/trans/index.rs
+++ b/rust/opendp-ffi/src/trans/index.rs
@@ -1,0 +1,69 @@
+use std::hash::Hash;
+use std::os::raw::c_char;
+use std::convert::TryFrom;
+
+use opendp::err;
+use opendp::traits::CheckNull;
+use opendp::trans::{make_find, make_find_bin, make_index};
+
+use crate::any::{AnyObject, AnyTransformation};
+use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
+use crate::util::Type;
+use crate::any::Downcast;
+
+#[no_mangle]
+pub extern "C" fn opendp_trans__make_find(
+    categories: *const AnyObject,
+    TIA: *const c_char,
+) -> FfiResult<*mut AnyTransformation> {
+    fn monomorphize<TIA>(
+        categories: *const AnyObject
+    ) -> FfiResult<*mut AnyTransformation>
+        where TIA: 'static + CheckNull + Clone + Hash + Eq {
+        let categories = try_!(try_as_ref!(categories).downcast_ref::<Vec<TIA>>()).clone();
+        make_find::<TIA>(categories).into_any()
+    }
+    let TIA = try_!(Type::try_from(TIA));
+    dispatch!(monomorphize, [
+        (TIA, @hashable)
+    ], (categories))
+}
+
+#[no_mangle]
+pub extern "C" fn opendp_trans__make_find_bin(
+    edges: *const AnyObject,
+    TIA: *const c_char,
+) -> FfiResult<*mut AnyTransformation> {
+    fn monomorphize<TIA>(
+        edges: *const AnyObject
+    ) -> FfiResult<*mut AnyTransformation>
+        where TIA: 'static + Clone + PartialOrd + CheckNull {
+        let edges = try_!(try_as_ref!(edges).downcast_ref::<Vec<TIA>>()).clone();
+        make_find_bin::<TIA>(edges).into_any()
+    }
+    let TIA = try_!(Type::try_from(TIA));
+    dispatch!(monomorphize, [
+        (TIA, @numbers)
+    ], (edges))
+}
+
+#[no_mangle]
+pub extern "C" fn opendp_trans__make_index(
+    categories: *const AnyObject,
+    null: *const AnyObject,
+    TOA: *const c_char,
+) -> FfiResult<*mut AnyTransformation> {
+    fn monomorphize<TOA>(
+        edges: *const AnyObject,
+        null: *const AnyObject,
+    ) -> FfiResult<*mut AnyTransformation>
+        where TOA: 'static + Clone + PartialOrd + CheckNull {
+        let edges = try_!(try_as_ref!(edges).downcast_ref::<Vec<TOA>>()).clone();
+        let null = try_!(try_as_ref!(null).downcast_ref::<TOA>()).clone();
+        make_index::<TOA>(edges, null).into_any()
+    }
+    let TOA = try_!(Type::try_from(TOA));
+    dispatch!(monomorphize, [
+        (TOA, @hashable)
+    ], (categories, null))
+}

--- a/rust/opendp-ffi/src/trans/index.rs
+++ b/rust/opendp-ffi/src/trans/index.rs
@@ -64,6 +64,6 @@ pub extern "C" fn opendp_trans__make_index(
     }
     let TOA = try_!(Type::try_from(TOA));
     dispatch!(monomorphize, [
-        (TOA, @hashable)
+        (TOA, @primitives)
     ], (categories, null))
 }

--- a/rust/opendp-ffi/src/trans/mod.rs
+++ b/rust/opendp-ffi/src/trans/mod.rs
@@ -15,6 +15,8 @@ pub mod variance;
 #[cfg(feature="contrib")]
 pub mod impute;
 #[cfg(feature="contrib")]
+pub mod index;
+#[cfg(feature="contrib")]
 pub mod clamp;
 #[cfg(feature="contrib")]
 pub mod cast;

--- a/rust/opendp-ffi/src/util.rs
+++ b/rust/opendp-ffi/src/util.rs
@@ -231,24 +231,24 @@ lazy_static! {
         let types: Vec<Type> = vec![
             // data types
             vec![t!(())],
-            type_vec![bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String, AnyObject],
-            type_vec![(bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String, AnyObject)],
-            type_vec![[bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String, AnyObject]; 1], // Arrays are here just for unit tests, unlikely we'll use them.
-            type_vec![[bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String, AnyObject]],
-            type_vec![Vec, <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String, AnyObject>],
-            type_vec![HashMap, <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, String>, <bool, char, u8, u16, u32, i16, i32, i64, i128, f32, f64, String, AnyObject>],
+            type_vec![bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, String, AnyObject],
+            type_vec![(bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, String, AnyObject)],
+            type_vec![[bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, String, AnyObject]; 1], // Arrays are here just for unit tests, unlikely we'll use them.
+            type_vec![[bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, String, AnyObject]],
+            type_vec![Vec, <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, String, AnyObject>],
+            type_vec![HashMap, <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, String>, <bool, char, u8, u16, u32, i16, i32, i64, i128, f32, f64, usize, String, AnyObject>],
             // OptionNullDomain<AllDomain<_>>::Carrier
-            type_vec![[Vec Option], <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String, AnyObject>],
+            type_vec![[Vec Option], <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, String, AnyObject>],
 
             // domains
-            type_vec![AllDomain, <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String>],
-            type_vec![BoundedDomain, <u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64>],
+            type_vec![AllDomain, <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, String>],
+            type_vec![BoundedDomain, <u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64>],
             type_vec![[InherentNullDomain AllDomain], <f32, f64>],
-            type_vec![[OptionNullDomain AllDomain], <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String>],
-            type_vec![[VectorDomain AllDomain], <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String>],
-            type_vec![[VectorDomain BoundedDomain], <u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64>],
-            type_vec![[VectorDomain OptionNullDomain AllDomain], <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String>],
-            type_vec![[SizedDomain VectorDomain AllDomain], <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String>],
+            type_vec![[OptionNullDomain AllDomain], <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, String>],
+            type_vec![[VectorDomain AllDomain], <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, String>],
+            type_vec![[VectorDomain BoundedDomain], <u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64>],
+            type_vec![[VectorDomain OptionNullDomain AllDomain], <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, String>],
+            type_vec![[SizedDomain VectorDomain AllDomain], <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, String>],
 
             // metrics
             type_vec![SubstituteDistance, SymmetricDistance],

--- a/rust/opendp/src/traits.rs
+++ b/rust/opendp/src/traits.rs
@@ -346,7 +346,7 @@ macro_rules! impl_round_cast_self_string_bool {
         }
     }
 }
-cartesian!{[u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64], impl_round_cast_num, impl_round_cast_self_string_bool, impl_round_cast_num}
+cartesian!{[u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64], impl_round_cast_num, impl_round_cast_self_string_bool, impl_round_cast_num}
 
 // final four casts among bool and string
 impl RoundCast<bool> for bool { fn round_cast(v: bool) -> Fallible<Self> {Ok(v)} }
@@ -484,7 +484,7 @@ macro_rules! impl_total_ord_for_ord {
         fn total_cmp(&self, other: &Self) -> Fallible<Ordering> {Ok(Ord::cmp(self, other))}
     })*}
 }
-impl_total_ord_for_ord!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128);
+impl_total_ord_for_ord!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize);
 
 macro_rules! impl_total_ord_for_float {
     ($($ty:ty),*) => {

--- a/rust/opendp/src/trans/index/mod.rs
+++ b/rust/opendp/src/trans/index/mod.rs
@@ -4,14 +4,14 @@ use std::iter::FromIterator;
 
 use crate::core::Transformation;
 use crate::dist::SymmetricDistance;
-use crate::dom::{AllDomain, VectorDomain};
+use crate::dom::{AllDomain, VectorDomain, OptionNullDomain};
 use crate::error::Fallible;
 use crate::traits::CheckNull;
 use crate::trans::make_row_by_row;
 
 pub fn make_find<TIA>(
     categories: Vec<TIA>
-) -> Fallible<Transformation<VectorDomain<AllDomain<TIA>>, VectorDomain<AllDomain<usize>>, SymmetricDistance, SymmetricDistance>>
+) -> Fallible<Transformation<VectorDomain<AllDomain<TIA>>, VectorDomain<OptionNullDomain<AllDomain<usize>>>, SymmetricDistance, SymmetricDistance>>
     where TIA: 'static + CheckNull + Clone + Hash + Eq {
     let categories_len = categories.len();
     let indexes = HashMap::<TIA, usize>::from_iter(categories.into_iter()
@@ -22,8 +22,8 @@ pub fn make_find<TIA>(
     }
 
     make_row_by_row(
-        AllDomain::new(), AllDomain::new(),
-        move |v| indexes.get(v).cloned().unwrap_or(categories_len))
+        AllDomain::new(), OptionNullDomain::new(AllDomain::new()),
+        move |v| indexes.get(v).cloned())
 }
 
 pub fn make_find_bin<TIA>(
@@ -59,7 +59,7 @@ mod test {
         let find = make_find(vec!["1", "3", "4"])?;
         assert_eq!(
             find.invoke(&vec!["1", "2", "3", "4", "5"])?,
-            vec![0, 3, 1, 2, 3]);
+            vec![Some(0), None, Some(1), Some(2), None]);
         Ok(())
     }
 

--- a/rust/opendp/src/trans/index/mod.rs
+++ b/rust/opendp/src/trans/index/mod.rs
@@ -8,12 +8,12 @@ use std::collections::HashMap;
 use std::iter::FromIterator;
 
 
-pub fn make_find<TI>(
-    categories: Vec<TI>
-) -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<AllDomain<usize>>, SymmetricDistance, SymmetricDistance>>
-    where TI: 'static + CheckNull + Clone + Hash + Eq {
+pub fn make_find<TIA>(
+    categories: Vec<TIA>
+) -> Fallible<Transformation<VectorDomain<AllDomain<TIA>>, VectorDomain<AllDomain<usize>>, SymmetricDistance, SymmetricDistance>>
+    where TIA: 'static + CheckNull + Clone + Hash + Eq {
     let categories_len = categories.len();
-    let indexes = HashMap::<TI, usize>::from_iter(categories.into_iter()
+    let indexes = HashMap::<TIA, usize>::from_iter(categories.into_iter()
         .enumerate().map(|(i, v)| (v, i)));
 
     if indexes.len() != categories_len {
@@ -23,7 +23,7 @@ pub fn make_find<TI>(
     Ok(Transformation::new(
         VectorDomain::new_all(),
         VectorDomain::new_all(),
-        Function::new(move |arg: &Vec<TI>| arg.iter()
+        Function::new(move |arg: &Vec<TIA>| arg.iter()
             .map(|v| indexes.get(v).cloned().unwrap_or(categories_len))
             .collect()),
         SymmetricDistance::default(),
@@ -32,17 +32,17 @@ pub fn make_find<TI>(
     ))
 }
 
-pub fn make_bin_edges<TI, TO>(
-    edges: Vec<TI>
-) -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<AllDomain<usize>>, SymmetricDistance, SymmetricDistance>>
-    where TI: 'static + PartialOrd + CheckNull {
+pub fn make_find_bin<TIA>(
+    edges: Vec<TIA>
+) -> Fallible<Transformation<VectorDomain<AllDomain<TIA>>, VectorDomain<AllDomain<usize>>, SymmetricDistance, SymmetricDistance>>
+    where TIA: 'static + PartialOrd + CheckNull {
     if !edges.windows(2).all(|pair| pair[0] < pair[1]) {
         return fallible!(MakeTransformation, "edges must be unique and ordered")
     }
     Ok(Transformation::new(
         VectorDomain::new_all(),
         VectorDomain::new_all(),
-        Function::new(move |arg: &Vec<TI>| arg.iter().map(|v| edges
+        Function::new(move |arg: &Vec<TIA>| arg.iter().map(|v| edges
             .iter().enumerate()
             .find(|(_, edge)| v < edge).map(|(i, _)| i)
             .unwrap_or(edges.len()))
@@ -53,10 +53,10 @@ pub fn make_bin_edges<TI, TO>(
     ))
 }
 
-pub fn make_index<TO>(
-    categories: Vec<TO>, null: TO
-) -> Fallible<Transformation<VectorDomain<AllDomain<usize>>, VectorDomain<AllDomain<TO>>, SymmetricDistance, SymmetricDistance>>
-    where TO: 'static + CheckNull + Clone {
+pub fn make_index<TOA>(
+    categories: Vec<TOA>, null: TOA
+) -> Fallible<Transformation<VectorDomain<AllDomain<usize>>, VectorDomain<AllDomain<TOA>>, SymmetricDistance, SymmetricDistance>>
+    where TOA: 'static + CheckNull + Clone {
     Ok(Transformation::new(
         VectorDomain::new_all(),
         VectorDomain::new_all(),

--- a/rust/opendp/src/trans/index/mod.rs
+++ b/rust/opendp/src/trans/index/mod.rs
@@ -1,0 +1,70 @@
+use crate::core::{Function, StabilityRelation, Transformation};
+use crate::dist::SymmetricDistance;
+use crate::dom::{AllDomain, VectorDomain};
+use crate::error::Fallible;
+use crate::traits::CheckNull;
+use std::hash::Hash;
+use std::collections::HashMap;
+use std::iter::FromIterator;
+
+
+pub fn make_find<TI>(
+    categories: Vec<TI>
+) -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<AllDomain<usize>>, SymmetricDistance, SymmetricDistance>>
+    where TI: 'static + CheckNull + Clone + Hash + Eq {
+    let categories_len = categories.len();
+    let indexes = HashMap::<TI, usize>::from_iter(categories.into_iter()
+        .enumerate().map(|(i, v)| (v, i)));
+
+    if indexes.len() != categories_len {
+        return fallible!(MakeTransformation, "categories must be unique")
+    }
+
+    Ok(Transformation::new(
+        VectorDomain::new_all(),
+        VectorDomain::new_all(),
+        Function::new(move |arg: &Vec<TI>| arg.iter()
+            .map(|v| indexes.get(v).cloned().unwrap_or(categories_len))
+            .collect()),
+        SymmetricDistance::default(),
+        SymmetricDistance::default(),
+        StabilityRelation::new_from_constant(1)
+    ))
+}
+
+pub fn make_bin_edges<TI, TO>(
+    edges: Vec<TI>
+) -> Fallible<Transformation<VectorDomain<AllDomain<TI>>, VectorDomain<AllDomain<usize>>, SymmetricDistance, SymmetricDistance>>
+    where TI: 'static + PartialOrd + CheckNull {
+    if !edges.windows(2).all(|pair| pair[0] < pair[1]) {
+        return fallible!(MakeTransformation, "edges must be unique and ordered")
+    }
+    Ok(Transformation::new(
+        VectorDomain::new_all(),
+        VectorDomain::new_all(),
+        Function::new(move |arg: &Vec<TI>| arg.iter().map(|v| edges
+            .iter().enumerate()
+            .find(|(_, edge)| v < edge).map(|(i, _)| i)
+            .unwrap_or(edges.len()))
+            .collect()),
+        SymmetricDistance::default(),
+        SymmetricDistance::default(),
+        StabilityRelation::new_from_constant(1)
+    ))
+}
+
+pub fn make_index<TO>(
+    categories: Vec<TO>, null: TO
+) -> Fallible<Transformation<VectorDomain<AllDomain<usize>>, VectorDomain<AllDomain<TO>>, SymmetricDistance, SymmetricDistance>>
+    where TO: 'static + CheckNull + Clone {
+    Ok(Transformation::new(
+        VectorDomain::new_all(),
+        VectorDomain::new_all(),
+        Function::new(move |arg: &Vec<usize>| arg.iter()
+            .map(|v| categories.get(*v).unwrap_or(&null).clone())
+            .collect()),
+        SymmetricDistance::default(),
+        SymmetricDistance::default(),
+        StabilityRelation::new_from_constant(1)
+    ))
+}

--- a/rust/opendp/src/trans/index/mod.rs
+++ b/rust/opendp/src/trans/index/mod.rs
@@ -68,3 +68,36 @@ pub fn make_index<TOA>(
         StabilityRelation::new_from_constant(1)
     ))
 }
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_find() -> Fallible<()> {
+        let find = make_find(vec!["1", "3", "4"])?;
+        assert_eq!(
+            find.invoke(&vec!["1", "2", "3", "4", "5"])?,
+            vec![0, 3, 1, 2, 3]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_bin() -> Fallible<()> {
+        let bin = make_find_bin(vec![2, 3, 5])?;
+        assert_eq!(
+            bin.invoke(&(1..10).collect())?,
+            vec![0, 1, 2, 2, 3, 3, 3, 3, 3]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_index() -> Fallible<()> {
+        let index = make_index(vec!["A", "B", "C"], "NA")?;
+        assert_eq!(
+            index.invoke(&vec![0, 1, 3, 1, 5])?,
+            vec!["A", "B", "NA", "B", "NA"]);
+        Ok(())
+    }
+}

--- a/rust/opendp/src/trans/mod.rs
+++ b/rust/opendp/src/trans/mod.rs
@@ -39,6 +39,11 @@ pub mod impute;
 pub use crate::trans::impute::*;
 
 #[cfg(feature="contrib")]
+pub mod index;
+#[cfg(feature="contrib")]
+pub use crate::trans::index::*;
+
+#[cfg(feature="contrib")]
 pub mod clamp;
 #[cfg(feature="contrib")]
 pub use crate::trans::clamp::*;


### PR DESCRIPTION
Closes #320 
This adds three transformations:
- `make_find` finds the index of a category for each value in a hashable vector
- `make_find_bin` finds the edge index for each value in a numeric vector
- `make_index` indexes into a category set

The `make_find` and `make_index` transformations can be used for relabeling and merging categories.
The `make_find_bin` can be used to bin numeric data. If you then chain with `make_index` then you can also label bins.
