### PR TITLE
preparation for v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,25 +3,30 @@
 This file documents the version history of OpenDP.
 
 
-## [0.4.0] - 2021-11-15
-[0.4.0]: https://github.com/opendp/opendp/compare/v0.3.0...v0.4.0
+## [Unreleased](https://github.com/opendp/opendp/compare/stable...HEAD)
 
 ### Added
 - `make_randomized_response_bool` and `make_randomized_response` for local differential privacy.
-- `make_base_gaussian` now has an optional boolean to enable tighter analytic gaussian bounds.
+- `make_base_analytic_gaussian` for a tighter, analytic calibration of the gaussian mechanism.  
 - `make_population_amplification` combinator for privacy amplification by subsampling.
 - `make_drop_null` transformation for dropping null values in nullish data.
 - `make_find`, `make_find_bin` and `make_index` transformations for categorical relabeling and binning.
-- `make_count_by_ptr` for stability-based histograms.
-- Added floating-point numbers to the admissible output types on integer queries like `make_count`, `make_count_by_categories` and `make_count_distinct`.
-- Simple attack notebook (thanks to https://github.com/orespo)
+- `make_base_alp` for histograms via approximate laplace projections from Christian Lebeda (https://github.com/ChristianLebeda)
+- `make_base_ptr` for stability histograms via propose-test-release.
+- Added floating-point numbers to the admissible output types on integer queries like `make_count`, `make_count_by`, `make_count_by_categories` and `make_count_distinct`.
+- Simple attack notebook from Oren Renard (https://github.com/orespo)
+- Support for Numpy data types.
+
+### Fixed
+- Resolved memory leaks in FFI
 
 ### Changed
 - moved windows patch directory into `/rust`
 - added minimum rust version of 1.56 and updated to the 2021 edition.
+- dropped sized-ness domain requirements from `make_count_by`
 
 ### Security
-- `make_base_stability` underestimated the sensitivity of queries. Removed in favor of `make_count_by_ptr`.
+- `make_base_stability` underestimated the sensitivity of queries. Removed in favor of `make_base_ptr`.
 - Floating-point arithmetic throughout the library now has explicit rounding modes such that the budget is always slightly overestimated. There is still some potential for small floating-point leaks via rounding in floating-point aggregations.
 - Fixed integer truncation issue in the sized bounded sum privacy relation.
 - The resize relation is now looser to account for a worst-case situation where d_in records removed, and d_in new records are imputed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 This file documents the version history of OpenDP.
 
+
+## [0.4.0] - 2021-11-15
+[0.4.0]: https://github.com/opendp/opendp/compare/v0.3.0...v0.4.0
+
+### Added
+- `make_randomized_response_bool` and `make_randomized_response` for local differential privacy.
+- `make_base_gaussian` now has an optional boolean to enable tighter analytic gaussian bounds.
+- `make_population_amplification` combinator for privacy amplification by subsampling.
+- `make_drop_null` transformation for dropping null values in nullish data.
+- `make_find`, `make_find_bin` and `make_index` transformations for categorical relabeling and binning.
+- `make_count_by_ptr` for stability-based histograms.
+- Added floating-point numbers to the admissible output types on integer queries like `make_count`, `make_count_by_categories` and `make_count_distinct`.
+- Simple attack notebook (thanks to https://github.com/orespo)
+
+### Changed
+- moved windows patch directory into `/rust`
+- added minimum rust version of 1.56 and updated to the 2021 edition.
+
+### Security
+- `make_base_stability` underestimated the sensitivity of queries. Removed in favor of `make_count_by_ptr`.
+- Floating-point arithmetic throughout the library now has explicit rounding modes such that the budget is always slightly overestimated. There is still some potential for small floating-point leaks via rounding in floating-point aggregations.
+- Fixed integer truncation issue in the sized bounded sum privacy relation.
+- The resize relation is now looser to account for a worst-case situation where d_in records removed, and d_in new records are imputed.
+
+
 ## [0.3.0] - 2021-09-21
 [0.3.0]: https://github.com/opendp/opendp/compare/v0.2.4...v0.3.0
 

--- a/docs/source/user/combinator-constructors.rst
+++ b/docs/source/user/combinator-constructors.rst
@@ -1,3 +1,8 @@
+.. testsetup::
+
+    from opendp.mod import enable_features
+    enable_features('contrib', 'floating-point')
+
 .. _combinator-constructors:
 
 Combinator Constructors
@@ -24,11 +29,6 @@ Notice that `there is no` ``make_chain_mm`` for chaining measurements together!
 Any computation beyond a measurement is postprocessing and need not be governed by relations.
 
 In the following example we chain :py:func:`opendp.meas.make_base_geometric` with :py:func:`opendp.trans.make_bounded_sum`.
-
-.. testsetup::
-
-    from opendp.mod import enable_features
-    enable_features('contrib')
 
 .. doctest::
 

--- a/docs/source/user/combinator-constructors.rst
+++ b/docs/source/user/combinator-constructors.rst
@@ -106,7 +106,37 @@ Progress on more general composition constructors can be found in the following 
 Amplification
 -------------
 
-Population amplification based on sampling has an implementation but is not yet finalized.
-Progress on this can be found in the following PR:
+If your dataset is a simple sample from a larger population,
+you can make the privacy relation more permissive by wrapping your measurement with a privacy amplification combinator.
 
-:#233: `population amplification <https://github.com/opendp/opendp/pull/233>`_
+In order to demonstrate this API, we'll first create a measurement with a sized input domain.
+The resulting measurement expects the size of the input dataset to be 10.
+
+.. doctest::
+
+    >>> from opendp.trans import make_sized_bounded_mean
+    >>> from opendp.meas import make_base_laplace
+    >>> meas = make_sized_bounded_mean(size=10, bounds=(0., 10.)) >> make_base_laplace(scale=0.5)
+    >>> print("standard mean:", amplified([1.] * 10)) # -> 1.03 # doctest: +SKIP
+
+We can now use the amplification combinator to construct an amplified measurement.
+The function on the amplified measurement is identical to the standard measurement.
+
+.. doctest::
+
+    >>> from opendp.comb import make_population_amplification
+    >>> amplified = make_population_amplification(meas, population_size=100)
+    >>> print("amplified mean:", amplified([1.] * 10)) # -> .97 # doctest: +SKIP
+
+The privacy relation on the amplified measurement takes into account that the input dataset of size 10
+is a simple sample of individuals from a theoretical larger dataset that captures the entire population, with 100 rows.
+
+.. doctest::
+
+    >>> # Where we once had a privacy utilization of 2 epsilon...
+    >>> assert meas.check(2, 2.)
+    ...
+    >>> # ...we now have a privacy utilization of ~.4941 epsilon.
+    >>> assert amplified.check(2, .4941)
+
+The efficacy of this combinator improves as n gets larger.

--- a/docs/source/user/measurement-constructors.rst
+++ b/docs/source/user/measurement-constructors.rst
@@ -59,6 +59,14 @@ You can choose whether to construct scalar or vector-valued versions by setting 
      - ``MapDomain<AllDomain<TIA>, AllDomain<TOA>>``
      - ``L1Distance<T>``
      - ``SmoothedMaxDivergence<T>``
+   * - :func:`opendp.meas.make_randomized_response_bool`
+     - ``AllDomain<bool>``
+     - ``SymmetricDistance``
+     - ``MaxDivergence<T>``
+   * - :func:`opendp.meas.make_randomized_response`
+     - ``AllDomain<T>``
+     - ``SymmetricDistance``
+     - ``MaxDivergence<T>``
 
 .. _floating-point:
 
@@ -79,9 +87,13 @@ At this time these mechanisms are present in the library, but require explicit o
 The canonical paper on this and introduction of the snapping mechanism is here:
 `On Significance of the Least Significant Bits For Differential Privacy <https://www.microsoft.com/en-us/research/wp-content/uploads/2012/10/lsbs.pdf>`_.
 
-Precautions have been made to sample noise using the MPFR library, to avoid artifacts in noise,
-but our noise postprocessing re-introduces artifacts.
-We are developing alternative mechanisms for answering continuous queries.
+Precautions have been made to sample noise using the GNU MPFR library in a way
+that provides cryptographically secure, non-porous noise at standard scale.
+Noise at arbitrary scale is achieved through a combination of preprocessing and postprocessing
+that preserves the properties of differential privacy.
+
+Precautions have also been made to explicitly specify floating-point rounding modes
+in such a way that the privacy budget is always slightly overestimated.
 
 We acknowledge the snapping mechanism and have an implementation of it `in PR #84 <https://github.com/opendp/opendp/pull/84>`_.
 

--- a/docs/source/user/transformation-constructors.rst
+++ b/docs/source/user/transformation-constructors.rst
@@ -135,6 +135,63 @@ so long as you pass the DA (atomic domain) type argument.
      - ``VectorDomain<InherentNullDomain<AllDomain<TA>>>``
      - ``VectorDomain<AllDomain<TA>>``
 
+Indexing
+--------
+Indexing operations provide a way to relabel categorical data, or bin numeric data into categorical data.
+These operations work with `usize` data types: an integral data type representing an index.
+:func:`opendp.trans.make_find` finds the index of each input datum in a set of categories.
+In other words, it transforms a categorical data vector to a vector of numeric indices.
+
+.. testsetup::
+
+    from opendp.trans import make_find, make_impute_constant, make_find_bin, make_index
+    from opendp.typing import *
+    from opendp.mod import enable_features
+    enable_features('contrib')
+
+.. doctest::
+
+    >>> finder = (
+    ...     make_find(categories=["A", "B", "C"]) >>
+    ...     # impute any input datum that are not a part of the categories list as 3
+    ...     make_impute_constant(3, DA=OptionNullDomain[AllDomain["usize"]])
+    ... )
+    >>> finder(["A", "B", "C", "A", "D"])
+    [0, 1, 2, 0, 3]
+
+:func:`opendp.trans.make_find_bin` is a binning operation that transforms numerical input data to a vector of bin indices.
+
+.. doctest::
+
+    >>> binner = make_find_bin(edges=[1., 2., 10.])
+    >>> binner([0., 1., 3., 15.])
+    [0, 1, 2, 3]
+
+:func:`opendp.trans.make_index` uses each indicial input datum as an index into a category set.
+
+.. doctest::
+
+    >>> indexer = make_index(categories=["A", "B", "C"], null="D")
+    >>> indexer([0, 1, 2, 3, 2342])
+    ['A', 'B', 'C', 'D', 'D']
+
+You can use combinations of the indicial transformers to map hashable data to integers, bin numeric types, relabel hashable types, and label bins.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Indexer
+     - Input Domain
+     - Output Domain
+   * - :func:`opendp.trans.make_find`
+     - ``VectorDomain<AllDomain<TIA>>``
+     - ``VectorDomain<OptionNullDomain<AllDomain<usize>>>``
+   * - :func:`opendp.trans.make_find_bin`
+     - ``VectorDomain<AllDomain<TIA>>``
+     - ``VectorDomain<AllDomain<usize>>``
+   * - :func:`opendp.trans.make_index`
+     - ``VectorDomain<AllDomain<usize>>``
+     - ``VectorDomain<AllDomain<TOA>>``
 
 Clamping
 --------

--- a/python/example/README.md
+++ b/python/example/README.md
@@ -1,0 +1,7 @@
+## Python Notebooks
+The following notebooks show how to use the OpenDP library through the Python bindings.
+
+* [`basic_data_analysis.ipynb`](basic_data_analysis.ipynb) A brief tutorial of data analysis with the OpenDP library.
+* [`histograms.ipynb`](histograms.ipynb) A tour of algorithms to release histograms on integer, string and boolean variables.
+* [`unknown_dataset_size.ipynb`](unknown_dataset_size.ipynb) Learn how to use statistical estimators that require a known dataset size in situations where dataset size is unknown.
+* [`simple_attack.ipynb`](simple_attack.ipynb): Demonstrates a simple attack on traditional, non-private data releases.

--- a/rust/opendp-ffi/Cargo.toml
+++ b/rust/opendp-ffi/Cargo.toml
@@ -7,7 +7,8 @@ homepage = "https://opendp.org/"
 repository = "https://github.com/opendp/opendp"
 version = "0.0.0-development"
 authors = ["The OpenDP Project <info@opendp.org>"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 build = "build/main.rs"
 
 [dependencies]

--- a/rust/opendp/Cargo.toml
+++ b/rust/opendp/Cargo.toml
@@ -7,7 +7,8 @@ homepage = "https://opendp.org/"
 repository = "https://github.com/opendp/opendp"
 version = "0.0.0-development"
 authors = ["The OpenDP Project <info@opendp.org>"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 rand = "0.7.3"


### PR DESCRIPTION
- Updated changelog
- Close #169, updated rust edition to 2021
- Close #391 
- Close #406, fixed warnings from rust 1.56
- Updated documentation for the index transforms, randomized response, privacy amplification
- Updated documentation for floating-point vulnerabilities

Once unblocked, update this PR with respective documentation/changes and undraft.