### PR TITLE
QOL adjustments; python utility to specify default atomic type

### DIFF
--- a/docs/source/user/combinator-constructors.rst
+++ b/docs/source/user/combinator-constructors.rst
@@ -79,8 +79,8 @@ but the chaining fails because the sum emits floats and the geometric mechanism 
     ... except OpenDPException as err:
     ...     print(err.message[:-1])
     Intermediate domains don't match. See https://github.com/opendp/opendp/discussions/297
-        The structure of the intermediate domains are the same, but the types or parameters differ.
-        shared_domain: AllDomain()
+        output_domain: AllDomain(f64)
+        input_domain:  AllDomain(i32)
 
 Note that ``noisy_sum``'s input domain and input metric come from ``bounded_sum``'s input domain and input metric.
 This is intended to enable further chaining with preprocessors like :py:func:`make_cast <opendp.trans.make_cast>`, :py:func:`make_impute_constant <opendp.trans.make_impute_constant>`, :py:func:`make_clamp <opendp.trans.make_clamp>` and :py:func:`make_bounded_resize <opendp.trans.make_bounded_resize>`.

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -15,7 +15,7 @@ ATOM_EQUIVALENCE_CLASSES = {
 lib_dir = os.environ.get("OPENDP_LIB_DIR", os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 if not os.path.exists(lib_dir):
     # fall back to default location of binaries in a developer install
-    build_dir = 'debug' if os.environ.get('OPENDP_TEST_RELEASE', "false") == "false" else 'release'
+    build_dir = 'release'
     lib_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), *['..'] * 3, 'rust', 'target', build_dir)
 
 if os.path.exists(lib_dir):

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -15,7 +15,7 @@ ATOM_EQUIVALENCE_CLASSES = {
 lib_dir = os.environ.get("OPENDP_LIB_DIR", os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 if not os.path.exists(lib_dir):
     # fall back to default location of binaries in a developer install
-    build_dir = 'release'
+    build_dir = 'debug' if os.environ.get('OPENDP_TEST_RELEASE', "false") == "false" else 'release'
     lib_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), *['..'] * 3, 'rust', 'target', build_dir)
 
 if os.path.exists(lib_dir):

