### PR TITLE
common proof boilerplate

### DIFF
--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Compile LaTeX documents
         uses: xu-cheng/latex-action@v2

--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -47,7 +47,14 @@ jobs:
         uses: xu-cheng/latex-action@v2
         with:
           root_file: ${{ needs.pre-latex-build.outputs.tex }}
+          # so that cwd is relative to .tex file, not repository root
           work_in_root_file_dir: true
+          # so that shell commands run in .tex files
+          latexmk_shell_escape: true
+          # git is necessary for some shell commands to run
+          extra_system_packages: git
+          # give permissions for git commands to run
+          pre_compile: git config --global --add safe.directory /github/workspace
 
       - name: Pull request artifacts
         uses: opendp/pull-request-artifacts@main

--- a/rust/src/mod.sty
+++ b/rust/src/mod.sty
@@ -1,0 +1,90 @@
+\documentclass{article}
+\usepackage[top=1in, right=1in, left=1in, bottom=1.5in]{geometry}
+
+\usepackage{amsmath,amsthm,amsfonts,amssymb,amscd}
+\usepackage{listings}
+\usepackage{hyperref}
+\usepackage{xcolor}
+\usepackage{xr}
+
+\usepackage{enumerate} 
+\usepackage{physics}
+\usepackage{fancyhdr}
+\usepackage{hyperref}
+\usepackage{graphicx}
+\usepackage{tcolorbox}
+
+% hyperref
+\hypersetup{
+  colorlinks=true,
+  linkcolor=blue,
+  linkbordercolor={0 0 1}
+}
+
+% minted (pseudocode)
+\definecolor{codegreen}{rgb}{0,0.6,0}
+\definecolor{codegray}{rgb}{0.5,0.5,0.5}
+\definecolor{codepurple}{rgb}{0.58,0,0.82}
+\definecolor{backcolour}{rgb}{0.95,0.95,0.92}
+
+\lstdefinestyle{mystyle}{
+    backgroundcolor=\color{backcolour},   
+    commentstyle=\color{codegreen},
+    keywordstyle=\color{magenta},
+    numberstyle=\tiny\color{codegray},
+    stringstyle=\color{codepurple},
+    basicstyle=\ttfamily\footnotesize,
+    breakatwhitespace=false,         
+    breaklines=true,                 
+    captionpos=b,                    
+    keepspaces=true,                 
+    numbers=left,                    
+    numbersep=5pt,                  
+    showspaces=false,                
+    showstringspaces=false,
+    showtabs=false,                  
+    tabsize=2
+}
+
+\lstset{style=mystyle}
+
+
+% common commands
+\newtheorem{theorem}{Theorem}[section]
+\newtheorem{lemma}[theorem]{Lemma}
+\theoremstyle{definition}
+\newtheorem{definition}[theorem]{Definition}
+\newtheorem{warning}{Warning}
+\providecommand{\cardinality}[1]{\lvert#1\rvert} 
+\providecommand{\abs}[1]{\lvert#1\rvert}
+
+\newtheorem{corollary}{Corollary}
+\newtheorem{proposition}{Proposition}
+
+\theoremstyle{definition}
+\newtheorem{remark}{Remark}
+\newtheorem{definition}{Definition}
+\newtheorem{observation}{Observation}
+\newtheorem{note}{Note}
+\newtheorem{hope}{Hope}
+\newtheorem{warning}{Warning}
+
+\newcommand{\vicki}[1]{{ {\color{olive}{(vicki)~#1}}}}
+\newcommand{\hanwen}[1]{{ {\color{purple}{(hanwen)~#1}}}}
+\newcommand{\zach}[1]{{ {\color{red}{(zach)~#1}}}}
+
+\newcommand{\MultiSet}{\mathrm{MultiSet}}
+\newcommand{\len}{\mathrm{len}}
+\newcommand{\din}{\texttt{d\_in}}
+\newcommand{\dout}{\texttt{d\_out}}
+\newcommand{\T}{\texttt{T} }
+\newcommand{\F}{\texttt{F} }
+\newcommand{\Relation}{\texttt{Relation}}
+\newcommand{\X}{\mathcal{X}}
+\newcommand{\Y}{\mathcal{Y}}
+\newcommand{\True}{\texttt{True}}
+\newcommand{\False}{\texttt{False}}
+\newcommand{\clamp}{\texttt{clamp}}
+\newcommand{\function}{\texttt{function}}
+\newcommand{\float}{\texttt{float }}
+\newcommand{\questionc}[1]{\textcolor{red}{\textbf{Question:} #1}}

--- a/rust/src/mod.sty
+++ b/rust/src/mod.sty
@@ -14,6 +14,7 @@
 \usepackage{tcolorbox}
 \usepackage{catchfile}
 \usepackage{pdftexcmds}
+\usepackage[T1]{fontenc}
 
 % hyperref
 \hypersetup{
@@ -31,22 +32,27 @@
 \makeatletter
 \ifnum\pdf@shellescape=1
    % "private" command that builds a link to a blob
-  \newcommand{\linkOpendpBlob}[3]{
-    \href{https://github.com/opendp/opendp/blob/#1/#2#3}{#3 at commit #1}}
+  \newcommand{\linkOpendpBlob}[3]{%
+    \href{https://github.com/opendp/opendp/blob/#1/#2#3}{\path{#3} at commit #1}}
 
   % latex macro expansion has a separate phase for \input evaluation
   %     we instead immediately evaluate a command to write a temp file to ./out containing the current directory
-  \immediate\write18{mkdir -p out && git rev-parse --show-prefix > out/cwd.txt}
+  \immediate\write18{[ ! -f out/cwd.txt ] && (mkdir -p out && git rev-parse --show-prefix > out/cwd.txt)}
   %     ...and then retrieve the current working directory by loading the temp file
   \CatchFileDef\GitWorkingDir{out/cwd.txt}{\endlinechar=-1}
+
+  % command for building the (up to date) or (outdated) status
+  \newcommand{\fileStatus}[2]{%
+    \setbox0=\hbox{\input|"git --no-pager log -n1 --pretty='\@percentchar H' #1 | grep -E '^#2.*'"\unskip}\ifdim\wd0=0pt
+        (outdated\footnote{See new changes with \texttt{git diff #2..\input|"git --no-pager log -n1 --pretty='\@percentchar h' #1" \GitWorkingDir#1}})\else
+        (up to date)\fi
+  }
 
   \newcommand{\asOfCommit}[2]{%
       % permalink the target
       \linkOpendpBlob{#2}{\GitWorkingDir}{#1}
       % conditionally add (outdated) or (up to date) depending on matching commit hash
-      \setbox0=\hbox{\input|"git --no-pager log -n1 --pretty='\@percentchar H' #1 | grep -E '^#2.*'"\unskip}\ifdim\wd0=0pt
-        (outdated\footnote{See new changes with \texttt{git diff #2..\input|"git --no-pager log -n1 --pretty='\@percentchar h' #1}\texttt{\GitWorkingDir#1}})\else
-        (up to date)\fi
+      \fileStatus{#1}{#2}%
   }
 \else
   % simplified command if shell-escape not enabled

--- a/rust/src/mod.sty
+++ b/rust/src/mod.sty
@@ -1,4 +1,3 @@
-\documentclass{article}
 \usepackage[top=1in, right=1in, left=1in, bottom=1.5in]{geometry}
 
 \usepackage{amsmath,amsthm,amsfonts,amssymb,amscd}
@@ -13,6 +12,7 @@
 \usepackage{hyperref}
 \usepackage{graphicx}
 \usepackage{tcolorbox}
+\usepackage{catchfile}
 
 % hyperref
 \hypersetup{
@@ -20,6 +20,24 @@
   linkcolor=blue,
   linkbordercolor={0 0 1}
 }
+
+\usepackage{tcolorbox}
+\newtcolorbox{contrib_box}{colback=red!5!white,colframe=red!75!black}
+\newcommand{\contrib}{{\begin{contrib_box}This proof is in ``contrib'' and is still in the vetting process.\end{contrib_box}}} 
+
+% asOfCommit macro to version a code dependency
+\newcommand{\linkOpendpBlob}[3]{\href{https://github.com/opendp/opendp/blob/#1/#2#3}{#3 at commit #1}}
+\immediate\write18{git rev-parse --show-prefix > out/cwd.txt}
+\CatchFileDef\GitWorkingDir{cwd.txt}{\endlinechar=-1}
+\makeatletter
+\newcommand{\asOfCommit}[2]{%
+    \linkOpendpBlob{#2}{\GitWorkingDir}{#1}
+    \setbox0=\hbox{\input|"grep '^#2.*' <<< $(git --no-pager log -n1 --pretty='\@percentchar H' #1)"\unskip}\ifdim\wd0=0pt
+      (outdated\footnote{See new changes with \texttt{git diff #2..\input|"git --no-pager log -n1 --pretty='\@percentchar h' #1}\texttt{\GitWorkingDir#1}})\else
+      (up to date)\fi
+}
+
+\newcommand{\vettingPR}[1]{\href{https://github.com/opendp/opendp/pull/#1}{Pull Request \##1}}
 
 % minted (pseudocode)
 \definecolor{codegreen}{rgb}{0,0.6,0}
@@ -50,24 +68,16 @@
 
 
 % common commands
+\theoremstyle{definition}
 \newtheorem{theorem}{Theorem}[section]
 \newtheorem{lemma}[theorem]{Lemma}
-\theoremstyle{definition}
 \newtheorem{definition}[theorem]{Definition}
 \newtheorem{warning}{Warning}
-\providecommand{\cardinality}[1]{\lvert#1\rvert} 
-\providecommand{\abs}[1]{\lvert#1\rvert}
-
 \newtheorem{corollary}{Corollary}
 \newtheorem{proposition}{Proposition}
-
-\theoremstyle{definition}
 \newtheorem{remark}{Remark}
-\newtheorem{definition}{Definition}
 \newtheorem{observation}{Observation}
 \newtheorem{note}{Note}
-\newtheorem{hope}{Hope}
-\newtheorem{warning}{Warning}
 
 \newcommand{\vicki}[1]{{ {\color{olive}{(vicki)~#1}}}}
 \newcommand{\hanwen}[1]{{ {\color{purple}{(hanwen)~#1}}}}

--- a/rust/src/mod.sty
+++ b/rust/src/mod.sty
@@ -13,6 +13,7 @@
 \usepackage{graphicx}
 \usepackage{tcolorbox}
 \usepackage{catchfile}
+\usepackage{pdftexcmds}
 
 % hyperref
 \hypersetup{
@@ -21,22 +22,39 @@
   linkbordercolor={0 0 1}
 }
 
+% \contrib macro to indicate inclusion in "contrib"
 \usepackage{tcolorbox}
 \newtcolorbox{contrib_box}{colback=red!5!white,colframe=red!75!black}
-\newcommand{\contrib}{{\begin{contrib_box}This proof is in ``contrib'' and is still in the vetting process.\end{contrib_box}}} 
+\newcommand{\contrib}{{\begin{contrib_box}This proof resides in \textbf{``contrib''} because it has not completed the vetting process.\end{contrib_box}}} 
 
 % asOfCommit macro to version a code dependency
-\newcommand{\linkOpendpBlob}[3]{\href{https://github.com/opendp/opendp/blob/#1/#2#3}{#3 at commit #1}}
-\immediate\write18{git rev-parse --show-prefix > out/cwd.txt}
-\CatchFileDef\GitWorkingDir{cwd.txt}{\endlinechar=-1}
 \makeatletter
-\newcommand{\asOfCommit}[2]{%
-    \linkOpendpBlob{#2}{\GitWorkingDir}{#1}
-    \setbox0=\hbox{\input|"grep '^#2.*' <<< $(git --no-pager log -n1 --pretty='\@percentchar H' #1)"\unskip}\ifdim\wd0=0pt
-      (outdated\footnote{See new changes with \texttt{git diff #2..\input|"git --no-pager log -n1 --pretty='\@percentchar h' #1}\texttt{\GitWorkingDir#1}})\else
-      (up to date)\fi
-}
+\ifnum\pdf@shellescape=1
+   % "private" command that builds a link to a blob
+  \newcommand{\linkOpendpBlob}[3]{
+    \href{https://github.com/opendp/opendp/blob/#1/#2#3}{#3 at commit #1}}
 
+  % latex macro expansion has a separate phase for \input evaluation
+  %     we instead immediately evaluate a command to write a temp file to ./out containing the current directory
+  \immediate\write18{mkdir -p out && git rev-parse --show-prefix > out/cwd.txt}
+  %     ...and then retrieve the current working directory by loading the temp file
+  \CatchFileDef\GitWorkingDir{out/cwd.txt}{\endlinechar=-1}
+
+  \newcommand{\asOfCommit}[2]{%
+      % permalink the target
+      \linkOpendpBlob{#2}{\GitWorkingDir}{#1}
+      % conditionally add (outdated) or (up to date) depending on matching commit hash
+      \setbox0=\hbox{\input|"git --no-pager log -n1 --pretty='\@percentchar H' #1 | grep -E '^#2.*'"\unskip}\ifdim\wd0=0pt
+        (outdated\footnote{See new changes with \texttt{git diff #2..\input|"git --no-pager log -n1 --pretty='\@percentchar h' #1}\texttt{\GitWorkingDir#1}})\else
+        (up to date)\fi
+  }
+\else
+  % simplified command if shell-escape not enabled
+  \newcommand{\asOfCommit}[2]{#1 at commit #2 (unknown status\footnote{Shell-escape is not enabled. Enable \texttt{--shell-escape} to check if this proof is up-to-date with the code.})}
+\fi
+\makeatother
+
+% \vettingPR macro to link a PR
 \newcommand{\vettingPR}[1]{\href{https://github.com/opendp/opendp/pull/#1}{Pull Request \##1}}
 
 % minted (pseudocode)
@@ -89,7 +107,7 @@
 \newcommand{\dout}{\texttt{d\_out}}
 \newcommand{\T}{\texttt{T} }
 \newcommand{\F}{\texttt{F} }
-\newcommand{\Relation}{\texttt{Relation}}
+\newcommand{\Map}{\texttt{Map}}
 \newcommand{\X}{\mathcal{X}}
 \newcommand{\Y}{\mathcal{Y}}
 \newcommand{\True}{\texttt{True}}

--- a/rust/src/mod.sty
+++ b/rust/src/mod.sty
@@ -37,14 +37,14 @@
 
   % latex macro expansion has a separate phase for \input evaluation
   %     we instead immediately evaluate a command to write a temp file to ./out containing the current directory
-  \immediate\write18{[ ! -f out/cwd.txt ] && (mkdir -p out && git rev-parse --show-prefix > out/cwd.txt)}
+  \immediate\write18{[ ! -f out/cwd.txt ] && (mkdir -p out && git rev-parse --show-prefix | sed "s|_|\@backslashchar\@backslashchar\@backslashchar_|g" > out/cwd.txt)}
   %     ...and then retrieve the current working directory by loading the temp file
   \CatchFileDef\GitWorkingDir{out/cwd.txt}{\endlinechar=-1}
 
   % command for building the (up to date) or (outdated) status
   \newcommand{\fileStatus}[2]{%
-    \setbox0=\hbox{\input|"git --no-pager log -n1 --pretty='\@percentchar H' #1 | grep -E '^#2.*'"\unskip}\ifdim\wd0=0pt
-        (outdated\footnote{See new changes with \texttt{git diff #2..\input|"git --no-pager log -n1 --pretty='\@percentchar h' #1" \GitWorkingDir#1}})\else
+  \setbox0=\hbox{\input|"git --no-pager log -n1 --pretty='\@percentchar H' #1 | grep -E '^#2.*'"\unskip}\ifdim\wd0=0pt
+        (outdated\footnote{See new changes with \texttt{git diff #2..\input|"git --no-pager log -n1 --pretty='\@percentchar h' #1" \GitWorkingDir\path{#1}}})\else
         (up to date)\fi
   }
 


### PR DESCRIPTION
Closes #510 

Adds three macros:
- `\contrib` adds a red box indicating that the proof is part of contrib
- `\asOfCommit{relative_filepath}{commit_hash}` 
    - expands to a github permalink to the file at the specified commit hash
    - checks if relative_filepath has been updated since commit_hash. 
        - if relative_filepath has not been updated, the hash is equivalent, and it emits an `(up to date)` status 
        - if relative_filepath has been updated, its git hash won't match, and the macro expands to `(outdated\footnote{*message with git command to see diffs since proof was written})`
        - if shell commands are not enabled (like in overleaf), emits a simpler `(unknown\footnote{*instructions on how to enable})` status
    - since the proofs are rendered in CI, proof documents automatically indicate if they are out-of-date when the code is changed
- `\vettingPR{PR_number}` expands to a github permalink to the PR where the vetting process happened

### Examples

`fn make_clamp` (when out of date)
1. [how the macros are used](https://github.com/opendp/opendp/pull/512/files#diff-8e89f8702a5f5626f62d036471550235abea3967ed1c28018ddf34df365ebab5R12-R21)
2. [how the macros render](https://raw.githubusercontent.com/opendp/artifacts/main/PR/512/trans/clamp/make_clamp.pdf)

cks20 samplers (when up to date)
1. [how the macros are used](https://github.com/opendp/opendp/pull/519/files#diff-2f5597abc2afc2e04c6fa42cbbf86acd7ce048564713563276e1e272c149b701R10-R17)
2. [how the macros render](https://github.com/opendp/artifacts/blob/main/PR/519/samplers/cks20/sample_bernoulli_exp.pdf?raw=true)