### PR TITLE
avoid overflow in geometric mechanism

### DIFF
--- a/rust/opendp/src/samplers.rs
+++ b/rust/opendp/src/samplers.rs
@@ -384,7 +384,7 @@ impl<T: Clone + SampleGeometric + Sub<Output=T> + Bounded + Zero + One + TotalOr
         } else {None};
 
         // make alpha conservatively larger
-        let inf_alpha: f64 = scale.recip().neg_inf_exp()?.recip();
+        let inf_alpha: f64 = (-scale.recip()).inf_exp()?;
 
         // It should be possible to drop the input clamp at a cost of `delta = 2^(-(upper - lower))`.
         // Thanks for the input @ctcovington (Christian Covington)

--- a/rust/opendp/src/traits/arithmetic.rs
+++ b/rust/opendp/src/traits/arithmetic.rs
@@ -237,7 +237,7 @@ macro_rules! impl_float_inf_uni {
                 let this = Self::from_internal(this);
                 this.is_finite().then(|| this).ok_or_else(|| err!(
                     FailedFunction,
-                    concat!("({}).", stringify!($method), "() is not finite. Consider tightening your parameters."),
+                    concat!("({}).", stringify!($method_inf), "() is not finite. Consider tightening your parameters."),
                     self))
             }
             fn $method_neg_inf(self) -> Fallible<Self> {
@@ -247,7 +247,7 @@ macro_rules! impl_float_inf_uni {
                 let this = Self::from_internal(this);
                 this.is_finite().then(|| this).ok_or_else(|| err!(
                     FailedFunction,
-                    concat!("({}).", stringify!($method), "() is not finite. Consider tightening your parameters."),
+                    concat!("({}).", stringify!($method_neg_inf), "() is not finite. Consider tightening your parameters."),
                     self))
             }
         }
@@ -257,14 +257,14 @@ macro_rules! impl_float_inf_uni {
                 let this = self.$fallback();
                 this.is_finite().then(|| this).ok_or_else(|| err!(
                     FailedFunction,
-                    concat!("({}).", stringify!($method), "() is not finite. Consider tightening your parameters."),
+                    concat!("({}).", stringify!($method_inf), "() is not finite. Consider tightening your parameters."),
                     self))
             }
             fn $method_neg_inf(self) -> Fallible<Self> {
                 let this = self.$fallback();
                 this.is_finite().then(|| this).ok_or_else(|| err!(
                     FailedFunction,
-                    concat!("({}).", stringify!($method), "() is not finite. Consider tightening your parameters."),
+                    concat!("({}).", stringify!($method_neg_inf), "() is not finite. Consider tightening your parameters."),
                     self))
             }
         })+
@@ -314,7 +314,7 @@ macro_rules! impl_float_inf_bi {
                 let this = Self::from_internal(this);
                 this.is_finite().then(|| this).ok_or_else(|| err!(
                     FailedFunction,
-                    concat!("({}).", stringify!($method), "({}) is not finite. Consider tightening your parameters."),
+                    concat!("({}).", stringify!($method_inf), "({}) is not finite. Consider tightening your parameters."),
                     self, other))
             }
             fn $method_neg_inf(&self, other: &Self) -> Fallible<Self> {
@@ -324,7 +324,7 @@ macro_rules! impl_float_inf_bi {
                 let this = Self::from_internal(this);
                 this.is_finite().then(|| this).ok_or_else(|| err!(
                     FailedFunction,
-                    concat!("({}).", stringify!($method), "({}) is not finite. Consider tightening your parameters."),
+                    concat!("({}).", stringify!($method_neg_inf), "({}) is not finite. Consider tightening your parameters."),
                     self, other))
             }
         }
@@ -334,14 +334,14 @@ macro_rules! impl_float_inf_bi {
                 let this = self.$fallback(other);
                 this.is_finite().then(|| this).ok_or_else(|| err!(
                     FailedFunction,
-                    concat!("({}).", stringify!($method), "({}) is not finite. Consider tightening your parameters."),
+                    concat!("({}).", stringify!($method_inf), "({}) is not finite. Consider tightening your parameters."),
                     self, other))
             }
             fn $method_neg_inf(&self, other: &Self) -> Fallible<Self> {
                 let this = self.$fallback(other);
                 this.is_finite().then(|| this).ok_or_else(|| err!(
                     FailedFunction,
-                    concat!("({}).", stringify!($method), "({}) is not finite. Consider tightening your parameters."),
+                    concat!("({}).", stringify!($method_neg_inf), "({}) is not finite. Consider tightening your parameters."),
                     self, other))
             }
         })+


### PR DESCRIPTION
Closes #401 
The order of operations caused a greater tendency for overflow- even when scale is as large as `.0001`.

This PR also adjusts the error messages when you do overflow.