### PR TITLE
`make_chain_tm` postprocess combinator

### DIFF
--- a/python/src/opendp/combinators.py
+++ b/python/src/opendp/combinators.py
@@ -8,6 +8,7 @@ from opendp.core import *
 __all__ = [
     "make_chain_mt",
     "make_chain_tt",
+    "make_chain_tm",
     "make_basic_composition",
     "make_population_amplification",
     "make_fix_delta",
@@ -75,6 +76,37 @@ def make_chain_tt(
     function.restype = FfiResult
     
     return c_to_py(unwrap(function(transformation1, transformation0), Transformation))
+
+
+def make_chain_tm(
+    transformation: Transformation,
+    measurement: Measurement
+) -> Measurement:
+    """Construct the functional composition (`transformation` ○ `measurement`). Returns a Measurement. Used for postprocessing.
+    
+    :param transformation: outer postprocessor
+    :type transformation: Transformation
+    :param measurement: inner privatizer
+    :type measurement: Measurement
+    :return: Measurement representing the chained computation.
+    :rtype: Measurement
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    assert_features("contrib")
+    
+    # No type arguments to standardize.
+    # Convert arguments to c types.
+    transformation = py_to_c(transformation, c_type=Transformation)
+    measurement = py_to_c(measurement, c_type=Measurement)
+    
+    # Call library function.
+    function = lib.opendp_combinators__make_chain_tm
+    function.argtypes = [Transformation, Measurement]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(transformation, measurement), Measurement))
 
 
 def make_basic_composition(

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -86,6 +86,13 @@ class Measurement(ctypes.POINTER(AnyMeasurement)):
                 return False
             raise
 
+    def __rshift__(self, other: "Transformation"):
+        if isinstance(other, Transformation):
+            from opendp.comb import make_chain_tm
+            return make_chain_tm(other, self)
+
+        raise ValueError(f"rshift expected a postprocessing transformation, got {other}")
+
     @property
     def input_distance_type(self):
         """Retrieve the distance type of the input metric.

--- a/python/test/test_comb.py
+++ b/python/test/test_comb.py
@@ -86,8 +86,7 @@ def test_cast_zcdp_approxdp():
     smd_gaussian = make_zCDP_to_approxDP(base_gaussian)
 
     print(smd_gaussian.map(1.).epsilon(1e-6))
-
-
+    
 if __name__ == "__main__":
     test_cast_zcdp_approxdp()
 

--- a/rust/src/combinators/bootstrap.json
+++ b/rust/src/combinators/bootstrap.json
@@ -39,6 +39,26 @@
             "description": "Transformation representing the chained computation."
         }
     },
