### PR TITLE
parallel composition combinators and dataframe partitioner

### DIFF
--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -244,7 +244,7 @@ def _vector_to_slice(val: Sequence[Any], type_name: RuntimeType) -> FfiSlicePtr:
             return ctypes.c_char_p(val.encode())
         array = (ctypes.c_char_p * len(val))(*map(str_to_slice, val))
         return _wrap_in_slice(array, len(val))
-
+    
     if isinstance(inner_type_name, RuntimeType):
         c_repr = [py_to_c(v, c_type=AnyObjectPtr, type_name=inner_type_name) for v in val]
         array = (AnyObjectPtr * len(val))(*c_repr)

--- a/python/test/test_comb.py
+++ b/python/test/test_comb.py
@@ -65,8 +65,8 @@ def test_make_basic_composition_leak():
     # supporting that AnyObject's free recursively frees children
     meas = make_basic_composition([meas])
 
-    # watch for leaked AnyObjects with 1 million i32 values
-    # memory would jump by ~40mb every iteration
+    # watch for leaked AnyObjects with 10 million i32 values
+    # memory would jump significantly every iteration
     for i in range(1000):
         print('iteration', i)
         meas([0] * 10_000_000)
@@ -97,7 +97,6 @@ def test_make_pureDP_to_fixed_approxDP():
 
     print(meas.map(1.))
 
