### PR TITLE
windows build fix, development environment documentation

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -30,7 +30,10 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Build
-        run: cargo build --verbose --features=untrusted,ffi
+        run: cargo build --verbose --features untrusted,bindings-python
+      
+      - name: check --no-default-features
+        run: cargo check --verbose --no-default-features --features untrusted,bindings-python
 
       - name: Test
         run: cargo test --verbose

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -32,11 +32,11 @@ jobs:
       - name: Build
         run: cargo build --verbose --features untrusted,bindings-python
       
-      - name: check --no-default-features
-        run: cargo check --verbose --no-default-features --features untrusted,bindings-python
+      - name: Check --no-default-features
+        run: cargo check --verbose --no-default-features --features untrusted,ffi
 
       - name: Test
-        run: cargo test --verbose
+        run: cargo test --verbose --features untrusted,ffi
 
       - name: Upload libs
         uses: actions/upload-artifact@v2

--- a/docs/source/developer/development-environment.rst
+++ b/docs/source/developer/development-environment.rst
@@ -122,12 +122,60 @@ A few notes on VS Code:
 * Open ``rust-analyzer``'s extension settings, search "features" and add ``"untrusted", "bindings-python"``
 * Look for ``Problems`` in the bottom panel for live compilation errors as you work
 * Other useful extensions are "Better Toml", "crates" and "LaTex Workshop".
-* Latex Workshop configuration starter:
+* Starter json configurations:
 
 .. raw:: html
 
    <details style="margin:-1em 0 2em 4em">
-   <summary><a>settings.json</a></summary>
+   <summary><a>Expand Me</a></summary>
+
+Starter ``/.vscode/tasks.json``. 
+These tasks can be used to directly build OpenDP.
+`See also the VSCode documentation on tasks. <https://code.visualstudio.com/docs/editor/tasks>`_
+
+.. code-block:: json
+
+    {
+        "version": "2.0.0",
+        "tasks": [
+            {
+                "type": "cargo",
+                "command": "build",
+                "problemMatcher": [
+                    "$rustc"
+                ],
+                "args": [
+                    "--manifest-path=./rust/Cargo.toml"
+                ],
+                "group": "build",
+                "label": "rust: cargo build",
+                "presentation": {
+                    "clear": true
+                }
+            },
+            {
+                "type": "cargo",
+                "command": "build",
+                "problemMatcher": [
+                    "$rustc"
+                ],
+                "args": [
+                    "--manifest-path=./rust/Cargo.toml",
+                    "--features", "bindings-python untrusted"
+                ],
+                "group": "build",
+                "label": "rust: cargo build ffi",
+                "presentation": {
+                    "clear": true
+                }
+            }
+        ]
+    }
+
+
+Starter `settings.json` for LaTex Workshop. 
+Access this file through the LaTex Workshop extension settings.
+This configuration emits outputs into ``./out/``
 
 .. code-block:: json
 
@@ -185,3 +233,4 @@ A few notes on Intellij IDEA:
 * Be sure to open the project at the root of the git repository
 * Be sure to install the Python and Rust plugins for interactivity
 * Be sure to "attach" the Cargo.toml in the red banner the first time you open a Rust source file
+* Use run configurations to `build the rust library <https://plugins.jetbrains.com/plugin/8182-rust/docs/cargo-command-configuration.html#cargo-command-config>`_ and run tests

--- a/docs/source/developer/development-environment.rst
+++ b/docs/source/developer/development-environment.rst
@@ -22,33 +22,47 @@ Download Python from the `Python website`_.
 Clone the OpenDP Repo
 ---------------------
 
-If you don't have write access to the OpenDP repository, you will first need to make a fork.
-`The GitHub documentation explains this process well <https://docs.github.com/en/get-started/quickstart/fork-a-repo>`_.
+If you don't have write access to the OpenDP repository, you will either need to request to join the organization or make a fork.
+`The GitHub documentation explains forking <https://docs.github.com/en/get-started/quickstart/fork-a-repo>`_.
 
 Clone the repo (or your fork) and change into the ``opendp`` directory that's created.
 
 .. code-block:: bash
 
-    git clone https://github.com/opendp/opendp.git
+    git clone git@github.com:opendp/opendp.git
     cd opendp
+
+
+If you have not `set up SSH <https://docs.github.com/en/authentication/connecting-to-github-with-ssh>`_, you can clone with https instead:
+
+.. code-block:: bash
+
+    git clone https://github.com/opendp/opendp.git
+
 
 Building OpenDP
 ===============