+    "make_chain_tm": {
+        "description": "Construct the functional composition (`transformation` ○ `measurement`). Returns a Measurement. Used for postprocessing.",
+        "features": ["contrib"],
+        "args": [
+            {
+                "name": "transformation",
+                "c_type": "const AnyTransformation *",
+                "description": "outer postprocessor"
+            },
+            {
+                "name": "measurement",
+                "c_type": "const AnyMeasurement *",
+                "description": "inner privatizer"
+            }
+        ],
+        "ret": {
+            "c_type": "FfiResult<AnyMeasurement *>",
+            "description": "Measurement representing the chained computation."
+        }
+    },
     "make_basic_composition": {
         "description": "Construct the DP composition [`measurement0`, `measurement1`, ...]. Returns a Measurement.",
         "args": [

--- a/rust/src/combinators/chain/ffi.rs
+++ b/rust/src/combinators/chain/ffi.rs
@@ -1,4 +1,4 @@
-use crate::combinators::{make_chain_mt, make_chain_tt};
+use crate::combinators::{make_chain_mt, make_chain_tt, make_chain_tm};
 use crate::core::FfiResult;
 
 use crate::ffi::any::{AnyMeasurement, AnyTransformation};
@@ -15,6 +15,13 @@ pub extern "C" fn opendp_combinators__make_chain_tt(transformation1: *const AnyT
     let transformation0 = try_as_ref!(transformation0);
     let transformation1 = try_as_ref!(transformation1);
     make_chain_tt(transformation1, transformation0).into()
+}
+
+#[no_mangle]
+pub extern "C" fn opendp_comb__make_chain_tm(transformation1: *const AnyTransformation, measurement0: *const AnyMeasurement) -> FfiResult<*mut AnyMeasurement> {
+    let transformation1 = try_as_ref!(transformation1);
+    let measurement0 = try_as_ref!(measurement0);
+    make_chain_tm(transformation1, measurement0).into()
 }
 
 #[cfg(test)]
@@ -58,6 +65,23 @@ mod tests {
         let d_out = core::opendp_core__transformation_map(&chain, d_in);
         let d_out: u32 = Fallible::from(d_out)?.downcast()?;
         assert_eq!(d_out, 999);
+        Ok(())
+    }
+
+    #[test]
+    fn test_make_chain_tm_ffi() -> Fallible<()> {
+        let measurement0 = util::into_raw(make_test_measurement::<i32>().into_any());
+        let transformation1 = util::into_raw(make_test_transformation::<i32>().into_any());
+        let chain = Result::from(opendp_comb__make_chain_tm(transformation1, measurement0))?;
+        let arg = AnyObject::new_raw(999);
+        let res = core::opendp_core__measurement_invoke(&chain, arg);
+        let res: i32 = Fallible::from(res)?.downcast()?;
+        assert_eq!(res, 999);
+
+        let d_in = AnyObject::new_raw(999u32);
+        let d_out = core::opendp_core__measurement_map(&chain, d_in);
+        let d_out: f64 = Fallible::from(d_out)?.downcast()?;
+        assert_eq!(d_out, 1000.);
         Ok(())
     }
 }

--- a/rust/src/metrics/mod.rs
+++ b/rust/src/metrics/mod.rs
@@ -160,3 +160,16 @@ impl Debug for DiscreteDistance {
 impl Metric for DiscreteDistance {
     type Distance = IntDistance;
 }
+
+
+#[derive(Clone, Default, PartialEq)]
+pub struct AgnosticMetric;
+
+impl Debug for AgnosticMetric {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "AgnosticMetric()")
+    }
+}
+impl Metric for AgnosticMetric {
+    type Distance = ();
+}

--- a/rust/src/transformations/mod.rs
+++ b/rust/src/transformations/mod.rs
@@ -14,6 +14,11 @@ pub mod dataframe;
 pub use crate::transformations::dataframe::*;
 
 #[cfg(feature="contrib")]
+pub(crate) mod postprocess;
+#[cfg(feature="contrib")]
+pub(crate) use postprocess::*;
+
+#[cfg(feature="contrib")]
 pub mod manipulation;
 #[cfg(feature="contrib")]
 pub use crate::transformations::manipulation::*;

--- a/rust/src/transformations/postprocess/mod.rs
+++ b/rust/src/transformations/postprocess/mod.rs
@@ -1,0 +1,45 @@
+use crate::{
+    core::{Domain, Function, StabilityMap, Transformation},
+    error::Fallible,
+    metrics::AgnosticMetric,
+};
+
+// A crate-private function to build a postprocessor
+#[allow(dead_code)]
+pub(crate) fn make_postprocess<DI, DO>(
+    input_domain: DI,
+    output_domain: DO,
+    function: Function<DI, DO>,
+) -> Fallible<Transformation<DI, DO, AgnosticMetric, AgnosticMetric>>
+where
+    DI: Domain,
+    DO: Domain,
+{
+    Ok(Transformation::new(
+        input_domain,
+        output_domain,
+        function,
+        AgnosticMetric::default(),
+        AgnosticMetric::default(),
+        StabilityMap::new(|_| ()),
+    ))
+}
+
+
+#[cfg(test)]
+mod test {
+    use crate::domains::{AllDomain, VectorDomain};
+
+    use super::*;
+    #[test]
+    fn test_postprocess() -> Fallible<()> {
+        let post = make_postprocess(
+            AllDomain::new(), 
+            VectorDomain::new_all(), 
+            Function::new(|_| vec![12]))?;
+
+        assert_eq!(post.invoke(&"A".to_string())?, vec![12]);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Closes #498

- Adds `make_chain_tm` and the `Shr` trait impls for `>>` chaining
    - the chainer completely ignores the null metrics and null map in the postprocessor
- Adds `make_postprocess` that takes an input domain, output domain, and function
    - the constructor builds a transformation with null metrics and a null map