-
 def test_make_pureDP_to_zCDP():
     meas = make_basic_composition([
         make_pureDP_to_zCDP(make_base_laplace(10.)),
@@ -106,5 +105,34 @@ def test_make_pureDP_to_zCDP():
 
     print(meas.map(1.))
 
+def test_make_map_partitions_trans():
+    from opendp.combinators import make_partition_map_meas
+
+    meas = make_split_dataframe(
+        separator=",", 
+        col_names=["strat id", "values"]
+    ) >> make_partition_by(
+        ident_name="strat id",
+        partition_keys=list(map(str, range(4))),
+        keep_columns=["values"],
+    ) >> make_partition_map_meas([
+        make_select_column("values", TOA=str) >> 
+        make_cast_default(TIA=str, TOA=int) >> 
+        make_clamp((0, 1)) >> 
+        make_bounded_sum((0, 1)) >>
+        make_base_geometric(1.)
+    ] * 5)
+
+    # build some synthetic data:
+    from random import randint, choice
+    data_length = 500
+    strat_ids = [randint(0, 5) for _ in range(data_length)]
+    values = [choice([0, 1]) for _ in range(data_length)]
+    data = "\n".join(f"{k},{v}" for k, v in zip(strat_ids, values))
+    # print(data)
+    
+    # release noisy sums!
+    print(meas(data))
+
 if __name__ == "__main__":
-    test_make_pureDP_to_fixed_approxDP()
+    test_make_map_partitions_trans()

--- a/python/test/test_comb.py
+++ b/python/test/test_comb.py
@@ -106,7 +106,7 @@ def test_make_pureDP_to_zCDP():
     print(meas.map(1.))
 
 def test_make_map_partitions_trans():
-    from opendp.combinators import make_partition_map_trans, make_partition_map_meas
+    from opendp.combinators import make_parallel_transformation, make_parallel_composition
 
     meas = make_split_dataframe(
         separator=",", 
@@ -115,11 +115,11 @@ def test_make_map_partitions_trans():
         identifier_column="strat id",
         partition_keys=list(map(str, range(4))),
         keep_columns=["values"],
-    ) >> make_partition_map_trans([
+    ) >> make_parallel_transformation([
         make_select_column("values", TOA=str) >> 
         make_cast_default(TIA=str, TOA=int) >> 
         make_clamp((0, 1))
-    ] * 4) >> make_partition_map_meas([
+    ] * 4) >> make_parallel_composition([
         make_bounded_sum((0, 1)) >>
         make_base_geometric(1.)
     ] * 4)
@@ -138,7 +138,7 @@ def test_make_map_partitions_trans():
 
 # 2-way partitioning!
 def test_make_map_partitions_nested():
-    from opendp.combinators import make_partition_map_meas
+    from opendp.combinators import make_parallel_composition
 
     meas = make_split_dataframe(
         separator=",", 
@@ -148,12 +148,12 @@ def test_make_map_partitions_nested():
         partition_keys=list(map(str, range(4))),
         null_partition=True,
         keep_columns=["strat id 2", "values"],
-    ) >> make_partition_map_meas([
+    ) >> make_parallel_composition([
         make_partition_by(
             identifier_column="strat id 2",
             partition_keys=list(map(str, range(4))),
             keep_columns=["values"],
-        ) >> make_partition_map_meas([
+        ) >> make_parallel_composition([
             make_select_column("values", TOA=str) >> 
             make_cast_default(TIA=str, TOA=int) >> 
             make_clamp((0, 1)) >>

--- a/python/test/test_comb.py
+++ b/python/test/test_comb.py
@@ -119,10 +119,10 @@ def test_make_map_partitions_trans():
         make_select_column("values", TOA=str) >> 
         make_cast_default(TIA=str, TOA=int) >> 
         make_clamp((0, 1))
-    ] * 5) >> make_partition_map_meas([
+    ] * 4) >> make_partition_map_meas([
         make_bounded_sum((0, 1)) >>
         make_base_geometric(1.)
-    ] * 5)
+    ] * 4)
 
     # build some synthetic data:
     from random import randint, choice
@@ -146,6 +146,7 @@ def test_make_map_partitions_nested():
     ) >> make_partition_by(
         identifier_column="strat id 1",
         partition_keys=list(map(str, range(4))),
+        null_partition=True,
         keep_columns=["strat id 2", "values"],
     ) >> make_partition_map_meas([
         make_partition_by(
@@ -158,7 +159,7 @@ def test_make_map_partitions_nested():
             make_clamp((0, 1)) >>
             make_bounded_sum((0, 1)) >>
             make_base_geometric(1.)
-        ] * 5)
+        ] * 4)
     ] * 5)
 
     # build some synthetic data:

--- a/python/test/test_comb.py
+++ b/python/test/test_comb.py
@@ -106,19 +106,20 @@ def test_make_pureDP_to_zCDP():
     print(meas.map(1.))
 
 def test_make_map_partitions_trans():
-    from opendp.combinators import make_partition_map_meas
+    from opendp.combinators import make_partition_map_trans, make_partition_map_meas
 
     meas = make_split_dataframe(
         separator=",", 
         col_names=["strat id", "values"]
     ) >> make_partition_by(
-        ident_name="strat id",
+        identifier_column="strat id",
         partition_keys=list(map(str, range(4))),
         keep_columns=["values"],
-    ) >> make_partition_map_meas([
+    ) >> make_partition_map_trans([
         make_select_column("values", TOA=str) >> 
         make_cast_default(TIA=str, TOA=int) >> 
-        make_clamp((0, 1)) >> 
+        make_clamp((0, 1))
+    ] * 5) >> make_partition_map_meas([
         make_bounded_sum((0, 1)) >>
         make_base_geometric(1.)
     ] * 5)
@@ -134,5 +135,44 @@ def test_make_map_partitions_trans():
     # release noisy sums!
     print(meas(data))
 
+
+# 2-way partitioning!
+def test_make_map_partitions_nested():
+    from opendp.combinators import make_partition_map_meas
+
+    meas = make_split_dataframe(
+        separator=",", 
+        col_names=["strat id 1", "strat id 2", "values"]
+    ) >> make_partition_by(
+        identifier_column="strat id 1",
+        partition_keys=list(map(str, range(4))),
+        keep_columns=["strat id 2", "values"],
+    ) >> make_partition_map_meas([
+        make_partition_by(
+            identifier_column="strat id 2",
+            partition_keys=list(map(str, range(4))),
+            keep_columns=["values"],
+        ) >> make_partition_map_meas([
+            make_select_column("values", TOA=str) >> 
+            make_cast_default(TIA=str, TOA=int) >> 
+            make_clamp((0, 1)) >>
+            make_bounded_sum((0, 1)) >>
+            make_base_geometric(1.)
+        ] * 5)
+    ] * 5)
+
+    # build some synthetic data:
+    from random import randint, choice
+    data_length = 500
+    strat_ids_1 = [randint(0, 5) for _ in range(data_length)]
+    strat_ids_2 = [randint(0, 5) for _ in range(data_length)]
+    values = [choice([0, 1]) for _ in range(data_length)]
+    data = "\n".join(f"{k1},{k2},{v}" for k1, k2, v in zip(strat_ids_1, strat_ids_2, values))
+    # print(data)
+    
+    # release noisy sums!
+    print(meas(data))
+
+
 if __name__ == "__main__":
-    test_make_map_partitions_trans()
+    test_make_map_partitions_nested()

--- a/python/test/test_comb.py
+++ b/python/test/test_comb.py
@@ -105,7 +105,7 @@ def test_make_pureDP_to_zCDP():
 
     print(meas.map(1.))
 
-def test_make_map_partitions_trans():
+def test_make_parallel_transformation():
     from opendp.combinators import make_parallel_transformation, make_parallel_composition
 
     meas = make_split_dataframe(
@@ -135,9 +135,8 @@ def test_make_map_partitions_trans():
     # release noisy sums!
     print(meas(data))
 
-
 # 2-way partitioning!
-def test_make_map_partitions_nested():
+def test_make_map_parallel_composition():
     from opendp.combinators import make_parallel_composition
 
     meas = make_split_dataframe(
@@ -176,4 +175,4 @@ def test_make_map_partitions_nested():
 
 
 if __name__ == "__main__":
-    test_make_map_partitions_nested()
+    test_make_map_parallel_composition()

--- a/python/test/test_core.py
+++ b/python/test/test_core.py
@@ -7,7 +7,7 @@ enable_features('floating-point', 'contrib')
 def test_type_getters():
     from opendp.transformations import make_sized_bounded_mean
     transformation = make_sized_bounded_mean(size=9, bounds=(0., 10.), T=float)
-    assert transformation.input_distance_type == "u32"
+    assert transformation.input_distance_type == "usize"
     assert transformation.output_distance_type == "f64"
     assert transformation.input_carrier_type == "Vec<f64>"
 

--- a/python/test/test_core.py
+++ b/python/test/test_core.py
@@ -7,7 +7,7 @@ enable_features('floating-point', 'contrib')
 def test_type_getters():
     from opendp.transformations import make_sized_bounded_mean
     transformation = make_sized_bounded_mean(size=9, bounds=(0., 10.), T=float)
-    assert transformation.input_distance_type == "usize"
+    assert transformation.input_distance_type == "u32"
     assert transformation.output_distance_type == "f64"
     assert transformation.input_carrier_type == "Vec<f64>"
 

--- a/rust/src/comb/chain/ffi.rs
+++ b/rust/src/comb/chain/ffi.rs
@@ -1,0 +1,63 @@
+use crate::comb::{make_chain_mt, make_chain_tt};
+use crate::core::FfiResult;
+
+use crate::ffi::any::{AnyMeasurement, AnyTransformation};
+
+#[no_mangle]
+pub extern "C" fn opendp_comb__make_chain_mt(measurement1: *const AnyMeasurement, transformation0: *const AnyTransformation) -> FfiResult<*mut AnyMeasurement> {
+    let transformation0 = try_as_ref!(transformation0);
+    let measurement1 = try_as_ref!(measurement1);
+    make_chain_mt(measurement1, transformation0).into()
+}
+
+#[no_mangle]
+pub extern "C" fn opendp_comb__make_chain_tt(transformation1: *const AnyTransformation, transformation0: *const AnyTransformation) -> FfiResult<*mut AnyTransformation> {
+    let transformation0 = try_as_ref!(transformation0);
+    let transformation1 = try_as_ref!(transformation1);
+    make_chain_tt(transformation1, transformation0).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::comb::tests::{make_test_transformation, make_test_measurement};
+    use crate::core;
+    use crate::error::Fallible;
+    use crate::ffi::any::{AnyObject, Downcast, IntoAnyMeasurementExt, IntoAnyTransformationExt};
+    use crate::ffi::util;
+
+    use super::*;
+
+    #[test]
+    fn test_make_chain_mt_ffi() -> Fallible<()> {
+        let transformation0 = util::into_raw(make_test_transformation::<i32>().into_any());
+        let measurement1 = util::into_raw(make_test_measurement::<i32>().into_any());
+        let chain = Result::from(opendp_comb__make_chain_mt(measurement1, transformation0))?;
+        let arg = AnyObject::new_raw(999);
+        let res = core::opendp_core__measurement_invoke(&chain, arg);
+        let res: i32 = Fallible::from(res)?.downcast()?;
+        assert_eq!(res, 999);
+
+        let d_in = AnyObject::new_raw(999i32);
+        let d_out = core::opendp_core__measurement_map(&chain, d_in);
+        let d_out: f64 = Fallible::from(d_out)?.downcast()?;
+        assert_eq!(d_out, 1000.);
+        Ok(())
+    }
+
+    #[test]
+    fn test_make_chain_tt_ffi() -> Fallible<()> {
+        let transformation0 = util::into_raw(make_test_transformation::<i32>().into_any());
+        let transformation1 = util::into_raw(make_test_transformation::<i32>().into_any());
+        let chain = Result::from(opendp_comb__make_chain_tt(transformation1, transformation0))?;
+        let arg = AnyObject::new_raw(999);
+        let res = core::opendp_core__transformation_invoke(&chain, arg);
+        let res: i32 = Fallible::from(res)?.downcast()?;
+        assert_eq!(res, 999);
+
+        let d_in = AnyObject::new_raw(999);
+        let d_out = core::opendp_core__transformation_map(&chain, d_in);
+        let d_out: i32 = Fallible::from(d_out)?.downcast()?;
+        assert_eq!(d_out, 999);
+        Ok(())
+    }
+}

--- a/rust/src/comb/chain/ffi.rs
+++ b/rust/src/comb/chain/ffi.rs
@@ -37,7 +37,7 @@ mod tests {
         let res: i32 = Fallible::from(res)?.downcast()?;
         assert_eq!(res, 999);
 
-        let d_in = AnyObject::new_raw(999i32);
+        let d_in = AnyObject::new_raw(999u32);
         let d_out = core::opendp_core__measurement_map(&chain, d_in);
         let d_out: f64 = Fallible::from(d_out)?.downcast()?;
         assert_eq!(d_out, 1000.);
@@ -54,9 +54,9 @@ mod tests {
         let res: i32 = Fallible::from(res)?.downcast()?;
         assert_eq!(res, 999);
 
-        let d_in = AnyObject::new_raw(999);
+        let d_in = AnyObject::new_raw(999u32);
         let d_out = core::opendp_core__transformation_map(&chain, d_in);
-        let d_out: i32 = Fallible::from(d_out)?.downcast()?;
+        let d_out: u32 = Fallible::from(d_out)?.downcast()?;
         assert_eq!(d_out, 999);
         Ok(())
     }

--- a/rust/src/combinators/mod.rs
+++ b/rust/src/combinators/mod.rs
@@ -26,6 +26,11 @@ mod user_defined;
 pub(crate) use crate::combinators::user_defined::*;
 
 #[cfg(feature="contrib")]
+pub mod partition_map;
+#[cfg(feature="contrib")]
+pub use crate::combinators::partition_map::*;
+
+#[cfg(feature="contrib")]
 mod fix_delta;
 #[cfg(feature="contrib")]
 pub use crate::combinators::fix_delta::*;

--- a/rust/src/combinators/partition_map/ffi.rs
+++ b/rust/src/combinators/partition_map/ffi.rs
@@ -14,7 +14,10 @@ use crate::{
 
 use super::ParallelCompositionMeasure;
 
-#[bootstrap(features("contrib"))]
+#[bootstrap(
+    features("contrib"),
+    arguments(transformations(rust_type = "Vec<AnyTransformationPtr>"))
+)]
 /// Construct the parallel execution of [`transformation0`, `transformation1`, ...]. Returns a Transformation.
 /// 
 /// # Arguments
@@ -26,7 +29,7 @@ fn make_parallel_transformation(
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_comb__make_parallel_transformation(
+pub extern "C" fn opendp_combinators__make_parallel_transformation(
     transformations: *const AnyObject,
 ) -> FfiResult<*mut AnyTransformation> {
     let trans_ptrs =
@@ -47,7 +50,10 @@ pub extern "C" fn opendp_comb__make_parallel_transformation(
     )).into()
 }
 
-#[bootstrap(features("contrib"))]
+#[bootstrap(
+    features("contrib"),
+    arguments(measurements(rust_type = "Vec<AnyMeasurementPtr>"))
+)]
 /// Construct the parallel composition of [`measurement0`, `measurement1`, ...]. Returns a Measurement.
 /// 
 /// # Arguments
@@ -83,7 +89,7 @@ impl ParallelCompositionMeasure for AnyMeasure {
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_comb__make_parallel_composition(
+pub extern "C" fn opendp_combinators__make_parallel_composition(
     measurements: *const AnyObject,
 ) -> FfiResult<*mut AnyMeasurement> {
     let meas_ptrs =

--- a/rust/src/combinators/partition_map/ffi.rs
+++ b/rust/src/combinators/partition_map/ffi.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     error::Fallible, 
     traits::{TotalOrd, ExactIntCast, InfMul}, 
-    measures::{MaxDivergence, FixedSmoothedMaxDivergence, ZeroConcentratedDivergence, SmoothedMaxDivergence}, domains::ProductDomain, metrics::ProductMetric,
+    measures::{MaxDivergence, FixedSmoothedMaxDivergence, ZeroConcentratedDivergence, SmoothedMaxDivergence}, domains::ProductDomain, metrics::{ProductMetric, IntDistance},
 };
 
 use super::ParallelCompositionMeasure;
@@ -59,13 +59,13 @@ fn make_partition_map_meas(
 }
 
 impl ParallelCompositionMeasure for AnyMeasure {
-    fn compose(&self, d_i: Vec<AnyObject>, partition_limit: usize) -> crate::error::Fallible<Self::Distance> {
-        fn monomorphize1<Q: 'static + Zero + Clone + TotalOrd + ExactIntCast<usize> + InfMul>(
-            self_: &AnyMeasure, d_i: Vec<AnyObject>, partition_limit: usize
+    fn compose(&self, d_i: Vec<AnyObject>, partition_limit: IntDistance) -> crate::error::Fallible<Self::Distance> {
+        fn monomorphize1<Q: 'static + Zero + Clone + TotalOrd + ExactIntCast<IntDistance> + InfMul>(
+            self_: &AnyMeasure, d_i: Vec<AnyObject>, partition_limit: IntDistance
         ) -> Fallible<AnyObject> {
 
             fn monomorphize2<M: 'static + ParallelCompositionMeasure>(
-                self_: &AnyMeasure, d_i: Vec<AnyObject>, partition_limit: usize
+                self_: &AnyMeasure, d_i: Vec<AnyObject>, partition_limit: IntDistance
             ) -> Fallible<AnyObject>
                 where M::Distance: Clone {
                 let d_i = d_i.into_iter()

--- a/rust/src/combinators/partition_map/ffi.rs
+++ b/rust/src/combinators/partition_map/ffi.rs
@@ -1,0 +1,77 @@
+use opendp_derive::bootstrap;
+
+use crate::{
+    core::{FfiResult, Measurement, Transformation},
+    ffi::{
+        any::{AnyObject, AnyTransformation, Downcast, AnyMeasurement, IntoAnyFunctionExt, AnyDomain, AnyMetric, AnyMeasure},
+        util::{AnyTransformationPtr, AnyMeasurementPtr},
+    }, error::Fallible, domains::ProductDomain,
+};
+
+#[bootstrap(features("contrib"))]
+/// Construct the parallel execution of [`transformation0`, `transformation1`, ...]. Returns a Transformation.
+/// 
+/// # Arguments
+/// * `transformations` - A list of transformations to apply, one to each element.
+fn make_partition_map_trans(
+    transformations: Vec<&AnyTransformation>,
+) -> Fallible<Transformation<ProductDomain<AnyDomain>, ProductDomain<AnyDomain>, AnyMetric, AnyMetric>> {
+    super::make_partition_map_trans(transformations)
+}
+
+#[no_mangle]
+pub extern "C" fn opendp_comb__make_partition_map_trans(
+    transformations: *const AnyObject,
+) -> FfiResult<*mut AnyTransformation> {
+    let trans_ptrs =
+        try_!(try_as_ref!(transformations).downcast_ref::<Vec<AnyTransformationPtr>>());
+
+    let transformations: Vec<&AnyTransformation> =
+        try_!(trans_ptrs.iter().map(|ptr| Ok(try_as_ref!(*ptr))).collect());
+
+    let trans = try_!(make_partition_map_trans(transformations));
+
+    // don't wrap the input metric, output metric and stability map!
+    Ok(Transformation::new(
+        AnyDomain::new(trans.input_domain),
+        AnyDomain::new(trans.output_domain),
+        trans.function.into_any(),
+        trans.input_metric,
+        trans.output_metric,
+        trans.stability_map
+    )).into()
+}
+
+#[bootstrap(features("contrib"))]
+/// Construct the parallel composition of [`measurement0`, `measurement1`, ...]. Returns a Measurement.
+/// 
+/// # Arguments
+/// * `measurements` - A list of measuerements to apply, one to each element.
+fn make_partition_map_meas(
+    measurements: Vec<&AnyMeasurement>,
+) -> Fallible<Measurement<ProductDomain<AnyDomain>, ProductDomain<AnyDomain>, AnyMetric, AnyMeasure>> {
+    super::make_partition_map_meas(measurements)
+}
+
+#[no_mangle]
+pub extern "C" fn opendp_comb__make_partition_map_meas(
+    measurements: *const AnyObject,
+) -> FfiResult<*mut AnyMeasurement> {
+    let meas_ptrs =
+        try_!(try_as_ref!(measurements).downcast_ref::<Vec<AnyMeasurementPtr>>());
+
+    let measurements: Vec<&AnyMeasurement> =
+        try_!(meas_ptrs.iter().map(|ptr| Ok(try_as_ref!(*ptr))).collect());
+
+    let meas = try_!(make_partition_map_meas(measurements));
+
+    // don't wrap the input metric, output measure and privacy map!
+    Ok(Measurement::new(
+        AnyDomain::new(meas.input_domain),
+        AnyDomain::new(meas.output_domain),
+        meas.function.into_any(),
+        meas.input_metric,
+        meas.output_measure,
+        meas.privacy_map
+    )).into()
+}

--- a/rust/src/combinators/partition_map/ffi.rs
+++ b/rust/src/combinators/partition_map/ffi.rs
@@ -19,14 +19,14 @@ use super::ParallelCompositionMeasure;
 /// 
 /// # Arguments
 /// * `transformations` - A list of transformations to apply, one to each element.
-fn make_partition_map_trans(
+fn make_parallel_transformation(
     transformations: Vec<&AnyTransformation>,
 ) -> Fallible<Transformation<ProductDomain<AnyDomain>, ProductDomain<AnyDomain>, ProductMetric<AnyMetric>, ProductMetric<AnyMetric>>> {
-    super::make_partition_map_trans(transformations)
+    super::make_parallel_transformation(transformations)
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_comb__make_partition_map_trans(
+pub extern "C" fn opendp_comb__make_parallel_transformation(
     transformations: *const AnyObject,
 ) -> FfiResult<*mut AnyTransformation> {
     let trans_ptrs =
@@ -35,7 +35,7 @@ pub extern "C" fn opendp_comb__make_partition_map_trans(
     let transformations: Vec<&AnyTransformation> =
         try_!(trans_ptrs.iter().map(|ptr| Ok(try_as_ref!(*ptr))).collect());
 
-    let trans = try_!(make_partition_map_trans(transformations));
+    let trans = try_!(make_parallel_transformation(transformations));
 
     Ok(Transformation::new(
         AnyDomain::new(trans.input_domain),
@@ -51,11 +51,11 @@ pub extern "C" fn opendp_comb__make_partition_map_trans(
 /// Construct the parallel composition of [`measurement0`, `measurement1`, ...]. Returns a Measurement.
 /// 
 /// # Arguments
-/// * `measurements` - A list of measuerements to apply, one to each element.
-fn make_partition_map_meas(
+/// * `measurements` - A list of measurements to apply, one to each element.
+fn make_parallel_composition(
     measurements: Vec<&AnyMeasurement>,
 ) -> Fallible<Measurement<ProductDomain<AnyDomain>, ProductDomain<AnyDomain>, ProductMetric<AnyMetric>, AnyMeasure>> {
-    super::make_partition_map_meas(measurements)
+    super::make_parallel_composition(measurements)
 }
 
 impl ParallelCompositionMeasure for AnyMeasure {
@@ -83,7 +83,7 @@ impl ParallelCompositionMeasure for AnyMeasure {
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_comb__make_partition_map_meas(
+pub extern "C" fn opendp_comb__make_parallel_composition(
     measurements: *const AnyObject,
 ) -> FfiResult<*mut AnyMeasurement> {
     let meas_ptrs =
@@ -92,7 +92,7 @@ pub extern "C" fn opendp_comb__make_partition_map_meas(
     let measurements: Vec<&AnyMeasurement> =
         try_!(meas_ptrs.iter().map(|ptr| Ok(try_as_ref!(*ptr))).collect());
 
-    let meas = try_!(make_partition_map_meas(measurements));
+    let meas = try_!(make_parallel_composition(measurements));
     let privacy_map = meas.privacy_map;
 
     // don't wrap the input metric, output measure and privacy map!

--- a/rust/src/combinators/partition_map/mod.rs
+++ b/rust/src/combinators/partition_map/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     core::{Domain, Function, Metric, StabilityMap, Transformation, Measurement, Measure, PrivacyMap},
     domains::ProductDomain,
     error::{Fallible, ExplainUnwrap},
-    traits::TotalOrd,
+    traits::TotalOrd, metrics::ProductMetric,
 };
 
 #[cfg(feature = "ffi")]
@@ -14,7 +14,7 @@ mod ffi;
 /// * `transformations` - A list of transformations to apply, one to each element.
 pub fn make_partition_map_trans<DI, DO, MI, MO>(
     transformations: Vec<&Transformation<DI, DO, MI, MO>>,
-) -> Fallible<Transformation<ProductDomain<DI>, ProductDomain<DO>, MI, MO>>
+) -> Fallible<Transformation<ProductDomain<DI>, ProductDomain<DO>, ProductMetric<MI>, ProductMetric<MO>>>
 where
     MO::Distance: TotalOrd,
     DI: 'static + Domain,
@@ -64,8 +64,8 @@ where
                 .collect()
         }),
 
-        input_metric,
-        output_metric,
+        ProductMetric::new(input_metric),
+        ProductMetric::new(output_metric),
         StabilityMap::new_fallible(move |d_in: &MI::Distance| {
             maps.iter()
                 .map(|map| map.eval(d_in))
@@ -81,7 +81,7 @@ where
 /// * `measuerements` - A list of measuerements to apply, one to each element.
 pub fn make_partition_map_meas<DI, DO, MI, MO>(
     measurements: Vec<&Measurement<DI, DO, MI, MO>>,
-) -> Fallible<Measurement<ProductDomain<DI>, ProductDomain<DO>, MI, MO>>
+) -> Fallible<Measurement<ProductDomain<DI>, ProductDomain<DO>, ProductMetric<MI>, MO>>
 where
     MO::Distance: TotalOrd,
     DI: 'static + Domain,
@@ -130,7 +130,7 @@ where
                 .map(|(func, part)| func.eval(part))
                 .collect()
         }),
-        input_metric,
+        ProductMetric::new(input_metric),
         output_measure,
         PrivacyMap::new_fallible(move |d_in: &MI::Distance| {
             maps.iter()

--- a/rust/src/combinators/partition_map/mod.rs
+++ b/rust/src/combinators/partition_map/mod.rs
@@ -14,7 +14,7 @@ mod ffi;
 /// 
 /// # Arguments
 /// * `transformations` - A list of transformations to apply, one to each element.
-pub fn make_partition_map_trans<DI, DO, MI, MO>(
+pub fn make_parallel_transformation<DI, DO, MI, MO>(
     transformations: Vec<&Transformation<DI, DO, MI, MO>>,
 ) -> Fallible<Transformation<ProductDomain<DI>, ProductDomain<DO>, ProductMetric<MI>, ProductMetric<MO>>>
 where
@@ -132,8 +132,8 @@ impl<Q> ParallelCompositionMeasure for ZeroConcentratedDivergence<Q>
 /// Construct the parallel composition of [`measurement0`, `measurement1`, ...]. Returns a Measurement.
 /// 
 /// # Arguments
-/// * `measurements` - A list of measuerements to apply, one to each element.
-pub fn make_partition_map_meas<DI, DO, MI, MO>(
+/// * `measurements` - A list of measurements to apply, one to each element.
+pub fn make_parallel_composition<DI, DO, MI, MO>(
     measurements: Vec<&Measurement<DI, DO, MI, MO>>,
 ) -> Fallible<Measurement<ProductDomain<DI>, ProductDomain<DO>, ProductMetric<MI>, MO>>
 where

--- a/rust/src/combinators/partition_map/mod.rs
+++ b/rust/src/combinators/partition_map/mod.rs
@@ -1,0 +1,142 @@
+use crate::{
+    core::{Domain, Function, Metric, StabilityMap, Transformation, Measurement, Measure, PrivacyMap},
+    domains::ProductDomain,
+    error::{Fallible, ExplainUnwrap},
+    traits::TotalOrd,
+};
+
+#[cfg(feature = "ffi")]
+mod ffi;
+
+/// Construct the parallel execution of [`transformation0`, `transformation1`, ...]. Returns a Transformation.
+/// 
+/// # Arguments
+/// * `transformations` - A list of transformations to apply, one to each element.
+pub fn make_partition_map_trans<DI, DO, MI, MO>(
+    transformations: Vec<&Transformation<DI, DO, MI, MO>>,
+) -> Fallible<Transformation<ProductDomain<DI>, ProductDomain<DO>, MI, MO>>
+where
+    MO::Distance: TotalOrd,
+    DI: 'static + Domain,
+    DO: 'static + Domain,
+    MI: 'static + Metric,
+    MO: 'static + Metric,
+{
+    if transformations.is_empty() {
+        return fallible!(MakeTransformation, "must pass at least one transformation");
+    }
+    let input_metric = transformations[0].input_metric.clone();
+    if transformations.iter().any(|meas| meas.input_metric != input_metric) {
+        return fallible!(MakeTransformation, "all transformations must have the same input metric")
+    }
+    let output_metric = transformations[0].output_metric.clone();
+    if transformations.iter().any(|meas| meas.output_metric != output_metric) {
+        return fallible!(MakeTransformation, "all transformations must have the same output metric")
+    }
+
+    let functions = transformations
+        .iter()
+        .map(|trans| trans.function.clone())
+        .collect::<Vec<_>>();
+    let maps = transformations
+        .iter()
+        .map(|trans| trans.stability_map.clone())
+        .collect::<Vec<_>>();
+
+    Ok(Transformation::new(
+        ProductDomain::new(
+            transformations
+                .iter()
+                .map(|trans| trans.input_domain.clone())
+                .collect(),
+        ),
+        ProductDomain::new(
+            transformations
+                .iter()
+                .map(|trans| trans.output_domain.clone())
+                .collect(),
+        ),
+        Function::new_fallible(move |arg: &Vec<DI::Carrier>| {
+            functions
+                .iter()
+                .zip(arg)
+                .map(|(func, part)| func.eval(part))
+                .collect()
+        }),
+
+        input_metric,
+        output_metric,
+        StabilityMap::new_fallible(move |d_in: &MI::Distance| {
+            maps.iter()
+                .map(|map| map.eval(d_in))
+                .reduce(|l, r| l?.total_max(r?))
+                .unwrap_assert("there is at least one transformation")
+        }),
+    ))
+}
+
+/// Construct the parallel composition of [`measurement0`, `measurement1`, ...]. Returns a Measurement.
+/// 
+/// # Arguments
+/// * `measuerements` - A list of measuerements to apply, one to each element.
+pub fn make_partition_map_meas<DI, DO, MI, MO>(
+    measurements: Vec<&Measurement<DI, DO, MI, MO>>,
+) -> Fallible<Measurement<ProductDomain<DI>, ProductDomain<DO>, MI, MO>>
+where
+    MO::Distance: TotalOrd,
+    DI: 'static + Domain,
+    DO: 'static + Domain,
+    MI: 'static + Metric,
+    MO: 'static + Measure,
+{
+    if measurements.is_empty() {
+        return fallible!(MakeMeasurement, "must pass at least one measurement");
+    }
+    let input_metric = measurements[0].input_metric.clone();
+    if measurements.iter().any(|meas| meas.input_metric != input_metric) {
+        return fallible!(MakeMeasurement, "all measurements must have the same input metric")
+    }
+    let output_measure = measurements[0].output_measure.clone();
+    if measurements.iter().any(|meas| meas.output_measure != output_measure) {
+        return fallible!(MakeMeasurement, "all measurements must have the same output measure")
+    }
+
+    let functions = measurements
+        .iter()
+        .map(|meas| meas.function.clone())
+        .collect::<Vec<_>>();
+    let maps = measurements
+        .iter()
+        .map(|meas| meas.privacy_map.clone())
+        .collect::<Vec<_>>();
+
+    Ok(Measurement::new(
+        ProductDomain::new(
+            measurements
+                .iter()
+                .map(|meas| meas.input_domain.clone())
+                .collect(),
+        ),
+        ProductDomain::new(
+            measurements
+                .iter()
+                .map(|meas| meas.output_domain.clone())
+                .collect(),
+        ),
+        Function::new_fallible(move |arg: &Vec<DI::Carrier>| {
+            functions
+                .iter()
+                .zip(arg)
+                .map(|(func, part)| func.eval(part))
+                .collect()
+        }),
+        input_metric,
+        output_measure,
+        PrivacyMap::new_fallible(move |d_in: &MI::Distance| {
+            maps.iter()
+                .map(|map| map.eval(d_in))
+                .reduce(|l, r| l?.total_max(r?))
+                .unwrap_assert("there is at least one measurement")
+        }),
+    ))
+}

--- a/rust/src/data/ffi.rs
+++ b/rust/src/data/ffi.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::ffi::{c_void, CString};
-use std::fmt::Formatter;
+
 use std::hash::Hash;
 use std::os::raw::c_char;
 use std::slice;
@@ -9,10 +9,8 @@ use std::slice;
 use opendp_derive::bootstrap;
 
 use crate::measures::SMDCurve;
-use crate::traits::TotalOrd;
 use crate::{err, fallible, try_, try_as_ref};
 use crate::core::{FfiError, FfiResult, FfiSlice};
-use crate::data::Column;
 use crate::error::Fallible;
 use crate::ffi::any::{AnyObject, Downcast};
 use crate::ffi::util::{self, into_c_char_p};
@@ -309,65 +307,6 @@ pub extern "C" fn opendp_data__bool_free(this: *mut c_bool) -> FfiResult<*mut ()
     util::into_owned(this).map(|_| ()).into()
 }
 
-
-impl std::fmt::Debug for AnyObject {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        fn monomorphize<T: 'static + std::fmt::Debug>(this: &AnyObject) -> Fallible<String> {
-            Ok(match this.downcast_ref::<T>() {
-                Ok(v) => format!("{:?}", v),
-                Err(e) => e.to_string()
-            })
-        }
-        let type_arg = &self.type_;
-        f.write_str(dispatch!(monomorphize, [(type_arg, [
-            u32, u64, i32, i64, f32, f64, bool, String, u8, Column,
-            Vec<u32>, Vec<u64>, Vec<i32>, Vec<i64>, Vec<f32>, Vec<f64>, Vec<bool>, Vec<String>, Vec<u8>, Vec<Column>, Vec<Vec<String>>,
-            HashMap<String, Column>,
-            // FIXME: The following are for Python demo use of compositions. Need to figure this out!!!
-            (Box<i32>, Box<f64>),
-            (Box<i32>, Box<u32>),
-            (Box<(Box<f64>, Box<f64>)>, Box<f64>),
-            (AnyObject, AnyObject),
-            AnyObject
-        ])], (self)).unwrap_or_else(|_| "[Non-debuggable]".to_string()).as_str())
-    }
-}
-
-impl PartialEq for AnyObject {
-    fn eq(&self, other: &Self) -> bool {
-        fn monomorphize<T: 'static + PartialEq>(this: &AnyObject, other: &AnyObject) -> Fallible<bool> {
-            Ok(this.downcast_ref::<T>()? == other.downcast_ref::<T>()?)
-        }
-
-        let type_arg = &self.type_;
-        dispatch!(monomorphize, [(type_arg, @hashable)], (self, other)).unwrap_or(false)
-    }
-}
-
-impl PartialOrd for AnyObject {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        fn monomorphize<T: 'static + PartialOrd>(this: &AnyObject, other: &AnyObject) -> Fallible<Option<std::cmp::Ordering>> {
-            Ok(this.downcast_ref::<T>()?.partial_cmp(other.downcast_ref::<T>()?))
-        }
-
-        let type_arg = &self.type_;
-        dispatch!(monomorphize, [(type_arg, @numbers)], (self, other)).unwrap_or(None)
-    }
-}
-
-impl TotalOrd for AnyObject {
-    fn total_cmp(&self, other: &Self) -> Fallible<std::cmp::Ordering> {
-        fn monomorphize<T: 'static + TotalOrd>(this: &AnyObject, other: &AnyObject) -> Fallible<std::cmp::Ordering> {
-            this.downcast_ref::<T>()?.total_cmp(other.downcast_ref::<T>()?)
-        }
-
-        let type_arg = &self.type_;
-        // type list is explicit because (f32, f32), (f64, f64) are not in @numbers
-        dispatch!(monomorphize, [(type_arg, [
-            u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, (f32, f32), (f64, f64)
-        ])], (self, other))
-    }
-}
 
 #[bootstrap(
     name = "smd_curve_epsilon",

--- a/rust/src/domains/mod.rs
+++ b/rust/src/domains/mod.rs
@@ -196,8 +196,8 @@ pub struct MapDomain<DK: Domain, DV: Domain> where DK::Carrier: Eq + Hash {
     pub value_domain: DV
 }
 impl<DK: Domain, DV: Domain> MapDomain<DK, DV> where DK::Carrier: Eq + Hash {
-    pub fn new(key_domain: DK, element_domain: DV) -> Self {
-        MapDomain { key_domain, value_domain: element_domain }
+    pub fn new(key_domain: DK, value_domain: DV) -> Self {
+        MapDomain { key_domain, value_domain }
     }
 }
 impl<K: CheckNull, V: CheckNull> MapDomain<AllDomain<K>, AllDomain<V>> where K: Eq + Hash {
@@ -424,6 +424,33 @@ impl<D: Domain> Domain for OptionNullDomain<D> {
         value.as_ref()
             .map(|v| self.element_domain.member(v))
             .unwrap_or(Ok(true))
+    }
+}
+
+
+/// A Domain that represents partitioned data
+#[derive(Clone, PartialEq)]
+pub struct ProductDomain<D: Domain> {
+    pub inner_domains: Vec<D>
+}
+impl<D: Domain> ProductDomain<D> {
+    pub fn new(inner_domains: Vec<D>) -> Self {
+        ProductDomain { inner_domains }
+    }
+}
+impl<D: Domain> Debug for ProductDomain<D> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "ProductDomain({:?})", self.inner_domains)
+    }
+}
+
+impl<D: Domain> Domain for ProductDomain<D> {
+    type Carrier = Vec<D::Carrier>;
+    fn member(&self, val: &Vec<D::Carrier>) -> Fallible<bool> {
+        if self.inner_domains.len() != val.len() {
+            return Ok(false)
+        }
+        val.iter().zip(self.inner_domains.iter()).try_fold(true, |acc, (v, d)| d.member(v).map(|v| acc && v))
     }
 }
 

--- a/rust/src/ffi/any/mod.rs
+++ b/rust/src/ffi/any/mod.rs
@@ -16,6 +16,8 @@ use crate::error::*;
 use super::glue::Glue;
 use super::util::Type;
 
+mod object;
+
 /// A trait for something that can be downcast to a concrete type.
 pub trait Downcast {
     fn downcast<T: 'static>(self) -> Fallible<T>;

--- a/rust/src/ffi/any/object.rs
+++ b/rust/src/ffi/any/object.rs
@@ -1,0 +1,62 @@
+use std::{fmt::Formatter, collections::HashMap};
+
+use crate::{data::Column, traits::TotalOrd, error::Fallible, ffi::any::Downcast};
+
+use super::AnyObject;
+use crate::err;
+
+
+impl std::fmt::Debug for AnyObject {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        fn monomorphize<T: 'static + std::fmt::Debug>(this: &AnyObject) -> Fallible<String> {
+            Ok(match this.downcast_ref::<T>() {
+                Ok(v) => format!("{:?}", v),
+                Err(e) => e.to_string()
+            })
+        }
+        let type_arg = &self.type_;
+        f.write_str(dispatch!(monomorphize, [(type_arg, [
+            u32, u64, i32, i64, f32, f64, bool, String, u8, Column,
+            Vec<u32>, Vec<u64>, Vec<i32>, Vec<i64>, Vec<f32>, Vec<f64>, Vec<bool>, Vec<String>, Vec<u8>, Vec<Column>, Vec<Vec<String>>,
+            HashMap<String, Column>,
+            (AnyObject, AnyObject),
+            AnyObject
+        ])], (self)).unwrap_or("[Non-debuggable]".to_string()).as_str())
+    }
+}
+
+impl PartialEq for AnyObject {
+    fn eq(&self, other: &Self) -> bool {
+        fn monomorphize<T: 'static + PartialEq>(this: &AnyObject, other: &AnyObject) -> Fallible<bool> {
+            Ok(this.downcast_ref::<T>()? == other.downcast_ref::<T>()?)
+        }
+
+        let type_arg = &self.type_;
+        dispatch!(monomorphize, [(type_arg, @hashable)], (self, other)).unwrap_or(false)
+    }
+}
+
+impl PartialOrd for AnyObject {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        fn monomorphize<T: 'static + PartialOrd>(this: &AnyObject, other: &AnyObject) -> Fallible<Option<std::cmp::Ordering>> {
+            Ok(this.downcast_ref::<T>()?.partial_cmp(other.downcast_ref::<T>()?))
+        }
+
+        let type_arg = &self.type_;
+        dispatch!(monomorphize, [(type_arg, @numbers)], (self, other)).unwrap_or(None)
+    }
+}
+
+impl TotalOrd for AnyObject {
+    fn total_cmp(&self, other: &Self) -> Fallible<std::cmp::Ordering> {
+        fn monomorphize<T: 'static + TotalOrd>(this: &AnyObject, other: &AnyObject) -> Fallible<std::cmp::Ordering> {
+            this.downcast_ref::<T>()?.total_cmp(other.downcast_ref::<T>()?)
+        }
+
+        let type_arg = &self.type_;
+        // type list is explicit because (f32, f32), (f64, f64) are not in @numbers
+        dispatch!(monomorphize, [(type_arg, [
+            u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, (f32, f32), (f64, f64)
+        ])], (self, other))
+    }
+}

--- a/rust/src/metrics/mod.rs
+++ b/rust/src/metrics/mod.rs
@@ -361,3 +361,32 @@ impl Debug for AgnosticMetric {
 impl Metric for AgnosticMetric {
     type Distance = ();
 }
+
+#[derive(Clone)]
+pub struct ProductMetric<M: Metric>{
+    pub inner_metric: M
+}
+
+impl<M: Metric> Default for ProductMetric<M> {
+    fn default() -> Self { ProductMetric::new(M::default()) }
+}
+
+impl<M: Metric> ProductMetric<M> {
+    pub fn new(inner_metric: M) -> Self {
+        ProductMetric { inner_metric }
+    }
+}
+
+impl<M: Metric> PartialEq for ProductMetric<M> {
+    fn eq(&self, other: &Self) -> bool { 
+        self.inner_metric == other.inner_metric
+    }
+}
+impl<M: Metric> Debug for ProductMetric<M> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "ProductMetric({:?})", self.inner_metric)
+    }
+}
+impl<M: Metric> Metric for ProductMetric<M> {
+    type Distance = M::Distance;
+}

--- a/rust/src/metrics/mod.rs
+++ b/rust/src/metrics/mod.rs
@@ -18,7 +18,7 @@ use std::fmt::{Debug, Formatter};
 
 /// The type that represents the distance between datasets.
 /// It is used as the associated [`Metric`]::Distance type for e.g. [`SymmetricDistance`], [`InsertDeleteDistance`], etc.
-pub type IntDistance = u32;
+pub type IntDistance = usize;
 
 
 /// The smallest number of additions or removals to make two datasets equivalent.
@@ -388,5 +388,5 @@ impl<M: Metric> Debug for ProductMetric<M> {
     }
 }
 impl<M: Metric> Metric for ProductMetric<M> {
-    type Distance = M::Distance;
+    type Distance = (Vec<M::Distance>, usize);
 }

--- a/rust/src/metrics/mod.rs
+++ b/rust/src/metrics/mod.rs
@@ -18,7 +18,7 @@ use std::fmt::{Debug, Formatter};
 
 /// The type that represents the distance between datasets.
 /// It is used as the associated [`Metric`]::Distance type for e.g. [`SymmetricDistance`], [`InsertDeleteDistance`], etc.
-pub type IntDistance = usize;
+pub type IntDistance = u32;
 
 
 /// The smallest number of additions or removals to make two datasets equivalent.
@@ -388,5 +388,5 @@ impl<M: Metric> Debug for ProductMetric<M> {
     }
 }
 impl<M: Metric> Metric for ProductMetric<M> {
-    type Distance = (M::Distance, usize);
+    type Distance = (M::Distance, IntDistance);
 }

--- a/rust/src/metrics/mod.rs
+++ b/rust/src/metrics/mod.rs
@@ -388,5 +388,5 @@ impl<M: Metric> Debug for ProductMetric<M> {
     }
 }
 impl<M: Metric> Metric for ProductMetric<M> {
-    type Distance = (Vec<M::Distance>, usize);
+    type Distance = (M::Distance, usize);
 }

--- a/rust/src/traits/operations/mod.rs
+++ b/rust/src/traits/operations/mod.rs
@@ -278,11 +278,19 @@ fn min_by<T, F: FnOnce(&T, &T) -> Fallible<Ordering>>(v1: T, v2: T, compare: F) 
 
 impl<T1: TotalOrd, T2: TotalOrd> TotalOrd for (T1, T2) {
     fn total_cmp(&self, other: &Self) -> Fallible<Ordering> {
-        let cmp = self.0.total_cmp(&other.0)?;
-        if Ordering::Equal == cmp {
-            self.1.total_cmp(&other.1)
-        } else {
-            Ok(cmp)
+        let cmp0 = self.0.total_cmp(&other.0)?;
+        let cmp1 = self.1.total_cmp(&other.1)?;
+        use Ordering::*;
+        match (cmp0, cmp1) {
+            (Less, Less) => Ok(Less),
+            (Less, Equal) => Ok(Less),
+            (Less, Greater) => fallible!(FailedFunction, "arguments are not totally ordered"),
+            (Equal, Less) => Ok(Less),
+            (Equal, Equal) => Ok(Equal),
+            (Equal, Greater) => Ok(Greater),
+            (Greater, Less) => fallible!(FailedFunction, "arguments are not totally ordered"),
+            (Greater, Equal) => Ok(Greater),
+            (Greater, Greater) => Ok(Greater)
         }
     }
 }

--- a/rust/src/transformations/mod.rs
+++ b/rust/src/transformations/mod.rs
@@ -54,6 +54,11 @@ mod mean;
 pub use crate::transformations::mean::*;
 
 #[cfg(feature="contrib")]
+pub mod partition;
+#[cfg(feature="contrib")]
+pub use crate::transformations::partition::*;
+
+#[cfg(feature="contrib")]
 mod variance;
 #[cfg(feature="contrib")]
 pub use crate::transformations::variance::*;

--- a/rust/src/transformations/partition/ffi.rs
+++ b/rust/src/transformations/partition/ffi.rs
@@ -1,0 +1,66 @@
+use std::{convert::TryFrom, os::raw::c_char};
+
+use crate::{
+    core::{FfiResult, Function, IntoAnyTransformationFfiResultExt, Transformation},
+    domains::ProductDomain,
+    ffi::{
+        any::{AnyDomain, AnyObject, AnyTransformation, Downcast},
+        util::Type,
+    },
+    traits::Hashable,
+    transformations::{make_partition_by, DataFrame},
+};
+
+#[no_mangle]
+pub extern "C" fn opendp_trans__make_partition_by(
+    ident_name: *const AnyObject,
+    partition_keys: *const AnyObject,
+    keep_columns: *const AnyObject,
+    TK: *const c_char,
+    TV: *const c_char,
+) -> FfiResult<*mut AnyTransformation> {
+    fn monomorphize<TK: Hashable, TV: Hashable>(
+        ident_name: *const AnyObject,
+        partition_keys: *const AnyObject,
+        keep_columns: *const AnyObject,
+    ) -> FfiResult<*mut AnyTransformation> {
+        let ident_name = try_!(try_as_ref!(ident_name).downcast_ref::<TK>()).clone();
+        let partition_keys = try_!(try_as_ref!(partition_keys).downcast_ref::<Vec<TV>>()).clone();
+        let keep_columns = try_!(try_as_ref!(keep_columns).downcast_ref::<Vec<TK>>()).clone();
+        let trans = try_!(make_partition_by::<TK, TV>(
+            ident_name,
+            partition_keys,
+            keep_columns
+        ));
+
+        // rewrite the partitioner to emit ProductDomain<AnyDomain>, and box output partitions in the function
+        let inner_output_domains = (trans.output_domain.inner_domains)
+            .into_iter()
+            .map(AnyDomain::new)
+            .collect();
+        let function = trans.function;
+
+        Ok(Transformation::new(
+            trans.input_domain,
+            ProductDomain::new(inner_output_domains),
+            Function::new_fallible(move |arg: &DataFrame<TK>| {
+                let res = function.eval(arg);
+                res.map(|o| {
+                    o.into_iter()
+                        .map(AnyObject::new)
+                        .collect::<Vec<AnyObject>>()
+                })
+            }),
+            trans.input_metric,
+            trans.output_metric,
+            trans.stability_map,
+        ))
+        .into_any()
+    }
+    let TK = try_!(Type::try_from(TK));
+    let TV = try_!(Type::try_from(TV));
+    dispatch!(monomorphize, [
+        (TK, @hashable),
+        (TV, @hashable)
+    ], (ident_name, partition_keys, keep_columns))
+}

--- a/rust/src/transformations/partition/ffi.rs
+++ b/rust/src/transformations/partition/ffi.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 #[no_mangle]
-pub extern "C" fn opendp_trans__make_partition_by(
+pub extern "C" fn opendp_transformations__make_partition_by(
     identifier_column: *const AnyObject,
     partition_keys: *const AnyObject,
     keep_columns: *const AnyObject,

--- a/rust/src/transformations/partition/ffi.rs
+++ b/rust/src/transformations/partition/ffi.rs
@@ -13,22 +13,22 @@ use crate::{
 
 #[no_mangle]
 pub extern "C" fn opendp_trans__make_partition_by(
-    ident_name: *const AnyObject,
+    identifier_column: *const AnyObject,
     partition_keys: *const AnyObject,
     keep_columns: *const AnyObject,
     TK: *const c_char,
     TV: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<TK: Hashable, TV: Hashable>(
-        ident_name: *const AnyObject,
+        identifier_column: *const AnyObject,
         partition_keys: *const AnyObject,
         keep_columns: *const AnyObject,
     ) -> FfiResult<*mut AnyTransformation> {
-        let ident_name = try_!(try_as_ref!(ident_name).downcast_ref::<TK>()).clone();
+        let identifier_column = try_!(try_as_ref!(identifier_column).downcast_ref::<TK>()).clone();
         let partition_keys = try_!(try_as_ref!(partition_keys).downcast_ref::<Vec<TV>>()).clone();
         let keep_columns = try_!(try_as_ref!(keep_columns).downcast_ref::<Vec<TK>>()).clone();
         let trans = try_!(make_partition_by::<TK, TV>(
-            ident_name,
+            identifier_column,
             partition_keys,
             keep_columns
         ));
@@ -62,5 +62,5 @@ pub extern "C" fn opendp_trans__make_partition_by(
     dispatch!(monomorphize, [
         (TK, @hashable),
         (TV, @hashable)
-    ], (ident_name, partition_keys, keep_columns))
+    ], (identifier_column, partition_keys, keep_columns))
 }

--- a/rust/src/transformations/partition/ffi.rs
+++ b/rust/src/transformations/partition/ffi.rs
@@ -59,7 +59,7 @@ pub extern "C" fn opendp_trans__make_partition_by(
             ProductMetric::new(AnyMetric::new(trans.output_metric.inner_metric)),
             StabilityMap::new_fallible(move |d_in: &IntDistance| {
                 let (k, r) = stability_map.eval(d_in)?;
-                Ok((k.into_iter().map(AnyObject::new).collect(), r))
+                Ok((AnyObject::new(k), r))
             }),
         ))
         .into_any()

--- a/rust/src/transformations/partition/mod.rs
+++ b/rust/src/transformations/partition/mod.rs
@@ -2,15 +2,22 @@ use std::collections::HashMap;
 
 use opendp_derive::bootstrap;
 
-use crate::{traits::Hashable, error::Fallible, core::{Transformation, Function, StabilityMap}, domains::ProductDomain, metrics::SymmetricDistance};
+use crate::{
+    core::{Function, StabilityMap, Transformation},
+    domains::ProductDomain,
+    error::Fallible,
+    metrics::SymmetricDistance,
+    traits::Hashable,
+};
 
-use super::{DataFrameDomain, DataFrame};
+use super::{DataFrame, DataFrameDomain};
 
-#[cfg(feature="ffi")]
+#[cfg(feature = "ffi")]
 mod ffi;
 
 #[bootstrap(
     features("contrib"),
+    arguments(null_partition(default = false)),
     generics(TK(default = "String"), TV(example = "$get_first(partition_keys)"))
 )]
 /// Make a Transformation that partitions a dataframe by a given column.
@@ -19,6 +26,7 @@ mod ffi;
 /// * `identifier_column` - Name of column to split dataframe by.
 /// * `partition_keys` - Unique values in the `identifier_column` column.
 /// * `keep_columns` - Columns to keep in the partitioned dataframes.
+/// * `null_partition` - Whether to include a trailing null partition for rows that were not in the `partition_keys`
 /// 
 /// # Generics
 /// * `TK` - Type of column names.
@@ -26,47 +34,76 @@ mod ffi;
 pub fn make_partition_by<TK: Hashable, TV: Hashable>(
     identifier_column: TK,
     partition_keys: Vec<TV>,
-    keep_columns: Vec<TK>
-) -> Fallible<Transformation<DataFrameDomain<TK>, ProductDomain<DataFrameDomain<TK>>, SymmetricDistance, SymmetricDistance>> {
-    let partition_indexes: HashMap<TV, usize> = partition_keys.iter().cloned().enumerate().map(|(i, k)| (k, i)).collect();
-    let num_partitions = partition_keys.len() + 1;
+    keep_columns: Vec<TK>,
+    null_partition: bool,
+) -> Fallible<
+    Transformation<
+        DataFrameDomain<TK>,
+        ProductDomain<DataFrameDomain<TK>>,
+        SymmetricDistance,
+        SymmetricDistance,
+    >,
+> {
+    let partition_indexes: HashMap<TV, usize> = partition_keys
+        .iter()
+        .cloned()
+        .enumerate()
+        .map(|(i, k)| (k, i))
+        .collect();
+    let true_partitions = partition_keys.len() + 1;
+    let output_partitions = partition_keys.len() + if null_partition { 1 } else { 0 };
+
     Ok(Transformation::new(
         DataFrameDomain::new_all(),
-        ProductDomain::new((0..num_partitions).map(|_| DataFrameDomain::new_all()).collect()),
+        ProductDomain::new(
+            (0..output_partitions)
+                .map(|_| DataFrameDomain::new_all())
+                .collect(),
+        ),
         Function::new_fallible(move |data: &DataFrame<TK>| {
             // the partition to move each row into
-            let partition_ids: Vec<usize> = data.get(&identifier_column)
+            let partition_ids: Vec<usize> = (data.get(&identifier_column))
                 .ok_or_else(|| err!(FailedFunction, "{:?} does not exist in the input dataframe"))?
                 .as_form::<Vec<TV>>()?
                 .iter()
-                .map(|v| partition_indexes.get(v).cloned().unwrap_or(partition_keys.len()))
+                .map(|v| {
+                    (partition_indexes.get(v))
+                        .cloned()
+                        .unwrap_or(partition_keys.len())
+                })
                 .collect();
 
             // where to collect partitioned data
-            let mut partitioned_data = std::vec::from_elem(DataFrame::new(), num_partitions);
+            let mut partitioned_data = std::vec::from_elem(DataFrame::new(), true_partitions);
 
             // iteratively partition each column
             keep_columns.iter().try_for_each(|column_name| {
                 // retrieve a Column from the dataframe
-                let column = data.get(&column_name)
-                    .ok_or_else(|| err!(FailedFunction, "{:?} does not exist in the input dataframe"))?;
+                let column = data.get(&column_name).ok_or_else(|| {
+                    err!(FailedFunction, "{:?} does not exist in the input dataframe")
+                })?;
 
-                // partition the column by the partition ids, 
+                // partition the column by the partition ids,
                 //    then insert each subset into the respective partitioned dataframe
-                column.partition(&partition_ids, num_partitions)
+                column
+                    .partition(&partition_ids, true_partitions)
                     .into_iter()
                     .zip(partitioned_data.iter_mut())
                     .for_each(|(subset, df)| {
                         df.insert(column_name.clone(), subset);
                     });
-                
+
                 Fallible::Ok(())
             })?;
+
+            if !null_partition {
+                partitioned_data.pop();
+            }
 
             Ok(partitioned_data)
         }),
         SymmetricDistance::default(),
         SymmetricDistance::default(),
-        StabilityMap::new_from_constant(1)
+        StabilityMap::new_from_constant(1),
     ))
 }

--- a/rust/src/transformations/partition/mod.rs
+++ b/rust/src/transformations/partition/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     domains::ProductDomain,
     error::Fallible,
     metrics::{SymmetricDistance, ProductMetric, IntDistance},
-    traits::Hashable,
+    traits::{Hashable, ExactIntCast},
 };
 
 use super::{DataFrame, DataFrameDomain};
@@ -52,6 +52,7 @@ pub fn make_partition_by<TK: Hashable, TV: Hashable>(
         .collect();
     let true_partitions = partition_keys.len() + 1;
     let output_partitions = partition_keys.len() + if null_partition { 1 } else { 0 };
+    let d_output_partitions = IntDistance::exact_int_cast(output_partitions)?;
 
     Ok(Transformation::new(
         DataFrameDomain::new_all(),
@@ -104,6 +105,6 @@ pub fn make_partition_by<TK: Hashable, TV: Hashable>(
         }),
         SymmetricDistance::default(),
         ProductMetric::new(SymmetricDistance::default()),
-        StabilityMap::new(move |d_in: &IntDistance| (*d_in, *d_in.min(&output_partitions))),
+        StabilityMap::new(move |d_in: &IntDistance| (*d_in, *d_in.min(&d_output_partitions))),
     ))
 }

--- a/rust/src/transformations/partition/mod.rs
+++ b/rust/src/transformations/partition/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     core::{Function, StabilityMap, Transformation},
     domains::ProductDomain,
     error::Fallible,
-    metrics::SymmetricDistance,
+    metrics::{SymmetricDistance, ProductMetric},
     traits::Hashable,
 };
 
