### PR TITLE
smooth sensitivity estimators

### DIFF
--- a/rust/opendp/src/dist.rs
+++ b/rust/opendp/src/dist.rs
@@ -9,8 +9,11 @@ use std::fmt::{Debug, Formatter};
 pub type IntDistance = u32;
 
 /// Measures
-#[derive(Clone)]
 pub struct MaxDivergence<Q>(PhantomData<Q>);
+
+impl<Q> Clone for MaxDivergence<Q> {
+    fn clone(&self) -> Self { MaxDivergence::default() }
+}
 impl<Q> Default for MaxDivergence<Q> {
     fn default() -> Self { MaxDivergence(PhantomData) }
 }
@@ -25,12 +28,16 @@ impl<Q> Debug for MaxDivergence<Q> {
     }
 }
 
-impl<Q: Clone> Measure for MaxDivergence<Q> {
+impl<Q> Measure for MaxDivergence<Q> {
     type Distance = Q;
 }
 
-#[derive(Clone)]
+
 pub struct SmoothedMaxDivergence<Q>(PhantomData<Q>);
+
+impl<Q> Clone for SmoothedMaxDivergence<Q> {
+    fn clone(&self) -> Self { SmoothedMaxDivergence::default() }
+}
 
 impl<Q> Default for SmoothedMaxDivergence<Q> {
     fn default() -> Self { SmoothedMaxDivergence(PhantomData) }
@@ -44,7 +51,7 @@ impl<Q> Debug for SmoothedMaxDivergence<Q> {
         write!(f, "SmoothedMaxDivergence()")
     }
 }
-impl<Q: Clone> Measure for SmoothedMaxDivergence<Q> {
+impl<Q> Measure for SmoothedMaxDivergence<Q> {
     type Distance = (Q, Q);
 }
 

--- a/rust/opendp/src/meas/median/mod.rs
+++ b/rust/opendp/src/meas/median/mod.rs
@@ -1,0 +1,61 @@
+use crate::core::{Domain, Function, Measurement, Metric, PrivacyRelation};
+use crate::dist::{MaxDivergence, SymmetricDistance};
+use crate::dom::{AllDomain, BoundedDomain, VectorDomain};
+use crate::error::Fallible;
+use std::cmp::Ordering;
+use crate::samplers::SampleLaplace;
+
+fn median_smooth_sensitivity(
+    epsilon: f64,
+    bounds: (f64, f64),
+    sorted_data: Vec<f64>,
+) -> f64 {
+    let (lower, upper) = bounds;
+
+    let m = (sorted_data.len() + 1) / 2;
+    let difference = |t, k|
+        sorted_data.get(m + t).unwrap_or(&upper) -
+            sorted_data.get(m + t - k - 1).unwrap_or(&lower);
+
+    (0..sorted_data.len()).flat_map(move |k|
+        (0..=k).filter(move |t| m + t > k + 1).map(move |t|
+            difference(t, k) * (-(k as f64) * epsilon).exp()))
+        .max_by(|x, y| x.partial_cmp(y).unwrap_or(Ordering::Equal))
+        .unwrap_or(f64::INFINITY)
+}
+
+pub fn make_smooth_sensitivity_median<DIA: Domain, DO: Domain, MI: 'static + Metric>(
+    bounds: (f64, f64), influence: u32, epsilon: f64,
+) -> Fallible<Measurement<VectorDomain<BoundedDomain<f64>>, AllDomain<f64>, SymmetricDistance, MaxDivergence<f64>>> {
+    if influence < 1 { return fallible!(MakeMeasurement, "influence must be positive") }
+    if epsilon.is_sign_negative() { return fallible!(MakeMeasurement, "budget must be non-negative") }
+    let epsilon_prime = epsilon / influence as f64;
+
+    Ok(Measurement::new(
+        VectorDomain::new(BoundedDomain::new_closed(bounds)?),
+        AllDomain::new(),
+        Function::new_fallible(move |data: &Vec<f64>| {
+            let mut sorted_data = data.clone();
+            sorted_data.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
+            let median = sorted_data[(sorted_data.len() + 1) / 2];
+
+            let sensitivity = median_smooth_sensitivity(epsilon_prime, bounds, sorted_data);
+            f64::sample_laplace(median, sensitivity / epsilon_prime, false)
+        }),
+        SymmetricDistance::default(),
+        MaxDivergence::default(),
+        PrivacyRelation::new(
+            move |&d_in, &d_out: &f64| d_in <= influence && epsilon <= d_out),
+    ))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_function() {
+        let sens = median_smooth_sensitivity(1., (1., 0.3), vec![2., 3., 4.]);
+        println!("{}", sens);
+    }
+}

--- a/rust/opendp/src/meas/median/mod.rs
+++ b/rust/opendp/src/meas/median/mod.rs
@@ -18,7 +18,7 @@ fn median_smooth_sensitivity(
         let l = if m + t < k + 1 {lower} else {
             sorted_data[m + t - k - 1]
         };
-        let u = if m + t > sorted_data.len() {upper} else {
+        let u = if m + t >= sorted_data.len() {upper} else {
             sorted_data[m + t]
         };
         u - l

--- a/rust/opendp/src/meas/median/mod.rs
+++ b/rust/opendp/src/meas/median/mod.rs
@@ -15,11 +15,13 @@ fn median_smooth_sensitivity(
 
     let m = (sorted_data.len() + 1) / 2;
     let difference = |t, k| {
-        let lower_ = if m + t < k + 1 {&lower} else {
-            sorted_data.get(m + t - k - 1).unwrap_or(&lower)
+        let l = if m + t < k + 1 {lower} else {
+            sorted_data[m + t - k - 1]
         };
-        let upper_ = sorted_data.get(m + t).unwrap_or(&upper);
-        upper_ - lower_
+        let u = if m + t > sorted_data.len() {upper} else {
+            sorted_data[m + t]
+        };
+        u - l
     };
 
     (0..sorted_data.len()).flat_map(move |k| (0..=k).map(move |t|

--- a/rust/opendp/src/meas/median/mod.rs
+++ b/rust/opendp/src/meas/median/mod.rs
@@ -15,7 +15,7 @@ fn median_smooth_sensitivity(
 
     let m = (sorted_data.len() + 1) / 2;
     let difference = |t, k| {
-        let lower_ = if m + t < k + 1 {lower} else {
+        let lower_ = if m + t < k + 1 {&lower} else {
             sorted_data.get(m + t - k - 1).unwrap_or(&lower)
         };
         let upper_ = sorted_data.get(m + t).unwrap_or(&upper);

--- a/rust/opendp/src/meas/median/mod.rs
+++ b/rust/opendp/src/meas/median/mod.rs
@@ -1,58 +1,189 @@
 use std::cmp::Ordering;
+use std::marker::PhantomData;
+use std::ops::Sub;
 
-use crate::core::{Function, Measurement, PrivacyRelation};
-use crate::dist::{MaxDivergence, SymmetricDistance};
+use num::Float;
+
+use crate::core::{Function, Measurement, Metric, PrivacyRelation};
+use crate::dist::{IntDistance, L1Distance, L2Distance, SmoothedMaxDivergence, SymmetricDistance};
 use crate::dom::{AllDomain, BoundedDomain, VectorDomain};
-use crate::error::Fallible;
-use crate::samplers::SampleLaplace;
+use crate::error::{ExplainUnwrap, Fallible};
+use crate::samplers::{SampleGaussian, SampleLaplace, SampleTwoSidedGeometric};
+use crate::traits::{CheckNull, ExactIntCast, InfCast, TotalOrd};
 
 fn partial_max<T: PartialOrd>(x: &T, y: &T) -> Ordering {
     x.partial_cmp(y).unwrap_or(Ordering::Equal)
 }
 
-fn median_smooth_sensitivity(
-    sorted_data: Vec<f64>,
-    bounds: (f64, f64),
-    epsilon: f64,
-) -> f64 {
-    let (lower, upper) = bounds;
-    let m = (sorted_data.len() + 1) / 2;
-
-    let difference = |k, t| {
-        // return lower bound if index is negative
-        let l = if m + t < k + 1 { lower } else { sorted_data[m + t - k - 1] };
-        // return upper bound if index is past array length
-        let u = if m + t >= sorted_data.len() { upper } else { sorted_data[m + t] };
-        u - l
-    };
-
-    (0..sorted_data.len()).flat_map(|k|
-        (0..=k).map(move |t| difference(k, t) * (-(k as f64) * epsilon).exp()))
-        .max_by(partial_max).unwrap_or(f64::INFINITY)
+fn fallible_max<T: PartialOrd>(x: &Fallible<T>, y: &Fallible<T>) -> Ordering {
+    let x = if let Ok(x) = x {x} else {return Ordering::Greater};
+    let y = if let Ok(y) = y {y} else {return Ordering::Less};
+    partial_max(x, y)
 }
 
-pub fn make_smooth_sensitivity_median(
-    bounds: (f64, f64), influence: u32, epsilon: f64,
-) -> Fallible<Measurement<VectorDomain<BoundedDomain<f64>>, AllDomain<f64>, SymmetricDistance, MaxDivergence<f64>>> {
+struct Median<T>(PhantomData<T>);
+struct Minimum<T>(PhantomData<T>);
+struct Maximum<T>(PhantomData<T>);
+
+pub trait SmoothSensitivityQuery {
+    type Atom;
+    fn compute(sorted_data: &Vec<Self::Atom>) -> Self::Atom;
+    fn a_k(sorted_data: &Vec<Self::Atom>, bounds: &(Self::Atom, Self::Atom), k: usize) -> Self::Atom;
+}
+
+impl<T: Clone + Sub<Output=T> + PartialOrd> SmoothSensitivityQuery for Median<T> {
+    type Atom = T;
+    fn compute(sorted_data: &Vec<T>) -> T {
+        sorted_data[(sorted_data.len() + 1) / 2].clone()
+    }
+
+    fn a_k(sorted_data: &Vec<T>, bounds: &(T, T), k: usize) -> T {
+        let m = (sorted_data.len() + 1) / 2;
+        // function to compute the local sensitivity of the median on the given data
+        // at median_index + t, when up to k entries may be changed
+        (0..=k).map(move |t| {
+            // return lower bound if index is negative
+            let l = if m + t < k + 1 { &bounds.0 } else { &sorted_data[m + t - k - 1] }.clone();
+            // return upper bound if index is past array length
+            let u = if m + t >= sorted_data.len() { &bounds.1 } else { &sorted_data[m + t] }.clone();
+            u - l
+        })
+            .max_by(partial_max)
+            .unwrap_assert("dataset consists of at least one element")
+    }
+}
+
+impl<T: Clone + PartialOrd + Sub<Output=T>> SmoothSensitivityQuery for Minimum<T> {
+    type Atom = T;
+    fn compute(sorted_data: &Vec<T>) -> T {
+        sorted_data[0].clone()
+    }
+
+    fn a_k(sorted_data: &Vec<T>, bounds: &(T, T), k: usize) -> T {
+        let n = sorted_data.len();
+        let t1 = if k == n { bounds.1.clone() } else { sorted_data[k].clone() - bounds.0.clone() };
+        let t2 = if k + 1 == n { &bounds.1 } else { &sorted_data[k + 1] }.clone()
+            - sorted_data[0].clone();
+
+        if t1 > t2 { t1 } else { t2 }
+    }
+}
+
+impl<T: Clone + PartialOrd + Sub<Output=T>> SmoothSensitivityQuery for Maximum<T> {
+    type Atom = T;
+    fn compute(sorted_data: &Vec<T>) -> T {
+        sorted_data[sorted_data.len() - 1].clone()
+    }
+
+    fn a_k(sorted_data: &Vec<T>, bounds: &(T, T), k: usize) -> T {
+        let n = sorted_data.len();
+        let t1 = if k == n { bounds.0.clone() } else { bounds.1.clone() - sorted_data[n - k - 1].clone() };
+        let t2 = if k + 1 == n { &bounds.0 } else { &sorted_data[n - k - 2] }.clone()
+            - sorted_data[n - 1].clone();
+
+        if t1 > t2 { t1 } else { t2 }
+    }
+}
+
+pub trait SmoothSensitivityNoise: Metric {
+    type Unit: ExactIntCast<usize> + Float;
+    fn alpha(budget: (Self::Unit, Self::Unit)) -> Fallible<Self::Unit>;
+    fn beta(budget: (Self::Unit, Self::Unit)) -> Fallible<Self::Unit> {
+        let _1 = Self::Unit::exact_int_cast(1)?;
+        let _2 = Self::Unit::exact_int_cast(2)?;
+        let _4 = Self::Unit::exact_int_cast(4)?;
+        // the same beta is shared between all l1 and l2 noise distributions
+        let (epsilon, delta) = budget;
+        Ok(epsilon / (_4 * (_1 + (_2 / delta).ln())))
+    }
+    fn sample(shift: Self::Distance, scale: Self::Unit) -> Fallible<Self::Distance>;
+}
+impl SmoothSensitivityNoise for L1Distance<f64> {
+    type Unit = f64;
+    fn alpha(budget: (Self::Unit, Self::Unit)) -> Fallible<Self::Unit> {
+        Ok(budget.0 / 2.)
+    }
+    fn sample(shift: Self::Distance, scale: Self::Unit) -> Fallible<Self::Distance> {
+        Self::Distance::sample_laplace(shift, scale, false)
+    }
+}
+impl SmoothSensitivityNoise for L1Distance<i32> {
+    type Unit = f64;
+    fn alpha(budget: (Self::Unit, Self::Unit)) -> Fallible<Self::Unit> {
+        Ok(budget.0 / 2.)
+    }
+    fn sample(shift: Self::Distance, scale: Self::Unit) -> Fallible<Self::Distance> {
+        Self::Distance::sample_two_sided_geometric(shift, scale, None)
+    }
+}
+
+impl SmoothSensitivityNoise for L2Distance<f64> {
+    type Unit = f64;
+    fn alpha(budget: (Self::Unit, Self::Unit)) -> Fallible<Self::Unit> {
+        Ok(budget.0 / (5. * (2. * (2. / budget.1).ln()).sqrt()))
+    }
+    fn sample(shift: Self::Distance, scale: Self::Unit) -> Fallible<Self::Distance> {
+        Self::Distance::sample_gaussian(shift, scale, false)
+    }
+}
+
+fn compute_smooth_sensitivity<Query, Noise>(
+    sorted_data: Vec<Query::Atom>,
+    bounds: (Query::Atom, Query::Atom),
+    budget: (Noise::Unit, Noise::Unit),
+) -> Fallible<Noise::Unit>
+    where Query: SmoothSensitivityQuery,
+          Noise: SmoothSensitivityNoise,
+          Query::Atom: Clone + Sub<Output=Query::Atom>,
+          Noise::Unit: Float + InfCast<Query::Atom> + ExactIntCast<usize> {
+    let beta = Noise::beta(budget)?;
+
+    (0..sorted_data.len())
+        .map(move |k|
+            Ok(Noise::Unit::inf_cast(Query::a_k(&sorted_data, &bounds, k))? * (-Noise::Unit::exact_int_cast(k)? * beta).exp()))
+        // upgrade NaN to an Err
+        .map(|v|
+            v.and_then(|v| if v.is_nan() {fallible!(FailedFunction)} else {Ok(v)}))
+        // get max, or if Err, return Inf
+        .max_by(fallible_max).unwrap_or(Ok(Noise::Unit::infinity()))
+}
+
+pub fn make_ss_estimate<Query, Noise>(
+    bounds: (Query::Atom, Query::Atom),
+    influence: IntDistance,
+    budget: (Noise::Unit, Noise::Unit),
+) -> Fallible<Measurement<VectorDomain<BoundedDomain<Query::Atom>>, AllDomain<Query::Atom>, SymmetricDistance, SmoothedMaxDivergence<Noise::Unit>>>
+    where Query: SmoothSensitivityQuery,
+          Noise: SmoothSensitivityNoise<Distance=Query::Atom>,
+          Query::Atom: 'static + CheckNull + TotalOrd + Clone + Sub<Output=Query::Atom>,
+          Noise::Unit: 'static + Float + InfCast<Query::Atom> + ExactIntCast<usize> + ExactIntCast<IntDistance> {
+
     if influence < 1 { return fallible!(MakeMeasurement, "influence must be positive") }
+    let (epsilon, delta) = budget;
     if epsilon.is_sign_negative() { return fallible!(MakeMeasurement, "epsilon must be non-negative") }
-    let epsilon_prime = epsilon / influence as f64;
+    if delta.is_sign_negative() { return fallible!(MakeMeasurement, "delta must be non-negative") }
+
+    let epsilon_prime = epsilon.clone() / Noise::Unit::exact_int_cast(influence)?;
+    let delta_prime = epsilon / Noise::Unit::exact_int_cast(influence)?;
+    let budget_prime = (epsilon_prime.clone(), delta_prime);
 
     Ok(Measurement::new(
-        VectorDomain::new(BoundedDomain::new_closed(bounds)?),
+        VectorDomain::new(BoundedDomain::new_closed(bounds.clone())?),
         AllDomain::new(),
-        Function::new_fallible(move |data: &Vec<f64>| {
+        Function::new_fallible(move |data: &Vec<Query::Atom>| {
             let mut sorted_data = data.clone();
             sorted_data.sort_by(partial_max);
-            let median = sorted_data[(sorted_data.len() + 1) / 2];
 
-            let sensitivity = median_smooth_sensitivity(sorted_data, bounds, epsilon_prime);
-            f64::sample_laplace(median, sensitivity / epsilon_prime, false)
+            let value = Query::compute(&sorted_data);
+
+            let sens: Noise::Unit = compute_smooth_sensitivity::<Query, Noise>(sorted_data, bounds.clone(), budget_prime)?;
+
+            Noise::sample(value, sens / Noise::alpha(budget_prime)?)
         }),
         SymmetricDistance::default(),
-        MaxDivergence::default(),
+        SmoothedMaxDivergence::default(),
         PrivacyRelation::new(
-            move |&d_in, &d_out: &f64| d_in <= influence && epsilon <= d_out),
+            move |&d_in, &d_out: &(Noise::Unit, Noise::Unit)| d_in <= influence && budget <= d_out),
     ))
 }
 
@@ -62,13 +193,20 @@ mod test {
 
     #[test]
     fn test_function() -> Fallible<()> {
-        let sens = median_smooth_sensitivity(vec![2., 3., 4.], (1., 0.3), 1.);
-        println!("{}", sens);
+        let meas = make_ss_estimate::<Median<f64>, L1Distance<f64>>(
+            (-1., 10.), 1, (1., 1e-6))?;
+        let res = meas.invoke(&vec![-0.05, 2., 3., 0., 4., 1.2, 0.7, 1.3])?;
+        println!("fp median {}", res);
 
-        let meas = make_smooth_sensitivity_median((-1., 5.), 1, 1.)?;
+        let meas = make_ss_estimate::<Median<i32>, L1Distance<i32>>(
+            (-1, 10), 1, (1., 1e-6))?;
+        let res = meas.invoke(&vec![1,2,3,4,4,4,4,5,6,7,8])?;
+        println!("int median {}", res);
 
-        let res= meas.invoke(&vec![-0.05, 2., 3., 0., 4., 1.2, 0.7, 1.3])?;
-        println!("{}", res);
+        let meas = make_ss_estimate::<Minimum<i32>, L1Distance<i32>>(
+            (-1, 10), 1, (1., 1e-6))?;
+        let res = meas.invoke(&vec![1,1,2,3,4,4,4,4,5,6,7,8])?;
+        println!("int min {}", res);
         Ok(())
     }
 }

--- a/rust/opendp/src/meas/median/mod.rs
+++ b/rust/opendp/src/meas/median/mod.rs
@@ -6,6 +6,10 @@ use crate::dom::{AllDomain, BoundedDomain, VectorDomain};
 use crate::error::Fallible;
 use crate::samplers::SampleLaplace;
 
+fn partial_max<T: PartialOrd>(x: &T, y: &T) -> Ordering {
+    x.partial_cmp(y).unwrap_or(Ordering::Equal)
+}
+
 fn median_smooth_sensitivity(
     epsilon: f64,
     bounds: (f64, f64),
@@ -26,7 +30,7 @@ fn median_smooth_sensitivity(
 
     (0..sorted_data.len()).flat_map(move |k| (0..=k).map(move |t|
         difference(t, k) * (-(k as f64) * epsilon).exp()))
-        .max_by(|x, y| x.partial_cmp(y).unwrap_or(Ordering::Equal))
+        .max_by(partial_max)
         .unwrap_or(f64::INFINITY)
 }
 

--- a/rust/opendp/src/meas/median/mod.rs
+++ b/rust/opendp/src/meas/median/mod.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use crate::core::{Domain, Function, Measurement, Metric, PrivacyRelation};
+use crate::core::{Function, Measurement, PrivacyRelation};
 use crate::dist::{MaxDivergence, SymmetricDistance};
 use crate::dom::{AllDomain, BoundedDomain, VectorDomain};
 use crate::error::Fallible;
@@ -31,7 +31,7 @@ fn median_smooth_sensitivity(
         .max_by(partial_max).unwrap_or(f64::INFINITY)
 }
 
-pub fn make_smooth_sensitivity_median<DIA: Domain, DO: Domain, MI: 'static + Metric>(
+pub fn make_smooth_sensitivity_median(
     bounds: (f64, f64), influence: u32, epsilon: f64,
 ) -> Fallible<Measurement<VectorDomain<BoundedDomain<f64>>, AllDomain<f64>, SymmetricDistance, MaxDivergence<f64>>> {
     if influence < 1 { return fallible!(MakeMeasurement, "influence must be positive") }
@@ -43,7 +43,7 @@ pub fn make_smooth_sensitivity_median<DIA: Domain, DO: Domain, MI: 'static + Met
         AllDomain::new(),
         Function::new_fallible(move |data: &Vec<f64>| {
             let mut sorted_data = data.clone();
-            sorted_data.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
+            sorted_data.sort_by(partial_max);
             let median = sorted_data[(sorted_data.len() + 1) / 2];
 
             let sensitivity = median_smooth_sensitivity(sorted_data, bounds, epsilon_prime);
@@ -61,8 +61,14 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_function() {
+    fn test_function() -> Fallible<()> {
         let sens = median_smooth_sensitivity(vec![2., 3., 4.], (1., 0.3), 1.);
         println!("{}", sens);
+
+        let meas = make_smooth_sensitivity_median((-1., 5.), 1, 1.)?;
+
+        let res= meas.invoke(&vec![-0.05, 2., 3., 0., 4., 1.2, 0.7, 1.3])?;
+        println!("{}", res);
+        Ok(())
     }
 }

--- a/rust/opendp/src/meas/mod.rs
+++ b/rust/opendp/src/meas/mod.rs
@@ -18,6 +18,11 @@ pub mod geometric;
 #[cfg(feature="contrib")]
 pub use crate::meas::geometric::*;
 
+#[cfg(feature="contrib")]
+pub mod median;
+#[cfg(feature="contrib")]
+pub use crate::meas::median::*;
+
 #[cfg(all(feature="floating-point", feature="contrib"))]
 pub mod ptr;
 #[cfg(all(feature="floating-point", feature="contrib"))]

--- a/rust/opendp/src/meas/mod.rs
+++ b/rust/opendp/src/meas/mod.rs
@@ -19,9 +19,9 @@ pub mod geometric;
 pub use crate::meas::geometric::*;
 
 #[cfg(feature="contrib")]
-pub mod median;
+pub mod smooth_sensitivity;
 #[cfg(feature="contrib")]
-pub use crate::meas::median::*;
+pub use crate::meas::smooth_sensitivity::*;
 
 #[cfg(all(feature="floating-point", feature="contrib"))]
 pub mod ptr;


### PR DESCRIPTION
This PR adds a collection of smooth sensitivity estimators for the median, minimum and maximum, using the the laplace, gaussian and 2-sided geometric. You choose the p-space and the constructor chooses the appropriate noise distribution for your data type.

It mainly comes from the [smooth sensitivity paper](https://cs-people.bu.edu/ads22/pubs/NRS07/NRS07-full-draft-v1.pdf) and work with Monika Hu! 

Remains in draft mode until:
1. more feedback
2. refactor into a quantile estimator
2. test the utility, add more thorough tests
3. check that the geometric is (alpha, beta)-admissible
4. expand alpha-beta impls to more than just i32 and f64
5. is the proof only valid on sized datasets?
5. FFI