### PR TITLE
__del__ destructor for AnyObjects

### DIFF
--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -276,20 +276,23 @@ def _hashmap_to_slice(val: Dict[Any, Any], type_name: str) -> FfiSlicePtr:
     ffislice = _wrap_in_slice(ctypes.pointer((AnyObjectPtr * 2)(keys, vals)), 2)
 
     # The __del__ destructor on `keys` and `vals` is called and memory freed when their refcounts go to zero.
-    # We can't allow their refcount to go to zero until ffislice is freed.
+    # ffislice needs keys and vals to have a lifetime at least as long as itself,
+    # so we can't allow their refcount to go to zero until ffislice is freed.
     ffislice.depends_on(keys, vals)
     return ffislice
 
 
 def _slice_to_hashmap(raw: FfiSlicePtr) -> Dict[Any, Any]:
-    keys_obj, vals_obj = ctypes.cast(raw.contents.ptr, ctypes.POINTER(AnyObjectPtr))[0:2]
-    result = dict(zip(c_to_py(keys_obj), c_to_py(vals_obj)))
+    slice_array = ctypes.cast(raw.contents.ptr, ctypes.POINTER(AnyObjectPtr))
+    keys: AnyObjectPtr = slice_array[0]
+    vals: AnyObjectPtr = slice_array[1]
+    result = dict(zip(c_to_py(keys), c_to_py(vals)))
 
-    # AnyObjectPtr's __del__ would free the memory behind keys_obj and vals_obj when this stack frame is popped.
+    # AnyObjectPtr.__del__ would free the memory behind keys and vals when this stack frame is popped.
     # But that memory has a lifetime at least as long as raw, so it cannot be freed yet.
-    # Adjust the class to avoid calling AnyObject.__del__, which would free the backing memory.
-    keys_obj.__class__ = ctypes.POINTER(AnyObject)
-    vals_obj.__class__ = ctypes.POINTER(AnyObject)
+    # Adjust the class to avoid calling AnyObjectPtr.__del__, which would free the backing memory.
+    keys.__class__ = ctypes.POINTER(AnyObject)
+    vals.__class__ = ctypes.POINTER(AnyObject)
     return result
 
 

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -68,9 +68,11 @@ class FfiSlicePtr(ctypes.POINTER(FfiSlice)):
     _dependencies = {}
 
     def depends_on(self, *args):
+        """Extends the memory lifetime of args to the lifetime of self."""
         FfiSlicePtr._dependencies.setdefault(id(self), []).extend(args)
 
     def __del__(self):
+        """When self is deleted, stop keeping dependencies alive by freeing the reference."""
         FfiSlicePtr._dependencies.pop(id(self), None)
 
 

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -58,9 +58,20 @@ class BoolPtr(ctypes.POINTER(ctypes.c_bool)):
 class AnyObjectPtr(ctypes.POINTER(AnyObject)):
     _type_ = AnyObject
 
+    def __del__(self):
+        from opendp._data import object_free
+        object_free(self)
+
 
 class FfiSlicePtr(ctypes.POINTER(FfiSlice)):
     _type_ = FfiSlice
+    _dependencies = {}
+
+    def depends_on(self, *args):
+        FfiSlicePtr._dependencies.setdefault(id(self), []).extend(args)
+
+    def __del__(self):
+        FfiSlicePtr._dependencies.pop(id(self), None)
 
 
 class FfiError(ctypes.Structure):


### PR DESCRIPTION
Closes #397 

This adds a `__del__` destructor for AnyObjects, so that constructor arguments, invoke arguments/returns, and check arguments are freed. 

It also adds some python refcounting manipulation to prevent the AnyObjects used to build HashMaps from being freed too early, or to be double-freed.