### PR TITLE
Support aarch64-apple-darwin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
             ~\.cargo\git\db
             ~\AppData\Local\gmp-mpfr-sys
             rust\target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/*/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Create Rust build for windows
@@ -75,7 +75,7 @@ jobs:
 
 
   python-pre-publish-mac:
-    runs-on: macos-10.15
+    runs-on: macos-11
     needs: credential-check
     steps:
       - name: Checkout repository
@@ -91,11 +91,27 @@ jobs:
             ~/.cargo/git/db
             ~/Library/Caches/gmp-mpfr-sys
             rust/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/*/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-
 
-      - name: Create Rust build for macos
-        run: bash tools/rust_build.sh -i -r -t -f "$FEATURES"
+      - name: Create Rust build for macos x86_64
+        run: bash tools/rust_build.sh -i -r -t -g x86_64-apple-darwin -f "$FEATURES"
+        env:
+          CC: clang -target x86_64-apple-darwin
+
+      - name: Create Rust build for macos aarch64 (no tests)
+        run: bash tools/rust_build.sh -i -r -g aarch64-apple-darwin -f "$FEATURES"
+        env:
+          CC: clang -target aarch64-apple-darwin
+
+      - name: Create universal binary of Rust build for macos
+        # https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary#Update-the-Architecture-List-of-Custom-Makefiles
+        run: |
+          mkdir -p rust/target/release
+          lipo \
+              rust/target/x86_64-apple-darwin/release/libopendp.dylib \
+              rust/target/aarch64-apple-darwin/release/libopendp.dylib \
+              -output rust/target/release/libopendp.dylib -create
 
       - name: Upload .dylib
         uses: actions/upload-artifact@v2
@@ -123,7 +139,7 @@ jobs:
             ~/.cargo/git/db
             ~/.cache/gmp-mpfr-sys
             rust/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/*/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Create Rust build for linux

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -26,7 +26,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             rust/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/*/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Please keep this up to date, following the [instructions](#instructions) below.
 
 ## [Unreleased](https://github.com/opendp/opendp/compare/stable...HEAD)
 
+### Added
+- Support for Apple silicon (`aarch64-apple-darwin` target)
+- More example notebooks
+
+### Changed
+- Switched to a single Rust crate (merged `opendp-ffi` into `opendp`)
+
 
 ## [0.4.0] - 2021-12-10
 [0.4.0]: https://github.com/opendp/opendp/compare/v0.3.0...v0.4.0

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,7 +17,7 @@ backtrace = "0.3"
 ieee754 = "0.2.6"
 statrs = "0.13.0"
 rug = { version = "1.14.0", default-features = false, features = ["integer", "float", "rand"], optional = true }
-gmp-mpfr-sys = { version = "1.4.7", default-features = false, features = ["mpfr"], optional = true }
+gmp-mpfr-sys = { version = "1.4.7", default-features = false, features = ["mpfr", "force-cross"], optional = true }
 openssl = { version = "0.10.29", features = ["vendored"], optional = true }
 
 lazy_static = { version = "1.4.0", optional = true }

--- a/tools/publish_tool.py
+++ b/tools/publish_tool.py
@@ -24,7 +24,7 @@ def rust(args):
     os.environ["CARGO_REGISTRY_TOKEN"] = os.environ["CRATES_IO_API_TOKEN"]
     run_command("Logging into crates.io", f"cargo login")
     dry_run_arg = " --dry-run" if args.dry_run else ""
-    run_command("Publishing opendp crate", f"cargo publish{dry_run_arg} --verbose --manifest-path=rust/opendp/Cargo.toml")
+    run_command("Publishing opendp crate", f"cargo publish{dry_run_arg} --verbose --manifest-path=rust/Cargo.toml")
 
 
 def python(args):

--- a/tools/release_tool.py
+++ b/tools/release_tool.py
@@ -177,7 +177,7 @@ def version(args):
     log(f"Updating versioned files")
     inplace_arg = "-i ''" if platform.system() == "Darwin" else "-i"
     run_command(None, f"echo {resolved_target_version} >VERSION")
-    run_command(None, f"sed {inplace_arg} 's/^version = \"{cached_version}\"$/version = \"{resolved_target_version}\"/' rust/opendp/Cargo.toml")
+    run_command(None, f"sed {inplace_arg} 's/^version = \"{cached_version}\"$/version = \"{resolved_target_version}\"/' rust/Cargo.toml")
     run_command(None, f"sed {inplace_arg} 's/^version = {cached_version}$/version = {resolved_target_version}/' python/setup.cfg")
     commit("versioned files", versioned_files, f"RELEASE_TOOL: Set version to {resolved_target_version}.")
 


### PR DESCRIPTION
Fixes #439. Thanks @Shoeboxam for doing the core of this!

    * Add target option to rust_build.sh
    * Extend release.yml to cross-compile aarch64 and merge into universal binary
    * Fix some Cargo.toml paths missed in #396
    * Update CHANGELOG