@@ -41,7 +41,7 @@ pub fn make_partition_by<TK: Hashable, TV: Hashable>(
         DataFrameDomain<TK>,
         ProductDomain<DataFrameDomain<TK>>,
         SymmetricDistance,
-        SymmetricDistance,
+        ProductMetric<SymmetricDistance>,
     >,
 > {
     let partition_indexes: HashMap<TV, usize> = partition_keys
@@ -103,7 +103,7 @@ pub fn make_partition_by<TK: Hashable, TV: Hashable>(
             Ok(partitioned_data)
         }),
         SymmetricDistance::default(),
-        SymmetricDistance::default(),
+        ProductMetric::new(SymmetricDistance::default()),
         StabilityMap::new_from_constant(1),
     ))
 }

--- a/rust/src/transformations/partition/mod.rs
+++ b/rust/src/transformations/partition/mod.rs
@@ -16,15 +16,15 @@ mod ffi;
 /// Make a Transformation that partitions a dataframe by a given column.
 /// 
 /// # Arguments
-/// * `ident_name` - Name of column to split dataframe by.
-/// * `partition_keys` - Unique values in the `ident_name` column.
-/// * `keep_columns` - Columns to keep in the partioned dataframes.
+/// * `identifier_column` - Name of column to split dataframe by.
+/// * `partition_keys` - Unique values in the `identifier_column` column.
+/// * `keep_columns` - Columns to keep in the partitioned dataframes.
 /// 
 /// # Generics
 /// * `TK` - Type of column names.
 /// * `TV` - Type of values in the identifier column.
 pub fn make_partition_by<TK: Hashable, TV: Hashable>(
-    ident_name: TK,
+    identifier_column: TK,
     partition_keys: Vec<TV>,
     keep_columns: Vec<TK>
 ) -> Fallible<Transformation<DataFrameDomain<TK>, ProductDomain<DataFrameDomain<TK>>, SymmetricDistance, SymmetricDistance>> {
@@ -35,7 +35,7 @@ pub fn make_partition_by<TK: Hashable, TV: Hashable>(
         ProductDomain::new((0..num_partitions).map(|_| DataFrameDomain::new_all()).collect()),
         Function::new_fallible(move |data: &DataFrame<TK>| {
             // the partition to move each row into
-            let partition_ids: Vec<usize> = data.get(&ident_name)
+            let partition_ids: Vec<usize> = data.get(&identifier_column)
                 .ok_or_else(|| err!(FailedFunction, "{:?} does not exist in the input dataframe"))?
                 .as_form::<Vec<TV>>()?
                 .iter()

--- a/rust/src/transformations/partition/mod.rs
+++ b/rust/src/transformations/partition/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     core::{Function, StabilityMap, Transformation},
     domains::ProductDomain,
     error::Fallible,
-    metrics::{SymmetricDistance, ProductMetric},
+    metrics::{SymmetricDistance, ProductMetric, IntDistance},
     traits::Hashable,
 };
 
@@ -104,6 +104,6 @@ pub fn make_partition_by<TK: Hashable, TV: Hashable>(
         }),
         SymmetricDistance::default(),
         ProductMetric::new(SymmetricDistance::default()),
-        StabilityMap::new_from_constant(1),
+        StabilityMap::new(move |d_in: &IntDistance| (vec![*d_in; output_partitions], *d_in.min(&output_partitions))),
     ))
 }

