### PR TITLE
handle ordering in resize

### DIFF
--- a/docs/source/user/transformation-constructors.rst
+++ b/docs/source/user/transformation-constructors.rst
@@ -340,6 +340,8 @@ At this time, there are two separate resize transforms:
 one that works on unbounded data, and one that works on bounded data.
 We intend to merge these in the future.
 
+The input and output metrics may be configured to any combination of ``SymmetricDistance`` and ``InsertDeleteDistance``.
+
 .. list-table::
    :header-rows: 1
 
@@ -349,12 +351,12 @@ We intend to merge these in the future.
      - Input/Output Metric
    * - :func:`opendp.trans.make_resize`
      - ``VectorDomain<AllDomain<TA>>``
-     - ``VectorDomain<AllDomain<TA>>``
-     - ``SymmetricDistance``
+     - ``SizedDomain<VectorDomain<AllDomain<TA>>>``
+     - ``SymmetricDistance/InsertDeleteDistance``
    * - :func:`opendp.trans.make_bounded_resize`
      - ``VectorDomain<BoundedDomain<TA>>``
      - ``VectorDomain<BoundedDomain<TA>>``
-     - ``SymmetricDistance``
+     - ``SymmetricDistance/InsertDeleteDistance``
 
 
 .. _aggregators:

--- a/python/src/opendp/trans.py
+++ b/python/src/opendp/trans.py
@@ -1176,7 +1176,9 @@ def make_sized_bounded_mean(
 def make_resize(
     size: int,
     constant: Any,
-    TA: RuntimeTypeDescriptor = None
+    TA: RuntimeTypeDescriptor = None,
+    MI: RuntimeTypeDescriptor = "SymmetricDistance",
+    MO: RuntimeTypeDescriptor = "InsertDeleteDistance"
 ) -> Transformation:
     """Make a Transformation that either truncates or imputes records with `constant` in a Vec<`TA`> to match a provided `size`.
     
@@ -1186,6 +1188,10 @@ def make_resize(
     :type constant: Any
     :param TA: Atomic type.
     :type TA: :ref:`RuntimeTypeDescriptor`
+    :param MI: Input metric.
+    :type MI: :ref:`RuntimeTypeDescriptor`
+    :param MO: Output metric.
+    :type MO: :ref:`RuntimeTypeDescriptor`
     :return: A vector of the same type `TA`, but with the provided `size`.
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
@@ -1196,25 +1202,31 @@ def make_resize(
     
     # Standardize type arguments.
     TA = RuntimeType.parse_or_infer(type_name=TA, public_example=constant)
+    MI = RuntimeType.parse(type_name=MI)
+    MO = RuntimeType.parse(type_name=MO)
     
     # Convert arguments to c types.
     size = py_to_c(size, c_type=ctypes.c_uint)
     constant = py_to_c(constant, c_type=AnyObjectPtr, type_name=TA)
     TA = py_to_c(TA, c_type=ctypes.c_char_p)
+    MI = py_to_c(MI, c_type=ctypes.c_char_p)
+    MO = py_to_c(MO, c_type=ctypes.c_char_p)
     
     # Call library function.
     function = lib.opendp_trans__make_resize
-    function.argtypes = [ctypes.c_uint, AnyObjectPtr, ctypes.c_char_p]
+    function.argtypes = [ctypes.c_uint, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, constant, TA), Transformation))
+    return c_to_py(unwrap(function(size, constant, TA, MI, MO), Transformation))
 
 
 def make_bounded_resize(
     size: int,
     bounds: Tuple[Any, Any],
     constant,
-    TA: RuntimeTypeDescriptor = None
+    TA: RuntimeTypeDescriptor = None,
+    MI: RuntimeTypeDescriptor = "SymmetricDistance",
+    MO: RuntimeTypeDescriptor = "SymmetricDistance"
 ) -> Transformation:
     """Make a Transformation that either truncates or imputes records with `constant` in a Vec<`TA`> to match a provided `size`.
     
@@ -1225,6 +1237,10 @@ def make_bounded_resize(
     :param constant: Value to impute with.
     :param TA: Atomic type. If not passed, TA is inferred from the lower bound.
     :type TA: :ref:`RuntimeTypeDescriptor`
+    :param MI: Input metric.
+    :type MI: :ref:`RuntimeTypeDescriptor`
+    :param MO: Output metric.
+    :type MO: :ref:`RuntimeTypeDescriptor`
     :return: A vector of the same type `TA`, but with the provided `size`.
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
@@ -1235,19 +1251,23 @@ def make_bounded_resize(
     
     # Standardize type arguments.
     TA = RuntimeType.parse_or_infer(type_name=TA, public_example=get_first(bounds))
+    MI = RuntimeType.parse(type_name=MI)
+    MO = RuntimeType.parse(type_name=MO)
     
     # Convert arguments to c types.
     size = py_to_c(size, c_type=ctypes.c_uint)
     bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[TA, TA]))
     constant = py_to_c(constant, c_type=ctypes.c_void_p, type_name=TA)
     TA = py_to_c(TA, c_type=ctypes.c_char_p)
+    MI = py_to_c(MI, c_type=ctypes.c_char_p)
+    MO = py_to_c(MO, c_type=ctypes.c_char_p)
     
     # Call library function.
     function = lib.opendp_trans__make_bounded_resize
-    function.argtypes = [ctypes.c_uint, AnyObjectPtr, ctypes.c_void_p, ctypes.c_char_p]
+    function.argtypes = [ctypes.c_uint, AnyObjectPtr, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, bounds, constant, TA), Transformation))
+    return c_to_py(unwrap(function(size, bounds, constant, TA, MI, MO), Transformation))
 
 
 def make_bounded_sum(

--- a/python/test/test_trans.py
+++ b/python/test/test_trans.py
@@ -245,14 +245,14 @@ def test_count_by_categories():
 def test_resize():
     from opendp.trans import make_bounded_resize
     query = make_bounded_resize(size=4, bounds=(0, 10), constant=0)
-    assert query([-1, 2, 5]) == [-1, 2, 5, 0]
+    assert sorted(query([-1, 2, 5])) == [-1, 0, 2, 5]
     assert not query.check(1, 1)
     assert query.check(1, 2)
     assert query.check(2, 4)
 
     from opendp.trans import make_resize
     query = make_resize(size=4, constant=0)
-    assert query([-1, 2, 5]) == [-1, 2, 5, 0]
+    assert sorted(query([-1, 2, 5])) == [-1, 0, 2, 5]
     assert not query.check(1, 1)
     assert query.check(1, 2)
     assert query.check(2, 4)

--- a/rust/src/trans/bootstrap.json
+++ b/rust/src/trans/bootstrap.json
@@ -719,6 +719,18 @@
                 "name": "TA",
                 "is_type": true,
                 "description": "Atomic type."
+            },
+            {
+                "name": "MI",
+                "is_type": true,
+                "default": "SymmetricDistance",
+                "description": "Input metric."
+            },
+            {
+                "name": "MO",
+                "is_type": true,
+                "default": "InsertDeleteDistance",
+                "description": "Output metric."
             }
         ],
         "ret": {
@@ -759,6 +771,18 @@
                     "function": "get_first",
                     "params": ["bounds"]
                 }