-
-Build OpenDP
-------------
 
 Change to the ``rust`` directory before attempting a build, run the tests, and then return to the ``opendp`` directory.
 
 .. code-block:: bash
 
     cd rust
-    cargo build
-    cargo test
+    cargo build --features untrusted,bindings-python
+    cargo test --features untrusted,bindings-python
     cd ..
 
-Add `--features=untrusted` to the `cargo` commands to include non-secure floating-point and contrib features like `make_base_laplace`.
-Refer to the :ref:`developer-faq` section if you run into compilation problems.
+Features are optional. The ``untrusted`` feature includes non-secure floating-point and contrib features like ``make_base_laplace``,
+and the ``bindings-python`` feature updates the python bindings when you build.
+
+Refer to the :ref:`developer-faq` if you run into compilation problems.
+
+.. note::
+
+    There is a more involved `setup guide <https://github.com/opendp/opendp/tree/main/rust/windows>`_ for Windows users.
+    You can compromise to simple and vulnerable builds instead, by adding the ``--no-default-features`` flag to cargo commands.
+    Be advised this flag disables GMP's exact float handling, as well as OpenSSL's secure noise generation.
+
 
 Install Python Dependencies
 ---------------------------
@@ -58,29 +72,29 @@ Change to the ``python`` directory, create a Python virtual environment, activat
 .. code-block:: bash
 
     cd python
+
+    # recommended. conda is just as valid
     python3 -m venv venv
     source venv/bin/activate
+
     pip install flake8 pytest
-    mkdir src/opendp/lib
     pip install -e .
 
-The developer install will not work if you don't use the `-e` flag when installing with pip!
+The `-e` flag is significant! It stands for "editable", meaning you only have to run this command once.
 
-Run the Tests
--------------
+Testing Python
+--------------
 
-From the ``python`` directory, set an environment variable to the location of the OpenDP library you built. Then run the tests.
+Run the tests from the ``python`` directory. 
 
 .. code-block:: bash
 
-    export OPENDP_LIB_DIR=../rust/target/debug
     pytest -v
+
+If pytest is not found, don't forget to activate your virtual environment.
 
 Documentation
 =============
-
-Documentation Source
---------------------
 
 The source for this documentation can be found in the "docs" directory at https://github.com/opendp/opendp
 
@@ -95,14 +109,75 @@ Tooling
 
 There are many development environments that work with Rust. Here are a few:
 
+* `VS Code <https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer>`_
 * `Intellij IDEA <https://plugins.jetbrains.com/plugin/8182-rust>`_
-* `VS Code <https://marketplace.visualstudio.com/items?itemName=rust-lang.rust>`_
 * `Sublime <https://github.com/rust-lang/rust-enhanced>`_
 
 Use whatever developer tooling you are comfortable with.
-The benefit to using Intellij IDEA is that the core developers use it,
-which makes it possible for one of us to actually join your IDE with the `CodeWithMe Plugin <https://www.jetbrains.com/code-with-me/>`_,
-and talk through issues.
+
+
+A few notes on VS Code:
+
+* Be sure to install the `rust-analyzer <https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer>`_ plugin, not the rust plugin
+* Open ``rust-analyzer``'s extension settings, search "features" and add ``"untrusted", "bindings-python"``
+* Look for ``Problems`` in the bottom panel for live compilation errors as you work
+* Other useful extensions are "Better Toml", "crates" and "LaTex Workshop".
+* Latex Workshop configuration starter:
+
+.. raw:: html
+
+   <details style="margin:-1em 0 2em 4em">
+   <summary><a>settings.json</a></summary>
+
+.. code-block:: json
+
+    {
+        "latex-workshop.latex.outDir": "%DIR%/out/",
+        "latex-workshop.latex.recipes": [
+            {
+                "name": "latexmk",
+                "tools": [
+                    "latexmk"
+                ]
+            }
+        ],
+        "latex-workshop.latex.tools": [
+            {
+                "name": "latexmk",
+                "command": "latexmk",
+                "args": [
+                    "-synctex=1",
+                    "-interaction=nonstopmode",
+                    "-file-line-error",
+                    "-recorder",
+                    "-pdf",
+                    "--shell-escape",
+                    "-aux-directory=out",
+                    "-output-directory=out",
+                    "%DOC%"
+                ]
+            },
+            {
+                "name": "pdflatex",
+                "command": "pdflatex",
+                "args": [
+                    "-synctex=1",
+                    "-interaction=nonstopmode",
+                    "-file-line-error",
+                    "-aux-directory=out",
+                    "-output-directory=out",
+                    "%DOC%"
+                ]
+            }
+        ],
+        "latex-workshop.view.pdf.viewer": "tab"
+    }
+
+.. raw:: html
+
+   </details>
+
+
 
 A few notes on Intellij IDEA:
 
