### PR TITLE
fix permission denied url with git clone

### DIFF
--- a/docs/source/user/getting-started.rst
+++ b/docs/source/user/getting-started.rst
@@ -83,7 +83,7 @@ Assuming your base environment is ready, start by cloning the `opendp git repo <
 
 .. prompt:: bash
 
-    git clone git@github.com:opendp/opendp.git
+    git clone https://github.com/opendp/opendp.git
     cd opendp
 
 Next, you'll need to build the Rust binaries. This is done by running ``cargo build`` in the ``rust`` subdirectory of the repo:


### PR DESCRIPTION
When i use `git clone git@github.com:opendp/opendp.git`, got this
```bash
git@github.com: Permission denied (publickey).
``` 
So i try to fix it with github url