### PR TITLE
simplify mean to be a lipschitz extension of sum

### DIFF
--- a/docs/source/user/application-structure.rst
+++ b/docs/source/user/application-structure.rst
@@ -197,7 +197,7 @@ can be used to convert the earlier discovered noise scale parameter into an accu
     ...  f"the DP estimate differs from the true value by no more than {accuracy} "
     ...  f"at a statistical significance level alpha of {alpha}, "
     ...  f"or with (1 - {alpha})100% = {(1 - alpha) * 100}% confidence.")
-    'When the laplace scale is 2.0000000000000004, the DP estimate differs from the true value by no more than 5.991464547107983 at a statistical significance level alpha of 0.05, or with (1 - 0.05)100% = 95.0% confidence.'
+    'When the laplace scale is 2.0000000000000338, the DP estimate differs from the true value by no more than 5.991464547108083 at a statistical significance level alpha of 0.05, or with (1 - 0.05)100% = 95.0% confidence.'
 
 Please be aware that the preprocessing (impute, clamp, resize) can introduce bias that the accuracy estimate cannot account for.
 In this example, since the sensitive dataset is short two exams,

--- a/docs/source/user/application-structure.rst
+++ b/docs/source/user/application-structure.rst
@@ -197,7 +197,7 @@ can be used to convert the earlier discovered noise scale parameter into an accu
     ...  f"the DP estimate differs from the true value by no more than {accuracy} "
     ...  f"at a statistical significance level alpha of {alpha}, "
     ...  f"or with (1 - {alpha})100% = {(1 - alpha) * 100}% confidence.")
-    'When the laplace scale is 2.0000000000000338, the DP estimate differs from the true value by no more than 5.991464547108083 at a statistical significance level alpha of 0.05, or with (1 - 0.05)100% = 95.0% confidence.'
+    'When the laplace scale is 2.0000000000003215, the DP estimate differs from the true value by no more than 5.9914645471089445 at a statistical significance level alpha of 0.05, or with (1 - 0.05)100% = 95.0% confidence.'
 
 Please be aware that the preprocessing (impute, clamp, resize) can introduce bias that the accuracy estimate cannot account for.
 In this example, since the sensitive dataset is short two exams,

--- a/docs/source/user/application-structure.rst
+++ b/docs/source/user/application-structure.rst
@@ -197,7 +197,7 @@ can be used to convert the earlier discovered noise scale parameter into an accu
     ...  f"the DP estimate differs from the true value by no more than {accuracy} "
     ...  f"at a statistical significance level alpha of {alpha}, "
     ...  f"or with (1 - {alpha})100% = {(1 - alpha) * 100}% confidence.")
-    'When the laplace scale is 2.0000000000003215, the DP estimate differs from the true value by no more than 5.9914645471089445 at a statistical significance level alpha of 0.05, or with (1 - 0.05)100% = 95.0% confidence.'
+    'When the laplace scale is 2.0000000000003357, the DP estimate differs from the true value by no more than 5.991464547108987 at a statistical significance level alpha of 0.05, or with (1 - 0.05)100% = 95.0% confidence.'
 
 Please be aware that the preprocessing (impute, clamp, resize) can introduce bias that the accuracy estimate cannot account for.
 In this example, since the sensitive dataset is short two exams,

--- a/docs/source/user/combinator-constructors.rst
+++ b/docs/source/user/combinator-constructors.rst
@@ -133,8 +133,8 @@ is a simple sample of individuals from a theoretical larger dataset that capture
 
 .. doctest::
 