--- a/rust/src/transformations/partition/mod.rs
+++ b/rust/src/transformations/partition/mod.rs
@@ -1,0 +1,72 @@
+use std::collections::HashMap;
+
+use opendp_derive::bootstrap;
+
+use crate::{traits::Hashable, error::Fallible, core::{Transformation, Function, StabilityMap}, domains::ProductDomain, metrics::SymmetricDistance};
+
+use super::{DataFrameDomain, DataFrame};
+
+#[cfg(feature="ffi")]
+mod ffi;
+
+#[bootstrap(
+    features("contrib"),
+    generics(TK(default = "String"), TV(example = "$get_first(partition_keys)"))
+)]
+/// Make a Transformation that partitions a dataframe by a given column.
+/// 
+/// # Arguments
+/// * `ident_name` - Name of column to split dataframe by.
+/// * `partition_keys` - Unique values in the `ident_name` column.
+/// * `keep_columns` - Columns to keep in the partioned dataframes.
+/// 
+/// # Generics
+/// * `TK` - Type of column names.
+/// * `TV` - Type of values in the identifier column.
+pub fn make_partition_by<TK: Hashable, TV: Hashable>(
+    ident_name: TK,
+    partition_keys: Vec<TV>,
+    keep_columns: Vec<TK>
+) -> Fallible<Transformation<DataFrameDomain<TK>, ProductDomain<DataFrameDomain<TK>>, SymmetricDistance, SymmetricDistance>> {
+    let partition_indexes: HashMap<TV, usize> = partition_keys.iter().cloned().enumerate().map(|(i, k)| (k, i)).collect();
+    let num_partitions = partition_keys.len() + 1;
+    Ok(Transformation::new(
+        DataFrameDomain::new_all(),
+        ProductDomain::new((0..num_partitions).map(|_| DataFrameDomain::new_all()).collect()),
+        Function::new_fallible(move |data: &DataFrame<TK>| {
+            // the partition to move each row into
+            let partition_ids: Vec<usize> = data.get(&ident_name)
+                .ok_or_else(|| err!(FailedFunction, "{:?} does not exist in the input dataframe"))?
+                .as_form::<Vec<TV>>()?
+                .iter()
+                .map(|v| partition_indexes.get(v).cloned().unwrap_or(partition_keys.len()))
+                .collect();
+
+            // where to collect partitioned data
+            let mut partitioned_data = std::vec::from_elem(DataFrame::new(), num_partitions);
+
+            // iteratively partition each column
+            keep_columns.iter().try_for_each(|column_name| {
+                // retrieve a Column from the dataframe
+                let column = data.get(&column_name)
+                    .ok_or_else(|| err!(FailedFunction, "{:?} does not exist in the input dataframe"))?;
+
+                // partition the column by the partition ids, 
+                //    then insert each subset into the respective partitioned dataframe
+                column.partition(&partition_ids, num_partitions)
+                    .into_iter()
+                    .zip(partitioned_data.iter_mut())
+                    .for_each(|(subset, df)| {
+                        df.insert(column_name.clone(), subset);
+                    });
+                
+                Fallible::Ok(())
+            })?;
+
+            Ok(partitioned_data)
+        }),
+        SymmetricDistance::default(),
+        SymmetricDistance::default(),
+        StabilityMap::new_from_constant(1)
+    ))
+}

