### PR TITLE
add `make_base_discrete_gaussian` constructor

### DIFF
--- a/docs/source/user/measurement-constructors.rst
+++ b/docs/source/user/measurement-constructors.rst
@@ -39,6 +39,14 @@ You can choose whether to construct scalar or vector-valued versions by setting 
      - ``VectorDomain<AllDomain<T>>``
      - ``L1Distance<T>``
      - ``MaxDivergence<T>``
+   * - :func:`opendp.meas.make_base_discrete_gaussian`
+     - ``AllDomain<T>``
+     - ``AbsoluteDistance<T>``
+     - ``MaxDivergence<T>``
+   * - :func:`opendp.meas.make_base_discrete_gaussian`
+     - ``VectorDomain<AllDomain<T>>``
+     - ``L1Distance<T>``
+     - ``MaxDivergence<T>``
    * - :func:`opendp.meas.make_base_gaussian`
      - ``AllDomain<T>``
      - ``AbsoluteDistance<T>``

--- a/python/src/opendp/meas.py
+++ b/python/src/opendp/meas.py
@@ -12,6 +12,7 @@ __all__ = [
     "make_base_discrete_laplace_linear",
     "make_base_discrete_laplace_cks20",
     "make_base_discrete_laplace",
+    "make_base_discrete_gaussian",
     "make_randomized_response_bool",
     "make_randomized_response",
     "make_base_ptr"
@@ -296,6 +297,46 @@ def make_base_discrete_laplace(
     function.restype = FfiResult
     
     return c_to_py(unwrap(function(scale, D, QO), Measurement))
+
+
+def make_base_discrete_gaussian(
+    scale,
+    D: RuntimeTypeDescriptor = "AllDomain<int>",
+    MO: RuntimeTypeDescriptor = "ZeroConcentratedDivergence<Q>"
+) -> Measurement:
+    """Make a Measurement that adds noise from the discrete_gaussian(`scale`) distribution to the input.
+    Adjust D to noise vector-valued data.
+    
+    :param scale: noise scale parameter for the distribution. `scale` == standard_deviation.
+    :param D: Domain of the data type to be privatized. Valid values are VectorDomain<AllDomain<T>> or AllDomain<T>
+    :type D: :ref:`RuntimeTypeDescriptor`
+    :param MO: Output measure. The only valid measure is ZeroConcentratedDivergence<Q>, but Q can be f32 or f64
+    :type MO: :ref:`RuntimeTypeDescriptor`
+    :return: A base_discrete_gaussian step.
+    :rtype: Measurement
+    :raises AssertionError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type-argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    assert_features("contrib")
+    
+    # Standardize type arguments.
+    D = RuntimeType.parse(type_name=D)
+    MO = RuntimeType.parse(type_name=MO, generics=["Q"])
+    Q = get_atom_or_infer(MO, scale)
+    MO = MO.substitute(Q=Q)
+    
+    # Convert arguments to c types.
+    scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=Q)
+    D = py_to_c(D, c_type=ctypes.c_char_p)
+    MO = py_to_c(MO, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    function = lib.opendp_meas__make_base_discrete_gaussian
+    function.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
+    function.restype = FfiResult
+    
+    return c_to_py(unwrap(function(scale, D, MO), Measurement))
 
 
 def make_randomized_response_bool(

--- a/python/test/test_meas.py
+++ b/python/test/test_meas.py
@@ -158,8 +158,8 @@ def test_base_vector_discrete_gaussian():
     from opendp.meas import make_base_discrete_gaussian
     meas = make_base_discrete_gaussian(scale=2., D="VectorDomain<AllDomain<i32>>")
     print("vector base_dl:", meas([100, 10, 12]))
-    assert meas.check(1, 0.125)
-    assert not meas.check(1, 0.124)
+    assert meas.check(1., 0.125)
+    assert not meas.check(1., 0.124)
 
 def test_make_count_by_ptr():
     from opendp.trans import make_count_by

--- a/python/test/test_meas.py
+++ b/python/test/test_meas.py
@@ -145,7 +145,21 @@ def test_base_vector_discrete_laplace():
     print("vector base_dl:", meas([100, 10, 12]))
     assert meas.check(1, 0.5)
     assert not meas.check(1, 0.49999)
-    
+
+def test_base_discrete_gaussian():
+    from opendp.meas import make_base_discrete_gaussian
+    meas = make_base_discrete_gaussian(scale=2.)
+    print("base_discrete_gaussian:", meas(100))
+    assert meas.check(1., 0.5)
+    assert meas.check(1., 0.125)
+
+
+def test_base_vector_discrete_gaussian():
+    from opendp.meas import make_base_discrete_gaussian
+    meas = make_base_discrete_gaussian(scale=2., D="VectorDomain<AllDomain<i32>>")
+    print("vector base_dl:", meas([100, 10, 12]))
+    assert meas.check(1, 0.125)
+    assert not meas.check(1, 0.124)
 
 def test_make_count_by_ptr():
     from opendp.trans import make_count_by

--- a/rust/src/meas/bootstrap.json
+++ b/rust/src/meas/bootstrap.json
@@ -267,6 +267,45 @@
             "c_type": "FfiResult<AnyMeasurement *>"
         }
     },
+    "make_base_discrete_gaussian": {
+        "description": "Make a Measurement that adds noise from the discrete_gaussian(`scale`) distribution to the input.\nAdjust D to noise vector-valued data.",
+        "features": ["contrib"],
+        "args": [
+            {
+                "name": "scale",
+                "c_type": "void *",
+                "rust_type": "Q",
+                "description": "noise scale parameter for the distribution. `scale` == standard_deviation."
+            },
+            {
+                "name": "D",
+                "default": "AllDomain<int>",
+                "description": "Domain of the data type to be privatized. Valid values are VectorDomain<AllDomain<T>> or AllDomain<T>",
+                "is_type": true
+            },
+            {
+                "name": "MO",
+                "default": "ZeroConcentratedDivergence<Q>",
+                "generics": ["Q"],
+                "description": "Output measure. The only valid measure is ZeroConcentratedDivergence<Q>, but Q can be f32 or f64",
+                "is_type": true
+            }
+        ],
+        "derived_types": [
+            {
+                "name": "Q",
+                "rust_type": {
+                    "function": "get_atom_or_infer",
+                    "params": [
+                        "MO", "scale"
+                    ]
+                }
+            }
+        ],
+        "ret": {
+            "c_type": "FfiResult<AnyMeasurement *>"
+        }
+    },
     "make_randomized_response_bool": {
         "description": "Make a Measurement that implements randomized response on a boolean value.",
         "features": ["contrib"],

--- a/rust/src/meas/discrete_gaussian/ffi.rs
+++ b/rust/src/meas/discrete_gaussian/ffi.rs
@@ -1,0 +1,85 @@
+use std::convert::TryFrom;
+use std::os::raw::{c_char, c_void};
+
+use az::SaturatingCast;
+use rug::{Rational, Integer};
+
+use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
+use crate::domains::{AllDomain, VectorDomain};
+use crate::ffi::any::AnyMeasurement;
+use crate::ffi::util::Type;
+use crate::meas::{make_base_discrete_gaussian, DiscreteGaussianDomain};
+
+#[no_mangle]
+pub extern "C" fn opendp_meas__make_base_discrete_gaussian(
+    scale: *const c_void,
+    D: *const c_char,
+    Q: *const c_char,
+) -> FfiResult<*mut AnyMeasurement> {
+    fn monomorphize<T>(scale: *const c_void, D: Type, Q: Type) -> FfiResult<*mut AnyMeasurement>
+    where
+        T: crate::traits::Integer,
+        rug::Integer: From<T> + az::SaturatingCast<T>,
+    {
+        fn monomorphize2<D, Q>(scale: *const c_void) -> FfiResult<*mut AnyMeasurement>
+        where
+            D: 'static + DiscreteGaussianDomain<Q>,
+            D::Atom: crate::traits::Integer,
+            Q: crate::traits::Float,
+            Rational: TryFrom<Q>,
+            Integer: From<D::Atom> + SaturatingCast<D::Atom>,
+        {
+            let scale = try_as_ref!(scale as *const Q).clone();
+            make_base_discrete_gaussian::<D, Q>(scale).into_any()
+        }
+        dispatch!(monomorphize2, [
+            (D, [VectorDomain<AllDomain<T>>, AllDomain<T>]),
+            (Q, @floats)
+        ], (scale))
+    }
+    let D = try_!(Type::try_from(D));
+    let Q = try_!(Type::try_from(Q));
+    let T = try_!(D.get_atom());
+    dispatch!(monomorphize, [
+        (T, @integers)
+    ], (scale, D, Q))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core;
+    use crate::error::Fallible;
+    use crate::ffi::any::{AnyObject, Downcast};
+    use crate::ffi::util;
+    use crate::ffi::util::ToCharP;
+
+    use super::*;
+
+    #[test]
+    fn test_make_base_simple_geometric() -> Fallible<()> {
+        let measurement = Result::from(opendp_meas__make_base_discrete_gaussian(
+            util::into_raw(0.0) as *const c_void,
+            "AllDomain<i32>".to_char_p(),
+            "f64".to_char_p(),
+        ))?;
+        let arg = AnyObject::new_raw(99);
+        let res = core::opendp_core__measurement_invoke(&measurement, arg);
+        let res: i32 = Fallible::from(res)?.downcast()?;
+        assert_eq!(res, 99);
+        Ok(())
+    }
+
+    #[test]
+    fn test_make_base_simple_constant_time_geometric() -> Fallible<()> {
+        let measurement = Result::from(opendp_meas__make_base_discrete_gaussian(
+            util::into_raw(0.0) as *const c_void,
+            "AllDomain<i32>".to_char_p(),
+            "f64".to_char_p(),
+        ))?;
+        let arg = AnyObject::new_raw(99);
+        let res = core::opendp_core__measurement_invoke(&measurement, arg);
+        let res: i32 = Fallible::from(res)?.downcast()?;
+        assert_eq!(res, 99);
+        Ok(())
+    }
+}

--- a/rust/src/meas/discrete_gaussian/ffi.rs
+++ b/rust/src/meas/discrete_gaussian/ffi.rs
@@ -67,7 +67,7 @@ mod tests {
         let measurement = Result::from(opendp_meas__make_base_discrete_gaussian(
             util::into_raw(0.0) as *const c_void,
             "AllDomain<i32>".to_char_p(),
-            "f64".to_char_p(),
+            "ZeroConcentratedDivergence<f64>".to_char_p(),
         ))?;
         let arg = AnyObject::new_raw(99);
         let res = core::opendp_core__measurement_invoke(&measurement, arg);

--- a/rust/src/meas/discrete_gaussian/ffi.rs
+++ b/rust/src/meas/discrete_gaussian/ffi.rs
@@ -56,21 +56,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_make_base_simple_geometric() -> Fallible<()> {
-        let measurement = Result::from(opendp_meas__make_base_discrete_gaussian(
-            util::into_raw(0.0) as *const c_void,
-            "AllDomain<i32>".to_char_p(),
-            "f64".to_char_p(),
-        ))?;
-        let arg = AnyObject::new_raw(99);
-        let res = core::opendp_core__measurement_invoke(&measurement, arg);
-        let res: i32 = Fallible::from(res)?.downcast()?;
-        assert_eq!(res, 99);
-        Ok(())
-    }
-
-    #[test]
-    fn test_make_base_simple_constant_time_geometric() -> Fallible<()> {
+    fn test_make_base_discrete_gaussian() -> Fallible<()> {
         let measurement = Result::from(opendp_meas__make_base_discrete_gaussian(
             util::into_raw(0.0) as *const c_void,
             "AllDomain<i32>".to_char_p(),

--- a/rust/src/meas/discrete_gaussian/mod.rs
+++ b/rust/src/meas/discrete_gaussian/mod.rs
@@ -1,0 +1,98 @@
+use std::convert::TryFrom;
+
+use az::{SaturatingAs, SaturatingCast};
+use num::traits::Pow;
+use rug::{Integer, Rational};
+
+use crate::{
+    core::{Measurement, PrivacyMap, SensitivityMetric},
+    domains::{AllDomain, VectorDomain},
+    error::Fallible,
+    measures::ZeroConcentratedDivergence,
+    metrics::{AbsoluteDistance, L2Distance},
+    traits::{samplers::sample_discrete_gaussian, CheckNull},
+};
+
+#[cfg(feature="ffi")]
+mod ffi;
+
+use super::MappableDomain;
+
+pub trait DiscreteGaussianDomain<Q>: MappableDomain + Default {
+    type InputMetric: SensitivityMetric<Distance = Q> + Default;
+}
+impl<T: CheckNull, Q> DiscreteGaussianDomain<Q> for AllDomain<T> {
+    type InputMetric = AbsoluteDistance<Q>;
+}
+impl<T: CheckNull, Q> DiscreteGaussianDomain<Q> for VectorDomain<AllDomain<T>> {
+    type InputMetric = L2Distance<Q>;
+}
+
+pub fn make_base_discrete_gaussian<D, Q>(
+    scale: Q,
+) -> Fallible<Measurement<D, D, D::InputMetric, ZeroConcentratedDivergence<Q>>>
+where
+    D: DiscreteGaussianDomain<Q>,
+    D::Atom: crate::traits::Integer,
+    Q: crate::traits::Float,
+    Rational: TryFrom<Q>,
+    Integer: From<D::Atom> + SaturatingCast<D::Atom>,
+{
+    if scale.is_sign_negative() {
+        return fallible!(MakeMeasurement, "scale must not be negative");
+    }
+    let _2 = Q::exact_int_cast(2)?;
+    let scale_rational =
+        Rational::try_from(scale).map_err(|_| err!(MakeMeasurement, "scale must be finite"))?;
+
+    Ok(Measurement::new(
+        D::default(),
+        D::default(),
+        D::new_map_function(move |arg: &D::Atom| {
+            // exact conversion to bignum int
+            let arg = Integer::from(arg.clone());
+            // exact sampling of noise
+            let noise = sample_discrete_gaussian(scale_rational.clone())?;
+            // exact addition, and then postprocess by casting to D::Atom
+            //     clamp to the data type's bounds if out of range
+            Ok((arg + noise).saturating_as())
+        }),
+        D::InputMetric::default(),
+        ZeroConcentratedDivergence::default(),
+        PrivacyMap::new_fallible(move |d_in: &Q| {
+            if d_in.is_sign_negative() {
+                return fallible!(InvalidDistance, "sensitivity must be non-negative");
+            }
+            if scale.is_zero() {
+                return Ok(Q::infinity());
+            }
+
+            // (d_in / scale)^2 / 2
+            (d_in.inf_div(&scale)?).inf_pow(&_2)?.inf_div(&_2)
+        }),
+    ))
+}
+
+
+
+pub fn make_base_discrete_gaussian_rug<D>(
+    scale: Rational,
+) -> Fallible<Measurement<D, D, D::InputMetric, ZeroConcentratedDivergence<Rational>>>
+where
+    D: DiscreteGaussianDomain<Rational, Atom = Integer>,
+{
+    if scale <= 0 {
+        return fallible!(MakeMeasurement, "scale must be positive");
+    }
+
+    Ok(Measurement::new(
+        D::default(),
+        D::default(),
+        D::new_map_function(enclose!(scale, move |arg: &Integer| {
+            sample_discrete_gaussian(scale.clone()).map(|n| arg + n)
+        })),
+        D::InputMetric::default(),
+        ZeroConcentratedDivergence::default(),
+        PrivacyMap::new(move |d_in: &Rational| (d_in.clone() / &scale).pow(2) / 2),
+    ))
+}

--- a/rust/src/meas/discrete_laplace/mod.rs
+++ b/rust/src/meas/discrete_laplace/mod.rs
@@ -23,7 +23,7 @@ mod linear;
 pub use linear::*;
 
 pub trait MappableDomain: Domain {
-    type Atom;
+    type Atom: Clone;
     fn map_over(
         arg: &Self::Carrier,
         func: &impl Fn(&Self::Atom) -> Fallible<Self::Atom>,
@@ -36,7 +36,7 @@ pub trait MappableDomain: Domain {
     }
 }
 
-impl<T: CheckNull> MappableDomain for AllDomain<T> {
+impl<T: Clone + CheckNull> MappableDomain for AllDomain<T> {
     type Atom = T;
     fn map_over(
         arg: &Self::Carrier,
@@ -58,10 +58,10 @@ impl<D: MappableDomain> MappableDomain for VectorDomain<D> {
 pub trait DiscreteLaplaceDomain: MappableDomain + Default {
     type InputMetric: SensitivityMetric<Distance = Self::Atom> + Default;
 }
-impl<T: CheckNull> DiscreteLaplaceDomain for AllDomain<T> {
+impl<T: Clone + CheckNull> DiscreteLaplaceDomain for AllDomain<T> {
     type InputMetric = AbsoluteDistance<T>;
 }
-impl<T: CheckNull> DiscreteLaplaceDomain for VectorDomain<AllDomain<T>> {
+impl<T: Clone + CheckNull> DiscreteLaplaceDomain for VectorDomain<AllDomain<T>> {
     type InputMetric = L1Distance<T>;
 }
 

--- a/rust/src/meas/mod.rs
+++ b/rust/src/meas/mod.rs
@@ -2,14 +2,14 @@
 //!
 //! The different [`Measurement`] implementations in this module are accessed by calling the appropriate constructor function.
 //! Constructors are named in the form `make_xxx()`, where `xxx` indicates what the resulting `Measurement` does.
-#[cfg(all(feature="floating-point", feature="contrib"))]
+#[cfg(all(feature="use-mpfr", feature="contrib"))]
 pub mod discrete_gaussian;
-#[cfg(all(feature="floating-point", feature="contrib"))]
+#[cfg(all(feature="use-mpfr", feature="contrib"))]
 pub use crate::meas::discrete_gaussian::*;
 
-#[cfg(all(feature="floating-point", feature="contrib"))]
+#[cfg(feature="contrib")]
 pub mod discrete_laplace;
-#[cfg(all(feature="floating-point", feature="contrib"))]
+#[cfg(feature="contrib")]
 pub use crate::meas::discrete_laplace::*;
 
 #[cfg(all(feature="floating-point", feature="contrib"))]

--- a/rust/src/meas/mod.rs
+++ b/rust/src/meas/mod.rs
@@ -2,6 +2,10 @@
 //!
 //! The different [`Measurement`] implementations in this module are accessed by calling the appropriate constructor function.
 //! Constructors are named in the form `make_xxx()`, where `xxx` indicates what the resulting `Measurement` does.
+#[cfg(all(feature="floating-point", feature="contrib"))]
+pub mod discrete_gaussian;
+#[cfg(all(feature="floating-point", feature="contrib"))]
+pub use crate::meas::discrete_gaussian::*;
 
 #[cfg(all(feature="floating-point", feature="contrib"))]
 pub mod discrete_laplace;


### PR DESCRIPTION
Closes #186 

This extends the discrete laplace PR to provide a constructor for the discrete gaussian mechanism.
In this implementation, I simply use the Rational type from the rug wrapper for GMP to avoid fixed-point complications.