-    >>> # Where we once had a privacy utilization of 2 epsilon...
-    >>> assert meas.check(2, 2.)
+    >>> # Where we once had a privacy utilization of ~2 epsilon...
+    >>> assert meas.check(2, 2. + 1e-6)
     ...
     >>> # ...we now have a privacy utilization of ~.4941 epsilon.
     >>> assert amplified.check(2, .4941)

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -493,7 +493,7 @@ def binary_search(
     >>> binary_search(
     ...     lambda d_out: dp_mean.check(3, (d_out, 1e-8)), 
     ...     bounds = (0., 1.))
-    0.6105625903337409
+    0.6105625903350966
 
     Find the L2 distance sensitivity of a histogram when neighboring datasets differ by up to 3 additions/removals.
 

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -493,7 +493,7 @@ def binary_search(
     >>> binary_search(
     ...     lambda d_out: dp_mean.check(3, (d_out, 1e-8)), 
     ...     bounds = (0., 1.))
-    0.6105625903350966
+    0.6105625903364432
 
     Find the L2 distance sensitivity of a histogram when neighboring datasets differ by up to 3 additions/removals.
 

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -493,7 +493,7 @@ def binary_search(
     >>> binary_search(
     ...     lambda d_out: dp_mean.check(3, (d_out, 1e-8)), 
     ...     bounds = (0., 1.))
-    0.6105625903364432
+    0.6105625903365299
 
     Find the L2 distance sensitivity of a histogram when neighboring datasets differ by up to 3 additions/removals.
 

--- a/python/src/opendp/trans.py
+++ b/python/src/opendp/trans.py
@@ -1194,6 +1194,7 @@ def make_lipschitz_float_mul(
 def make_sized_bounded_mean(
     size: int,
     bounds: Tuple[Any, Any],
+    MI: RuntimeTypeDescriptor = "SymmetricDistance",
     T: RuntimeTypeDescriptor = None
 ) -> Transformation:
     """Make a Transformation that computes the mean of bounded data. 
@@ -1204,6 +1205,8 @@ def make_sized_bounded_mean(
     :type size: int
     :param bounds: Tuple of inclusive lower and upper bounds of the input data.
     :type bounds: Tuple[Any, Any]
+    :param MI: input metric. One of SymmetricDistance or InsertDeleteDistance
+    :type MI: :ref:`RuntimeTypeDescriptor`
     :param T: atomic data type
     :type T: :ref:`RuntimeTypeDescriptor`
     :return: A sized_bounded_mean step.
@@ -1215,19 +1218,21 @@ def make_sized_bounded_mean(
     assert_features("contrib")
     
     # Standardize type arguments.
+    MI = RuntimeType.parse(type_name=MI)
     T = RuntimeType.parse_or_infer(type_name=T, public_example=get_first(bounds))
     
     # Convert arguments to c types.
     size = py_to_c(size, c_type=ctypes.c_uint)
     bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
+    MI = py_to_c(MI, c_type=ctypes.c_char_p)
     T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
     function = lib.opendp_trans__make_sized_bounded_mean
-    function.argtypes = [ctypes.c_uint, AnyObjectPtr, ctypes.c_char_p]
+    function.argtypes = [ctypes.c_uint, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, bounds, T), Transformation))
+    return c_to_py(unwrap(function(size, bounds, MI, T), Transformation))
 
 
 def make_resize(

--- a/python/test/test_binary_search.py
+++ b/python/test/test_binary_search.py
@@ -47,8 +47,8 @@ def test_type_inference():
 
     def mean_chainer_n(n):
         return make_sized_bounded_mean(n, (-20., 20.))
-    assert binary_search_param(mean_chainer_n, 2, 1.) == 40
+    assert binary_search_param(mean_chainer_n, 2, 1.) == 41
 
     def mean_chainer_b(b):
         return make_sized_bounded_mean(1000, (-b, b))
-    assert binary_search_param(mean_chainer_b, 2, 1.) == 500.
+    assert 499.999 < binary_search_param(mean_chainer_b, 2, 1.) < 500.

--- a/python/test/test_comb.py
+++ b/python/test/test_comb.py
@@ -12,8 +12,8 @@ def test_amplification():
 
     amplified = make_population_amplification(meas, population_size=100)
     print("amplified base laplace:", amplified([1.] * 10))
-    assert meas.check(2, 2.)
-    assert not meas.check(2, 1.999)
+    assert meas.check(2, 2. + 1e-6)
+    assert not meas.check(2, 2.)
     assert amplified.check(2, 1.494)
     assert not amplified.check(2, .494)
 

--- a/python/test/test_trans.py
+++ b/python/test/test_trans.py
@@ -172,7 +172,7 @@ def test_bounded_mean():
     from opendp.trans import make_sized_bounded_mean
     query = make_sized_bounded_mean(size=9, bounds=(0., 10.))
     assert query(FLOAT_DATA) == 5.
-    assert query.check(2, 10. / 9.)
+    assert query.check(2, 10. / 9. + 1e-6)
 
 
 def test_bounded_sum():

--- a/rust/src/comb/amplify/mod.rs
+++ b/rust/src/comb/amplify/mod.rs
@@ -66,8 +66,8 @@ mod test {
         let meas = (make_sized_bounded_mean(10, (0., 10.))? >> make_base_laplace(0.5)?)?;
         let amp = make_population_amplification(&meas, 100)?;
         amp.function.eval(&vec![1.; 10])?;
-        assert!(meas.check(&2, &2.)?);
-        assert!(!meas.check(&2, &1.999)?);
+        assert!(meas.check(&2, &(2. + 1e-6))?);
+        assert!(!meas.check(&2, &2.)?);
         assert!(amp.check(&2, &0.4941)?);
         assert!(!amp.check(&2, &0.494)?);
         Ok(())

--- a/rust/src/comb/amplify/mod.rs
+++ b/rust/src/comb/amplify/mod.rs
@@ -56,6 +56,7 @@ pub fn make_population_amplification<DIA, DO, MI, MO>(
 
 #[cfg(test)]
 mod test {
+    use crate::dist::SymmetricDistance;
     use crate::error::Fallible;
     use crate::trans::make_sized_bounded_mean;
     use crate::meas::make_base_laplace;
@@ -63,7 +64,7 @@ mod test {
 
     #[test]
     fn test_amplifier() -> Fallible<()> {
-        let meas = (make_sized_bounded_mean(10, (0., 10.))? >> make_base_laplace(0.5)?)?;
+        let meas = (make_sized_bounded_mean::<SymmetricDistance, _>(10, (0., 10.))? >> make_base_laplace(0.5)?)?;
         let amp = make_population_amplification(&meas, 100)?;
         amp.function.eval(&vec![1.; 10])?;
         assert!(meas.check(&2, &(2. + 1e-6))?);

--- a/rust/src/meas/laplace/mod.rs
+++ b/rust/src/meas/laplace/mod.rs
@@ -71,12 +71,12 @@ pub fn make_base_laplace<D>(scale: D::Atom) -> Fallible<Measurement<D, D, D::Met
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::trans::make_sized_bounded_mean;
+    use crate::{trans::make_sized_bounded_mean, dist::SymmetricDistance};
 
     #[test]
     fn test_chain_laplace() -> Fallible<()> {
         let chain = (
-            make_sized_bounded_mean(3, (10.0, 12.0))? >>
+            make_sized_bounded_mean::<SymmetricDistance, _>(3, (10.0, 12.0))? >>
             make_base_laplace(1.0)?
         )?;
         let _ret = chain.invoke(&vec![10.0, 11.0, 12.0])?;

--- a/rust/src/trans/bootstrap.json
+++ b/rust/src/trans/bootstrap.json
@@ -735,6 +735,12 @@
                 "description": "Tuple of inclusive lower and upper bounds of the input data."
             },
             {
+                "name": "MI",
+                "is_type": true,
+                "description": "input metric. One of SymmetricDistance or InsertDeleteDistance",
+                "default": "SymmetricDistance"
+            },
+            {
                 "name": "T",
                 "is_type": true,
                 "description": "atomic data type",

--- a/rust/src/trans/mean/ffi.rs
+++ b/rust/src/trans/mean/ffi.rs
@@ -3,8 +3,8 @@ use std::os::raw::{c_char, c_uint};
 
 use num::Float;
 
-use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
-use crate::dist::AbsoluteDistance;
+use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt, Metric};
+use crate::dist::{AbsoluteDistance, InsertDeleteDistance, SymmetricDistance};
 use crate::dom::AllDomain;
 use crate::err;
 use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
@@ -18,20 +18,29 @@ use crate::trans::{
 pub extern "C" fn opendp_trans__make_sized_bounded_mean(
     size: c_uint,
     bounds: *const AnyObject,
+    MI: *const c_char,
     T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<T>(size: usize, bounds: *const AnyObject) -> FfiResult<*mut AnyTransformation>
+    fn monomorphize<MI, T>(
+        size: usize,
+        bounds: *const AnyObject,
+    ) -> FfiResult<*mut AnyTransformation>
     where
-        T: 'static + MakeSizedBoundedSum + ExactIntCast<usize> + Float,
-        AllDomain<T>: LipschitzMulDomain<Atom=T>,
+        MI: 'static + Metric,
+        T: 'static + MakeSizedBoundedSum<MI> + ExactIntCast<usize> + Float,
+        AllDomain<T>: LipschitzMulDomain<Atom = T>,
         AbsoluteDistance<T>: LipschitzMulMetric<Distance = T>,
     {
         let bounds = try_!(try_as_ref!(bounds).downcast_ref::<(T, T)>()).clone();
-        make_sized_bounded_mean::<T>(size, bounds).into_any()
+        make_sized_bounded_mean::<MI, T>(size, bounds).into_any()
     }
     let size = size as usize;
+    let MI = try_!(Type::try_from(MI));
     let T = try_!(Type::try_from(T));
-    dispatch!(monomorphize, [(T, @floats)], (size, bounds))
+    dispatch!(monomorphize, [
+        (MI, [SymmetricDistance, InsertDeleteDistance]),
+        (T, @floats)
+    ], (size, bounds))
 }
 
 #[cfg(test)]
@@ -49,6 +58,7 @@ mod tests {
         let transformation = Result::from(opendp_trans__make_sized_bounded_mean(
             3 as c_uint,
             util::into_raw(AnyObject::new((0., 10.))),
+            "InsertDeleteDistance".to_char_p(),
             "f64".to_char_p(),
         ))?;
         let arg = AnyObject::new_raw(vec![1.0, 2.0, 3.0]);

--- a/rust/src/trans/mean/ffi.rs
+++ b/rust/src/trans/mean/ffi.rs
@@ -11,7 +11,7 @@ use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
 use crate::ffi::util::Type;
 use crate::traits::ExactIntCast;
 use crate::trans::{
-    make_sized_bounded_mean, LipschitzMulDomain, LipschitzMulMetric, MakeSizedBoundedSum,
+    make_sized_bounded_mean, LipschitzMulFloatDomain, LipschitzMulFloatMetric, MakeSizedBoundedSum,
 };
 
 #[no_mangle]
@@ -28,8 +28,8 @@ pub extern "C" fn opendp_trans__make_sized_bounded_mean(
     where
         MI: 'static + Metric,
         T: 'static + MakeSizedBoundedSum<MI> + ExactIntCast<usize> + Float,
-        AllDomain<T>: LipschitzMulDomain<Atom = T>,
-        AbsoluteDistance<T>: LipschitzMulMetric<Distance = T>,
+        AllDomain<T>: LipschitzMulFloatDomain<Atom = T>,
+        AbsoluteDistance<T>: LipschitzMulFloatMetric<Distance = T>,
     {
         let bounds = try_!(try_as_ref!(bounds).downcast_ref::<(T, T)>()).clone();
         make_sized_bounded_mean::<MI, T>(size, bounds).into_any()

--- a/rust/src/trans/mean/ffi.rs
+++ b/rust/src/trans/mean/ffi.rs
@@ -9,7 +9,7 @@ use crate::dom::AllDomain;
 use crate::err;
 use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
 use crate::ffi::util::Type;
-use crate::traits::ExactIntCast;
+use crate::traits::{ExactIntCast, InfMul};
 use crate::trans::{
     make_sized_bounded_mean, LipschitzMulFloatDomain, LipschitzMulFloatMetric, MakeSizedBoundedSum,
 };
@@ -27,7 +27,7 @@ pub extern "C" fn opendp_trans__make_sized_bounded_mean(
     ) -> FfiResult<*mut AnyTransformation>
     where
         MI: 'static + Metric,
-        T: 'static + MakeSizedBoundedSum<MI> + ExactIntCast<usize> + Float,
+        T: 'static + MakeSizedBoundedSum<MI> + ExactIntCast<usize> + Float + InfMul,
         AllDomain<T>: LipschitzMulFloatDomain<Atom = T>,
         AbsoluteDistance<T>: LipschitzMulFloatMetric<Distance = T>,
     {

--- a/rust/src/trans/mean/mod.rs
+++ b/rust/src/trans/mean/mod.rs
@@ -10,7 +10,7 @@ use crate::error::Fallible;
 use crate::traits::ExactIntCast;
 
 use super::{
-    make_lipschitz_mul, make_sized_bounded_sum, LipschitzMulDomain, LipschitzMulMetric,
+    make_lipschitz_float_mul, make_sized_bounded_sum, LipschitzMulFloatDomain, LipschitzMulFloatMetric,
     MakeSizedBoundedSum,
 };
 
@@ -28,14 +28,15 @@ pub fn make_sized_bounded_mean<MI, T>(
 where
     MI: 'static + Metric,
     T: 'static + MakeSizedBoundedSum<MI> + ExactIntCast<usize> + Float,
-    AllDomain<T>: LipschitzMulDomain<Atom = T>,
-    AbsoluteDistance<T>: LipschitzMulMetric<Distance = T>,
+    AllDomain<T>: LipschitzMulFloatDomain<Atom = T>,
+    AbsoluteDistance<T>: LipschitzMulFloatMetric<Distance = T>,
 {
     if size == 0 {
         return fallible!(MakeTransformation, "dataset size must be positive");
     }
     let size_ = T::exact_int_cast(size)?;
-    make_sized_bounded_sum::<MI, T>(size, bounds)? >> make_lipschitz_mul(size_.recip())?
+    let sum_bounds = (size_ * bounds.0, size_ * bounds.1);
+    make_sized_bounded_sum::<MI, T>(size, bounds)? >> make_lipschitz_float_mul(size_.recip(), sum_bounds)?
 }
 
 #[cfg(test)]

--- a/rust/src/trans/sum/float/checked/mod.rs
+++ b/rust/src/trans/sum/float/checked/mod.rs
@@ -100,8 +100,8 @@ where
         StabilityMap::new_fallible(move |d_in: &IntDistance| {
             // d_out =  |BS*(v) - BS*(v')| where BS* is the finite sum and BS the ideal sum
             //       <= |BS*(v) - BS(v)| + |BS(v) - BS(v')| + |BS(v') - BS*(v')|
-            //       <= d_in * (U - L) + 2 * error
-            //       =  d_in * (U - L) + relaxation
+            //       <= d_in / 2 * (U - L) + 2 * error
+            //       =  d_in / 2 * (U - L) + relaxation
             S::Item::inf_cast(d_in / 2)?
                 .inf_mul(&ideal_sensitivity)?
                 .inf_add(&relaxation)

--- a/rust/src/trans/sum/float/ordered/mod.rs
+++ b/rust/src/trans/sum/float/ordered/mod.rs
@@ -78,8 +78,8 @@ where
         StabilityMap::new_fallible(move |d_in: &IntDistance| {
             // d_out =  |BS*(v) - BS*(v')| where BS* is the finite sum and BS the ideal sum
             //       <= |BS*(v) - BS(v)| + |BS(v) - BS(v')| + |BS(v') - BS*(v')|
-            //       <= d_in * (U - L) + 2 * error
-            //       =  d_in * (U - L) + relaxation
+            //       <= d_in  / 2* (U - L) + 2 * error
+            //       =  d_in / 2 * (U - L) + relaxation
             S::Item::inf_cast(d_in / 2)?
                 .inf_mul(&ideal_sensitivity)?
                 .inf_add(&relaxation)

--- a/rust/src/trans/sum/float/ordered/mod.rs
+++ b/rust/src/trans/sum/float/ordered/mod.rs
@@ -78,7 +78,7 @@ where
         StabilityMap::new_fallible(move |d_in: &IntDistance| {
             // d_out =  |BS*(v) - BS*(v')| where BS* is the finite sum and BS the ideal sum
             //       <= |BS*(v) - BS(v)| + |BS(v) - BS(v')| + |BS(v') - BS*(v')|
-            //       <= d_in  / 2* (U - L) + 2 * error
+            //       <= d_in / 2 * (U - L) + 2 * error
             //       =  d_in / 2 * (U - L) + relaxation
             S::Item::inf_cast(d_in / 2)?
                 .inf_mul(&ideal_sensitivity)?

--- a/rust/src/trans/variance/mod.rs
+++ b/rust/src/trans/variance/mod.rs
@@ -44,8 +44,7 @@ where
     // Using Popoviciu's inequality on variances:
     //     variance <= (U - L)^2 / 4
     // Therefore ssd <= variance * size <= (U - L)^2 / 4 * size
-    let upper_var_bound = bounds
-        .1
+    let upper_var_bound = (bounds.1)
         .inf_sub(&bounds.0)?
         .inf_pow(&_2)?
         .inf_div(&_4)?


### PR DESCRIPTION
Closes #470
Simplifies the mean aggregator to a simple chaining of the `sized_bounded_sum` and `lipschitz_mul` transformations.