--- a/python/src/opendp/meas.py
+++ b/python/src/opendp/meas.py
@@ -132,7 +132,7 @@ def make_base_analytic_gaussian(
 def make_base_geometric(
     scale,
     bounds: Any = None,
-    D: RuntimeTypeDescriptor = "AllDomain<i32>",
+    D: RuntimeTypeDescriptor = "AllDomain<int>",
     QO: RuntimeTypeDescriptor = None
 ) -> Measurement:
     """Make a Measurement that adds noise from the geometric(`scale`) distribution to the input.

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -384,7 +384,7 @@ def binary_search_chain(
     ...     return make_sized_bounded_sum(10_000, (-b, b)) >> make_base_geometric(100.)
     ...
     >>> # `meas` is a Measurement with the widest possible clamping bounds.
-    >>> meas = binary_search_chain(make_sum, d_in=2, d_out=1., bounds=(0, 10_000))
+    >>> meas = binary_search_chain(make_sum, d_in=2, d_out=1.)
     ...
     >>> # If you want the discovered clamping bound, use `binary_search_param` instead.
     """
@@ -580,10 +580,8 @@ def exponential_bounds_search(
             try:
                 predicate(v)
             except TypeError as e:
-                print(e)
                 return False
             except OpenDPException as e:
-                print(e)
                 if "No match for concrete type" in e.message:
                     return False
             return True

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -384,7 +384,7 @@ def binary_search_chain(
     ...     return make_sized_bounded_sum(10_000, (-b, b)) >> make_base_geometric(100.)
     ...
     >>> # `meas` is a Measurement with the widest possible clamping bounds.
-    >>> meas = binary_search_chain(make_sum, d_in=2, d_out=1.)
+    >>> meas = binary_search_chain(make_sum, d_in=2, d_out=1., bounds=(0, 10_000))
     ...
     >>> # If you want the discovered clamping bound, use `binary_search_param` instead.
     """

--- a/python/src/opendp/trans.py
+++ b/python/src/opendp/trans.py
@@ -601,7 +601,7 @@ def make_unclamp(
 
 def make_count(
     TIA: RuntimeTypeDescriptor,
-    TO: RuntimeTypeDescriptor = "i32"
+    TO: RuntimeTypeDescriptor = "int"
 ) -> Transformation:
     """Make a Transformation that computes a count of the number of records in data.
     
@@ -635,7 +635,7 @@ def make_count(
 
 def make_count_distinct(
     TIA: RuntimeTypeDescriptor,
-    TO: RuntimeTypeDescriptor = "i32"
+    TO: RuntimeTypeDescriptor = "int"
 ) -> Transformation:
     """Make a Transformation that computes a count of the number of unique, distinct records in data.
     
@@ -670,7 +670,7 @@ def make_count_distinct(
 def make_count_by(
     MO: SensitivityMetric,
     TK: RuntimeTypeDescriptor,
-    TV: RuntimeTypeDescriptor = "i32"
+    TV: RuntimeTypeDescriptor = "int"
 ) -> Transformation:
     """Make a Transformation that computes the count of each unique value in data. 
     This assumes that the category set is unknown.
@@ -709,9 +709,9 @@ def make_count_by(
 
 def make_count_by_categories(
     categories: Any,
-    MO: SensitivityMetric = "L1Distance<i32>",
+    MO: SensitivityMetric = "L1Distance<int>",
     TIA: RuntimeTypeDescriptor = None,
-    TOA: RuntimeTypeDescriptor = "i32"
+    TOA: RuntimeTypeDescriptor = "int"
 ) -> Transformation:
     """Make a Transformation that computes the number of times each category appears in the data. 
     This assumes that the category set is known.

--- a/python/src/opendp/trans.py
+++ b/python/src/opendp/trans.py
@@ -1238,9 +1238,9 @@ def make_sized_bounded_mean(
 def make_resize(
     size: int,
     constant: Any,
-    TA: RuntimeTypeDescriptor = None,
     MI: RuntimeTypeDescriptor = "SymmetricDistance",
-    MO: RuntimeTypeDescriptor = "InsertDeleteDistance"
+    MO: RuntimeTypeDescriptor = "InsertDeleteDistance",
+    TA: RuntimeTypeDescriptor = None
 ) -> Transformation:
     """Make a Transformation that either truncates or imputes records with `constant` in a Vec<`TA`> to match a provided `size`.
     
@@ -1248,12 +1248,12 @@ def make_resize(
     :type size: int
     :param constant: Value to impute with.
     :type constant: Any
-    :param TA: Atomic type.
-    :type TA: :ref:`RuntimeTypeDescriptor`
     :param MI: Input metric.
     :type MI: :ref:`RuntimeTypeDescriptor`
     :param MO: Output metric.
     :type MO: :ref:`RuntimeTypeDescriptor`
+    :param TA: Atomic type.
+    :type TA: :ref:`RuntimeTypeDescriptor`
     :return: A vector of the same type `TA`, but with the provided `size`.
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
@@ -1263,32 +1263,32 @@ def make_resize(
     assert_features("contrib")
     
     # Standardize type arguments.
-    TA = RuntimeType.parse_or_infer(type_name=TA, public_example=constant)
     MI = RuntimeType.parse(type_name=MI)
     MO = RuntimeType.parse(type_name=MO)
+    TA = RuntimeType.parse_or_infer(type_name=TA, public_example=constant)
     
     # Convert arguments to c types.
     size = py_to_c(size, c_type=ctypes.c_uint)
     constant = py_to_c(constant, c_type=AnyObjectPtr, type_name=TA)
-    TA = py_to_c(TA, c_type=ctypes.c_char_p)
     MI = py_to_c(MI, c_type=ctypes.c_char_p)
     MO = py_to_c(MO, c_type=ctypes.c_char_p)
+    TA = py_to_c(TA, c_type=ctypes.c_char_p)
     
     # Call library function.
     function = lib.opendp_trans__make_resize
     function.argtypes = [ctypes.c_uint, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, constant, TA, MI, MO), Transformation))
+    return c_to_py(unwrap(function(size, constant, MI, MO, TA), Transformation))
 
 
 def make_bounded_resize(
     size: int,
     bounds: Tuple[Any, Any],
     constant,
-    TA: RuntimeTypeDescriptor = None,
     MI: RuntimeTypeDescriptor = "SymmetricDistance",
-    MO: RuntimeTypeDescriptor = "SymmetricDistance"
+    MO: RuntimeTypeDescriptor = "SymmetricDistance",
+    TA: RuntimeTypeDescriptor = None
 ) -> Transformation:
     """Make a Transformation that either truncates or imputes records with `constant` in a Vec<`TA`> to match a provided `size`.
     
@@ -1297,12 +1297,12 @@ def make_bounded_resize(
     :param bounds: Tuple of lower and upper bounds for data in the input domain
     :type bounds: Tuple[Any, Any]
     :param constant: Value to impute with.
-    :param TA: Atomic type. If not passed, TA is inferred from the lower bound.
-    :type TA: :ref:`RuntimeTypeDescriptor`
     :param MI: Input metric.
     :type MI: :ref:`RuntimeTypeDescriptor`
     :param MO: Output metric.
     :type MO: :ref:`RuntimeTypeDescriptor`
+    :param TA: Atomic type. If not passed, TA is inferred from the lower bound.
+    :type TA: :ref:`RuntimeTypeDescriptor`
     :return: A vector of the same type `TA`, but with the provided `size`.
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
@@ -1312,24 +1312,24 @@ def make_bounded_resize(
     assert_features("contrib")
     
     # Standardize type arguments.
-    TA = RuntimeType.parse_or_infer(type_name=TA, public_example=get_first(bounds))
     MI = RuntimeType.parse(type_name=MI)
     MO = RuntimeType.parse(type_name=MO)
+    TA = RuntimeType.parse_or_infer(type_name=TA, public_example=get_first(bounds))
     
     # Convert arguments to c types.
     size = py_to_c(size, c_type=ctypes.c_uint)
     bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[TA, TA]))
     constant = py_to_c(constant, c_type=ctypes.c_void_p, type_name=TA)
-    TA = py_to_c(TA, c_type=ctypes.c_char_p)
     MI = py_to_c(MI, c_type=ctypes.c_char_p)
     MO = py_to_c(MO, c_type=ctypes.c_char_p)
+    TA = py_to_c(TA, c_type=ctypes.c_char_p)
     
     # Call library function.
     function = lib.opendp_trans__make_bounded_resize
     function.argtypes = [ctypes.c_uint, AnyObjectPtr, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, bounds, constant, TA, MI, MO), Transformation))
+    return c_to_py(unwrap(function(size, bounds, constant, MI, MO, TA), Transformation))
 
 
 def make_bounded_sum(

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -57,7 +57,7 @@ RuntimeTypeDescriptor = Union[
 
 def set_default_int_type(T: RuntimeTypeDescriptor):
     """Set the default integer type throughout the library.
-    This function is particularly when building computation chains with constructors.
+    This function is particularly useful when building computation chains with constructors.
     When you build a computation chain, any unspecified integer types default to this int type.
 
     The default int type is i32.
@@ -72,7 +72,7 @@ def set_default_int_type(T: RuntimeTypeDescriptor):
 
 def set_default_float_type(T: RuntimeTypeDescriptor):
     """Set the default float type throughout the library.
-    This function is particularly when building computation chains with constructors.
+    This function is particularly useful when building computation chains with constructors.
     When you build a computation chain, any unspecified float types default to this float type.
 
     The default float type is f64.

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -205,10 +205,16 @@ class RuntimeType(object):
             return RuntimeType('Tuple', list(map(cls.infer, public_example)))
 
         if isinstance(public_example, list):
-            return RuntimeType('Vec', [
-                cls.infer(public_example[0]) if public_example else UnknownType(
-                    "cannot infer atomic type of empty list")
-            ])
+            if public_example:
+                inner_type = cls.infer(public_example[0])
+                for inner in public_example[1:]:
+                    other_type = cls.infer(inner)
+                    if other_type != inner_type:
+                        raise TypeError(f"vectors must be homogeneously typed, found {inner_type} and {other_type}")
+            else:
+                inner_type = UnknownType("cannot infer atomic type of empty list")
+
+            return RuntimeType('Vec', [inner_type])
 
         if np is not None and isinstance(public_example, np.ndarray):
             if public_example.ndim == 0:
@@ -374,20 +380,20 @@ class Carrier(RuntimeType):
 
 Vec = Carrier('Vec')
 HashMap = Carrier('HashMap')
-i8 = RuntimeType('i8')
-i16 = RuntimeType('i16')
-i32 = RuntimeType('i32')
-i64 = RuntimeType('i64')
-i128 = RuntimeType('i128')
-isize = RuntimeType('isize')
-u8 = RuntimeType('u8')
-u16 = RuntimeType('u16')
-u32 = RuntimeType('u32')
-u64 = RuntimeType('u64')
-u128 = RuntimeType('u128')
-usize = RuntimeType('usize')
-f32 = RuntimeType('f32')
-f64 = RuntimeType('f64')
+i8 = 'i8'
+i16 = 'i16'
+i32 = 'i32'
+i64 = 'i64'
+i128 = 'i128'
+isize = 'isize'
+u8 = 'u8'
+u16 = 'u16'
+u32 = 'u32'
+u64 = 'u64'
+u128 = 'u128'
+usize = 'usize'
+f32 = 'f32'
+f64 = 'f64'
 
 
 class Domain(RuntimeType):

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -62,7 +62,7 @@ def set_default_int_type(T: RuntimeTypeDescriptor):
     ATOM_EQUIVALENCE_CLASSES[T] = ATOM_EQUIVALENCE_CLASSES.pop(ELEMENTARY_TYPES[int])
     ELEMENTARY_TYPES[int] = T
 
-def set_default_float_Type(T: RuntimeTypeDescriptor):
+def set_default_float_type(T: RuntimeTypeDescriptor):
     equivalence_class = ATOM_EQUIVALENCE_CLASSES[ELEMENTARY_TYPES[float]]
     assert T in equivalence_class, f"T must be a float type in {equivalence_class}"
 

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -56,13 +56,29 @@ RuntimeTypeDescriptor = Union[
 
 
 def set_default_int_type(T: RuntimeTypeDescriptor):
+    """Set the default integer type throughout the library.
+    This function is particularly when building computation chains with constructors.
+    When you build a computation chain, any unspecified integer types default to this int type.
+
+    The default int type is i32.
+    :params T: must be one of [u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize]
+    """
     equivalence_class = ATOM_EQUIVALENCE_CLASSES[ELEMENTARY_TYPES[int]]
-    assert T in equivalence_class, f"T must be an integer type in {equivalence_class}"
+    assert T in equivalence_class, f"T must be one of {equivalence_class}"
 
     ATOM_EQUIVALENCE_CLASSES[T] = ATOM_EQUIVALENCE_CLASSES.pop(ELEMENTARY_TYPES[int])
     ELEMENTARY_TYPES[int] = T
 
+
 def set_default_float_type(T: RuntimeTypeDescriptor):
+    """Set the default float type throughout the library.
+    This function is particularly when building computation chains with constructors.
+    When you build a computation chain, any unspecified float types default to this float type.
+
+    The default float type is f64.
+    :params T: must be one of [f32, f64]
+    """
+
     equivalence_class = ATOM_EQUIVALENCE_CLASSES[ELEMENTARY_TYPES[float]]
     assert T in equivalence_class, f"T must be a float type in {equivalence_class}"
 

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -55,6 +55,21 @@ RuntimeTypeDescriptor = Union[
 ]
 
 
+def set_default_int_type(T: RuntimeTypeDescriptor):
+    equivalence_class = ATOM_EQUIVALENCE_CLASSES[ELEMENTARY_TYPES[int]]
+    assert T in equivalence_class, f"T must be an integer type in {equivalence_class}"
+
+    ATOM_EQUIVALENCE_CLASSES[T] = ATOM_EQUIVALENCE_CLASSES.pop(ELEMENTARY_TYPES[int])
+    ELEMENTARY_TYPES[int] = T
+
+def set_default_float_Type(T: RuntimeTypeDescriptor):
+    equivalence_class = ATOM_EQUIVALENCE_CLASSES[ELEMENTARY_TYPES[float]]
+    assert T in equivalence_class, f"T must be a float type in {equivalence_class}"
+
+    ATOM_EQUIVALENCE_CLASSES[T] = ATOM_EQUIVALENCE_CLASSES.pop(ELEMENTARY_TYPES[float])
+    ELEMENTARY_TYPES[float] = T
+
+
 class RuntimeType(object):
     """Utility for validating, manipulating, inferring and parsing/normalizing type information.
     """
@@ -166,6 +181,10 @@ class RuntimeType(object):
             if 0 < start < end < len(type_name):
                 return RuntimeType(origin, args=cls._parse_args(type_name[start + 1: end], generics=generics))
             if start == end < 0:
+                if type_name == "int":
+                    return ELEMENTARY_TYPES[int]
+                if type_name == "float":
+                    return ELEMENTARY_TYPES[float]
                 return type_name
 
         if isinstance(type_name, Hashable) and type_name in ELEMENTARY_TYPES:

--- a/python/test/test_comb.py
+++ b/python/test/test_comb.py
@@ -2,7 +2,7 @@ import pytest
 from opendp.mod import enable_features
 from opendp.meas import *
 from opendp.trans import *
-from opendp.typing import AllDomain, L1Distance, VectorDomain
+from opendp.typing import AllDomain, L1Distance, VectorDomain, set_default_int_type
 
 enable_features("floating-point", "contrib")
 
@@ -34,8 +34,10 @@ def test_fix_delta():
 def test_make_basic_composition():
     from opendp.comb import make_basic_composition
     composed = make_basic_composition([
-        make_count(TIA=int, TO=int) >> make_base_geometric(scale=2.), 
-        make_count(TIA=int, TO=int) >> make_base_geometric(scale=200.), 
+        make_count(TIA=int, TO=int) >> make_basic_composition([
+            make_base_geometric(scale=2.), 
+            make_base_geometric(scale=200.)
+        ]), 
         make_cast_default(int, bool) >> make_cast_default(bool, int) >> make_count(TIA=int, TO=int) >> make_base_geometric(scale=2.), 
         make_cast_default(int, float) >> make_clamp((0., 10.)) >> make_bounded_sum((0., 10.)) >> make_base_laplace(scale=2.), 
 
@@ -45,7 +47,7 @@ def test_make_basic_composition():
             (
                 make_cast_default(int, str) >> 
                 make_count_by_categories(categories=["0", "12", "22"]) >> 
-                make_base_geometric(scale=2.)
+                make_base_geometric(scale=2., D=VectorDomain[AllDomain[int]])
             )
         ])
     ])

--- a/python/test/test_comb.py
+++ b/python/test/test_comb.py
@@ -42,7 +42,11 @@ def test_make_basic_composition():
         make_basic_composition([
             make_count(TIA=int, TO=int) >> make_base_geometric(scale=2.), 
             make_count(TIA=int, TO=float) >> make_base_laplace(scale=2.),
-            make_cast_default(int, str) >> make_count_by_categories(categories=["0", "12", "22"]) >> make_base_geometric(scale=2., D=VectorDomain[AllDomain[int]]),
+            (
+                make_cast_default(int, str) >> 
+                make_count_by_categories(categories=["0", "12", "22"]) >> 
+                make_base_geometric(scale=2.)
+            )
         ])
     ])
 

--- a/python/test/test_comb.py
+++ b/python/test/test_comb.py
@@ -2,7 +2,7 @@ import pytest
 from opendp.mod import enable_features
 from opendp.meas import *
 from opendp.trans import *
-from opendp.typing import AllDomain, L1Distance, VectorDomain, set_default_int_type
+from opendp.typing import AllDomain, L1Distance, VectorDomain
 
 enable_features("floating-point", "contrib")
 

--- a/python/test/test_trans.py
+++ b/python/test/test_trans.py
@@ -229,6 +229,7 @@ def test_count():
     assert ret == 3
     assert transformation.check(1, 1)
 
+test_count()
 
 def test_count_distinct():
     from opendp.trans import make_count_distinct

--- a/python/test/test_trans.py
+++ b/python/test/test_trans.py
@@ -229,8 +229,6 @@ def test_count():
     assert ret == 3
     assert transformation.check(1, 1)
 
-test_count()
-
 def test_count_distinct():
     from opendp.trans import make_count_distinct
     transformation = make_count_distinct(str, int)

--- a/python/test/test_typing.py
+++ b/python/test/test_typing.py
@@ -82,6 +82,7 @@ def test_default_type():
     assert RuntimeType.parse(int) == i32
     set_default_int_type(u64)
     assert RuntimeType.parse(int) == u64
+    set_default_int_type(i32)
 
 # for a more thorough manual test of the set_default_int_type and set_default_float_type functions:
 # 1. recompile with --release mode

--- a/python/test/test_typing.py
+++ b/python/test/test_typing.py
@@ -3,7 +3,7 @@ import sys
 from typing import List, Tuple, Any
 
 from opendp.mod import *
-from opendp.typing import RuntimeType, L1Distance, SensitivityMetric, L2Distance, DatasetMetric
+from opendp.typing import *
 
 
 try:
@@ -76,3 +76,17 @@ def test_set_feature():
 
     disable_features("A")
     assert "A" not in GLOBAL_FEATURES
+
+
+def test_default_type():
+    assert RuntimeType.parse(int) == i32
+    set_default_int_type(u64)
+    assert RuntimeType.parse(int) == u64
+
+# for a more thorough manual test of the set_default_int_type and set_default_float_type functions:
+# 1. recompile with --release mode
+# 2. set OPENDP_TEST_RELEASE
+# 3. uncomment these commands
+#    set_default_int_type(i64)
+#    set_default_float_type(f32)
+# 4. run pytest, and sanity check the failures

--- a/rust/src/comb/chain/mod.rs
+++ b/rust/src/comb/chain/mod.rs
@@ -13,7 +13,7 @@ fn mismatch_message<T1: Debug, T2: Debug>(mode: &str, struct1: &T1, struct2: &T2
     let str1 = format!("{:?}", struct1);
     let str2 = format!("{:?}", struct2);
     let explanation = if str1 == str2 {
-        format!("\n    The structure of the intermediate {mode}s are the same, but the types or parameters differ.\n    shared_{mode}: {str1}\n", mode=mode, str1=str1)
+        format!("\n    The structure of the intermediate {mode}s are the same, but the parameters differ.\n    shared_{mode}: {str1}\n", mode=mode, str1=str1)
     } else {
         format!("\n    output_{mode}: {struct1}\n    input_{mode}:  {struct2}\n", mode=mode, struct1=str1, struct2=str2)
     };

--- a/rust/src/domains/mod.rs
+++ b/rust/src/domains/mod.rs
@@ -15,13 +15,19 @@ use crate::error::Fallible;
 use crate::traits::{CheckNull, TotalOrd};
 use std::fmt::{Debug, Formatter};
 
+/// // retrieves the type_name for a given type
+macro_rules! type_name {
+    ($ty:ty) => (std::any::type_name::<$ty>().split("::").last().unwrap_or(""))
+}
+pub(crate) use type_name;
+
 /// A Domain that contains all non-null members of the carrier type.
 pub struct AllDomain<T> {
     _marker: PhantomData<T>,
 }
 impl<T> Debug for AllDomain<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "AllDomain()")
+        write!(f, "AllDomain({})", type_name!(T))
     }
 }
 impl<T> Default for AllDomain<T> {
@@ -122,7 +128,7 @@ impl<T: TotalOrd> BoundedDomain<T> {
 }
 impl<T> Debug for BoundedDomain<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "BoundedDomain()")
+        write!(f, "BoundedDomain({})", type_name!(T))
     }
 }
 impl<T: Clone + TotalOrd> Domain for BoundedDomain<T> {

--- a/rust/src/ffi/any.rs
+++ b/rust/src/ffi/any.rs
@@ -9,14 +9,9 @@ use std::any;
 use std::any::Any;
 use std::fmt::{Debug, Formatter};
 
-use num::Zero;
-
-use crate::comb::BasicCompositionMeasure;
 use crate::core::{Domain, Function, Measure, Measurement, Metric, PrivacyMap, StabilityMap, Transformation};
-use crate::measures::{MaxDivergence, ZeroConcentratedDivergence, FixedSmoothedMaxDivergence};
 use crate::err;
 use crate::error::*;
-use crate::traits::InfAdd;
 
 use super::glue::Glue;
 use super::util::Type;
@@ -206,29 +201,6 @@ impl AnyMeasure {
             type_: Type::of::<M>(),
             distance_type: Type::of::<M::Distance>()
         }
-    }
-}
-
-impl BasicCompositionMeasure for AnyMeasure {
-    fn compose(&self, d_i: &Vec<Self::Distance>) -> Fallible<Self::Distance> {
-        fn monomorphize1<Q: 'static + Clone + InfAdd + Zero>(
-            self_: &AnyMeasure, d_i: &Vec<AnyObject>
-        ) -> Fallible<AnyObject> {
-
-            fn monomorphize2<M: 'static + BasicCompositionMeasure>(
-                self_: &AnyMeasure, d_i: &Vec<AnyObject>
-            ) -> Fallible<AnyObject>
-                where M::Distance: Clone {
-                self_.downcast_ref::<M>()?.compose(&d_i.iter()
-                    .map(|d_i| d_i.downcast_ref::<M::Distance>().map(Clone::clone))
-                    .collect::<Fallible<Vec<M::Distance>>>()?).map(AnyObject::new)
-            }
-            dispatch!(monomorphize2, [
-                (self_.type_, [MaxDivergence<Q>, FixedSmoothedMaxDivergence<Q>, ZeroConcentratedDivergence<Q>])
-            ], (self_, d_i))
-        }
-
-        dispatch!(monomorphize1, [(self.distance_type, @floats)], (self, d_i))
     }
 }
 

--- a/rust/src/ffi/util.rs
+++ b/rust/src/ffi/util.rs
@@ -7,8 +7,6 @@ use std::ffi::CString;
 use std::os::raw::c_char;
 use std::str::Utf8Error;
 
-#[cfg(feature="untrusted")]
-use crate::trans::{Sequential, Pairwise};
 use crate::{err, fallible};
 use crate::metrics::{ChangeOneDistance, L1Distance, L2Distance, SymmetricDistance, AbsoluteDistance, InsertDeleteDistance, HammingDistance};
 use crate::measures::{MaxDivergence, SmoothedMaxDivergence, ZeroConcentratedDivergence};
@@ -18,6 +16,9 @@ use crate::domains::{VectorDomain, AllDomain, BoundedDomain, InherentNullDomain,
 
 use super::any::{AnyMeasurement, AnyTransformation};
 
+// If untrusted is not enabled, then these structs don't exist. 
+#[cfg(feature="untrusted")]
+use crate::trans::{Sequential, Pairwise};
 #[cfg(not(feature="untrusted"))]
 use std::marker::PhantomData;
 #[cfg(not(feature="untrusted"))]

--- a/rust/src/ffi/util.rs
+++ b/rust/src/ffi/util.rs
@@ -7,6 +7,7 @@ use std::ffi::CString;
 use std::os::raw::c_char;
 use std::str::Utf8Error;
 
+#[cfg(feature="untrusted")]
 use crate::trans::{Sequential, Pairwise};
 use crate::{err, fallible};
 use crate::metrics::{ChangeOneDistance, L1Distance, L2Distance, SymmetricDistance, AbsoluteDistance, InsertDeleteDistance, HammingDistance};
@@ -16,6 +17,13 @@ use crate::ffi::any::AnyObject;
 use crate::domains::{VectorDomain, AllDomain, BoundedDomain, InherentNullDomain, OptionNullDomain, SizedDomain};
 
 use super::any::{AnyMeasurement, AnyTransformation};
+
+#[cfg(not(feature="untrusted"))]
+use std::marker::PhantomData;
+#[cfg(not(feature="untrusted"))]
+pub struct Sequential<T>(PhantomData<T>);
+#[cfg(not(feature="untrusted"))]
+pub struct Pairwise<T>(PhantomData<T>);
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum TypeContents {

--- a/rust/src/meas/bootstrap.json
+++ b/rust/src/meas/bootstrap.json
@@ -122,7 +122,7 @@
             },
             {
                 "name": "D",
-                "default": "AllDomain<i32>",
+                "default": "AllDomain<int>",
                 "description": "Domain of the data type to be privatized. Valid values are VectorDomain<AllDomain<T>> or AllDomain<T>",
                 "is_type": true
             },

--- a/rust/src/measures/mod.rs
+++ b/rust/src/measures/mod.rs
@@ -4,7 +4,7 @@ use std::{
     rc::Rc,
 };
 
-use crate::{error::Fallible, core::Measure};
+use crate::{error::Fallible, core::Measure, domains::type_name};
 
 /// Measures
 #[derive(Clone)]
@@ -23,7 +23,7 @@ impl<Q> PartialEq for MaxDivergence<Q> {
 
 impl<Q> Debug for MaxDivergence<Q> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "MaxDivergence()")
+        write!(f, "MaxDivergence({})", type_name!(Q))
     }
 }
 
@@ -47,7 +47,7 @@ impl<Q> PartialEq for SmoothedMaxDivergence<Q> {
 }
 impl<Q> Debug for SmoothedMaxDivergence<Q> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "SmoothedMaxDivergence()")
+        write!(f, "SmoothedMaxDivergence({})", type_name!(Q))
     }
 }
 
@@ -92,7 +92,7 @@ impl<Q> PartialEq for FixedSmoothedMaxDivergence<Q> {
 
 impl<Q> Debug for FixedSmoothedMaxDivergence<Q> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "FixedSmoothedMaxDivergence()")
+        write!(f, "FixedSmoothedMaxDivergence({})", type_name!(Q))
     }
 }
 
@@ -117,7 +117,7 @@ impl<Q> PartialEq for ZeroConcentratedDivergence<Q> {
 
 impl<Q> Debug for ZeroConcentratedDivergence<Q> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "ZeroConcentratedDivergence()")
+        write!(f, "ZeroConcentratedDivergence({})", type_name!(Q))
     }
 }
 

--- a/rust/src/metrics/mod.rs
+++ b/rust/src/metrics/mod.rs
@@ -2,7 +2,7 @@
 
 use std::{marker::PhantomData};
 
-use crate::core::{DatasetMetric, Metric, SensitivityMetric};
+use crate::{core::{DatasetMetric, Metric, SensitivityMetric}, domains::type_name};
 use std::fmt::{Debug, Formatter};
 
 // default type for distances between datasets
@@ -108,7 +108,7 @@ impl<Q, const P: usize> PartialEq for LpDistance<Q, P> {
 }
 impl<Q, const P: usize> Debug for LpDistance<Q, P> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "L{}Distance()", P)
+        write!(f, "L{}Distance({})", P, type_name!(Q))
     }
 }
 impl<Q, const P: usize> Metric for LpDistance<Q, P> {
@@ -133,7 +133,7 @@ impl<Q> PartialEq for AbsoluteDistance<Q> {
 }
 impl<Q> Debug for AbsoluteDistance<Q> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "AbsoluteDistance()")
+        write!(f, "AbsoluteDistance({})", type_name!(Q))
     }
 }
 impl<Q> Metric for AbsoluteDistance<Q> {

--- a/rust/src/metrics/mod.rs
+++ b/rust/src/metrics/mod.rs
@@ -95,29 +95,29 @@ impl Metric for HammingDistance {
 impl DatasetMetric for HammingDistance {}
 
 // Sensitivity in P-space
-pub struct LpDistance<Q, const P: usize>(PhantomData<Q>);
-impl<Q, const P: usize> Default for LpDistance<Q, P> {
+pub struct LpDistance<const P: usize, Q>(PhantomData<Q>);
+impl<const P: usize, Q> Default for LpDistance<P, Q> {
     fn default() -> Self { LpDistance(PhantomData) }
 }
 
-impl<Q, const P: usize> Clone for LpDistance<Q, P> {
+impl<const P: usize, Q> Clone for LpDistance<P, Q> {
     fn clone(&self) -> Self { Self::default() }
 }
-impl<Q, const P: usize> PartialEq for LpDistance<Q, P> {
+impl<const P: usize, Q> PartialEq for LpDistance<P, Q> {
     fn eq(&self, _other: &Self) -> bool { true }
 }
-impl<Q, const P: usize> Debug for LpDistance<Q, P> {
+impl<const P: usize, Q> Debug for LpDistance<P, Q> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(f, "L{}Distance({})", P, type_name!(Q))
     }
 }
-impl<Q, const P: usize> Metric for LpDistance<Q, P> {
+impl<const P: usize, Q> Metric for LpDistance<P, Q> {
     type Distance = Q;
 }
-impl<Q, const P: usize> SensitivityMetric for LpDistance<Q, P> {}
+impl<const P: usize, Q> SensitivityMetric for LpDistance<P, Q> {}
 
-pub type L1Distance<Q> = LpDistance<Q, 1>;
-pub type L2Distance<Q> = LpDistance<Q, 2>;
+pub type L1Distance<Q> = LpDistance<1, Q>;
+pub type L2Distance<Q> = LpDistance<2, Q>;
 
 /// Represents a metric where d(a, b) = |a - b|
 pub struct AbsoluteDistance<Q>(PhantomData<Q>);

--- a/rust/src/trans/bootstrap.json
+++ b/rust/src/trans/bootstrap.json
@@ -770,11 +770,6 @@
                 "description": "Value to impute with."
             },
             {
-                "name": "TA",
-                "is_type": true,
-                "description": "Atomic type."
-            },
-            {
                 "name": "MI",
                 "is_type": true,
                 "default": "SymmetricDistance",
@@ -785,6 +780,11 @@
                 "is_type": true,
                 "default": "InsertDeleteDistance",
                 "description": "Output metric."
+            },
+            {
+                "name": "TA",
+                "is_type": true,
+                "description": "Atomic type."
             }
         ],
         "ret": {
@@ -818,15 +818,6 @@
                 "description": "Value to impute with."
             },
             {
-                "name": "TA",
-                "is_type": true,
-                "description": "Atomic type. If not passed, TA is inferred from the lower bound.",
-                "example": {
-                    "function": "get_first",
-                    "params": ["bounds"]
-                }
-            },
-            {
                 "name": "MI",
                 "is_type": true,
                 "default": "SymmetricDistance",
@@ -837,6 +828,15 @@
                 "is_type": true,
                 "default": "SymmetricDistance",
                 "description": "Output metric."
+            },
+            {
+                "name": "TA",
+                "is_type": true,
+                "description": "Atomic type. If not passed, TA is inferred from the lower bound.",
+                "example": {
+                    "function": "get_first",
+                    "params": ["bounds"]
+                }
             }
         ],
         "ret": {

--- a/rust/src/trans/bootstrap.json
+++ b/rust/src/trans/bootstrap.json
@@ -331,7 +331,7 @@
             },
             {
                 "name": "TO",
-                "default": "i32",
+                "default": "int",
                 "is_type": true,
                 "description": "Output Type. Must be numeric."
             }
@@ -349,7 +349,7 @@
             },
             {
                 "name": "TO",
-                "default": "i32",
+                "default": "int",
                 "is_type": true,
                 "description": "Output Type. Must be numeric."
             }
@@ -375,7 +375,7 @@
                 "name": "TV",
                 "is_type": true,
                 "description": "Type of Value. Express counts in terms of this integral type.",
-                "default": "i32"
+                "default": "int"
             }
         ],
         "ret": {
@@ -398,7 +398,7 @@
             },
             {
                 "name": "MO",
-                "default": "L1Distance<i32>",
+                "default": "L1Distance<int>",
                 "hint": "SensitivityMetric",
                 "is_type": true,
                 "description": "output sensitivity metric"
@@ -412,7 +412,7 @@
                 "name": "TOA",
                 "is_type": true,
                 "description": "express counts in terms of this numeric type",
-                "default": "i32"
+                "default": "int"
             }
         ],
         "ret": {"c_type": "FfiResult<AnyTransformation *>"}

--- a/rust/src/trans/count/mod.rs
+++ b/rust/src/trans/count/mod.rs
@@ -50,7 +50,7 @@ pub fn make_count_distinct<TIA, TO>(
 pub trait CountByCategoriesConstant<QO> {
     fn get_stability_constant() -> QO;
 }
-impl<Q: One, const P: usize> CountByCategoriesConstant<Q> for LpDistance<Q, P> {
+impl<const P: usize, Q: One> CountByCategoriesConstant<Q> for LpDistance<P, Q> {
     fn get_stability_constant() -> Q { Q::one() }
 }
 
@@ -96,7 +96,7 @@ pub fn make_count_by_categories<MO, TI, TO>(
 pub trait CountByConstant<QO> {
     fn get_stability_constant() -> Fallible<QO>;
 }
-impl<Q: One + Float + ExactIntCast<usize>, const P: usize> CountByConstant<Q> for LpDistance<Q, P> {
+impl<const P: usize, Q: One + Float + ExactIntCast<usize>> CountByConstant<Q> for LpDistance<P, Q> {
     fn get_stability_constant() -> Fallible<Q> {
         if P == 0 {return fallible!(MakeTransformation, "P must be positive")}
         let p = Q::exact_int_cast(P)?;

--- a/rust/src/trans/lipschitz_mul/mod.rs
+++ b/rust/src/trans/lipschitz_mul/mod.rs
@@ -105,8 +105,8 @@ where
 /// Implemented for any metric that supports multiplication lipschitz extensions
 pub trait LipschitzMulFloatMetric: Metric {}
 
-impl<T, const P: usize> LipschitzMulFloatMetric for LpDistance<T, P> {}
-impl<T> LipschitzMulFloatMetric for AbsoluteDistance<T> {}
+impl<const P: usize, Q> LipschitzMulFloatMetric for LpDistance<P, Q> {}
+impl<Q> LipschitzMulFloatMetric for AbsoluteDistance<Q> {}
 
 #[cfg(test)]
 pub mod test {

--- a/rust/src/trans/resize/ffi.rs
+++ b/rust/src/trans/resize/ffi.rs
@@ -9,18 +9,18 @@ use crate::ffi::any::{AnyObject, AnyTransformation};
 use crate::ffi::any::Downcast;
 use crate::ffi::util::Type;
 use crate::traits::{CheckNull, TotalOrd};
-use crate::trans::make_resize_constant;
+use crate::trans::make_resize;
 use crate::trans::resize::IsMetricOrdered;
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_bounded_resize(
     size: c_uint, bounds: *const AnyObject,
     constant: *const c_void,
-    TA: *const c_char,
     MI: *const c_char,
     MO: *const c_char,
+    TA: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<TA, MI, MO>(
+    fn monomorphize<MI, MO, TA>(
         size: usize, bounds: *const AnyObject,
         constant: *const c_void,
     ) -> FfiResult<*mut AnyTransformation>
@@ -31,44 +31,44 @@ pub extern "C" fn opendp_trans__make_bounded_resize(
         let bounds = try_!(try_as_ref!(bounds).downcast_ref::<(TA, TA)>()).clone();
         let atom_domain = try_!(BoundedDomain::new_closed(bounds));
         let constant = try_as_ref!(constant as *const TA).clone();
-        make_resize_constant::<_, MI, MO>(size, atom_domain, constant).into_any()
+        make_resize::<_, MI, MO>(size, atom_domain, constant).into_any()
     }
     let size = size as usize;
-    let TA = try_!(Type::try_from(TA));
     let MI = try_!(Type::try_from(MI));
     let MO = try_!(Type::try_from(MO));
+    let TA = try_!(Type::try_from(TA));
     dispatch!(monomorphize, [
-        (TA, @numbers), 
         (MI, [SymmetricDistance, InsertDeleteDistance]),
-        (MO, [SymmetricDistance, InsertDeleteDistance])
+        (MO, [SymmetricDistance, InsertDeleteDistance]),
+        (TA, @numbers)
     ], (size, bounds, constant))
 }
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_resize(
     size: c_uint, constant: *const AnyObject,
-    TA: *const c_char,
     MI: *const c_char,
     MO: *const c_char,
+    TA: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<TA, MI, MO>(
+    fn monomorphize<MI, MO, TA>(
         size: usize, constant: *const AnyObject,
     ) -> FfiResult<*mut AnyTransformation>
         where 
-            TA: 'static + Clone + CheckNull,
             MI: 'static + IsMetricOrdered<Distance=IntDistance>,
-            MO: 'static + IsMetricOrdered<Distance=IntDistance>, {
+            MO: 'static + IsMetricOrdered<Distance=IntDistance>,
+            TA: 'static + Clone + CheckNull, {
         let constant = try_!(try_as_ref!(constant).downcast_ref::<TA>()).clone();
-        make_resize_constant::<AllDomain<TA>, MI, MO>(size, AllDomain::new(), constant).into_any()
+        make_resize::<AllDomain<TA>, MI, MO>(size, AllDomain::new(), constant).into_any()
     }
     let size = size as usize;
-    let TA = try_!(Type::try_from(TA));
     let MI = try_!(Type::try_from(MI));
     let MO = try_!(Type::try_from(MO));
+    let TA = try_!(Type::try_from(TA));
     dispatch!(monomorphize, [
-        (TA, @numbers), 
         (MI, [SymmetricDistance, InsertDeleteDistance]),
-        (MO, [SymmetricDistance, InsertDeleteDistance])
+        (MO, [SymmetricDistance, InsertDeleteDistance]),
+        (TA, @numbers)
     ], (size, constant))
 }
 
@@ -88,9 +88,9 @@ mod tests {
         let transformation = Result::from(opendp_trans__make_resize(
             4 as c_uint,
             AnyObject::new_raw(0i32),
+            "SymmetricDistance".to_char_p(),
+            "SymmetricDistance".to_char_p(),
             "i32".to_char_p(),
-            "SymmetricDistance".to_char_p(),
-            "SymmetricDistance".to_char_p(),
         ))?;
         let arg = AnyObject::new_raw(vec![1, 2, 3]);
         let res = opendp_core__transformation_invoke(&transformation, arg);
@@ -106,9 +106,9 @@ mod tests {
             4 as c_uint,
             util::into_raw(AnyObject::new((0i32, 10))),
             util::into_raw(0i32) as *const c_void,
+            "SymmetricDistance".to_char_p(),
+            "SymmetricDistance".to_char_p(),
             "i32".to_char_p(),
-            "SymmetricDistance".to_char_p(),
-            "SymmetricDistance".to_char_p(),
         ))?;
         let arg = AnyObject::new_raw(vec![1, 2, 3]);
         let res = opendp_core__transformation_invoke(&transformation, arg);

--- a/rust/src/trans/resize/mod.rs
+++ b/rust/src/trans/resize/mod.rs
@@ -19,7 +19,7 @@ impl IsMetricOrdered for InsertDeleteDistance {
     const ORDERED: bool = true;
 }
 
-pub fn make_resize_constant<DA, MI, MO>(
+pub fn make_resize<DA, MI, MO>(
     size: usize,
     atom_domain: DA,
     constant: DA::Carrier,
@@ -83,7 +83,7 @@ mod test {
 
     #[test]
     fn test() -> Fallible<()> {
-        let trans = make_resize_constant::<_, SymmetricDistance, SymmetricDistance>(
+        let trans = make_resize::<_, SymmetricDistance, SymmetricDistance>(
             3,
             AllDomain::new(),
             "x",


### PR DESCRIPTION
* Adds a utility function to set the default int type, and default float type in the python bindings.
    * From the `set_default_int_type and set_default_float_type` commit.
    * Closes #431
* Renames the rust function `make_resize_constant` to `make_resize`, to be consistent with python
* Adjust the FFI for `make_*resize` such that `TA` is the last type argument
* Adds a check to `RuntimeType.infer` to ensure that the lists are homogeneous
    * Prevents a potential segfault if the input list has mixed types 
* Adjusts the Debug impl for domains, metrics and measures to include the type name