### PR TITLE
sequential compositor w/ static distances (double dispatch)

### DIFF
--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -3,7 +3,7 @@ from typing import Sequence, Tuple, List, Union, Dict
 from opendp._lib import *
 
 from opendp.mod import UnknownTypeException, OpenDPException, Transformation, Measurement
-from opendp.typing import RuntimeType
+from opendp.typing import RuntimeType, Vec
 
 try:
     import numpy as np
@@ -71,17 +71,19 @@ def py_to_c(value: Any, c_type, type_name: Union[RuntimeType, str] = None):
 
         # TODO: This is ugly!
         # the nested type will be different than the type_name, because it is now AnyObject
-        if type_name.origin.startswith("Vec") and isinstance(type_name.args[0], RuntimeType):
-            type_name.args[0] = "AnyObject"
+        # if type_name.origin.startswith("Vec") and isinstance(type_name.args[0], RuntimeType):
+        #     type_name.args[0] = "AnyObjectPtr"
 
         return slice_as_object(value, type_name)
 
     if c_type == FfiSlicePtr:
         assert type_name is not None
-        print("TAG", type_name, value)
+        print("py_to_c: c_type is FfiSlicePtr", type_name, value)
         return _py_to_slice(value, type_name)
 
     if isinstance(value, RuntimeType):
+        if value.origin == "Vec" and str(value.args[0]) not in ATOM_MAP:
+            value.args[0] = "AnyObjectPtr"
         value = str(value)
 
     if isinstance(value, str):
@@ -115,18 +117,19 @@ def c_to_py(value):
             # TODO: Remove this fallback once we have composition and/or tuples sorted out.
             return to_string(value)
         finally:
-            slice_free(ffi_slice)
+            pass
+            # slice_free(ffi_slice)
 
     if isinstance(value, ctypes.c_char_p):
         from opendp._data import str_free
         value_contents = value.value.decode()
-        str_free(value)
+        # str_free(value)
         return value_contents
 
     if isinstance(value, BoolPtr):
         from opendp._data import bool_free
         value_contents = value.contents.value
-        bool_free(value)
+        # bool_free(value)
         return value_contents
 
     if isinstance(value, (Transformation, Measurement)):
@@ -220,11 +223,13 @@ def _vector_to_slice(val: Sequence[Any], type_name: RuntimeType) -> FfiSlicePtr:
     assert len(type_name.args) == 1, "Vec only has one generic argument"
     inner_type_name = type_name.args[0]
 
+    # input is numpy array
+    # TODO: can we use the underlying buffer directly?
     if np is not None and isinstance(val, np.ndarray):
         val = val.tolist()
 
     if not isinstance(val, list):
-        raise OpenDPException(f"Cannot cast a non-list type to a vector")
+        raise TypeError(f"Cannot cast a non-list type to a vector")
 
     if inner_type_name == "String":
         def str_to_slice(val):
@@ -233,19 +238,20 @@ def _vector_to_slice(val: Sequence[Any], type_name: RuntimeType) -> FfiSlicePtr:
         return _wrap_in_slice(array, len(val))
 
     if isinstance(inner_type_name, RuntimeType):
-        print("TAG2", inner_type_name)
-        converted = (py_to_c(v, c_type=AnyObjectPtr, type_name=inner_type_name) for v in val)
-        array = (AnyObjectPtr * len(val))(*converted)
-        return _wrap_in_slice(array, len(val))
+        c_repr = [py_to_c(v, c_type=AnyObjectPtr, type_name=inner_type_name) for v in val]
+        array = (AnyObjectPtr * len(val))(*c_repr)
+        ffislice = _wrap_in_slice(array, len(val))
+        ffislice.depends_on(*c_repr)
+        return ffislice
 
     if inner_type_name not in ATOM_MAP:
-        raise OpenDPException(f"Members must be one of {ATOM_MAP.keys()}. Found {inner_type_name}.")
+        raise TypeError(f"Members must be one of {tuple(ATOM_MAP.keys())}. Found {inner_type_name}.")
 
     if val:
         # check that actual type can be represented by the inner_type_name
         equivalence_class = ATOM_EQUIVALENCE_CLASSES[str(RuntimeType.infer(val[0]))]
         if inner_type_name not in equivalence_class:
-            raise OpenDPException("Data cannot be represented by the suggested type_name")
+            raise TypeError("Data cannot be represented by the suggested type_name")
 
     array = (ATOM_MAP[inner_type_name] * len(val))(*val)
     return _wrap_in_slice(array, len(val))
@@ -266,35 +272,38 @@ def _slice_to_vector(raw: FfiSlicePtr, type_name: RuntimeType) -> List[Any]:
 def _tuple_to_slice(val: Tuple[Any, ...], type_name: RuntimeType) -> FfiSlicePtr:
     inner_type_names = type_name.args
     if not isinstance(val, tuple):