@@ -110,5 +185,3 @@ A few notes on Intellij IDEA:
 * Be sure to open the project at the root of the git repository
 * Be sure to install the Python and Rust plugins for interactivity
 * Be sure to "attach" the Cargo.toml in the red banner the first time you open a Rust source file
-
-To reiterate, of course, use whatever developer tooling you are comfortable with!

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -52,10 +52,5 @@ indexmap = { version = "1.6.2", features = ["serde"] }
 [lib]
 crate-type = ["rlib", "cdylib"]
 
-
-[dev-dependencies]
-# this enables the "untrusted" feature flag by default when doing tests
-opendp = { path = ".", features = ["untrusted"] }
-
 [package.metadata.docs.rs]
 features = ["untrusted", "ffi"]

--- a/rust/src/accuracy/mod.rs
+++ b/rust/src/accuracy/mod.rs
@@ -57,7 +57,7 @@ pub fn accuracy_to_gaussian_scale<T>(accuracy: T, alpha: T) -> Fallible<T>
 }
 
 
-#[cfg(test)]
+#[cfg(all(test, feature="untrusted"))]
 pub mod test {
     use std::fmt::Debug;
     use std::ops::{Mul, Sub};

--- a/rust/src/interactive.rs
+++ b/rust/src/interactive.rs
@@ -231,6 +231,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(feature="untrusted")]
     #[test]
     fn test_adaptive_composition_chain() -> Fallible<()> {
         // Definitions

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -39,11 +39,13 @@
 //! Here's a simple example of using OpenDP from Rust to create a private sum:
 //! ```
 //! use opendp::error::Fallible;
-//! use opendp::trans::{make_split_lines, make_cast_default, make_clamp, make_bounded_sum};
-//! use opendp::comb::{make_chain_tt, make_chain_mt};
-//! use opendp::meas::make_base_laplace;
 //!
+//! #[cfg(feature = "untrusted")]
 //! pub fn example() -> Fallible<()> {
+//!     use opendp::trans::{make_split_lines, make_cast_default, make_clamp, make_bounded_sum};
+//!     use opendp::comb::{make_chain_tt, make_chain_mt};
+//!     use opendp::meas::make_base_laplace;
+//! 
 //!     let data = "56\n15\n97\n56\n6\n17\n2\n19\n16\n50".to_owned();
 //!     let bounds = (0.0, 100.0);
 //!     let epsilon = 1.0;
@@ -81,6 +83,7 @@
 //!     println!("release = {}", release);
 //!     Ok(())
 //! }
+//! #[cfg(feature = "untrusted")]
 //! example().unwrap();
 //! ```
 //!
@@ -173,6 +176,7 @@ pub mod core;
 pub mod data;
 pub mod dist;
 pub mod dom;
+#[cfg(feature="contrib")]
 pub mod interactive;
 pub mod meas;
 pub mod poly;

--- a/rust/src/meas/mod.rs
+++ b/rust/src/meas/mod.rs
@@ -29,7 +29,7 @@ pub mod randomized_response;
 #[cfg(feature="contrib")]
 pub use crate::meas::randomized_response::*;
 
-#[cfg(all(feature="floating-point", feature="contrib"))]
+#[cfg(all(feature="use-mpfr", feature="floating-point", feature="contrib"))]
 pub mod alp;
-#[cfg(all(feature="floating-point", feature="contrib"))]
+#[cfg(all(feature="use-mpfr", feature="floating-point", feature="contrib"))]
 pub use crate::meas::alp::*;

--- a/rust/src/poly.rs
+++ b/rust/src/poly.rs
@@ -85,14 +85,14 @@ impl<DI, DO, MI, MO> Transformation<DI, DO, MI, MO>
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature="untrusted"))]
 mod tests {
     use crate::dist::SubstituteDistance;
     use crate::dom::AllDomain;
     use crate::error::*;
     use crate::meas;
     use crate::trans;
-
+    
     #[test]
     fn test_poly_measurement() -> Fallible<()> {
         let op_plain = meas::make_base_laplace::<AllDomain<_>>(0.0)?;

--- a/rust/src/samplers.rs
+++ b/rust/src/samplers.rs
@@ -34,19 +34,19 @@ pub fn fill_bytes(buffer: &mut [u8]) -> Fallible<()> {
 }
 
 #[cfg(feature="use-mpfr")]
-struct GeneratorOpenDP {
+struct GeneratorOpenSSL {
     error: Fallible<()>,
 }
 
 #[cfg(feature="use-mpfr")]
-impl GeneratorOpenDP {
+impl GeneratorOpenSSL {
     fn new() -> Self {
-        GeneratorOpenDP { error: Ok(()) }
+        GeneratorOpenSSL { error: Ok(()) }
     }
 }
 
 #[cfg(feature="use-mpfr")]
-impl ThreadRandGen for GeneratorOpenDP {
+impl ThreadRandGen for GeneratorOpenSSL {
     fn gen(&mut self) -> u32 {
         let mut buffer = [0u8; 4];
         if let Err(e) = fill_bytes(&mut buffer) {
@@ -557,7 +557,7 @@ impl<T: Clone + CastInternalReal + SampleRademacher + Zero + Mul<Output=T>> Samp
         }
 
         // initialize randomness
-        let mut rng = GeneratorOpenDP::new();
+        let mut rng = GeneratorOpenSSL::new();
         let laplace = {
             let mut state = ThreadRandState::new_custom(&mut rng);
 
@@ -596,7 +596,7 @@ impl<T: Clone + CastInternalReal + Zero + Mul<Output=T>> SampleGaussian for T {
         }
 
         // initialize randomness
-        let mut rng = GeneratorOpenDP::new();
+        let mut rng = GeneratorOpenSSL::new();
         let gauss = {
             let mut state = ThreadRandState::new_custom(&mut rng);
 

--- a/rust/src/traits/arithmetic.rs
+++ b/rust/src/traits/arithmetic.rs
@@ -2,6 +2,7 @@
 use rug::ops::{AddAssignRound, DivAssignRound, MulAssignRound, SubAssignRound};
 
 use crate::error::Fallible;
+#[cfg(feature="use-mpfr")]
 use crate::traits::CastInternalReal;
 
 /// Computes the absolute value and returns an error if overflowing.
@@ -331,14 +332,14 @@ macro_rules! impl_float_inf_bi {
         #[cfg(not(feature="use-mpfr"))]
         impl $name for $ty {
             fn $method_inf(&self, other: &Self) -> Fallible<Self> {
-                let this = self.$fallback(other);
+                let this = self.$fallback(other)?;
                 this.is_finite().then(|| this).ok_or_else(|| err!(
                     FailedFunction,
                     concat!("({}).", stringify!($method_inf), "({}) is not finite. Consider tightening your parameters."),
                     self, other))
             }
             fn $method_neg_inf(&self, other: &Self) -> Fallible<Self> {
-                let this = self.$fallback(other);
+                let this = self.$fallback(other)?;
                 this.is_finite().then(|| this).ok_or_else(|| err!(
                     FailedFunction,
                     concat!("({}).", stringify!($method_neg_inf), "({}) is not finite. Consider tightening your parameters."),

--- a/rust/src/traits/cast.rs
+++ b/rust/src/traits/cast.rs
@@ -4,7 +4,11 @@ use num::{NumCast, One, Zero};
 #[cfg(feature = "use-mpfr")]
 use rug::Float;
 
+#[cfg(not(feature = "use-mpfr"))]
+use crate::samplers::SampleGaussian;
+
 use crate::error::Fallible;
+#[cfg(feature="use-mpfr")]
 use crate::traits::FloatBits;
 
 // general overview of casters:
@@ -43,6 +47,7 @@ pub trait CastInternalReal: FloatBits + Sized {
 
 #[cfg(not(feature = "use-mpfr"))]
 pub trait CastInternalReal: rand::distributions::uniform::SampleUniform + SampleGaussian {
+    const MANTISSA_DIGITS: u32;
     fn from_internal(v: Self) -> Self;
     fn into_internal(self) -> Self;
 }


### PR DESCRIPTION
* fix the `--no-default-features` cargo flag
    * primarily used for easy windows builds
* smoke-test now checks that the `--no-default-features` flag works
* don't add opendp as a dev-dependency of opendp to enable the untrusted flag by default when testing
    * feature configuration wasn't being passed forward into the secondary opendp crate
    * therefore the secondary opendp crate re-introduces dependencies on openssl and rug
    * add cfg markup to all tests throughout the library that depend on untrusted
* expanded the Development Environment documentation
* fixes #400 