### PR TITLE
switch to rejection sampling in `SampleDiscreteLaplaceLinear`

### DIFF
--- a/rust/src/traits/samplers/cks20/mod.rs
+++ b/rust/src/traits/samplers/cks20/mod.rs
@@ -48,7 +48,7 @@ use crate::error::Fallible;
 
 use num::{Zero, One};
 
-use super::{SampleUniformIntBelow, SampleRademacher};
+use super::{SampleUniformIntBelow, SampleStandardBernoulli};
 
 
 // sample from a Bernoulli(exp(-x)) distribution
@@ -114,10 +114,15 @@ pub fn sample_discrete_laplace(scale: Rational) -> Fallible<Integer> {
     }
     let inv_scale = scale.recip();
     loop {
-        let sign = Integer::sample_standard_rademacher()?;
+
+        let sign = bool::sample_standard_bernoulli()?;
         let magnitude = sample_geometric_exp_fast(inv_scale.clone())?;
-        if !(sign.is_one() && magnitude.is_zero()) {
-            return Ok(sign * magnitude);
+        if sign || !magnitude.is_zero() {
+            return Ok(if sign {
+                -magnitude
+            } else {
+                magnitude
+            })
         }
     }
 }

--- a/rust/src/traits/samplers/cks20/mod.rs
+++ b/rust/src/traits/samplers/cks20/mod.rs
@@ -113,15 +113,15 @@ pub fn sample_discrete_laplace(scale: Rational) -> Fallible<Integer> {
         return Ok(0.into())
     }
     let inv_scale = scale.recip();
+    
     loop {
-
-        let sign = bool::sample_standard_bernoulli()?;
+        let positive = bool::sample_standard_bernoulli()?;
         let magnitude = sample_geometric_exp_fast(inv_scale.clone())?;
-        if sign || !magnitude.is_zero() {
-            return Ok(if sign {
-                -magnitude
-            } else {
+        if positive || !magnitude.is_zero() {
+            return Ok(if positive {
                 magnitude
+            } else {
+                -magnitude
             })
         }
     }

--- a/rust/src/traits/samplers/vulnerable_fallbacks/mod.rs
+++ b/rust/src/traits/samplers/vulnerable_fallbacks/mod.rs
@@ -1,5 +1,5 @@
 use crate::error::Fallible;
-use crate::traits::samplers::{SampleRademacher, SampleStandardBernoulli, SampleUniform};
+use crate::traits::samplers::{SampleStandardBernoulli, SampleUniform};
 use statrs::function::erf;
 
 pub trait SampleDiscreteLaplaceZ2k: Sized {
@@ -8,7 +8,7 @@ pub trait SampleDiscreteLaplaceZ2k: Sized {
 
 impl<T> SampleDiscreteLaplaceZ2k for T
 where
-    T: num::Float + SampleUniform + SampleRademacher,
+    T: num::Float + SampleUniform,
 {
     fn sample_discrete_laplace_Z2k(shift: Self, scale: Self, _k: i32) -> Fallible<Self> {
         let u = loop {


### PR DESCRIPTION
- removes the SampleRademacher trait
- adjusts `SampleDiscreteLaplaceLinear` to avoid some small float inaccuracy at the origin

Before, the algorithm would conservatively work out the probability of not adding noise, and then return the origin without adding noise if a bernoulli sample was positive with this probability. While all probabilities are calculated conservatively, the multiplicative difference between the probability of returning the origin or a neighbor is not exactly the same as the multiplicative differences between other shifts.

The simple solution is to sample geometric noise that starts at zero, and to reject the sample if the sign is negative and offset is zero.