-        raise OpenDPException("Cannot coerce a non-tuple type to a tuple")
+        raise TypeError("Cannot coerce a non-tuple type to a tuple")
     # TODO: temporary check
     if len(inner_type_names) != 2:
         raise OpenDPException("Only 2-tuples are currently supported.")
 
     if len(inner_type_names) != len(val):
-        raise OpenDPException("type_name members must have same length as tuple")
+        raise TypeError("type_name members must have same length as tuple")
 
     for t in inner_type_names:
         if t not in ATOM_MAP:
-            raise OpenDPException(f"Tuple members must be one of {ATOM_MAP.keys()}. Got {t}")
+            raise TypeError(f"Tuple members must be one of {ATOM_MAP.keys()}. Got {t}")
 
     # check that actual type can be represented by the inner_type_name
     for v, inner_type_name in zip(val, inner_type_names):
         equivalence_class = ATOM_EQUIVALENCE_CLASSES[str(RuntimeType.infer(v))]
         if inner_type_name not in equivalence_class:
-            raise OpenDPException("Data cannot be represented by the suggested type_name")
+            raise TypeError("Data cannot be represented by the suggested type_name")
 
     def scalar_to_c(v, name):
-        print("TAG3", name)
-        # no need to put measurements behind a pointer, they are already a pointer
-        if name == "AnyMeasurementPtr":
+        # some types are already in c representation
+        if name in {"AnyMeasurementPtr", "AnyTransformationPtr", "AnyObjectPtr"}:
             return v
         return ctypes.pointer(ATOM_MAP[name](v))
+
     # ctypes.byref has edge-cases that cause use-after-free errors. ctypes.pointer fixes these edge-cases
-    ptr_data = (ctypes.cast(scalar_to_c(v, name), ctypes.c_void_p)
-                for v, name in zip(val, inner_type_names))
+    c_reprs = [scalar_to_c(v, name) for v, name in zip(val, inner_type_names)]
+    ptr_data = (ctypes.cast(v, ctypes.c_void_p) for v in c_reprs)
+
     array = (ctypes.c_void_p * len(val))(*ptr_data)
-    return _wrap_in_slice(ctypes.pointer(array), len(val))
+    ffislice = _wrap_in_slice(ctypes.pointer(array), len(val))
+    ffislice.depends_on(c_reprs)
+    return ffislice
 
 
 def _slice_to_tuple(raw: FfiSlicePtr, type_name: RuntimeType) -> Tuple[Any, ...]:
@@ -310,8 +319,8 @@ def _slice_to_tuple(raw: FfiSlicePtr, type_name: RuntimeType) -> Tuple[Any, ...]
 
 def _hashmap_to_slice(val: Dict[Any, Any], type_name: RuntimeType) -> FfiSlicePtr:
     key_type, val_type = type_name.args
-    keys: AnyObjectPtr = py_to_c(list(val.keys()), type_name=f"Vec<{key_type}>", c_type=AnyObjectPtr)
-    vals: AnyObjectPtr = py_to_c(list(val.values()), type_name=f"Vec<{val_type}>", c_type=AnyObjectPtr)
+    keys: AnyObjectPtr = py_to_c(list(val.keys()), type_name=Vec[key_type], c_type=AnyObjectPtr)
+    vals: AnyObjectPtr = py_to_c(list(val.values()), type_name=Vec[val_type], c_type=AnyObjectPtr)
     ffislice = _wrap_in_slice(ctypes.pointer((AnyObjectPtr * 2)(keys, vals)), 2)
 
     # The __del__ destructor on `keys` and `vals` is called and memory freed when their refcounts go to zero.

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -63,9 +63,9 @@ class BoolPtr(ctypes.POINTER(ctypes.c_bool)):
 class AnyObjectPtr(ctypes.POINTER(AnyObject)):
     _type_ = AnyObject
 
-    def __del__(self):
-        from opendp._data import object_free
-        object_free(self)
+    # def __del__(self):
+    #     from opendp._data import object_free
+    #     object_free(self)
 
 
 class FfiSlicePtr(ctypes.POINTER(FfiSlice)):
@@ -76,9 +76,9 @@ class FfiSlicePtr(ctypes.POINTER(FfiSlice)):
         """Extends the memory lifetime of args to the lifetime of self."""
         FfiSlicePtr._dependencies.setdefault(id(self), []).extend(args)
 