+            },
+            {
+                "name": "MI",
+                "is_type": true,
+                "default": "SymmetricDistance",
+                "description": "Input metric."
+            },
+            {
+                "name": "MO",
+                "is_type": true,
+                "default": "SymmetricDistance",
+                "description": "Output metric."
             }
         ],
         "ret": {

--- a/rust/src/trans/cast_metric/traits.rs
+++ b/rust/src/trans/cast_metric/traits.rs
@@ -1,17 +1,7 @@
-use crate::{core::{Domain, Metric}, error::Fallible, samplers::Shuffle, dist::{SymmetricDistance, InsertDeleteDistance, ChangeOneDistance, HammingDistance}};
-
-pub trait ShuffleableDomain: Domain {
-    fn shuffle(val: Self::Carrier) -> Fallible<Self::Carrier>;
-}
-impl<D: Domain> ShuffleableDomain for D
-where
-    D::Carrier: Shuffle,
-{
-    fn shuffle(mut val: Self::Carrier) -> Fallible<Self::Carrier> {
-        val.shuffle()?;
-        Ok(val)
-    }
-}
+use crate::{
+    core::Metric,
+    dist::{ChangeOneDistance, HammingDistance, InsertDeleteDistance, SymmetricDistance},
+};
 
 pub trait UnorderedMetric: Metric {
     type OrderedMetric: Metric<Distance = Self::Distance>;

--- a/rust/src/trans/resize/ffi.rs
+++ b/rust/src/trans/resize/ffi.rs
@@ -2,6 +2,7 @@ use std::convert::TryFrom;
 use std::os::raw::{c_char, c_uint, c_void};
 
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
+use crate::dist::{InsertDeleteDistance, SymmetricDistance, IntDistance};
 use crate::dom::{AllDomain, BoundedDomain};
 use crate::err;
 use crate::ffi::any::{AnyObject, AnyTransformation};
@@ -9,43 +10,66 @@ use crate::ffi::any::Downcast;
 use crate::ffi::util::Type;
 use crate::traits::{CheckNull, TotalOrd};
 use crate::trans::make_resize_constant;
+use crate::trans::resize::IsMetricOrdered;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_bounded_resize(
     size: c_uint, bounds: *const AnyObject,
     constant: *const c_void,
     TA: *const c_char,
+    MI: *const c_char,
+    MO: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<TA>(
+    fn monomorphize<TA, MI, MO>(
         size: usize, bounds: *const AnyObject,
         constant: *const c_void,
     ) -> FfiResult<*mut AnyTransformation>
-        where TA: 'static + Clone + CheckNull + TotalOrd {
+        where 
+            TA: 'static + Clone + CheckNull + TotalOrd,
+            MI: 'static + IsMetricOrdered<Distance=IntDistance>,
+            MO: 'static + IsMetricOrdered<Distance=IntDistance>, {
         let bounds = try_!(try_as_ref!(bounds).downcast_ref::<(TA, TA)>()).clone();
         let atom_domain = try_!(BoundedDomain::new_closed(bounds));
         let constant = try_as_ref!(constant as *const TA).clone();
-        make_resize_constant::<BoundedDomain<TA>>(size, atom_domain, constant).into_any()
+        make_resize_constant::<_, MI, MO>(size, atom_domain, constant).into_any()
     }
     let size = size as usize;
     let TA = try_!(Type::try_from(TA));
-    dispatch!(monomorphize, [(TA, @numbers)], (size, bounds, constant))
+    let MI = try_!(Type::try_from(MI));
+    let MO = try_!(Type::try_from(MO));
+    dispatch!(monomorphize, [
+        (TA, @numbers), 
+        (MI, [SymmetricDistance, InsertDeleteDistance]),
+        (MO, [SymmetricDistance, InsertDeleteDistance])
+    ], (size, bounds, constant))
 }
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_resize(
     size: c_uint, constant: *const AnyObject,
     TA: *const c_char,
+    MI: *const c_char,
+    MO: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<TA>(
+    fn monomorphize<TA, MI, MO>(
         size: usize, constant: *const AnyObject,
     ) -> FfiResult<*mut AnyTransformation>
-        where TA: 'static + Clone + CheckNull {
+        where 
+            TA: 'static + Clone + CheckNull,
+            MI: 'static + IsMetricOrdered<Distance=IntDistance>,
+            MO: 'static + IsMetricOrdered<Distance=IntDistance>, {
         let constant = try_!(try_as_ref!(constant).downcast_ref::<TA>()).clone();
-        make_resize_constant::<AllDomain<TA>>(size, AllDomain::new(), constant).into_any()
+        make_resize_constant::<AllDomain<TA>, MI, MO>(size, AllDomain::new(), constant).into_any()
     }
     let size = size as usize;
     let TA = try_!(Type::try_from(TA));
-    dispatch!(monomorphize, [(TA, @primitives)], (size, constant))
+    let MI = try_!(Type::try_from(MI));
+    let MO = try_!(Type::try_from(MO));
+    dispatch!(monomorphize, [
+        (TA, @numbers), 
+        (MI, [SymmetricDistance, InsertDeleteDistance]),
+        (MO, [SymmetricDistance, InsertDeleteDistance])
+    ], (size, constant))
 }
 
 
@@ -65,6 +89,8 @@ mod tests {
             4 as c_uint,
             AnyObject::new_raw(0i32),
             "i32".to_char_p(),
+            "SymmetricDistance".to_char_p(),
+            "SymmetricDistance".to_char_p(),
         ))?;
         let arg = AnyObject::new_raw(vec![1, 2, 3]);
         let res = opendp_core__transformation_invoke(&transformation, arg);
@@ -81,6 +107,8 @@ mod tests {
             util::into_raw(AnyObject::new((0i32, 10))),
             util::into_raw(0i32) as *const c_void,
             "i32".to_char_p(),
+            "SymmetricDistance".to_char_p(),
+            "SymmetricDistance".to_char_p(),
         ))?;
         let arg = AnyObject::new_raw(vec![1, 2, 3]);
         let res = opendp_core__transformation_invoke(&transformation, arg);


### PR DESCRIPTION
See #357. Doesn't close.

Refactors the resize transformation to shuffle when necessary, in accordance with the ordered-ness of the input and output metric.