### PR TITLE
binary search fixes

### DIFF
--- a/docs/source/user/application-structure.rst
+++ b/docs/source/user/application-structure.rst
@@ -197,7 +197,7 @@ can be used to convert the earlier discovered noise scale parameter into an accu
     ...  f"the DP estimate differs from the true value by no more than {accuracy} "
     ...  f"at a statistical significance level alpha of {alpha}, "
     ...  f"or with (1 - {alpha})100% = {(1 - alpha) * 100}% confidence.")
-    'When the laplace scale is 2.00000000745058, the DP estimate differs from the true value by no more than 5.991464569427925 at a statistical significance level alpha of 0.05, or with (1 - 0.05)100% = 95.0% confidence.'
+    'When the laplace scale is 2.0000000000000004, the DP estimate differs from the true value by no more than 5.991464547107983 at a statistical significance level alpha of 0.05, or with (1 - 0.05)100% = 95.0% confidence.'
 
 Please be aware that the preprocessing (impute, clamp, resize) can introduce bias that the accuracy estimate cannot account for.
 In this example, since the sensitive dataset is short two exams,

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -565,21 +565,21 @@ def exponential_bounds_search(
             raise TypeError("unable to infer type `T`; pass the type `T` or bounds")
 
     # core search functionality
-    base = {int: 2, float: 2.}[T]
-
     def signed_band_search(center, at_center, sign):
         """identify which band (of eight) the decision boundary lies in, 
         starting from `center` in the direction indicated by `sign`"""
 
         if T == int:
-            bands = [center, center + 1, *(center + sign * base ** 16 * k for k in range(1, 9))]
+            # searching bands of [(k - 1) * 2^16, k * 2^16].
+            # center + 1 included because zero is prone to error
+            bands = [center, center + 1, *(center + sign * 2 ** 16 * k for k in range(1, 9))]
 
         if T == float:
             # searching bands of [2^((k - 1)^2), 2^(k^2)].
             # exponent has ten bits (2.^1024 overflows) so k must be in [0, 32).
             # unlikely to need numbers greater than 2**64, and to avoid overflow from shifted centers,
             #    only check k in [0, 8). Set your own bounds if this is not sufficient
-            bands = [center, *(center + sign * base ** k ** 2 for k in range(1024 // 32 // 4))]
+            bands = [center, *(center + sign * 2. ** k ** 2 for k in range(1024 // 32 // 4))]
 
         for i in range(1, len(bands)):
             # looking for a change in sign that indicates the decision boundary is within this band

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -437,7 +437,7 @@ def binary_search(
 
     :param predicate: a monotonic unary function from a number to a boolean
     :param bounds: a 2-tuple of the lower and upper bounds to the input of `predicate`
-    :param T: type of argument to predicate, one of {float, int}
+    :param T: type of argument to `predicate`, one of {float, int}
     :param return_sign: if True, also return the direction away from the decision boundary
     :return: the discovered parameter within the bounds
     :raises TypeError: if the type is not inferrable (pass T) or the type is invalid

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -424,6 +424,8 @@ def binary_search(
         tolerance=None):
     """Find the closest passing value to the decision boundary of `predicate` within float or integer `bounds`.
 
+    If bounds are not passed, conducts an exponential search.
+
     :example:
 
     >>> from opendp.mod import binary_search
@@ -468,10 +470,13 @@ def binary_search(
     3
     """
     if bounds is None:
-        k = 0
-        while not predicate(2. ** k):
-            k += 1
-        bounds = (2. ** (k - 1) if k else 0., 2. ** k)
+        zero = predicate(0.)
+        def find_k(sign):
+            for k in range(1024):
+                if zero != predicate(sign * 2. ** k):
+                    return sign, k
+        sign, k = find_k(1) or find_k(-1)
+        bounds = (sign * 2. ** (k - 1) if k else 0., sign * 2. ** k)
 
     assert len(set(map(type, bounds))) == 1, "bounds must share the same type"
     lower, upper = sorted(bounds)

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -1,5 +1,5 @@
 import ctypes
-from typing import Union, Tuple, Callable
+from typing import Union, Tuple, Callable, Optional
 
 from opendp._lib import AnyMeasurement, AnyTransformation
 
@@ -529,16 +529,19 @@ def binary_search(
     return (value, get_sign(minimize)) if return_sign else value
 
 
-def exponential_bounds_search(predicate: Callable[[Union[float, int]], bool], T):
+def exponential_bounds_search(
+    predicate: Callable[[Union[float, int]], bool], 
+    T: Optional[type]) -> Optional[Union[Tuple[float, float], Tuple[int, int]]]:
     """Determine bounds for a binary search via an exponential search,
     in large bands of [2^((k - 1)^2), 2^(k^2)] for k in [0, 8).
     Will attempt to recover once if `predicate` throws an exception, 
-        by searching bands on the ok side of the exception boundary.
+    by searching bands on the ok side of the exception boundary.
     
+
     :param predicate: a monotonic unary function from a number to a boolean
     :param T: type of argument to predicate, one of {float, int}
-    :returns a tuple of float or int bounds that the decision boundary lies within
-    :raises TypeError: if the type is not inferrable. Pass T.
+    :return: a tuple of float or int bounds that the decision boundary lies within
+    :raises TypeError: if the type is not inferrable (pass T)
     :raises ValueError: if the predicate function is constant
     """
 

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -319,6 +319,7 @@ def binary_search_chain(
     :param d_in: desired input distance of the computation chain
     :param d_out: desired output distance of the computation chain
     :param bounds: a 2-tuple of the lower and upper bounds to the input of `make_chain`
+    :param T: type of argument to `make_chain`, one of {float, int}
     :return: a chain parameterized at the nearest passing value to the decision point of the relation
     :rtype: Union[Transformation, Measurement]
     :raises TypeError: if the type is not inferrable (pass T) or the type is invalid
@@ -380,6 +381,7 @@ def binary_search_param(
     :param d_in: desired input distance of the computation chain
     :param d_out: desired output distance of the computation chain
     :param bounds: a 2-tuple of the lower and upper bounds to the input of `make_chain`
+    :param T: type of argument to `make_chain`, one of {float, int}
     :return: the nearest passing value to the decision point of the relation
     :raises TypeError: if the type is not inferrable (pass T) or the type is invalid
     :raises ValueError: if the predicate function is constant, bounds cannot be inferred, or decision boundary is not within `bounds`.
@@ -436,6 +438,7 @@ def binary_search(
     :param predicate: a monotonic unary function from a number to a boolean
     :param bounds: a 2-tuple of the lower and upper bounds to the input of `predicate`
     :param T: type of argument to predicate, one of {float, int}
+    :param return_sign: if True, also return the direction away from the decision boundary
     :return: the discovered parameter within the bounds
     :raises TypeError: if the type is not inferrable (pass T) or the type is invalid
     :raises ValueError: if the predicate function is constant, bounds cannot be inferred, or decision boundary is not within `bounds`.
@@ -524,9 +527,10 @@ def binary_search(
     value = upper if minimize else lower
 
     # optionally return sign
-    def get_sign(v):
-        return 1 if minimize else -1
-    return (value, get_sign(minimize)) if return_sign else value
+    if return_sign:
+        return value, 1 if minimize else -1
+    
+    return value
 
 
 def exponential_bounds_search(
@@ -586,6 +590,9 @@ def exponential_bounds_search(
             if at_center != predicate(bands[i]):
                 # return the band
                 return tuple(sorted(bands[i - 1:i + 1]))
+        
+        # No band found!
+        return None
 
     try:
         center = {int: 0, float: 0.}[T]
@@ -597,7 +604,7 @@ def exponential_bounds_search(
 
     # predicate has thrown an exception
     # 1. Treat exceptions as a secondary decision boundary, and find the edge value
-    # 2. Return a bound by search from the exception edge, in the direction away from the exception
+    # 2. Return a bound by searching from the exception edge, in the direction away from the exception
     def exception_predicate(v):
         try:
             predicate(v)

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -470,7 +470,7 @@ def binary_search(
     >>> binary_search(
     ...     lambda d_out: dp_mean.check(3, (d_out, 1e-8)), 
     ...     bounds = (0., 1.))
-    0.6105625927448273
+    0.6105625903337409
 
     Find the L2 distance sensitivity of a histogram when neighboring datasets differ by up to 3 additions/removals.
 

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -254,7 +254,7 @@ class RuntimeType(object):
 
         :param expected: the type that the data will be converted to
         :param inferred: the type inferred from data
-        :raises AssertionError: if `expected` type differs significantly from `inferred` type
+        :raises TypeError: if `expected` type differs significantly from `inferred` type
         """
 
         ERROR_URL_298 = "https://github.com/opendp/opendp/discussions/298"
@@ -262,28 +262,28 @@ class RuntimeType(object):
             return
         if isinstance(expected, str) and isinstance(inferred, str):
             if inferred in ATOM_EQUIVALENCE_CLASSES:
-                assert expected in ATOM_EQUIVALENCE_CLASSES[inferred], \
-                    f"inferred type is {inferred}, expected {expected}. See {ERROR_URL_298}"
+                if expected not in ATOM_EQUIVALENCE_CLASSES[inferred]:
+                    raise TypeError(f"inferred type is {inferred}, expected {expected}. See {ERROR_URL_298}")
             else:
-                assert expected == inferred, \
-                    f"inferred type is {inferred}, expected {expected}. See {ERROR_URL_298}"
+                if expected != inferred:
+                    raise TypeError(f"inferred type is {inferred}, expected {expected}. See {ERROR_URL_298}")
 
         elif isinstance(expected, RuntimeType) and isinstance(inferred, RuntimeType):
             # allow extra flexibility around options, as the inferred type of an Option::<T>::Some will just be T
             if expected.origin == "Option" and inferred.origin != "Option":
                 expected = expected.args[0]
 
-            assert expected.origin == inferred.origin, \
-                f"inferred type is {inferred.origin}, expected {expected.origin}. See {ERROR_URL_298}"
+            if expected.origin != inferred.origin:
+                raise TypeError(f"inferred type is {inferred.origin}, expected {expected.origin}. See {ERROR_URL_298}")
 
-            assert len(expected.args) == len(inferred.args), \
-                f"inferred type has {len(inferred.args)} arg(s), expected {len(expected.args)} arg(s). See {ERROR_URL_298}"
+            if len(expected.args) != len(inferred.args):
+                raise TypeError(f"inferred type has {len(inferred.args)} arg(s), expected {len(expected.args)} arg(s). See {ERROR_URL_298}")
 
             for (arg_par, arg_inf) in zip(expected.args, inferred.args):
                 RuntimeType.assert_is_similar(arg_par, arg_inf)
         else:
             # inferred type differs in structure
-            raise AssertionError(f"inferred type is {inferred}, expected {expected}. See {ERROR_URL_298}")
+            raise TypeError(f"inferred type is {inferred}, expected {expected}. See {ERROR_URL_298}")
 
     def substitute(self, **kwargs):
         if isinstance(self, GenericType):

--- a/python/test/test_binary_search.py
+++ b/python/test/test_binary_search.py
@@ -1,0 +1,34 @@
+from opendp.mod import binary_search_param, enable_features
+from opendp.trans import make_bounded_sum, make_clamp
+from opendp.meas import make_base_laplace
+
+enable_features('floating-point', 'contrib')
+
+
+def test_binary_search_overflow():
+    d_in = 1
+    d_out = 1.01
+    bounded_sum = (
+        make_clamp(bounds=(0.0, 1.0)) >>
+        make_bounded_sum(bounds=(0.0, 1.0))
+    )
+    binary_search_param(
+        lambda s: bounded_sum >> make_base_laplace(scale=s),
+        d_in=d_in,
+        d_out=d_out
+    )
+
+def test_stuck():
+    epsilon = 1.3
+    sens = 500_000.0 * 500_000.0
+    bounded_sum = (
+        make_clamp(bounds=(0.0, sens)) >>
+        make_bounded_sum(bounds=(0.0, sens))
+    )
+    real_v = sens / epsilon
+    discovered_scale = binary_search_param(
+        lambda s: bounded_sum >> make_base_laplace(scale=s),
+        d_in=1,
+        bounds=(0.0, real_v * 2.0),
+        d_out=(epsilon))
+    print(discovered_scale)

--- a/python/test/test_binary_search.py
+++ b/python/test/test_binary_search.py
@@ -1,4 +1,4 @@
-from opendp.mod import binary_search_param, enable_features
+from opendp.mod import binary_search_param, enable_features, binary_search
 from opendp.trans import make_bounded_sum, make_clamp
 from opendp.meas import make_base_laplace
 
@@ -32,3 +32,9 @@ def test_stuck():
         bounds=(0.0, real_v * 2.0),
         d_out=(epsilon))
     print(discovered_scale)
+
+def test_binary_search():
+    assert binary_search(lambda x: x <= -5) == -5
+    assert binary_search(lambda x: x <= 5) == 5
+    assert binary_search(lambda x: x >= -5) == -5
+    assert binary_search(lambda x: x >= 5) == 5

--- a/python/test/test_binary_search.py
+++ b/python/test/test_binary_search.py
@@ -1,5 +1,5 @@
 from opendp.mod import binary_search_param, enable_features, binary_search
-from opendp.trans import make_bounded_sum, make_clamp
+from opendp.trans import make_bounded_sum, make_clamp, make_sized_bounded_sum, make_sized_bounded_mean
 from opendp.meas import make_base_laplace
 
 enable_features('floating-point', 'contrib')
@@ -34,7 +34,21 @@ def test_stuck():
     print(discovered_scale)
 
 def test_binary_search():
-    assert binary_search(lambda x: x <= -5) == -5
-    assert binary_search(lambda x: x <= 5) == 5
-    assert binary_search(lambda x: x >= -5) == -5
-    assert binary_search(lambda x: x >= 5) == 5
+    assert binary_search(lambda x: x <= -5, T=int) == -5
+    assert binary_search(lambda x: x <= 5, T=int) == 5
+    assert binary_search(lambda x: x >= -5, T=int) == -5
+    assert binary_search(lambda x: x >= 5, T=int) == 5
+
+
+def test_type_inference():
+    def chainer(b):
+        return make_sized_bounded_sum(1000, (-b, b))
+    assert binary_search_param(chainer, 2, 100) == 50
+
+    def mean_chainer_n(n):
+        return make_sized_bounded_mean(n, (-20., 20.))
+    assert binary_search_param(mean_chainer_n, 2, 1.) == 40
+
+    def mean_chainer_b(b):
+        return make_sized_bounded_mean(1000, (-b, b))
+    assert binary_search_param(mean_chainer_b, 2, 1.) == 500.

--- a/python/test/test_core.py
+++ b/python/test/test_core.py
@@ -52,11 +52,11 @@ def test_bisect():
 
 def test_bisect_edge():
     from opendp.mod import binary_search
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         binary_search(lambda x: x > 5., (0., 5.))
     assert binary_search(lambda x: x > 0, (0, 1)) == 1
     assert binary_search(lambda x: x < 1, (0, 1)) == 0
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         binary_search(lambda x: x < 1, (0, 0))
 
     assert binary_search(lambda x: x > 5, bounds=(0, 10)) == 6

--- a/python/test/test_trans.py
+++ b/python/test/test_trans.py
@@ -197,7 +197,7 @@ def test_bounded_sum():
     try:
         query(FLOAT_DATA)
         raise ValueError("should not accept float data")
-    except AssertionError:
+    except TypeError:
         pass
 
 


### PR DESCRIPTION
Closes #443 
Closes #362 

- Fixes an infinite loop due to floating-point roundoff when distance to nearest neighbor is greater than tolerance.
- Removes the tolerance argument, because the algorithm terminates when the argument stops changing.
- Bounds on `binary_search` have been made optional via exponential search
- Exponential search bounds increase magnitudes incrementally, which avoids issues with overflow
- Exponential search bounds should converge in fewer steps, under the assumption that ideal parameters are typically distributed closer to zero
- Added a T argument to specify expected type 
   * T is also inferred by catching TypeErrors and "No match" FFI errors
   * Replaces AssertionErrors that have to do with typing with more informative TypeErrors