-    def __del__(self):
-        """When self is deleted, stop keeping dependencies alive by freeing the reference."""
-        FfiSlicePtr._dependencies.pop(id(self), None)
+    # def __del__(self):
+    #     """When self is deleted, stop keeping dependencies alive by freeing the reference."""
+    #     FfiSlicePtr._dependencies.pop(id(self), None)
 
 
 class FfiError(ctypes.Structure):

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -9,7 +9,7 @@ ATOM_EQUIVALENCE_CLASSES = {
     'f64': ['f32', 'f64'],
     'bool': ['bool'],
     'AnyMeasurementPtr': ['AnyMeasurementPtr'],
-    'AnyTransformationPtr': ['AnyTransformationPtr']
+    'AnyTransformationPtr': ['AnyTransformationPtr'],
 }
 
 lib_dir = os.environ.get("OPENDP_LIB_DIR", os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -7,7 +7,9 @@ from typing import Optional, Any
 ATOM_EQUIVALENCE_CLASSES = {
     'i32': ['u8', 'u16', 'u32', 'u64', 'i8', 'i16', 'i32', 'i64', 'usize'],
     'f64': ['f32', 'f64'],
-    'bool': ['bool']
+    'bool': ['bool'],
+    'AnyMeasurementPtr': ['AnyMeasurementPtr'],
+    'AnyTransformationPtr': ['AnyTransformationPtr']
 }
 
 lib_dir = os.environ.get("OPENDP_LIB_DIR", os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))

--- a/python/src/opendp/comb.py
+++ b/python/src/opendp/comb.py
@@ -7,7 +7,7 @@ from opendp.typing import *
 __all__ = [
     "make_chain_mt",
     "make_chain_tt",
-    "make_basic_composition",
+    "make_sequential_composition_static_distances",
     "make_population_amplification"
 ]
 
@@ -47,7 +47,7 @@ def make_chain_tt(
     transformation1: Transformation,
     transformation0: Transformation
 ) -> Transformation:
-    """Construct the functional composition (`transformation1` ○ `transformation0`). Returns a Tranformation.
+    """Construct the functional composition (`transformation1` ○ `transformation0`). Returns a Transformation.
     
     :param transformation1: outer transformation
     :type transformation1: Transformation
