### PR TITLE
fix resize relation

### DIFF
--- a/docs/source/user/application-structure.rst
+++ b/docs/source/user/application-structure.rst
@@ -182,7 +182,7 @@ can be used to convert the earlier discovered noise scale parameter into an accu
     ...  f"the DP estimate differs from the true value by no more than {accuracy} "
     ...  f"at a statistical significance level alpha of {alpha}, "
     ...  f"or with (1 - {alpha})100% = {(1 - alpha) * 100}% confidence.")
-    'When the laplace scale is 1.33333333581686, the DP estimate differs from the true value by no more than 3.9943097055119687 at a statistical significance level alpha of 0.05, or with (1 - 0.05)100% = 95.0% confidence.'
+    'When the laplace scale is 2.00000000745058, the DP estimate differs from the true value by no more than 5.991464569427925 at a statistical significance level alpha of 0.05, or with (1 - 0.05)100% = 95.0% confidence.'
 
 Please be aware that the preprocessing (impute, clamp, resize) can introduce bias that the accuracy estimate cannot account for.
 In this example, since the sensitive dataset is short two exams,

--- a/python/test/test_trans.py
+++ b/python/test/test_trans.py
@@ -255,14 +255,14 @@ def test_resize():
     assert query([-1, 2, 5]) == [-1, 2, 5, 0]
     assert not query.check(1, 1)
     assert query.check(1, 2)
-    assert query.check(2, 2)
+    assert query.check(2, 4)
 
     from opendp.trans import make_resize
     query = make_resize(size=4, constant=0)
     assert query([-1, 2, 5]) == [-1, 2, 5, 0]
     assert not query.check(1, 1)
     assert query.check(1, 2)
-    assert query.check(2, 2)
+    assert query.check(2, 4)
 
 
 def test_count_by_categories_str():

--- a/rust/opendp/src/trans/resize/mod.rs
+++ b/rust/opendp/src/trans/resize/mod.rs
@@ -1,6 +1,6 @@
 use crate::core::{Transformation, Function, StabilityRelation, Domain};
 use crate::error::Fallible;
-use crate::dist::{SymmetricDistance, IntDistance};
+use crate::dist::{SymmetricDistance};
 use crate::dom::{VectorDomain, SizedDomain};
 use std::cmp::Ordering;
 use crate::traits::CheckNull;
@@ -24,11 +24,7 @@ pub fn make_resize_constant<DA>(
         }),
         SymmetricDistance::default(),
         SymmetricDistance::default(),
-        StabilityRelation::new_all(
-            move |d_in: &IntDistance, d_out: &IntDistance| Ok(*d_out >= d_in + d_in % 2),
-            Some(|d_in: &IntDistance| Ok(d_in + d_in % 2)),
-            Some(|d_out: &IntDistance| Ok(*d_out))
-        )
+        StabilityRelation::new_from_constant(2)
     ))
 }
 


### PR DESCRIPTION
Closes #355 
This spawns a new issue: for the use-case when N is known, it is impossible to establish SizedDomain without incurring a 2x penalty.