--- a/rust/src/transformations/partition/mod.rs
+++ b/rust/src/transformations/partition/mod.rs
@@ -104,6 +104,6 @@ pub fn make_partition_by<TK: Hashable, TV: Hashable>(
         }),
         SymmetricDistance::default(),
         ProductMetric::new(SymmetricDistance::default()),
-        StabilityMap::new(move |d_in: &IntDistance| (vec![*d_in; output_partitions], *d_in.min(&output_partitions))),
+        StabilityMap::new(move |d_in: &IntDistance| (*d_in, *d_in.min(&output_partitions))),
     ))
 }


### PR DESCRIPTION
Closes #494

Adds a `ProductDomain<D>`:
```rust
struct ProductDomain<D: Domain> {
    inner_domains: Vec<D>
}
```
Members of this domain are members of the cartesian product of all the domains in inner_domains.

...and adds a `ProductMetric<M>`:
```rust
struct ProductMetric<M> {
    inner_metric: M
}
impl<M: Metric> Metric for ProductMetric<M> {
    type Distance = (M::Distance, IntDistance);
}
```

The distance type is `(k, r)`. `k` is an upper bound on the distance between any corresponding partition in neighboring datasets, and `r` is an upper bound on the number of partitions an individual may influence. The distance k is in terms of the inner metric, which can be any metric (either dataset distances or sensitivities), and could even be `ProductMetric<ProductMetric<M>>`, which expresses distances as `((M::Distance, IntDistance), IntDistance)` for nested partitionings.


It is also valid, and potentially tighter, to let k be a vector of distances. In this case, the distance type is a tuple `(k_i, r)`, where `k_i` is the upper bound on distance in partition i, and r is an upper bound on the number of partitions an individual could influence.
This PR implements the looser, simpler approach, as we don't have a clear use-case for separating distances. This can be changed internally later without affecting external APIs.

These domains and metrics are used in two new combinators, `make_parallel_transformation` and `make_parallel_composition`, that apply a list of transformations or a list of measurements to each partition.

The stability map of  `make_parallel_transformation` is `d_out = (k', r)`, where `k' = max_i t_i.map(k)` and the privacy map of  `make_parallel_composition` is `d_out = r * max_i m_i.map(k)`.
(t_i is the ith transformation, m_i is the ith measurement, and .map is the stability or privacy map)

This PR also adds a `make_partition_by` constructor to partition data. Since we don't currently have user IDs, there is no way to limit the number of partitions a user may contribute to. Thus the stability map does not bound the partition limit, letting it just be `d_in.min(output_partitions)`. This can be tightened in a later PR.

Thanks for all the help on this Shurong/Wanrong!