@@ -74,35 +74,35 @@ def make_chain_tt(
     return c_to_py(unwrap(function(transformation1, transformation0), Transformation))
 
 
-def make_basic_composition(
-    measurement0: Measurement,
-    measurement1: Measurement
+def make_sequential_composition_static_distances(
+    measurement_pairs: Any,
+    QO: RuntimeTypeDescriptor = "f64"
 ) -> Measurement:
-    """Construct the DP composition (`measurement0`, `measurement1`). Returns a Measurement.
+    """Construct the DP composition [`measurement0`, `measurement1`, ...]. Returns a Measurement.
     
-    :param measurement0: The left member of the resulting 2-tuple.
-    :type measurement0: Measurement
-    :param measurement1: The right member of the resulting 2-tuple.
-    :type measurement1: Measurement
+    :param measurement_pairs: A list of measurements to compose.
+    :type measurement_pairs: Any
+    :param QO: Type of output distance.
+    :type QO: RuntimeTypeDescriptor
     :return: Measurement representing the composed transformations.
     :rtype: Measurement
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
     :raises OpenDPException: packaged error from the core OpenDP library
     """
-    assert_features("contrib")
+    # Standardize type arguments.
+    QO = RuntimeType.parse(type_name=QO)
     
-    # No type arguments to standardize.
     # Convert arguments to c types.
-    measurement0 = py_to_c(measurement0, c_type=Measurement)
-    measurement1 = py_to_c(measurement1, c_type=Measurement)
+    measurement_pairs = py_to_c(measurement_pairs, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[RuntimeType(origin='Tuple', args=["AnyMeasurementPtr", QO])]))
+    QO = py_to_c(QO, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_comb__make_basic_composition
-    function.argtypes = [Measurement, Measurement]
+    function = lib.opendp_comb__make_sequential_composition_static_distances
+    function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(measurement0, measurement1), Measurement))
+    return c_to_py(unwrap(function(measurement_pairs, QO), Measurement))
 
 
 def make_population_amplification(

--- a/python/src/opendp/comb.py
+++ b/python/src/opendp/comb.py
@@ -83,7 +83,7 @@ def make_sequential_composition_static_distances(
     :param measurement_pairs: A list of measurements to compose.
     :type measurement_pairs: Any
     :param QO: Type of output distance.
-    :type QO: RuntimeTypeDescriptor
+    :type QO: :ref:`RuntimeTypeDescriptor`
     :return: Measurement representing the composed transformations.
     :rtype: Measurement
     :raises AssertionError: if an argument's type differs from the expected type

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -114,9 +114,13 @@ class Measurement(ctypes.POINTER(AnyMeasurement)):
         from opendp.typing import RuntimeType
         return RuntimeType.parse(measurement_input_carrier_type(self))
 
-    def __del__(self):
-        from opendp.core import _measurement_free
-        _measurement_free(self)
+    # def __del__(self):
+    #     try:
+    #         from opendp.core import _measurement_free
+    #         _measurement_free(self)
+    #     except ImportError:
+    #         # ImportError: sys.meta_path is None, Python is likely shutting down
+    #         pass
 
 
 class Transformation(ctypes.POINTER(AnyTransformation)):
@@ -239,12 +243,12 @@ class Transformation(ctypes.POINTER(AnyTransformation)):
         from opendp.typing import RuntimeType
         return RuntimeType.parse(transformation_input_carrier_type(self))
 
-    def __del__(self):
-        try:
-            from opendp.core import _transformation_free
-            _transformation_free(self)
-        except ImportError:
-            pass
+    # def __del__(self):
+    #     try:
+    #         from opendp.core import _transformation_free
+    #         _transformation_free(self)
+    #     except ImportError:
+    #         pass
 
 
 class UnknownTypeException(Exception):

--- a/python/src/opendp/trans.py
+++ b/python/src/opendp/trans.py
@@ -380,19 +380,13 @@ def make_count_distinct(
 
 
 def make_count_by(
-    size: int,
     MO: SensitivityMetric,
-    TIA: RuntimeTypeDescriptor,
-    TOA: RuntimeTypeDescriptor = "i32"
+    TK: RuntimeTypeDescriptor,
+    TV: RuntimeTypeDescriptor = "i32"
 ) -> Transformation:
     """Make a Transformation that computes the count of each unique value in data. 
-    This assumes that the category set is unknown. 
-    This uses a restricted-sensitivity proof that takes advantage of known dataset size. 
-    Use `make_resize` to establish dataset size. 
-    This transformation depends on a measurement that has not yet been implemented.
+    This assumes that the category set is unknown.
     
-    :param size: Number of records in input data.
-    :type size: int
     :param MO: Output Metric.
     :type MO: SensitivityMetric
     :param TK: Type of Key. Categorical/hashable input data type. Input data must be Vec<TK>.
@@ -409,21 +403,20 @@ def make_count_by(
     
     # Standardize type arguments.
     MO = RuntimeType.parse(type_name=MO)
-    TIA = RuntimeType.parse(type_name=TIA)
-    TOA = RuntimeType.parse(type_name=TOA)
+    TK = RuntimeType.parse(type_name=TK)
+    TV = RuntimeType.parse(type_name=TV)
     
     # Convert arguments to c types.
-    size = py_to_c(size, c_type=ctypes.c_uint)
     MO = py_to_c(MO, c_type=ctypes.c_char_p)
-    TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
-    TOA = py_to_c(TOA, c_type=ctypes.c_char_p)
+    TK = py_to_c(TK, c_type=ctypes.c_char_p)
+    TV = py_to_c(TV, c_type=ctypes.c_char_p)
     
     # Call library function.
     function = lib.opendp_trans__make_count_by
-    function.argtypes = [ctypes.c_uint, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+    function.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, MO, TIA, TOA), Transformation))
+    return c_to_py(unwrap(function(MO, TK, TV), Transformation))
 
 
 def make_count_by_categories(

--- a/python/src/opendp/trans.py
+++ b/python/src/opendp/trans.py
@@ -380,13 +380,19 @@ def make_count_distinct(
 
 
 def make_count_by(
+    size: int,
     MO: SensitivityMetric,
-    TK: RuntimeTypeDescriptor,
-    TV: RuntimeTypeDescriptor = "i32"
+    TIA: RuntimeTypeDescriptor,
+    TOA: RuntimeTypeDescriptor = "i32"
 ) -> Transformation:
     """Make a Transformation that computes the count of each unique value in data. 
-    This assumes that the category set is unknown.
+    This assumes that the category set is unknown. 
+    This uses a restricted-sensitivity proof that takes advantage of known dataset size. 
+    Use `make_resize` to establish dataset size. 
+    This transformation depends on a measurement that has not yet been implemented.
     
+    :param size: Number of records in input data.
+    :type size: int
     :param MO: Output Metric.
     :type MO: SensitivityMetric
     :param TK: Type of Key. Categorical/hashable input data type. Input data must be Vec<TK>.
@@ -403,20 +409,21 @@ def make_count_by(
     
     # Standardize type arguments.
     MO = RuntimeType.parse(type_name=MO)
-    TK = RuntimeType.parse(type_name=TK)
-    TV = RuntimeType.parse(type_name=TV)
+    TIA = RuntimeType.parse(type_name=TIA)
+    TOA = RuntimeType.parse(type_name=TOA)
     
     # Convert arguments to c types.
+    size = py_to_c(size, c_type=ctypes.c_uint)
     MO = py_to_c(MO, c_type=ctypes.c_char_p)
-    TK = py_to_c(TK, c_type=ctypes.c_char_p)
-    TV = py_to_c(TV, c_type=ctypes.c_char_p)
+    TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
+    TOA = py_to_c(TOA, c_type=ctypes.c_char_p)
     
     # Call library function.
     function = lib.opendp_trans__make_count_by
-    function.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+    function.argtypes = [ctypes.c_uint, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(MO, TK, TV), Transformation))
+    return c_to_py(unwrap(function(size, MO, TIA, TOA), Transformation))
 
 
 def make_count_by_categories(

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -273,7 +273,7 @@ class RuntimeType(object):
         """
 
         # TODO: this is ugly!
-        if expected == "AnyObject":
+        if expected == "AnyObjectPtr":
             return
 
         ERROR_URL_298 = "https://github.com/opendp/opendp/discussions/298"
@@ -364,6 +364,22 @@ class PrivacyMeasure(RuntimeType):
 
 MaxDivergence = PrivacyMeasure('MaxDivergence')
 SmoothedMaxDivergence = PrivacyMeasure('SmoothedMaxDivergence')
+
+class Carrier(RuntimeType):
+    def __getitem__(self, subdomain):
+        return Carrier(self.origin, [self.parse(type_name=subdomain)])
+
+Vec = Carrier('Vec')
+i8 = RuntimeType('i8')
+i16 = RuntimeType('i16')
+i32 = RuntimeType('i32')
+i64 = RuntimeType('i64')
+u8 = RuntimeType('u8')
+u16 = RuntimeType('u16')
+u32 = RuntimeType('u32')
+u64 = RuntimeType('u64')
+f32 = RuntimeType('f32')
+f64 = RuntimeType('f64')
 
 
 class Domain(RuntimeType):

--- a/python/test/test_comb.py
+++ b/python/test/test_comb.py
@@ -16,3 +16,18 @@ def test_amplification():
     assert not meas.check(2, 1.999)
     assert amplified.check(2, .4941)
     assert not amplified.check(2, .494)
+
+
+def test_basic_composition_multi():
+    from opendp.comb import make_sequential_composition_static_distances
+    from opendp.meas import make_base_geometric
+    composed = make_sequential_composition_static_distances([
+        (make_base_geometric(scale=2.), 1.),
+        (make_base_geometric(scale=2.), 1.)
+    ])
+    print("composed successfully")
+
+    print(composed.check(1, 2.))
+
+if __name__ == "__main__":
+    test_basic_composition_multi()

--- a/python/test/test_meas.py
+++ b/python/test/test_meas.py
@@ -103,3 +103,18 @@ def test_randomized_response_bool():
     import math
     assert meas.check(1, math.log(3.))
     assert not meas.check(1, math.log(2.999))
+
+
+def test_basic_composition_multi():
+    from opendp.comb import make_sequential_composition_static_distances
+    from opendp.meas import make_base_geometric
+    composed = make_sequential_composition_static_distances([
+        (make_base_geometric(scale=2.), 1.),
+        (make_base_geometric(scale=2.), 1.)
+    ])
+
+    print(composed.check(1, 2.))
+
+if __name__ == "__main__":
+    test_basic_composition_multi()
+

--- a/python/test/test_meas.py
+++ b/python/test/test_meas.py
@@ -105,16 +105,3 @@ def test_randomized_response_bool():
     assert not meas.check(1, math.log(2.999))
 
 
-def test_basic_composition_multi():
-    from opendp.comb import make_sequential_composition_static_distances
-    from opendp.meas import make_base_geometric
-    composed = make_sequential_composition_static_distances([
-        (make_base_geometric(scale=2.), 1.),
-        (make_base_geometric(scale=2.), 1.)
-    ])
-
-    print(composed.check(1, 2.))
-
-if __name__ == "__main__":
-    test_basic_composition_multi()
-

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -53,9 +53,11 @@ indexmap = { version = "1.6.2", features = ["serde"] }
 crate-type = ["rlib", "cdylib"]
 
 
-[dev-dependencies]
+# [dev-dependencies]
 # this enables the "untrusted" feature flag by default when doing tests
-opendp = { path = ".", features = ["untrusted"] }
+# incompatible with rust analyzer because of https://github.com/rust-lang/rust-analyzer/issues/2414
+# opendp = { path = ".", features = ["untrusted"] }
+
 
 [package.metadata.docs.rs]
 features = ["untrusted", "ffi"]

--- a/rust/build/main.rs
+++ b/rust/build/main.rs
@@ -135,7 +135,9 @@ fn main() {
         })
         .collect::<IndexMap<String, Module>>();
 
-    write_bindings(python::generate_bindings(_modules));
+    if cfg!(feature="bindings-python") {
+        write_bindings(python::generate_bindings(_modules));
+    }
 }
 
 #[allow(dead_code)]

--- a/rust/src/accuracy/mod.rs
+++ b/rust/src/accuracy/mod.rs
@@ -57,7 +57,7 @@ pub fn accuracy_to_gaussian_scale<T>(accuracy: T, alpha: T) -> Fallible<T>
 }
 
 
