### PR TITLE
Fix docs.rs documentation and historical python documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,13 +4,13 @@ import sys
 import os
 from datetime import datetime
 
-# We're inside source when this runs.
-sys.path.append(os.path.abspath('../../python/src'))
-# print("*****************************************")
-# [print(p) for p in sys.path]
-# print("*****************************************")
+# docs should be built without needing import the library binary for the specified version
+os.environ["OPENDP_HEADLESS"] = "true"
 
-print("*****************************************")
+# We're inside source when this runs.
+# Docs would be the same for all versions. Fix from: https://github.com/Holzhaus/sphinx-multiversion/issues/42
+rootdir = os.path.join(os.getenv("SPHINX_MULTIVERSION_SOURCEDIR", default="."), "..", "..", "python", "src")
+sys.path.insert(0, rootdir)
 
 extensions = [
     'sphinx.ext.autodoc',
@@ -118,8 +118,7 @@ rustdoc_cmd = '(cd ../rust && cargo doc --no-deps --target-dir ../docs/source/ap
 # Building the Rust docs locally takes forever, and is only necessary for latest branch (releases are automatically published to https://docs.rs).
 # TODO: Figure out how to use locally generated Rust docs for latest branch only.
 #smv_prebuild_command = '&&'.join([version_cmd, sphinx_apidoc_cmd, rustdoc_cmd])
-smv_prebuild_command = '&&'.join([version_cmd, sphinx_apidoc_cmd])
-
+smv_prebuild_command = '&&'.join(["pwd", version_cmd, sphinx_apidoc_cmd])
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
 #html_file_suffix = None

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -118,7 +118,7 @@ rustdoc_cmd = '(cd ../rust && cargo doc --no-deps --target-dir ../docs/source/ap
 # Building the Rust docs locally takes forever, and is only necessary for latest branch (releases are automatically published to https://docs.rs).
 # TODO: Figure out how to use locally generated Rust docs for latest branch only.
 #smv_prebuild_command = '&&'.join([version_cmd, sphinx_apidoc_cmd, rustdoc_cmd])
-smv_prebuild_command = '&&'.join(["pwd", version_cmd, sphinx_apidoc_cmd])
+smv_prebuild_command = '&&'.join([version_cmd, sphinx_apidoc_cmd])
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
 #html_file_suffix = None

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -29,7 +29,6 @@ if os.path.exists(lib_dir):
     lib = ctypes.cdll.LoadLibrary(os.path.join(lib_dir, lib_name))
 
 elif os.environ.get('OPENDP_HEADLESS', "false") != "false":
-    print("Not using lib.")
     lib = None
 
 else:

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -10,16 +10,13 @@ ATOM_EQUIVALENCE_CLASSES = {
     'bool': ['bool']
 }
 
-lib = None
-if os.environ.get('OPENDP_HEADLESS', "false") == "false":
-    lib_dir = os.environ.get("OPENDP_LIB_DIR", os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
-    if not os.path.exists(lib_dir):
-        # fall back to default location of binaries in a developer install
-        build_dir = 'debug' if os.environ.get('OPENDP_TEST_RELEASE', "false") == "false" else 'release'
-        lib_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), *['..'] * 3, 'rust', 'target', build_dir)
-    if not os.path.exists(lib_dir):
-        raise ValueError("Unable to find lib directory. Consider setting OPENDP_LIB_DIR to a valid directory.")
+lib_dir = os.environ.get("OPENDP_LIB_DIR", os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+if not os.path.exists(lib_dir):
+    # fall back to default location of binaries in a developer install
+    build_dir = 'debug' if os.environ.get('OPENDP_TEST_RELEASE', "false") == "false" else 'release'
+    lib_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), *['..'] * 3, 'rust', 'target', build_dir)
 
+if os.path.exists(lib_dir):
     platform_to_name = {
         "darwin": "libopendp.dylib",
         "linux": "libopendp.so",
@@ -30,6 +27,13 @@ if os.environ.get('OPENDP_HEADLESS', "false") == "false":
     lib_name = platform_to_name[sys.platform]
 
     lib = ctypes.cdll.LoadLibrary(os.path.join(lib_dir, lib_name))
+
+elif os.environ.get('OPENDP_HEADLESS', "false") != "false":
+    print("Not using lib.")
+    lib = None
+
+else:
+    raise ValueError("Unable to find lib directory. Consider setting OPENDP_LIB_DIR to a valid directory.")
 
 
 class FfiSlice(ctypes.Structure):

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -55,3 +55,6 @@ crate-type = ["rlib", "cdylib"]
 [dev-dependencies]
 # this enables the "untrusted" feature flag by default when doing tests
 opendp = { path = ".", features = ["untrusted"] }
+
+[package.metadata.docs.rs]
+features = ["untrusted", "ffi"]


### PR DESCRIPTION
Closes #433
Closes #432

This also changes the behavior of `OPENDP_HEADLESS`. The library will always attempt to load `lib`, but if `OPENDP_HEADLESS` is set, failure to load `lib` is not considered an error. This is so that headless may be set in sphinx multiversion via `conf.py`, but the smoke-test doctests still work.