### PR TITLE
ZeroConcentratedDivergence measure; parameterize `base_gaussian`

### DIFF
--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -348,6 +348,7 @@ class PrivacyMeasure(RuntimeType):
 
 MaxDivergence = PrivacyMeasure('MaxDivergence')
 SmoothedMaxDivergence = PrivacyMeasure('SmoothedMaxDivergence')
+ZeroConcentratedDivergence = PrivacyMeasure('ZeroConcentratedDivergence')
 
 
 class Domain(RuntimeType):

--- a/python/test/test_meas.py
+++ b/python/test/test_meas.py
@@ -1,4 +1,5 @@
 from opendp.mod import enable_features
+from opendp.typing import ZeroConcentratedDivergence
 
 enable_features('floating-point', 'contrib')
 
@@ -41,7 +42,7 @@ def test_base_vector_laplace():
     assert meas.check(1., 1.3)
 
 
-def test_base_gaussian_max_divergence():
+def test_base_gaussian_smoothed_max_divergence():
     from opendp.meas import make_base_gaussian
 
     meas = make_base_gaussian(scale=10.5)
@@ -50,6 +51,16 @@ def test_base_gaussian_max_divergence():
     epsilon = meas.map(d_in=1.).epsilon(delta=.000001)
     print("epsilon:", epsilon)
     assert epsilon > .5
+
+
+def test_base_gaussian_zcdp():
+    from opendp.meas import make_base_gaussian
+
+    meas = make_base_gaussian(scale=1.5, MO=ZeroConcentratedDivergence[float])
+    print("base gaussian:", meas(100.))
+
+    rho = meas.map(d_in=1.)
+    print("rho:", rho)
 
 
 def test_base_analytic_gaussian():