-#[cfg(test)]
+#[cfg(all(test, feature="untrusted"))]
 pub mod test {
     use std::fmt::Debug;
     use std::ops::{Mul, Sub};

--- a/rust/src/comb/amplify/ffi.rs
+++ b/rust/src/comb/amplify/ffi.rs
@@ -15,12 +15,13 @@ impl AmplifiableMeasure for AnyMeasure {
     fn amplify(
         &self, budget: &AnyObject, population_size: usize, sample_size: usize,
     ) -> Fallible<AnyObject> {
-        fn monomorphize1<QO: 'static + Float + ExactIntCast<usize>>(
+        fn monomorphize1<QO: 'static + Float + ExactIntCast<usize> + Clone>(
             measure: &AnyMeasure, budget: &AnyObject, population_size: usize, sample_size: usize,
         ) -> Fallible<AnyObject> {
             fn monomorphize2<M: 'static + AmplifiableMeasure>(
                 measure: &AnyMeasure, budget: &AnyObject, population_size: usize, sample_size: usize,
-            ) -> Fallible<AnyObject> {
+            ) -> Fallible<AnyObject> 
+                where M::Distance: Clone {
                 let measure = measure.downcast_ref::<M>()?;
                 let budget = budget.downcast_ref::<M::Distance>()?;
                 measure.amplify(budget, population_size, sample_size).map(AnyObject::new)

--- a/rust/src/comb/bootstrap.json
+++ b/rust/src/comb/bootstrap.json
@@ -20,7 +20,7 @@
         }
     },
     "make_chain_tt": {
-        "description": "Construct the functional composition (`transformation1` ○ `transformation0`). Returns a Tranformation.",
+        "description": "Construct the functional composition (`transformation1` ○ `transformation0`). Returns a Transformation.",
         "features": ["contrib"],
         "args": [
             {
@@ -39,19 +39,26 @@
             "description": "Transformation representing the chained computation."
         }
     },
-    "make_basic_composition": {
-        "description": "Construct the DP composition (`measurement0`, `measurement1`). Returns a Measurement.",
-        "features": ["contrib"],
+    "make_sequential_composition_static_distances": {
+        "description": "Construct the DP composition [`measurement0`, `measurement1`, ...]. Returns a Measurement.",
         "args": [
             {
-                "name": "measurement0",
-                "c_type": "const AnyMeasurement *",
-                "description": "The left member of the resulting 2-tuple."
+                "name": "measurement_pairs",
+                "rust_type": {
+                    "origin": "Vec",
+                    "args": [{
+                        "origin": "Tuple",
+                        "args": ["\"AnyMeasurementPtr\"", "QO"]
+                    }]
+                },
+                "c_type": "const AnyObject *",
+                "description": "A list of measurements to compose."
             },
             {
-                "name": "measurement1",
-                "c_type": "const AnyMeasurement *",
-                "description": "The right member of the resulting 2-tuple."
+                "name": "QO",
+                "default": "f64",
+                "description": "Type of output distance.",
+                "is_type": true
             }
         ],
         "ret": {

--- a/rust/src/comb/chain/mod.rs
+++ b/rust/src/comb/chain/mod.rs
@@ -82,7 +82,8 @@ pub fn make_chain_tt<DI, DX, DO, MI, MX, MO>(
 }
 
 pub trait ComposableMeasure: Measure {
-    fn compose(&self, d_i: &Vec<Self::Distance>) -> Fallible<Self::Distance>;
+    fn compose(&self, d_i: &Vec<Self::Distance>)
+        -> Fallible<Self::Distance>;
 }
 
 impl<Q: InfAdd + Zero + Clone> ComposableMeasure for MaxDivergence<Q> {

--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -49,7 +49,7 @@ pub struct Function<DI: Domain, DO: Domain> {
 }
 impl<DI: Domain, DO: Domain> Clone for Function<DI, DO> {
     fn clone(&self) -> Self {
-        Function {function: self.function.clone()}
+        Function { function: self.function.clone() }
     }
 }
 

--- a/rust/src/data/ffi.rs
+++ b/rust/src/data/ffi.rs
@@ -11,6 +11,7 @@ use crate::core::{FfiError, FfiResult, FfiSlice};
 use crate::data::Column;
 use crate::error::Fallible;
 use crate::ffi::any::{AnyObject, Downcast};
+use crate::data::ffi::util::AnyObjectPtr;
 use crate::ffi::util;
 use crate::ffi::util::{AnyMeasurementPtr, AnyTransformationPtr, c_bool, Type, TypeContents};
 
@@ -24,18 +25,18 @@ pub extern "C" fn opendp_data__slice_as_object(raw: *const FfiSlice, T: *const c
         }
         let plain = util::as_ref(raw.ptr as *const T)
             .ok_or_else(|| err!(FFI, "Attempted to follow a null pointer to create an object"))?.clone();
-        Ok(AnyObject::new(plain))
+        Ok(AnyObject::new_clone(plain))
     }
     fn raw_to_string(raw: &FfiSlice) -> Fallible<AnyObject> {
         let string = util::to_str(raw.ptr as *const c_char)?.to_owned();
-        Ok(AnyObject::new(string))
+        Ok(AnyObject::new_clone(string))
     }
     fn raw_to_vec_string(raw: &FfiSlice) -> Fallible<AnyObject> {
         let slice = unsafe { slice::from_raw_parts(raw.ptr as *const *const c_char, raw.len) };
         let vec = slice.iter()
             .map(|str_ptr| Ok(util::to_str(*str_ptr)?.to_owned()))
             .collect::<Fallible<Vec<String>>>()?;
-        Ok(AnyObject::new(vec))
+        Ok(AnyObject::new_clone(vec))
     }
     fn raw_to_slice<T: Clone>(_raw: &FfiSlice) -> Fallible<AnyObject> {
         // TODO: Need to do some extra wrapping to own the slice here.
@@ -44,8 +45,10 @@ pub extern "C" fn opendp_data__slice_as_object(raw: *const FfiSlice, T: *const c
     #[allow(clippy::unnecessary_wraps)]
     fn raw_to_vec<T: 'static + Clone>(raw: &FfiSlice) -> Fallible<AnyObject> {
         let slice = unsafe { slice::from_raw_parts(raw.ptr as *const T, raw.len) };
+        println!("slice to vec");
         let vec = slice.to_vec();
-        Ok(AnyObject::new(vec))
+        println!("slice to vec after");
+        Ok(AnyObject::new_clone(vec))
     }
     fn raw_to_tuple<T0: 'static + Clone, T1: 'static + Clone>(raw: &FfiSlice) -> Fallible<AnyObject> {
         if raw.len != 2 {
@@ -56,7 +59,7 @@ pub extern "C" fn opendp_data__slice_as_object(raw: *const FfiSlice, T: *const c
         let tuple = util::as_ref(slice[0] as *const T0).cloned()
             .zip(util::as_ref(slice[1] as *const T1).cloned())
             .ok_or_else(|| err!(FFI, "Attempted to follow a null pointer to create a tuple"))?;
-        Ok(AnyObject::new(tuple))
+        Ok(AnyObject::new_clone(tuple))
     }
     fn raw_to_hashmap<K: 'static + Clone + Hash + Eq, V: 'static + Clone>(raw: &FfiSlice) -> Fallible<AnyObject> {
         let slice = unsafe { slice::from_raw_parts(raw.ptr as *const *const AnyObject, raw.len) };
@@ -71,7 +74,7 @@ pub extern "C" fn opendp_data__slice_as_object(raw: *const FfiSlice, T: *const c
         let map = keys.iter().cloned()
             .zip(vals.iter().cloned())
             .collect::<HashMap<K, V>>();
-        Ok(AnyObject::new(map))
+        Ok(AnyObject::new_clone(map))
     }
     match T.contents {
         TypeContents::PLAIN("String") => {
@@ -83,23 +86,21 @@ pub extern "C" fn opendp_data__slice_as_object(raw: *const FfiSlice, T: *const c
         }
         TypeContents::VEC(element_id) => {
             let element = try_!(Type::of_id(&element_id));
-            println!("raw_to_hashmap: {:?}", element.descriptor);
+            println!("from rust, raw_to_vec: {:?}", element.descriptor);
             match element.descriptor.as_str() {
                 "String" => raw_to_vec_string(raw),
                 "AnyMeasurementPtr" => raw_to_vec::<AnyMeasurementPtr>(raw),
-                "AnyObject" => raw_to_vec::<AnyObject>(raw),
-                // "(AnyMeasurementPtr, f32)" => raw_to_vec::<(AnyMeasurementPtr, f32)>(raw),
-                // "(AnyMeasurementPtr, f64)" => raw_to_vec::<AnyObjectPtr>(raw),
+                "AnyObjectPtr" => raw_to_vec::<AnyObjectPtr>(raw),
                 "AnyTransformationPtr" => raw_to_vec::<AnyTransformationPtr>(raw),
                 _ => dispatch!(raw_to_vec, [(element, @primitives)], (raw))
-            }
+            } 
         }
         TypeContents::TUPLE(ref element_ids) => {
             if element_ids.len() != 2 {
                 return fallible!(FFI, "Only tuples of length 2 are supported").into();
             }
             let types = try_!(element_ids.iter().map(Type::of_id).collect::<Fallible<Vec<_>>>());
-            println!("from rust, dispatching types: {:?}", types);
+            println!("from rust, dispatching types: {:?}", types.iter().map(Type::to_string).collect::<Vec<_>>());
             if types.first() == Some(&Type::of::<AnyMeasurementPtr>()) {
                 dispatch!(raw_to_tuple, [(types[0], [AnyMeasurementPtr]), (types[1], [f64, f32])], (raw))
             } else {
@@ -172,8 +173,8 @@ pub extern "C" fn opendp_data__object_as_slice(obj: *const AnyObject) -> FfiResu
         let data: &HashMap<K, V> = obj.downcast_ref()?;
 
         // wrap keys and values up in an AnyObject
-        let keys = AnyObject::new(data.keys().cloned().collect::<Vec<K>>());
-        let vals = AnyObject::new(data.values().cloned().collect::<Vec<V>>());
+        let keys = AnyObject::new_clone(data.keys().cloned().collect::<Vec<K>>());
+        let vals = AnyObject::new_clone(data.values().cloned().collect::<Vec<V>>());
 
         // wrap the whole map up together in an FfiSlice
         let map = vec![util::into_raw(keys), util::into_raw(vals)];

--- a/rust/src/ffi/any.rs
+++ b/rust/src/ffi/any.rs
@@ -144,18 +144,27 @@ impl AnyObject {
         }
         fn monomorphize_clone<T: 'static + Clone>() -> Fallible<fn(&AnyObject) -> AnyObject> {
             Ok(|self_| AnyObject::new(self_.downcast_ref::<T>()
-                .expect("Clone called on non-cloneable AnyObject").clone()))
+                .expect("Downcast will always be of same type").clone()))
         }
 
         let type_ = Type::of::<T>();
+        println!("new Type {}", type_.to_string());
 
-        Self {
+        AnyObject {
             partial_eq_glue: dispatch!(monomorphize_partial_eq, [(type_, @hashable)], ()).ok().map(Glue::new),
             partial_cmp_glue: dispatch!(monomorphize_partial_cmp, [(type_, @hashable)], ()).ok().map(Glue::new),
+            // CAUTION: oftentimes clone_glue is None, because T is not in @primitives
             clone_glue: dispatch!(monomorphize_clone, [(type_, @primitives)], ()).ok().map(Glue::new),
             type_,
             value: AnyBox::new(value),
         }
+    }
+
+    pub fn new_clone<T: 'static + Clone>(value: T) -> Self {
+        let mut new = Self::new(value);
+        println!("new_clone Type {}", new.type_.to_string());
+        new.clone_glue = Some(Glue::new(|self_: &Self| AnyObject::new(self_.downcast_ref::<T>().expect("Downcast will always be of same type").clone())));
+        new
     }
 
     #[cfg(test)]
@@ -185,7 +194,9 @@ impl PartialOrd for AnyObject {
 }
 impl Clone for AnyObject {
     fn clone(&self) -> Self {
-        self.clone_glue.as_ref().map(|glue| glue(self)).unwrap()
+        println!("cloning now");
+        println!("AnyObject type: {}", self.type_.to_string());
+        self.clone_glue.as_ref().expect("Clone glue is missing")(self)
     }
 }
 

--- a/rust/src/ffi/util.rs
+++ b/rust/src/ffi/util.rs
@@ -92,7 +92,7 @@ impl ToString for Type {
     fn to_string(&self) -> String {
         let get_id_str = |type_id: &TypeId| Type::of_id(type_id)
             .as_ref().map(ToString::to_string)
-            .unwrap_or_else(|_| "?".to_string());
+            .unwrap_or_else(|_| format!("{:?} {:?}", type_id, TypeId::of::<f64>()));
 
         match &self.contents {
             TypeContents::PLAIN(v) => v.to_string(),
@@ -234,7 +234,7 @@ lazy_static! {
             // OptionNullDomain<AllDomain<_>>::Carrier
             type_vec![[Vec Option], <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, String, AnyObject>],
             type_vec![AnyMeasurementPtr, AnyTransformationPtr, AnyObjectPtr],
-            type_vec![Vec, <AnyMeasurementPtr, AnyTransformationPtr>],
+            type_vec![Vec, <AnyMeasurementPtr, AnyTransformationPtr, AnyObjectPtr>],
 
             // domains
             type_vec![AllDomain, <bool, char, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, String>],

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -173,8 +173,10 @@ pub mod core;
 pub mod data;
 pub mod dist;
 pub mod dom;
+#[cfg(feature="contrib")]
 pub mod interactive;
 pub mod meas;
+#[cfg(feature="contrib")]
 pub mod poly;
 pub mod samplers;
 pub mod traits;

--- a/rust/src/traits/cast.rs
+++ b/rust/src/traits/cast.rs
@@ -338,7 +338,6 @@ impl RoundCast<String> for bool { fn round_cast(v: String) -> Fallible<Self> { O
 
 impl RoundCast<bool> for String { fn round_cast(v: bool) -> Fallible<Self> { Ok(v.to_string()) } }
 
-
 #[cfg(feature = "use-mpfr")]
 impl CastInternalReal for f64 {
     const MANTISSA_DIGITS: u32 = Self::MANTISSA_DIGITS;


### PR DESCRIPTION
Closes #7.
Replaces #242. 

AnyMeasureDistances are gone. An additional dispatch is introduced to prevent the proliferation of composition traits in measurements.

I'm experimenting with a different way of handling the PRs, where the "branch I want to merge into" is the dependency, instead of merging directly into main.