--- a/rust/src/accuracy/mod.rs
+++ b/rust/src/accuracy/mod.rs
@@ -66,6 +66,7 @@ pub mod test {
     use crate::meas::{make_base_laplace, make_base_gaussian, make_base_geometric};
     use crate::error::ExplainUnwrap;
     use crate::domains::AllDomain;
+    use crate::measures::SmoothedMaxDivergence;
 
     fn print_statement<T: Copy + Debug + One + From<i8> + Sub<Output=T> + Mul<Output=T>>(dist: &str, scale: T, accuracy: T, alpha: T) {
         let _100 = T::from(100);
@@ -212,7 +213,7 @@ pub mod test {
         let accuracy = 1.0;
         let theoretical_alpha = 0.05;
         let scale = accuracy_to_gaussian_scale(accuracy, theoretical_alpha)?;
-        let base_gaussian = make_base_gaussian::<AllDomain<f64>>(scale)?;
+        let base_gaussian = make_base_gaussian::<AllDomain<f64>, SmoothedMaxDivergence<_>>(scale)?;
         let n = 50_000;
         let empirical_alpha = (0..n)
             .filter(|_| base_gaussian.invoke(&0.0).unwrap_test().abs() > accuracy)

--- a/rust/src/ffi/any.rs
+++ b/rust/src/ffi/any.rs
@@ -483,7 +483,7 @@ mod tests {
         let t3 = trans::make_cast_default::<String, f64>()?.into_any();
         let t4 = trans::make_clamp((0.0, 10.0))?.into_any();
         let t5 = trans::make_bounded_sum::<SymmetricDistance, _>((0.0, 10.0))?.into_any();
-        let m1 = meas::make_base_gaussian::<AllDomain<_>>(0.0)?.into_any();
+        let m1 = meas::make_base_gaussian::<AllDomain<_>, SmoothedMaxDivergence<_>>(0.0)?.into_any();
         let chain = (t1 >> t2 >> t3 >> t4 >> t5 >> m1)?;
         let arg = AnyObject::new("1.0, 10.0\n2.0, 20.0\n3.0, 30.0\n".to_owned());
         let res = chain.invoke(&arg);

--- a/rust/src/ffi/util.rs
+++ b/rust/src/ffi/util.rs
@@ -10,7 +10,7 @@ use std::str::Utf8Error;
 use crate::trans::{Sequential, Pairwise};
 use crate::{err, fallible};
 use crate::metrics::{ChangeOneDistance, L1Distance, L2Distance, SymmetricDistance, AbsoluteDistance, InsertDeleteDistance, HammingDistance};
-use crate::measures::{MaxDivergence, SmoothedMaxDivergence};
+use crate::measures::{MaxDivergence, SmoothedMaxDivergence, ZeroConcentratedDivergence};
 use crate::error::*;
 use crate::ffi::any::AnyObject;
 use crate::domains::{VectorDomain, AllDomain, BoundedDomain, InherentNullDomain, OptionNullDomain, SizedDomain};
@@ -254,6 +254,7 @@ lazy_static! {
             // measures
             type_vec![MaxDivergence, <u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64>],
             type_vec![SmoothedMaxDivergence, <u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64>],
+            type_vec![ZeroConcentratedDivergence, <u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64>],
         ].into_iter().flatten().collect();
         let descriptors: HashSet<_> = types.iter().map(|e| &e.descriptor).collect();
         assert_eq!(descriptors.len(), types.len());

--- a/rust/src/meas/bootstrap.json
+++ b/rust/src/meas/bootstrap.json
@@ -46,6 +46,13 @@
                 "generics": ["T"],
                 "description": "Domain of the data type to be privatized. Valid values are VectorDomain<AllDomain<T>> or AllDomain<T>",
                 "is_type": true
+            },
+            {
+                "name": "MO",
+                "default": "SmoothedMaxDivergence<T>",
+                "generics": ["T"],
+                "description": "Output measure. Valid values are SmoothedMaxDivergence<T> or ZeroConcentratedDivergence<T>",
+                "is_type": true
             }
         ],
         "derived_types": [

--- a/rust/src/meas/gaussian/ffi.rs
+++ b/rust/src/meas/gaussian/ffi.rs
@@ -19,17 +19,17 @@ pub extern "C" fn opendp_meas__make_base_gaussian(
     D: *const c_char,
     MO: *const c_char
 ) -> FfiResult<*mut AnyMeasurement> {
-    fn monomorphize_1<T>(scale: *const c_void, D: Type, MO: Type) -> FfiResult<*mut AnyMeasurement> where 
+    fn monomorphize1<T>(scale: *const c_void, D: Type, MO: Type) -> FfiResult<*mut AnyMeasurement> where 
         T: 'static + Clone + SampleGaussian + Float + InfCast<f64> + InfSub + InfDiv + CheckNull + InfMul + InfAdd + InfLn + InfSqrt + InfExp + ExactIntCast<usize> + InfPow {
             let scale = *try_as_ref!(scale as *const T);
-            fn monomorphize_2<D, MO>(scale: D::Atom) -> FfiResult<*mut AnyMeasurement> where
+            fn monomorphize2<D, MO>(scale: D::Atom) -> FfiResult<*mut AnyMeasurement> where
                 D: 'static + GaussianDomain,
                 MO: 'static + GaussianMeasure<D::Metric, Atom = D::Atom>,
                 MO::Distance: Clone {
                 make_base_gaussian::<D, MO>(scale).into_any()
             }
 
-            dispatch!(monomorphize_2, [
+            dispatch!(monomorphize2, [
                 (D, [AllDomain<T>, VectorDomain<AllDomain<T>>]),
                 (MO, [SmoothedMaxDivergence<T>, ZeroConcentratedDivergence<T>])
             ], (scale))
@@ -37,7 +37,7 @@ pub extern "C" fn opendp_meas__make_base_gaussian(
     let D = try_!(Type::try_from(D));
     let MO = try_!(Type::try_from(MO));
     let T = try_!(D.get_atom());
-    dispatch!(monomorphize_1, [
+    dispatch!(monomorphize1, [
         (T, @floats)
     ], (scale, D, MO))
 }
@@ -92,6 +92,17 @@ mod tests {
         let res = core::opendp_core__measurement_invoke(&measurement, arg);
         let res: Vec<f64> = Fallible::from(res)?.downcast()?;
         assert_eq!(res, vec![1.0, 2.0, 3.0]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_make_base_gaussian_zcdp() -> Fallible<()> {
+        let measurement = Result::from(opendp_meas__make_base_gaussian(
+            util::into_raw(0.0) as *const c_void, "AllDomain<f64>".to_char_p(), "ZeroConcentratedDivergence<f64>".to_char_p()))?;
+        let arg = AnyObject::new_raw(1.0);
+        let res = core::opendp_core__measurement_invoke(&measurement, arg);
+        let res: f64 = Fallible::from(res)?.downcast()?;
+        assert_eq!(res, 1.0);
         Ok(())
     }
 }

--- a/rust/src/meas/gaussian/ffi.rs
+++ b/rust/src/meas/gaussian/ffi.rs
@@ -3,30 +3,43 @@ use std::os::raw::{c_char, c_void};
 
 use num::Float;
 
+use crate::measures::{SmoothedMaxDivergence, ZeroConcentratedDivergence};
 use crate::{err, try_, try_as_ref};
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::domains::{AllDomain, VectorDomain};
 use crate::ffi::any::AnyMeasurement;
 use crate::ffi::util::Type;
-use crate::meas::{GaussianDomain, make_base_analytic_gaussian, make_base_gaussian};
+use crate::meas::{GaussianDomain, make_base_analytic_gaussian, make_base_gaussian, GaussianMeasure};
 use crate::traits::samplers::SampleGaussian;
-use crate::traits::{CheckNull, InfAdd, InfCast, InfLn, InfMul, InfSqrt, InfDiv, InfSub, InfExp};
+use crate::traits::{CheckNull, InfAdd, InfCast, InfLn, InfMul, InfSqrt, InfDiv, InfSub, InfExp, InfPow, ExactIntCast};
 
 #[no_mangle]
 pub extern "C" fn opendp_meas__make_base_gaussian(
     scale: *const c_void,
     D: *const c_char,
+    MO: *const c_char
 ) -> FfiResult<*mut AnyMeasurement> {
-    fn monomorphize<D>(scale: *const c_void) -> FfiResult<*mut AnyMeasurement> where
-        D: 'static + GaussianDomain,
-        D::Atom: 'static + Clone + SampleGaussian + Float + InfCast<f64> + InfSub + InfDiv + CheckNull + InfMul + InfAdd + InfLn + InfSqrt + InfExp {
-        let scale = *try_as_ref!(scale as *const D::Atom);
-        make_base_gaussian::<D>(scale).into_any()
-    }
+    fn monomorphize_1<T>(scale: *const c_void, D: Type, MO: Type) -> FfiResult<*mut AnyMeasurement> where 
+        T: 'static + Clone + SampleGaussian + Float + InfCast<f64> + InfSub + InfDiv + CheckNull + InfMul + InfAdd + InfLn + InfSqrt + InfExp + ExactIntCast<usize> + InfPow {
+            let scale = *try_as_ref!(scale as *const T);
+            fn monomorphize_2<D, MO>(scale: D::Atom) -> FfiResult<*mut AnyMeasurement> where
+                D: 'static + GaussianDomain,
+                MO: 'static + GaussianMeasure<D::Metric, Atom = D::Atom>,
+                MO::Distance: Clone {
+                make_base_gaussian::<D, MO>(scale).into_any()
+            }
+
+            dispatch!(monomorphize_2, [
+                (D, [AllDomain<T>, VectorDomain<AllDomain<T>>]),
+                (MO, [SmoothedMaxDivergence<T>, ZeroConcentratedDivergence<T>])
+            ], (scale))
+        }
     let D = try_!(Type::try_from(D));
-    dispatch!(monomorphize, [
-        (D, [AllDomain<f64>, AllDomain<f32>, VectorDomain<AllDomain<f64>>, VectorDomain<AllDomain<f32>>])
-    ], (scale))
+    let MO = try_!(Type::try_from(MO));
+    let T = try_!(D.get_atom());
+    dispatch!(monomorphize_1, [
+        (T, @floats)
+    ], (scale, D, MO))
 }
 
 #[no_mangle]
@@ -72,7 +85,9 @@ mod tests {
     #[test]
     fn test_make_base_gaussian_vec() -> Fallible<()> {
         let measurement = Result::from(opendp_meas__make_base_gaussian(
-            util::into_raw(0.0) as *const c_void, "VectorDomain<AllDomain<f64>>".to_char_p()))?;
+            util::into_raw(0.0) as *const c_void, 
+            "VectorDomain<AllDomain<f64>>".to_char_p(), 
+            "SmoothedMaxDivergence<f64>".to_char_p()))?;
         let arg = AnyObject::new_raw(vec![1.0, 2.0, 3.0]);
         let res = core::opendp_core__measurement_invoke(&measurement, arg);
         let res: Vec<f64> = Fallible::from(res)?.downcast()?;

--- a/rust/src/meas/gaussian/mod.rs
+++ b/rust/src/meas/gaussian/mod.rs
@@ -1,17 +1,19 @@
-#[cfg(feature="ffi")]
+#[cfg(feature = "ffi")]
 mod ffi;
 
-use num::{Float, One, Zero};
+use num::{Float, Zero};
 
-use crate::core::{Domain, Function, Measurement, PrivacyMap, SensitivityMetric};
+use crate::core::{Domain, Function, Measurement, PrivacyMap, Measure, Metric};
 use crate::metrics::{AbsoluteDistance, L2Distance};
-use crate::measures::{SmoothedMaxDivergence, SMDCurve};
+use crate::measures::{SmoothedMaxDivergence, SMDCurve, ZeroConcentratedDivergence};
 use crate::domains::{AllDomain, VectorDomain};
 use crate::error::*;
 use crate::traits::samplers::SampleGaussian;
 
-use crate::traits::{InfCast, CheckNull, InfMul, InfAdd, InfLn, InfSqrt, InfDiv, InfSub, InfExp};
-
+use crate::traits::{
+    CheckNull, ExactIntCast, InfAdd, InfCast, InfDiv, InfExp, InfLn, InfMul, InfPow, InfSqrt,
+    InfSub,
+};
 
 mod analytic;
 
@@ -21,92 +23,154 @@ use self::analytic::get_analytic_gaussian_epsilon;
 const ADDITIVE_GAUSS_CONST: f64 = 0.4373061836;
 
 pub trait GaussianDomain: Domain {
-    type Metric: SensitivityMetric<Distance=Self::Atom> + Default;
-    type Atom;
+    type Metric: GaussianMetric<Distance = Self::Atom> + Default;
+    type Atom: Float;
     fn new() -> Self;
     fn noise_function(scale: Self::Atom) -> Function<Self, Self>;
 }
 
-
 impl<T> GaussianDomain for AllDomain<T>
-    where T: 'static + SampleGaussian + Float + CheckNull {
+where
+    T: 'static + SampleGaussian + Float + CheckNull,
+{
     type Metric = AbsoluteDistance<T>;
     type Atom = T;
 
-    fn new() -> Self { AllDomain::new() }
+    fn new() -> Self {
+        AllDomain::new()
+    }
     fn noise_function(scale: Self::Carrier) -> Function<Self, Self> {
-        Function::new_fallible(move |arg: &Self::Carrier|
-            Self::Carrier::sample_gaussian(*arg, scale, false))
+        Function::new_fallible(move |arg: &Self::Carrier| {
+            Self::Carrier::sample_gaussian(*arg, scale, false)
+        })
     }
 }
 
 impl<T> GaussianDomain for VectorDomain<AllDomain<T>>
-    where T: 'static + SampleGaussian + Float + CheckNull {
+where
+    T: 'static + SampleGaussian + Float + CheckNull,
+{
     type Metric = L2Distance<T>;
     type Atom = T;
 
-    fn new() -> Self { VectorDomain::new_all() }
+    fn new() -> Self {
+        VectorDomain::new_all()
+    }
     fn noise_function(scale: T) -> Function<Self, Self> {
-        Function::new_fallible(move |arg: &Self::Carrier| arg.iter()
-            .map(|v| T::sample_gaussian(*v, scale, false))
-            .collect())
+        Function::new_fallible(move |arg: &Self::Carrier| {
+            arg.iter()
+                .map(|v| T::sample_gaussian(*v, scale, false))
+                .collect()
+        })
     }
 }
 
+pub trait GaussianMeasure<MI: GaussianMetric>: Measure + Default {
+    type Atom;
+    fn new_forward_map(scale: Self::Atom) -> PrivacyMap<MI, Self>;
+}
 
-pub fn make_base_gaussian<D>(
-    scale: D::Atom
-) -> Fallible<Measurement<D, D, D::Metric, SmoothedMaxDivergence<D::Atom>>>
-    where D: GaussianDomain,
-          D::Atom: 'static + Clone + SampleGaussian + Float + InfCast<f64> + InfSub + InfDiv + CheckNull + InfMul + InfAdd + InfLn + InfSqrt + InfExp + Zero {
+pub trait GaussianMetric: Metric {}
+impl<Q: CheckNull> GaussianMetric for L2Distance<Q> {}
+impl<Q: CheckNull> GaussianMetric for AbsoluteDistance<Q> {}
+
+impl<MI: GaussianMetric, Q> GaussianMeasure<MI> for SmoothedMaxDivergence<Q>
+where
+    MI: Metric<Distance = Q>,
+    Q: 'static
+        + Clone
+        + SampleGaussian
+        + Float
+        + InfCast<f64>
+        + InfSub
+        + InfDiv
+        + CheckNull
+        + InfMul
+        + InfAdd
+        + InfLn
+        + InfSqrt
+        + InfExp
+        + Zero,
+{
+    type Atom = Q;
+    fn new_forward_map(scale: Q) -> PrivacyMap<MI, Self> {
+        PrivacyMap::new_fallible(move |&d_in: &Q| {
+            if d_in.is_sign_negative() {
+                return fallible!(InvalidDistance, "sensitivity must be non-negative");
+            }
+
+            let _2 = Q::inf_cast(2.)?;
+            let additive_gauss_const = Q::inf_cast(ADDITIVE_GAUSS_CONST)?;
+
+            Ok(SMDCurve::new(move |del: &Q| {
+                if !del.is_sign_positive() {
+                    return fallible!(FailedRelation, "delta must be positive");
+                }
+
+                if scale.is_zero() {
+                    return Ok(Q::infinity());
+                }
+
+                let eps = d_in
+                    .inf_mul(
+                        &additive_gauss_const
+                            .inf_add(&_2.inf_mul(&del.recip().inf_ln()?)?)?
+                            .inf_sqrt()?,
+                    )?
+                    .inf_div(&scale)?;
+
+                if eps > Q::one() {
+                    return fallible!(RelationDebug, "The gaussian mechanism has an epsilon of at most one. Epsilon is greater than one at the given delta.");
+                }
+                Ok(eps)
+            }))
+        })
+    }
+}
+
+impl<MI, Q> GaussianMeasure<MI> for ZeroConcentratedDivergence<Q>
+where
+    MI: GaussianMetric<Distance = Q>,
+    Q: 'static + Clone + ExactIntCast<usize> + InfPow + InfDiv,
+{
+    type Atom = Q;
+
+    fn new_forward_map(scale: Q) -> PrivacyMap<MI, Self> {
+        PrivacyMap::new_fallible(move |d_in: &Q| {
+            let _2 = Q::exact_int_cast(2)?;
+            d_in.inf_div(&scale)?.inf_pow(&_2)?.inf_div(&_2)
+        })
+    }
+}
+
+pub fn make_base_gaussian<D, MO>(scale: D::Atom) -> Fallible<Measurement<D, D, D::Metric, MO>>
+where
+    D: GaussianDomain,
+    MO: GaussianMeasure<D::Metric, Atom = D::Atom>,
+{
     if scale.is_sign_negative() {
-        return fallible!(MakeMeasurement, "scale must not be negative")
+        return fallible!(MakeMeasurement, "scale must not be negative");
     }
     Ok(Measurement::new(
         D::new(),
         D::new(),
         D::noise_function(scale.clone()),
         D::Metric::default(),
-        SmoothedMaxDivergence::default(),
-        PrivacyMap::new_fallible(move |&d_in: &D::Atom| {
-            if d_in.is_sign_negative() {
-                return fallible!(InvalidDistance, "sensitivity must be non-negative")
-            }
-
-            let _2 = D::Atom::inf_cast(2.)?;
-            let additive_gauss_const = D::Atom::inf_cast(ADDITIVE_GAUSS_CONST)?;
-
-            Ok(SMDCurve::new(
-                move |del: &D::Atom| {
-                    if !del.is_sign_positive() {
-                        return fallible!(FailedRelation, "delta must be positive")
-                    }
-
-                    if scale.is_zero() {
-                        return Ok(D::Atom::infinity())
-                    }
-
-                    let eps = d_in.inf_mul(&additive_gauss_const.inf_add(
-                        &_2.inf_mul(&del.recip().inf_ln()?)?)?.inf_sqrt()?)?.inf_div(&scale)?;
-                    
-                    if eps > D::Atom::one() {
-                        return fallible!(RelationDebug, "The gaussian mechanism has an epsilon of at most one. Epsilon is greater than one at the given delta.")
-                    }
-                    Ok(eps)
-                }
-            ))
-        }),
+        MO::default(),
+        MO::new_forward_map(scale),
     ))
 }
 
 pub fn make_base_analytic_gaussian<D>(
-    scale: D::Atom
+    scale: D::Atom,
 ) -> Fallible<Measurement<D, D, D::Metric, SmoothedMaxDivergence<D::Atom>>>
-    where D: GaussianDomain,
-          f64: InfCast<D::Atom>,
-          D::Atom: 'static + Clone + SampleGaussian + Float + InfCast<f64> + CheckNull {
+where
+    D: GaussianDomain,
+    f64: InfCast<D::Atom>,
+    D::Atom: 'static + Clone + SampleGaussian + Float + InfCast<f64> + CheckNull,
+{
     if scale.is_sign_negative() {
-        return fallible!(MakeMeasurement, "scale must not be negative")
+        return fallible!(MakeMeasurement, "scale must not be negative");
     }
     Ok(Measurement::new(
         D::new(),
@@ -116,7 +180,7 @@ pub fn make_base_analytic_gaussian<D>(
         SmoothedMaxDivergence::default(),
         PrivacyMap::new_fallible(move |&d_in: &D::Atom| {
             if d_in.is_sign_negative() {
-                return fallible!(InvalidDistance, "sensitivity must be non-negative")
+                return fallible!(InvalidDistance, "sensitivity must be non-negative");
             }
 
             let d_in = f64::inf_cast(d_in.clone())?;
@@ -135,14 +199,13 @@ pub fn make_base_analytic_gaussian<D>(
     ))
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_make_gaussian_mechanism() -> Fallible<()> {
-        let measurement = make_base_gaussian::<AllDomain<_>>(1.0f64)?;
+        let measurement = make_base_gaussian::<AllDomain<_>, SmoothedMaxDivergence<_>>(1.0f64)?;
         let arg = 0.0;
         let _ret = measurement.invoke(&arg)?;
 
@@ -152,7 +215,7 @@ mod tests {
 
     #[test]
     fn test_make_gaussian_vec_mechanism() -> Fallible<()> {
-        let measurement = make_base_gaussian::<VectorDomain<_>>(1.0f64)?;
+        let measurement = make_base_gaussian::<VectorDomain<_>, SmoothedMaxDivergence<_>>(1.0f64)?;
         let arg = vec![0.0, 1.0];
         let _ret = measurement.invoke(&arg)?;
 

--- a/rust/src/meas/gaussian/mod.rs
+++ b/rust/src/meas/gaussian/mod.rs
@@ -138,7 +138,8 @@ where
     fn new_forward_map(scale: Q) -> PrivacyMap<MI, Self> {
         PrivacyMap::new_fallible(move |d_in: &Q| {
             let _2 = Q::exact_int_cast(2)?;
-            d_in.inf_div(&scale)?.inf_pow(&_2)?.inf_div(&_2)
+            // (d_in / scale)^2 / 2
+            (d_in.inf_div(&scale)?).inf_pow(&_2)?.inf_div(&_2)
         })
     }
 }
@@ -220,6 +221,16 @@ mod tests {
         let _ret = measurement.invoke(&arg)?;
 
         assert!(measurement.map(&0.1)?.epsilon(&0.00001)? <= 0.5);
+        Ok(())
+    }
+
+    #[test]
+    fn test_make_gaussian_mechanism_zcdp() -> Fallible<()> {
+        let measurement = make_base_gaussian::<AllDomain<_>, ZeroConcentratedDivergence<_>>(1.0f64)?;
+        let arg = 0.0;
+        let _ret = measurement.invoke(&arg)?;
+
+        assert!(measurement.check(&0.1, &0.0050000001)?);
         Ok(())
     }
 }

--- a/rust/src/measures/mod.rs
+++ b/rust/src/measures/mod.rs
@@ -99,3 +99,28 @@ impl<Q> Debug for FixedSmoothedMaxDivergence<Q> {
 impl<Q: Clone> Measure for FixedSmoothedMaxDivergence<Q> {
     type Distance = (Q, Q);
 }
+
+
+#[derive(Clone)]
+pub struct ZeroConcentratedDivergence<Q>(PhantomData<Q>);
+impl<Q> Default for ZeroConcentratedDivergence<Q> {
+    fn default() -> Self {
+        ZeroConcentratedDivergence(PhantomData)
+    }
+}
+
+impl<Q> PartialEq for ZeroConcentratedDivergence<Q> {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl<Q> Debug for ZeroConcentratedDivergence<Q> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "ZeroConcentratedDivergence()")
+    }
+}
+
+impl<Q: Clone> Measure for ZeroConcentratedDivergence<Q> {
+    type Distance = Q;
+}


### PR DESCRIPTION
This minimally introduces ZeroConcentratedDivergence into OpenDP. Caster combinators and compositors are subject to future PRs.