### PR TITLE
Port of make_count proof

### DIFF
--- a/rust/src/lib.sty
+++ b/rust/src/lib.sty
@@ -152,23 +152,21 @@
 \newcommand{\questionc}[1]{\textcolor{red}{\textbf{Question:} #1}}
 
 
-\newcommand{\transformationTheorem}[2]{%
-  \begin{theorem}
-    For every setting of the input parameters #1 to #2 such that the given preconditions
-    hold, #2 raises an exception (at compile time or run time) or returns a valid transformation. A valid transformation has the following properties:
-    \begin{enumerate}
-        \item \textup{(Appropriate output domain).} 
-        For every element $v$ in \texttt{input\_domain}, $\function(v)$ is in \texttt{output\_domain} or raises a data-independent runtime exception.
-        
-        \item \textup{(Domain-metric compatibility).} 
-        The domain \texttt{input\_domain} matches one of the possible domains listed in the definition of \texttt{input\_metric}, 
-        and likewise \texttt{output\_domain} matches one of the possible domains listed in the definition of \texttt{output\_metric}.
-        
-        \item \textup{(Stability guarantee).} 
-        For every pair of elements $u, v$ in \texttt{input\_domain} and for every pair $(\din, \dout)$, 
-        where \din\ has the associated type for \texttt{input\_metric} and \dout\ has the associated type for \\ \texttt{output\_metric}, 
-        if $u, v$ are \din-close under \texttt{input\_metric} and $\texttt{stability\_map}(\din) \leq \dout$, 
-        then $\function(u), \function(v)$ are $\dout$-close under \texttt{output\_metric}.
-    \end{enumerate}
-  \end{theorem}
+\newcommand{\validTransformation}[2]{%
+  For every setting of the input parameters #1 to #2 such that the given preconditions
+  hold, #2 raises an exception (at compile time or run time) or returns a valid transformation. A valid transformation has the following properties:
+  \begin{enumerate}
+      \item \textup{(Appropriate output domain).} 
+      For every element $v$ in \texttt{input\_domain}, $\function(v)$ is in \texttt{output\_domain} or raises a data-independent runtime exception.
+      
+      \item \textup{(Domain-metric compatibility).} 
+      The domain \texttt{input\_domain} matches one of the possible domains listed in the definition of \texttt{input\_metric}, 
+      and likewise \texttt{output\_domain} matches one of the possible domains listed in the definition of \texttt{output\_metric}.
+      
+      \item \textup{(Stability guarantee).} 
+      For every pair of elements $u, v$ in \texttt{input\_domain} and for every pair $(\din, \dout)$, 
+      where \din\ has the associated type for \texttt{input\_metric} and \dout\ has the associated type for \\ \texttt{output\_metric}, 
+      if $u, v$ are \din-close under \texttt{input\_metric} and $\texttt{stability\_map}(\din) \leq \dout$, 
+      then $\function(u), \function(v)$ are $\dout$-close under \texttt{output\_metric}.
+  \end{enumerate}
 }

--- a/rust/src/lib.sty
+++ b/rust/src/lib.sty
@@ -119,7 +119,6 @@
 
 \lstset{style=mystyle}
 
-
 % common commands
 \theoremstyle{definition}
 \newtheorem{theorem}{Theorem}[section]

--- a/rust/src/lib.sty
+++ b/rust/src/lib.sty
@@ -150,3 +150,25 @@
 \newcommand{\function}{\texttt{function}}
 \newcommand{\float}{\texttt{float }}
 \newcommand{\questionc}[1]{\textcolor{red}{\textbf{Question:} #1}}
+
+
+\newcommand{\transformationTheorem}[2]{%
+  \begin{theorem}
+    For every setting of the input parameters #1 to #2 such that the given preconditions
+    hold, #2 raises an exception (at compile time or run time) or returns a valid transformation. A valid transformation has the following properties:
+    \begin{enumerate}
+        \item \textup{(Appropriate output domain).} 
+        For every element $v$ in \texttt{input\_domain}, $\function(v)$ is in \texttt{output\_domain} or raises a data-independent runtime exception.
+        
+        \item \textup{(Domain-metric compatibility).} 
+        The domain \texttt{input\_domain} matches one of the possible domains listed in the definition of \texttt{input\_metric}, 
+        and likewise \texttt{output\_domain} matches one of the possible domains listed in the definition of \texttt{output\_metric}.
+        
+        \item \textup{(Stability guarantee).} 
+        For every pair of elements $u, v$ in \texttt{input\_domain} and for every pair $(\din, \dout)$, 
+        where \din\ has the associated type for \texttt{input\_metric} and \dout\ has the associated type for \texttt{output\_metric}, 
+        if $u, v$ are \din-close under \texttt{input\_metric} and $\texttt{stability\_map}(\din) \leq \dout$, 
+        then $\function(u), \function(v)$ are $\dout$-close under \texttt{output\_metric}.
+    \end{enumerate}
+  \end{theorem}
+}

--- a/rust/src/lib.sty
+++ b/rust/src/lib.sty
@@ -166,7 +166,7 @@
         
         \item \textup{(Stability guarantee).} 
         For every pair of elements $u, v$ in \texttt{input\_domain} and for every pair $(\din, \dout)$, 
-        where \din\ has the associated type for \texttt{input\_metric} and \dout\ has the associated type for \texttt{output\_metric}, 
+        where \din\ has the associated type for \texttt{input\_metric} and \dout\ has the associated type for \\ \texttt{output\_metric}, 
         if $u, v$ are \din-close under \texttt{input\_metric} and $\texttt{stability\_map}(\din) \leq \dout$, 
         then $\function(u), \function(v)$ are $\dout$-close under \texttt{output\_metric}.
     \end{enumerate}

--- a/rust/src/transformations/count/make_count.tex
+++ b/rust/src/transformations/count/make_count.tex
@@ -17,16 +17,12 @@ The length of the vector, of type \texttt{usize}, is exactly casted to a user sp
 If the length is too large to be represented exactly by \texttt{TO}, 
 the cast saturates at the maximum value of type \texttt{TO}.
 
-\section{Vetting history}
+\subsection*{Vetting History}
 \begin{itemize}
     \item \vettingPR{513}
 \end{itemize}
 
-\section{Pseudocode}
-
-\label{sec:pseudocode}
-
-\subsection*{Preconditions}
+\section{Preconditions}
 \begin{itemize}
 
     \item \texttt{TIA} (atomic input type) is a type with trait \rustdoc{traits}{trait}{Primitive}. \texttt{Primitive} implies \texttt{TIA} has the trait bound:
@@ -48,7 +44,7 @@ the cast saturates at the maximum value of type \texttt{TO}.
     \end{itemize}
 \end{itemize}
 
-\subsection*{Implementation}
+\section{Pseudocode}
 \begin{lstlisting}[language = Python, escapechar=|]
 def make_count():
     input_domain = VectorDomain(AllDomain(TIA))
@@ -71,12 +67,10 @@ def make_count():
         input_metric, output_metric, stability_map)
 \end{lstlisting}
 
-\subsection*{Postcondition}
-\texttt{make\_count} raises an exception or returns a valid \texttt{Transformation}.
+\section{Postcondition}
+\validTransformation{\texttt{(TIA, TO)}}{\texttt{make\_count}}
 
-\section{Proof}
-
-\transformationTheorem{\texttt{(TIA, TO)}}{\texttt{make\_count}}
+\subsection*{Proofs}
 
 \begin{proof} \textbf{(Part 1 -- appropriate output domain).}
     The \texttt{output\_domain} is \texttt{AllDomain(TO)}, so it is sufficient to show that \texttt{function} always returns non-null values of type \texttt{TO}.

--- a/rust/src/transformations/count/make_count.tex
+++ b/rust/src/transformations/count/make_count.tex
@@ -1,5 +1,5 @@
 \documentclass{article}
-\input{../../mod.sty}
+\input{../../lib.sty}
 
 \title{\texttt{fn make\_count}}
 \author{S\'ilvia Casacuberta, Grace Tian, Connor Wagaman}

--- a/rust/src/transformations/count/make_count.tex
+++ b/rust/src/transformations/count/make_count.tex
@@ -1,0 +1,223 @@
+\input{../../mod.sty}
+
+\newcommand{\permalink}[2]{This proof is based on the code in \url{#1} from \changeformat{#2}.}
+
+\def\changeformat#1{\xchangeformat#1\relax}
+\def\xchangeformat#1/#2/#3\relax{%
+#1 %
+\ifcase#2 \or
+January\or February\or March\or April\or May\or June\or July\or
+August\or September\or October\or November\or December\fi
+\ #3}
+
+\setlength{\parindent}{0.0in}
+\setlength{\parskip}{0.05in}
+\title{Privacy Proofs for OpenDP: MakeCount}
+\author{S\'ilvia Casacuberta, Grace Tian, Connor Wagaman -- wagaman@college.harvard.edu}
+\date{Version as of \today~(UTC)}
+
+\begin{document}
+
+\maketitle
+
+\tableofcontents
+
+\subsection{Versions of definitions documents}
+\label{sec:versioned-docs}
+
+When looking for definitions for terms that appear in this document, the following versions of the definitions documents should be used.
+
+\begin{itemize}
+    \item \textbf{Pseudocode definitions document:} This proof file uses the version of the pseudocode definitions document available as of September 23, 2021, which can be found at \href{https://github.com/opendp/whitepapers/blob/pseudocode-defns/pseudocode-defns/pseudocode_defns.pdf}{this link} (archived \href{https://web.archive.org/web/20210906201546/https://raw.githubusercontent.com/opendp/whitepapers/pseudocode-defns/pseudocode-defns/pseudocode_defns.pdf}{here}).
+    
+    \item \textbf{Proof definitions document:} This file uses the version of the proof definitions document available as of September 23, 2021, which can be found at \href{https://github.com/opendp/whitepapers/blob/proof-defns/proof-defns/proof_defns.pdf}{this link} (archived \href{https://web.archive.org/web/20210906201056/https://raw.githubusercontent.com/opendp/whitepapers/proof-defns/proof-defns/proof_defns.pdf}{here}). 
+\end{itemize}
+
+\section{MakeCount}
+
+\subsection{Implementation of MakeCount in Rust}
+\label{sub:rust-implementation}
+
+
+
+\permalink{https://github.com/opendp/opendp/blob/c3b5c3bd9fc50c556362b628f08c5fddea069b4d/rust/opendp/src/trans/count.rs\#L14-L27}{12/07/2021} (It is from \href{https://github.com/opendp/opendp/pull/173}{this pull request}.)
+The Rust code can also be seen below. 
+
+\subsection{Implementation of MakeCount in Python-style pseudocode, with preconditions}
+\label{sec:python-pseudocode}
+
+We now use Python-style pseudocode to present a representation of the Rust function.
+
+\emph{The use of \texttt{code}-style parameters in the preconditions section below (for example, \texttt{input\_domain}) means that this information should be passed along to the \texttt{Transformation} constructor.}
+
+Here, we use preconditions to check for traits, and to specify the domains and metrics.
+
+\textbf{Preconditions}
+\begin{itemize}
+    \item \textbf{User-specified types:} The \texttt{make\_count} function takes two inputs: a generic input type \texttt{TIA} for the \texttt{Transformation} (meaning that the input vector to \texttt{Transformation} is of type \texttt{Vec(TIA)}), and a generic output type \texttt{TO} for the \texttt{Transformation}.
+    
+    \begin{itemize}
+        \item \texttt{TO} has traits \texttt{One}, \texttt{ExactIntCast(usize)}, and \texttt{DistanceConstant(IntDistance)}.
+        
+        Examples: \texttt{u32} and \texttt{i64} have these traits because they have (1) a multiplicative identity element, (2) every value of type \texttt{usize} that falls within the minimum and maximum consecutive integers of type \texttt{u32} has an exact representation of type \texttt{u32} (the same applies for \texttt{i64}), and (3) multiplication and division apply to types \texttt{u32} and \texttt{i64}, values of type \texttt{u32} and \texttt{i64} have a partial ordering, and every value of type \texttt{usize} can be \texttt{inf\_cast}ed to a value of type \texttt{u32} (meaning that the \texttt{inf\_cast} will either result in an error or will result in a value of type \texttt{u32} that is at least as large as the input value of type \texttt{usize}; this also applies for \texttt{i64}).
+        
+        Currently, the \texttt{ExactIntCast} and \texttt{DistanceConstant} traits are implemented for casting between all numeric types, with the exception of \texttt{InfCast} not being implemented for going to or from \texttt{usize} and \texttt{isize} (and thus \texttt{DistanceConstant} not being implemented). Therefore, \texttt{usize} and \texttt{isize} do not have these traits. 
+        
+        \item \texttt{IntDistance} has trait \texttt{InfCast(TO)}. (Note that this bullet point is not needed in this proof, but it is needed in the code so a hint can be constructed; otherwise a binary search would be needed to construct the hint.)
+        
+        Examples: Recall that \texttt{IntDistance} is an alias for the type \texttt{u32}. \texttt{IntDistance} has trait \texttt{InfCast(u32)}, because any unsigned 32-bit integer can be converted to an unsigned 32-bit integer (type \texttt{IntDistance}) that is at least as big. On the other hand, \texttt{IntDistance} has trait \texttt{InfCast(u64)}, because every value of type \texttt{u64} can either be \texttt{infcast}ed to a value of type \texttt{u32} that is at least as large, or an error can be returned.
+        
+        On the other hand, \texttt{IntDistance} does not have trait \texttt{InfCast(usize)} because \texttt{InfCast} is not implemented for going to or from \texttt{usize}.
+        
+    \end{itemize}
+    
+    % \question{Salil had recommended that examples of types that do and don't work be provided. Should these examples and anti-examples be provided? Should I just say, ``\texttt{u32} has these traits'', or should I provide the description for why it has these traits (as I did above)?}
+\end{itemize}
+
+\textbf{Postconditions:} a valid \texttt{Transformation} must be returned (i.e. if a \texttt{Transformation} cannot be returned successfully, a runtime error should be returned)
+
+\begin{lstlisting}[language = Python, escapechar=|]
+def MakeCount(TIA, TO):
+
+    input_domain = VectorDomain(AllDomain(TIA))
+    output_domain = AllDomain(TO) |\label{line:output-domain}|
+    input_metric = SymmetricDistance()
+    output_metric = AbsoluteDistance(TO)
+    
+    # give the Transformation the following properties
+    max_value = get_max_consecutive_int(TO) 
+    def function(data: Vec[TIA]) -> TO:|\label{line:TO-output}|
+        try:|\label{code:try-catch}|
+            return exact_int_cast(len(data), TO)
+        except FailedCast:
+            return max_value |\label{line:except-return}|
+    def stability_relation(din:IntDistance, dout:TO) -> bool: |\label{line:din-dout-type}|
+        return 1 * inf_cast(din,TO) <= dout |\label{line:stability-relation}|
+
+    # now, return the Transformation
+    return Transformation(input_domain,output_domain,function,input_metric,output_metric,stability_relation)
+
+\end{lstlisting}
+
+\section{Proofs for the pseudocode}
+
+\begin{theorem}
+\label{thrm:domain-and-stability}
+    For every setting of the input parameters \texttt{TIA}, \texttt{TO} for \texttt{MakeCount} such that the given preconditions hold, \texttt{MakeCount} raises an exception (at compile time or run time) or returns a valid \texttt{Transformation} with the following properties:
+    \begin{enumerate}
+        \item \textup{(Appropriate output domain).} For every vector \texttt{v} in the \texttt{input\_domain}, \texttt{function(v)} is in the \texttt{output\_domain}.
+        
+        \item \textup{(Domain-metric compatibility).} The domain \texttt{input\_domain} matches one of the possible domains listed in the definition of \texttt{input\_metric}, and likewise \texttt{output\_domain} matches one of the possible domains listed in the definition of \texttt{output\_metric}.
+        
+        \item \textup{(Stability guarantee).} For every input \texttt{u}, \texttt{v} drawn from the \texttt{input\_domain} and for every pair $(\din, \dout)$, where $\din$ is of type \texttt{u32} and $\dout$ is of type \texttt{TO} (see line \ref{line:din-dout-type} of the pseudocode), if \texttt{u}, \texttt{v} are $\din$-close under the \texttt{input\_metric} and $\texttt{stability\_relation(din, dout) = True}$, then \texttt{function(u)}, \texttt{function(v)} are $\dout$-close under the \texttt{output\_metric}.
+    \end{enumerate}
+\end{theorem}
+
+\begin{proof} \textbf{(Part 1 -- appropriate output domain).}
+In line \ref{line:output-domain} of the pseudocode, we have \texttt{output\_domain = AllDomain(TO)}, so every value of type \texttt{TO} is in the \texttt{output\_domain}, and in line \ref{line:TO-output} of the Python-style pseudocode, we see that the \texttt{function} is always guaranteed to return a value of type \texttt{TO}. Because Rust employs ``type checking'',
+% copied from clamp:
+if the Rust code compiles correctly, then the type correctness follows from the definition of the type signature enforced by Rust. Otherwise, the code raises an exception for incorrect input type.
+% end "copied from clamp"
+Therefore, since our output domain is any value of type \texttt{TO}, we see that $\function$ has the appropriate output domain \texttt{output\_domain}.
+
+\end{proof}
+
+\begin{proof} \textbf{(Part 2 -- domain-metric compatibility).}
+
+The \texttt{input\_domain} is \texttt{VectorDomain(AllDomain(TIA))}. Because our \texttt{input\_metric} of \texttt{SymmetricDistance} is compatible with any domain of the form \\\texttt{VectorDomain(inner\_domain)}, and because \texttt{VectorDomain(AllDomain(TIA))} is of this form, we see that it is compatible with our \texttt{input\_metric} of \texttt{SymmetricDistance}.
+
+The \texttt{output\_domain} is \texttt{AllDomain(TO)}. Because our \texttt{output\_metric} of \texttt{AbsoluteDistance(TO)} is compatible with any domain of the form \texttt{AllDomain(T)} where \texttt{T} has the trait \texttt{Sub(Output=T)}, and because \texttt{AllDomain(TO)} is of this form and \texttt{TO} has the necessary trait, we see that it is compatible with our \texttt{output\_metric} of \texttt{AbsoluteDistance(TO)}.
+\end{proof}
+
+Before proceeding with proving the third part of theorem \ref{thrm:domain-and-stability}, we provide a lemma.
+
+% \begin{definition}[Symmetric distance]
+% \label{defn:symm-dist}
+% Let $u,v$ be vectors of elements drawn from domain $\mathcal{X}$. Define $h_v(\ell)$ as the multiplicity of element $\ell$ in vector $v$. For example, if $v$ contains five instances of the number ``21'', then $h_v(21) = 5$.
+
+% A definition of the symmetric distance between $u$ and $v$, then, is $$d_{\text{Sym}}(u,v) = \sum_{z\in \mathcal{X}} |h_u(z) - h_v(z)|.$$
+% \end{definition}
+
+\begin{lemma}
+\label{lemma:len-sum-equiv}
+For vector $v$ with each element $\ell\in v$ drawn from domain $\mathcal{X}$, $\texttt{len(v)} = \sum_{z\in\mathcal{X}} h_v(z)$.
+\end{lemma}
+
+\begin{proof}
+
+Every element $\ell \in v$ is drawn from domain $\mathcal{X}$, so summing over all $z\in \mathcal{X}$ will sum over every element $\ell\in x$. Recall that definition \ref{defn:symm-dist} states that $h_v(z)$ will return the number of occurrences of value $z$ in vector $v$. Therefore,  $\sum_{z\in\mathcal{X}} h_v(z)$ is the sum of the number of occurrences of each unique value; this is equivalent to the total number of items in the vector. By the definition of \texttt{len}
+ available in the pseudocode definitions document linked in section \ref{sec:versioned-docs}, then, $\sum_{z\in\mathcal{X}} h_v(z)$ is equivalent to \texttt{len(v)}.
+
+\end{proof}
+
+% \question{I am unsure whether the proof of lemma \ref{lemma:len-sum-equiv} is good. It seems clear to me that $\texttt{len(v)} = \sum_{z\in\mathcal{X}} h_v(z)$, so I had trouble knowing what needs to be written and what doesn't need to be written.}
+
+\begin{proof} \textbf{(Part 3 -- stability relation).} Here, we consider two inputs: a vector $\texttt{u}$ of elements of type \texttt{TIA}; and a vector $\texttt{v}$ of elements of type \texttt{TIA}. (This \texttt{input\_domain} is specified in the pseudocode in section \ref{sec:python-pseudocode}.) We prove that if $\texttt{stability\_relation}(\din, \dout) = \True$, then \texttt{function(u)}, \texttt{function(v)} are $\dout$-close.
+
+Assume it is the case that $\texttt{stability\_relation}(\din, \dout) = \True$. From  the stability relation provided on line \ref{line:stability-relation}, this means that $\texttt{inf\_cast}(\din, \texttt{TO}) \leq \dout$. From the pseudocode definitions file linked in section \ref{sec:versioned-docs}, we know that \texttt{inf\_cast} will cast $\din$ to a value at least as large as $\din$, so this assumption that $\texttt{stability\_relation}$ is $\True$ also means that $\din \leq \dout$. Also assume that \texttt{u}, \texttt{v} are $\din$-close under the symmetric distance metric (in accordance with the \texttt{input\_metric} specified in the preconditions in section \ref{sec:python-pseudocode}).
+
+We now refer to the definition of symmetric distance provided in the proof definitions document (a link to this document is available in section \ref{sec:versioned-docs}).
+
+Combining the assumptions that $\texttt{inf\_cast}(\din, \texttt{TO}) \leq \dout$, and that \texttt{u}, \texttt{v} are $\din$-close under the symmetric distance metric, means that
+\begin{equation}
+    d_\text{Sym}(\texttt{u}, \texttt{v})
+    \leq \din \leq \dout.
+\end{equation}
+
+Let $\mathcal{X}$ be the domain of all elements of type \texttt{TIA}. Therefore, we see that the symmetric distance  between \texttt{u} and \texttt{v} is 
+\begin{equation}
+\label{eq:expand-dymm-dist}
+    d_\text{Sym}(\texttt{u}, \texttt{v}) = \sum_{z\in \mathcal{X}} |h_{\texttt{u}}(z) - h_{\texttt{v}}(z)| \leq \din \leq \dout.
+\end{equation}
+
+We now prove that $\texttt{len(u)}$ and $\texttt{len(v)}$ are $\dout$-close. By lemma \ref{lemma:len-sum-equiv}, we know that $\texttt{len(v)} = \sum_{z\in\mathcal{X}} h_v(z)$. Substituting, we have
+\begin{equation}
+\label{eq:len-sum}
+    |\texttt{len(u)} - \texttt{len(v)}|
+    =
+    |\sum_{z\in \mathcal{X}} h_{\texttt{u}}(z) - \sum_{z\in \mathcal{X}} h_{\texttt{v}}(z)|
+    =
+    |\sum_{z\in \mathcal{X}}\left(h_{\texttt{u}}(z) - h_{\texttt{v}}(z)\right)|.
+\end{equation}
+
+By the triangle inequality,
+\begin{equation}
+\label{ineq:sum-ineq}
+    |\sum_{z\in \mathcal{X}}\left(h_{\texttt{u}}(z) - h_{\texttt{v}}(z)\right)|
+    \leq 
+    \sum_{z\in \mathcal{X}}|h_{\texttt{u}}(z) - h_{\texttt{v}}(z)|.
+\end{equation}
+
+Therefore, combining equation \ref{eq:len-sum} and inequality \ref{ineq:sum-ineq}, we have that
+\begin{equation}
+\label{ineq:relate-eqs}
+    |\texttt{len(u)} - \texttt{len(v)}|
+    \leq 
+    \sum_{z\in \mathcal{X}}|h_{\texttt{u}}(z) - h_{\texttt{v}}(z)|.
+\end{equation}
+
+Combining inequalities \ref{ineq:relate-eqs} and \ref{eq:expand-dymm-dist}, we have
+\begin{equation}
+\label{ineq:dout-close}
+    |\texttt{len(u)} - \texttt{len(v)}|
+    \leq
+    \dout,
+\end{equation}
+
+so \texttt{len(u)} and \texttt{len(v)} must be $\dout$-close. This, however, does not complete the proof that the stability relation holds because $\texttt{function(u)}$ does not return \texttt{len(u)}, but either \texttt{exact\_cast(len(u),TO)} or -- in the event \texttt{exact\_cast} fails -- \texttt{get\_max\_consecutive\_int(TO)}.
+
+We now consider the two cases that could occur:
+
+\begin{enumerate}
+    \item (Without loss of generality, \texttt{exact\_cast(len(u),TO)} fails -- which causes the try-catch statement in line \ref{code:try-catch} to catch and return \texttt{max\_value} -- and \texttt{exact\_cast(len(v),TO)} succeeds). Because \texttt{TO} has trait \texttt{ExactIntCast(usize)}, if the \texttt{exact\_cast} fails for \texttt{len(u)}, we then know that \texttt{len(u)} is greater than \texttt{get\_max\_consecutive\_int(TO)}. Likewise, if the \texttt{exact\_cast} succeeds for \texttt{len(v)}, we then know that \texttt{len(v)} is no larger than \texttt{get\_max\_consecutive\_int(TO)}. Therefore, because the return value  \texttt{get\_max\_consecutive\_int(TO)} for \texttt{u} is smaller than the true length value \texttt{len(u)}, the absolute difference between the output for \texttt{u} and the output for \texttt{v} will be \emph{smaller} than the absolute distance between \texttt{len(u)} and \texttt{len(v)}. Since we showed that the \texttt{len(u)} and \texttt{len(v)} are $\dout$-close in inequality \ref{ineq:dout-close}, therefore the outputs will still be $\dout$-close.
+    
+    Note that if \texttt{exact\_cast} fails and causes the try-catch statement in line \ref{code:try-catch} to catch and return \texttt{max\_value} for both \texttt{len(u)} and \texttt{len(v)}, then the output for both \texttt{u} and \texttt{v} is \texttt{get\_max\_consecutive\_int(TO)}, resulting in an absolute distance of 0 between the outputs -- the smallest possible absolute distance -- so the outputs for \texttt{u} and \texttt{v} must be $\dout$-close.
+    
+    \item (Both \texttt{exact\_cast(len(u),TO)} and \texttt{exact\_cast(len(v),TO)} succeed). Because \texttt{TO} implements \texttt{ExactIntCast(usize)}, we know \texttt{exact\_cast}s from \texttt{len(u)} to \texttt{TO} will be exact. Therefore, the returned values will be \texttt{len(u)} and \texttt{len(v)}, except the values will now be of type \texttt{TO}. Since we showed that the \texttt{len(u)} and \texttt{len(v)} are $\dout$-close in inequality \ref{ineq:dout-close}, therefore the \texttt{exact\_cast}ed lengths will also be $\dout$-close.
+\end{enumerate}
+
+Because the outputs will always be $\dout$-close for inputs that follow the conditions specified in part 2 of theorem \ref{thrm:domain-and-stability}, we see that the stability guarantee is proven.
+
+\end{proof}
+
+\end{document}

--- a/rust/src/transformations/count/make_count.tex
+++ b/rust/src/transformations/count/make_count.tex
@@ -1,26 +1,21 @@
+\documentclass{article}
 \input{../../mod.sty}
 
-\newcommand{\permalink}[2]{This proof is based on the code in \url{#1} from \changeformat{#2}.}
-
-\def\changeformat#1{\xchangeformat#1\relax}
-\def\xchangeformat#1/#2/#3\relax{%
-#1 %
-\ifcase#2 \or
-January\or February\or March\or April\or May\or June\or July\or
-August\or September\or October\or November\or December\fi
-\ #3}
-
-\setlength{\parindent}{0.0in}
-\setlength{\parskip}{0.05in}
-\title{Privacy Proofs for OpenDP: MakeCount}
+\title{\texttt{fn make\_count}}
 \author{S\'ilvia Casacuberta, Grace Tian, Connor Wagaman -- wagaman@college.harvard.edu}
-\date{Version as of \today~(UTC)}
+\date{}
 
 \begin{document}
 
 \maketitle
 
-\tableofcontents
+\contrib
+Proves soundness of \texttt{fn make\_count} in \asOfCommit{mod.rs}{f5bb719}.
+
+\section{Vetting history}
+\begin{itemize}
+    \item \vettingPR{513}
+\end{itemize}
 
 \subsection{Versions of definitions documents}
 \label{sec:versioned-docs}
@@ -33,191 +28,130 @@ When looking for definitions for terms that appear in this document, the followi
     \item \textbf{Proof definitions document:} This file uses the version of the proof definitions document available as of September 23, 2021, which can be found at \href{https://github.com/opendp/whitepapers/blob/proof-defns/proof-defns/proof_defns.pdf}{this link} (archived \href{https://web.archive.org/web/20210906201056/https://raw.githubusercontent.com/opendp/whitepapers/proof-defns/proof-defns/proof_defns.pdf}{here}). 
 \end{itemize}
 
-\section{MakeCount}
+\section{Pseudocode}
 
-\subsection{Implementation of MakeCount in Rust}
-\label{sub:rust-implementation}
+\label{sec:pseudocode}
 
-
-
-\permalink{https://github.com/opendp/opendp/blob/c3b5c3bd9fc50c556362b628f08c5fddea069b4d/rust/opendp/src/trans/count.rs\#L14-L27}{12/07/2021} (It is from \href{https://github.com/opendp/opendp/pull/173}{this pull request}.)
-The Rust code can also be seen below. 
-
-\subsection{Implementation of MakeCount in Python-style pseudocode, with preconditions}
-\label{sec:python-pseudocode}
-
-We now use Python-style pseudocode to present a representation of the Rust function.
-
-\emph{The use of \texttt{code}-style parameters in the preconditions section below (for example, \texttt{input\_domain}) means that this information should be passed along to the \texttt{Transformation} constructor.}
-
-Here, we use preconditions to check for traits, and to specify the domains and metrics.
-
-\textbf{Preconditions}
+\subsection*{Preconditions}
 \begin{itemize}
-    \item \textbf{User-specified types:} The \texttt{make\_count} function takes two inputs: a generic input type \texttt{TIA} for the \texttt{Transformation} (meaning that the input vector to \texttt{Transformation} is of type \texttt{Vec(TIA)}), and a generic output type \texttt{TO} for the \texttt{Transformation}.
-    
+
+    \item \texttt{TIA} (atomic input type) is a type with trait \texttt{Primitive}. \texttt{Primitive} implies \texttt{TIA} has the trait bound:
     \begin{itemize}
-        \item \texttt{TO} has traits \texttt{One}, \texttt{ExactIntCast(usize)}, and \texttt{DistanceConstant(IntDistance)}.
-        
-        Examples: \texttt{u32} and \texttt{i64} have these traits because they have (1) a multiplicative identity element, (2) every value of type \texttt{usize} that falls within the minimum and maximum consecutive integers of type \texttt{u32} has an exact representation of type \texttt{u32} (the same applies for \texttt{i64}), and (3) multiplication and division apply to types \texttt{u32} and \texttt{i64}, values of type \texttt{u32} and \texttt{i64} have a partial ordering, and every value of type \texttt{usize} can be \texttt{inf\_cast}ed to a value of type \texttt{u32} (meaning that the \texttt{inf\_cast} will either result in an error or will result in a value of type \texttt{u32} that is at least as large as the input value of type \texttt{usize}; this also applies for \texttt{i64}).
-        
-        Currently, the \texttt{ExactIntCast} and \texttt{DistanceConstant} traits are implemented for casting between all numeric types, with the exception of \texttt{InfCast} not being implemented for going to or from \texttt{usize} and \texttt{isize} (and thus \texttt{DistanceConstant} not being implemented). Therefore, \texttt{usize} and \texttt{isize} do not have these traits. 
-        
-        \item \texttt{IntDistance} has trait \texttt{InfCast(TO)}. (Note that this bullet point is not needed in this proof, but it is needed in the code so a hint can be constructed; otherwise a binary search would be needed to construct the hint.)
-        
-        Examples: Recall that \texttt{IntDistance} is an alias for the type \texttt{u32}. \texttt{IntDistance} has trait \texttt{InfCast(u32)}, because any unsigned 32-bit integer can be converted to an unsigned 32-bit integer (type \texttt{IntDistance}) that is at least as big. On the other hand, \texttt{IntDistance} has trait \texttt{InfCast(u64)}, because every value of type \texttt{u64} can either be \texttt{infcast}ed to a value of type \texttt{u32} that is at least as large, or an error can be returned.
-        
-        On the other hand, \texttt{IntDistance} does not have trait \texttt{InfCast(usize)} because \texttt{InfCast} is not implemented for going to or from \texttt{usize}.
-        
+        \item \texttt{CheckNull} so that \texttt{TIA} is a valid atomic type for \texttt{VectorDomain}
     \end{itemize}
-    
-    % \question{Salil had recommended that examples of types that do and don't work be provided. Should these examples and anti-examples be provided? Should I just say, ``\texttt{u32} has these traits'', or should I provide the description for why it has these traits (as I did above)?}
+
+    \item \texttt{TO} (output type) is a type with trait \texttt{Number}. \texttt{Number} further implies \texttt{TO} has the trait bounds:
+    \begin{itemize}
+        \item \texttt{CheckNull} so that \texttt{TO} is a valid atomic type for \texttt{AllDomain}
+        \item \texttt{ExactIntCast<usize>} for casting a vector length index of type \texttt{usize} to \texttt{TO}. \texttt{ExactIntCast} further implies \texttt{TO} has the trait bound:
+        \begin{itemize}
+            \item \texttt{ExactIntBounds}, which gives the \texttt{MAX\_CONSECUTIVE} value of type \texttt{TO}
+        \end{itemize}
+        
+        \item \texttt{One} provides a way to retrieve \texttt{TO}'s representation of 1
+        \item \texttt{DistanceConstant<IntDistance>} to satisfy the preconditions of \texttt{new\_stability\_map\_from\_constant}
+    \end{itemize}
 \end{itemize}
 
-\textbf{Postconditions:} a valid \texttt{Transformation} must be returned (i.e. if a \texttt{Transformation} cannot be returned successfully, a runtime error should be returned)
-
+\subsection*{Implementation}
 \begin{lstlisting}[language = Python, escapechar=|]
-def MakeCount(TIA, TO):
-
+def make_count():
     input_domain = VectorDomain(AllDomain(TIA))
     output_domain = AllDomain(TO) |\label{line:output-domain}|
+
+    def function(data: Vec[TIA]) -> TO:|\label{line:TO-output}|
+        try: |\label{line:try-catch}|
+            return TO.exact_int_cast(len(data))
+        except FailedCast:
+            return TO.MAX_CONSECUTIVE |\label{line:except-return}|
+
     input_metric = SymmetricDistance()
     output_metric = AbsoluteDistance(TO)
-    
-    # give the Transformation the following properties
-    max_value = get_max_consecutive_int(TO) 
-    def function(data: Vec[TIA]) -> TO:|\label{line:TO-output}|
-        try:|\label{code:try-catch}|
-            return exact_int_cast(len(data), TO)
-        except FailedCast:
-            return max_value |\label{line:except-return}|
-    def stability_relation(din:IntDistance, dout:TO) -> bool: |\label{line:din-dout-type}|
-        return 1 * inf_cast(din,TO) <= dout |\label{line:stability-relation}|
 
-    # now, return the Transformation
-    return Transformation(input_domain,output_domain,function,input_metric,output_metric,stability_relation)
+    stability_map = new_stability_map_from_constant(TO.one()) |\label{line:stability-map}|
 
+    return Transformation(
+        input_domain, output_domain, function,
+        input_metric, output_metric, stability_map)
 \end{lstlisting}
 
-\section{Proofs for the pseudocode}
+\subsection*{Postcondition}
+\texttt{make\_count} raises an exception or returns a valid \texttt{Transformation}.
 
-\begin{theorem}
-\label{thrm:domain-and-stability}
-    For every setting of the input parameters \texttt{TIA}, \texttt{TO} for \texttt{MakeCount} such that the given preconditions hold, \texttt{MakeCount} raises an exception (at compile time or run time) or returns a valid \texttt{Transformation} with the following properties:
-    \begin{enumerate}
-        \item \textup{(Appropriate output domain).} For every vector \texttt{v} in the \texttt{input\_domain}, \texttt{function(v)} is in the \texttt{output\_domain}.
-        
-        \item \textup{(Domain-metric compatibility).} The domain \texttt{input\_domain} matches one of the possible domains listed in the definition of \texttt{input\_metric}, and likewise \texttt{output\_domain} matches one of the possible domains listed in the definition of \texttt{output\_metric}.
-        
-        \item \textup{(Stability guarantee).} For every input \texttt{u}, \texttt{v} drawn from the \texttt{input\_domain} and for every pair $(\din, \dout)$, where $\din$ is of type \texttt{u32} and $\dout$ is of type \texttt{TO} (see line \ref{line:din-dout-type} of the pseudocode), if \texttt{u}, \texttt{v} are $\din$-close under the \texttt{input\_metric} and $\texttt{stability\_relation(din, dout) = True}$, then \texttt{function(u)}, \texttt{function(v)} are $\dout$-close under the \texttt{output\_metric}.
-    \end{enumerate}
-\end{theorem}
+\section{Proof}
+
+\transformationTheorem{\texttt{(TIA, TO)}}{\texttt{make\_count}}
 
 \begin{proof} \textbf{(Part 1 -- appropriate output domain).}
-In line \ref{line:output-domain} of the pseudocode, we have \texttt{output\_domain = AllDomain(TO)}, so every value of type \texttt{TO} is in the \texttt{output\_domain}, and in line \ref{line:TO-output} of the Python-style pseudocode, we see that the \texttt{function} is always guaranteed to return a value of type \texttt{TO}. Because Rust employs ``type checking'',
-% copied from clamp:
-if the Rust code compiles correctly, then the type correctness follows from the definition of the type signature enforced by Rust. Otherwise, the code raises an exception for incorrect input type.
-% end "copied from clamp"
-Therefore, since our output domain is any value of type \texttt{TO}, we see that $\function$ has the appropriate output domain \texttt{output\_domain}.
-
+    The \texttt{output\_domain} is \texttt{AllDomain(TO)}, so it is sufficient to show that \texttt{function} always returns non-null values of type \texttt{TO}.
+    By the definition of the \texttt{ExactIntCast} trait, \texttt{TO.exact\_int\_cast} always returns a non-null value of type \texttt{TO} or raises an exception.
+    If an exception is raised, the function returns \texttt{TO.MAXIMUM\_CONSECUTIVE}, which is also a non-null value of type \texttt{TO}.
+    Thus, in all cases, the function (from line \ref{line:try-catch}) returns a non-null value of type \texttt{TO}.
 \end{proof}
 
 \begin{proof} \textbf{(Part 2 -- domain-metric compatibility).}
+    Our \texttt{input\_metric} of \texttt{SymmetricDistance} is compatible with any domain of the form \texttt{VectorDomain(inner\_domain)}, 
+    and our \texttt{input\_domain} of \\\texttt{VectorDomain(AllDomain(TIA))} is of this form. 
+    Therefore our \texttt{input\_domain} and \texttt{input\_metric} are compatible.
 
-The \texttt{input\_domain} is \texttt{VectorDomain(AllDomain(TIA))}. Because our \texttt{input\_metric} of \texttt{SymmetricDistance} is compatible with any domain of the form \\\texttt{VectorDomain(inner\_domain)}, and because \texttt{VectorDomain(AllDomain(TIA))} is of this form, we see that it is compatible with our \texttt{input\_metric} of \texttt{SymmetricDistance}.
-
-The \texttt{output\_domain} is \texttt{AllDomain(TO)}. Because our \texttt{output\_metric} of \texttt{AbsoluteDistance(TO)} is compatible with any domain of the form \texttt{AllDomain(T)} where \texttt{T} has the trait \texttt{Sub(Output=T)}, and because \texttt{AllDomain(TO)} is of this form and \texttt{TO} has the necessary trait, we see that it is compatible with our \texttt{output\_metric} of \texttt{AbsoluteDistance(TO)}.
+    Our \texttt{output\_metric} of \texttt{AbsoluteDistance(TO)} is compatible with any domain of the form \texttt{AllDomain(T)} where \texttt{T} has the trait \texttt{InfSub}, 
+    and our \texttt{output\_domain} of \texttt{AllDomain(TO)} is of this form and \texttt{TO} has the necessary trait.
+    Therefore our \texttt{input\_domain} and \texttt{input\_metric} are compatible.
 \end{proof}
 
-Before proceeding with proving the third part of theorem \ref{thrm:domain-and-stability}, we provide a lemma.
-
-% \begin{definition}[Symmetric distance]
-% \label{defn:symm-dist}
-% Let $u,v$ be vectors of elements drawn from domain $\mathcal{X}$. Define $h_v(\ell)$ as the multiplicity of element $\ell$ in vector $v$. For example, if $v$ contains five instances of the number ``21'', then $h_v(21) = 5$.
-
-% A definition of the symmetric distance between $u$ and $v$, then, is $$d_{\text{Sym}}(u,v) = \sum_{z\in \mathcal{X}} |h_u(z) - h_v(z)|.$$
-% \end{definition}
+Before proceeding with proving the validity of the stability map, we provide a couple lemmas.
 
 \begin{lemma}
-\label{lemma:len-sum-equiv}
-For vector $v$ with each element $\ell\in v$ drawn from domain $\mathcal{X}$, $\texttt{len(v)} = \sum_{z\in\mathcal{X}} h_v(z)$.
+    \label{dsym-sens}
+    $|\function(u) - \function(v)| \leq |\texttt{len(u)} - \texttt{len(v)}|$.
 \end{lemma}
 
 \begin{proof}
+    In line \ref{line:try-catch}, we know the argument to \texttt{TO.exact\_int\_cast} is non-negative and integral.
+    Therefore, by the definition of \texttt{ExactIntCast}, the invocation of \texttt{TO.exact\_int\_cast} can only fail if the argument is greater than \texttt{TO.MAX\_CONSECUTIVE}.
+    In this case, the value is replaced with \texttt{TO.MAX\_CONSECUTIVE}.
+    Therefore, $\function(u) = min(\texttt{len(u)}, c)$, where $c = \texttt{TO.MAX\_CONSECUTIVE}$.
+    We use this equality to prove the lemma:
 
-Every element $\ell \in v$ is drawn from domain $\mathcal{X}$, so summing over all $z\in \mathcal{X}$ will sum over every element $\ell\in x$. Recall that definition \ref{defn:symm-dist} states that $h_v(z)$ will return the number of occurrences of value $z$ in vector $v$. Therefore,  $\sum_{z\in\mathcal{X}} h_v(z)$ is the sum of the number of occurrences of each unique value; this is equivalent to the total number of items in the vector. By the definition of \texttt{len}
- available in the pseudocode definitions document linked in section \ref{sec:versioned-docs}, then, $\sum_{z\in\mathcal{X}} h_v(z)$ is equivalent to \texttt{len(v)}.
-
+    \begin{align*}
+        |\function(u) - \function(v)| &= |min(\texttt{len(u)}, c) - min(\texttt{len(v)}, c)| \\
+        &\leq |\texttt{len(u)} - \texttt{len(v)}| &&\text{since clamping is stable} \\
+    \end{align*}
 \end{proof}
 
-% \question{I am unsure whether the proof of lemma \ref{lemma:len-sum-equiv} is good. It seems clear to me that $\texttt{len(v)} = \sum_{z\in\mathcal{X}} h_v(z)$, so I had trouble knowing what needs to be written and what doesn't need to be written.}
+\begin{lemma}
+    \label{lemma:len-sum-equiv}
+    For vector $v$ with each element $\ell\in v$ drawn from domain $\mathcal{X}$, $\texttt{len(v)} = \sum_{z\in\mathcal{X}} h_v(z)$.
+\end{lemma}
 
-\begin{proof} \textbf{(Part 3 -- stability relation).} Here, we consider two inputs: a vector $\texttt{u}$ of elements of type \texttt{TIA}; and a vector $\texttt{v}$ of elements of type \texttt{TIA}. (This \texttt{input\_domain} is specified in the pseudocode in section \ref{sec:python-pseudocode}.) We prove that if $\texttt{stability\_relation}(\din, \dout) = \True$, then \texttt{function(u)}, \texttt{function(v)} are $\dout$-close.
+\begin{proof}
+    Every element $\ell \in v$ is drawn from domain $\mathcal{X}$, so summing over all $z\in \mathcal{X}$ will sum over every element $\ell\in x$. 
+    Recall that the definition of \texttt{SymmetricDistance} states that $h_v(z)$ will return the number of occurrences of value $z$ in vector $v$.
+    Therefore, $\sum_{z\in\mathcal{X}} h_v(z)$ is the sum of the number of occurrences of each unique value; 
+    this is equivalent to the total number of items in the vector. 
+    By the definition of \texttt{len} available in the pseudocode definitions document linked in section \ref{sec:versioned-docs}, 
+    then, $\sum_{z\in\mathcal{X}} h_v(z)$ is equivalent to \texttt{len(v)}.
+\end{proof}
 
-Assume it is the case that $\texttt{stability\_relation}(\din, \dout) = \True$. From  the stability relation provided on line \ref{line:stability-relation}, this means that $\texttt{inf\_cast}(\din, \texttt{TO}) \leq \dout$. From the pseudocode definitions file linked in section \ref{sec:versioned-docs}, we know that \texttt{inf\_cast} will cast $\din$ to a value at least as large as $\din$, so this assumption that $\texttt{stability\_relation}$ is $\True$ also means that $\din \leq \dout$. Also assume that \texttt{u}, \texttt{v} are $\din$-close under the symmetric distance metric (in accordance with the \texttt{input\_metric} specified in the preconditions in section \ref{sec:python-pseudocode}).
+\begin{proof} \textbf{(Part 3 -- stability map).} 
+    Take any two elements $u, v$ in the \texttt{input\_domain} and any pair $(\din, \dout)$, 
+    where \din\ has the associated type for \texttt{input\_metric} and \dout\ has the associated type for \texttt{output\_metric}.
+    Assume $u, v$ are \din-close under \texttt{input\_metric} and that $\texttt{stability\_map}(\din) \leq \dout$. 
+    These assumptions are used to establish the following inequality:
+    \begin{align*}
+        |\function(u) - \function(v)| &\leq |\texttt{len(u)} - \texttt{len(v)}| &&\text{by }\ref{dsym-sens} \\
+        &= |\sum_{z\in \mathcal{X}} h_{\texttt{u}}(z) - \sum_{z\in \mathcal{X}} h_{\texttt{v}}(z)| &&\text{by } \ref{lemma:len-sum-equiv} \\
+        &= |\sum_{z\in \mathcal{X}}\left(h_{\texttt{u}}(z) - h_{\texttt{v}}(z)\right)| &&\text{by algebra} \\
+        &\leq \sum_{z\in \mathcal{X}}|h_{\texttt{u}}(z) - h_{\texttt{v}}(z)| &&\text{by triangle inequality} \\
+        &= d_{Sym}(u, v) &&\text{by } \texttt{SymmetricDistance}\\
+        &\leq \din &&\text{by the first assumption} \\
+        &\leq \texttt{TO.inf\_cast}(\din) &&\text{by } \texttt{InfCast} \\
+        &\leq \texttt{TO.one().inf\_mul(TO.inf\_cast(\din))} &&\text{by } \texttt{InfMul} \\
+        &=\texttt{stability\_map}(\din) &&\text{by pseudocode line } \ref{line:stability-map} \\
+        &\leq \dout &&\text{by the second assumption}
+    \end{align*}
 
-We now refer to the definition of symmetric distance provided in the proof definitions document (a link to this document is available in section \ref{sec:versioned-docs}).
-
-Combining the assumptions that $\texttt{inf\_cast}(\din, \texttt{TO}) \leq \dout$, and that \texttt{u}, \texttt{v} are $\din$-close under the symmetric distance metric, means that
-\begin{equation}
-    d_\text{Sym}(\texttt{u}, \texttt{v})
-    \leq \din \leq \dout.
-\end{equation}
-
-Let $\mathcal{X}$ be the domain of all elements of type \texttt{TIA}. Therefore, we see that the symmetric distance  between \texttt{u} and \texttt{v} is 
-\begin{equation}
-\label{eq:expand-dymm-dist}
-    d_\text{Sym}(\texttt{u}, \texttt{v}) = \sum_{z\in \mathcal{X}} |h_{\texttt{u}}(z) - h_{\texttt{v}}(z)| \leq \din \leq \dout.
-\end{equation}
-
-We now prove that $\texttt{len(u)}$ and $\texttt{len(v)}$ are $\dout$-close. By lemma \ref{lemma:len-sum-equiv}, we know that $\texttt{len(v)} = \sum_{z\in\mathcal{X}} h_v(z)$. Substituting, we have
-\begin{equation}
-\label{eq:len-sum}
-    |\texttt{len(u)} - \texttt{len(v)}|
-    =
-    |\sum_{z\in \mathcal{X}} h_{\texttt{u}}(z) - \sum_{z\in \mathcal{X}} h_{\texttt{v}}(z)|
-    =
-    |\sum_{z\in \mathcal{X}}\left(h_{\texttt{u}}(z) - h_{\texttt{v}}(z)\right)|.
-\end{equation}
-
-By the triangle inequality,
-\begin{equation}
-\label{ineq:sum-ineq}
-    |\sum_{z\in \mathcal{X}}\left(h_{\texttt{u}}(z) - h_{\texttt{v}}(z)\right)|
-    \leq 
-    \sum_{z\in \mathcal{X}}|h_{\texttt{u}}(z) - h_{\texttt{v}}(z)|.
-\end{equation}
-
-Therefore, combining equation \ref{eq:len-sum} and inequality \ref{ineq:sum-ineq}, we have that
-\begin{equation}
-\label{ineq:relate-eqs}
-    |\texttt{len(u)} - \texttt{len(v)}|
-    \leq 
-    \sum_{z\in \mathcal{X}}|h_{\texttt{u}}(z) - h_{\texttt{v}}(z)|.
-\end{equation}
-
-Combining inequalities \ref{ineq:relate-eqs} and \ref{eq:expand-dymm-dist}, we have
-\begin{equation}
-\label{ineq:dout-close}
-    |\texttt{len(u)} - \texttt{len(v)}|
-    \leq
-    \dout,
-\end{equation}
-
-so \texttt{len(u)} and \texttt{len(v)} must be $\dout$-close. This, however, does not complete the proof that the stability relation holds because $\texttt{function(u)}$ does not return \texttt{len(u)}, but either \texttt{exact\_cast(len(u),TO)} or -- in the event \texttt{exact\_cast} fails -- \texttt{get\_max\_consecutive\_int(TO)}.
-
-We now consider the two cases that could occur:
-
-\begin{enumerate}
-    \item (Without loss of generality, \texttt{exact\_cast(len(u),TO)} fails -- which causes the try-catch statement in line \ref{code:try-catch} to catch and return \texttt{max\_value} -- and \texttt{exact\_cast(len(v),TO)} succeeds). Because \texttt{TO} has trait \texttt{ExactIntCast(usize)}, if the \texttt{exact\_cast} fails for \texttt{len(u)}, we then know that \texttt{len(u)} is greater than \texttt{get\_max\_consecutive\_int(TO)}. Likewise, if the \texttt{exact\_cast} succeeds for \texttt{len(v)}, we then know that \texttt{len(v)} is no larger than \texttt{get\_max\_consecutive\_int(TO)}. Therefore, because the return value  \texttt{get\_max\_consecutive\_int(TO)} for \texttt{u} is smaller than the true length value \texttt{len(u)}, the absolute difference between the output for \texttt{u} and the output for \texttt{v} will be \emph{smaller} than the absolute distance between \texttt{len(u)} and \texttt{len(v)}. Since we showed that the \texttt{len(u)} and \texttt{len(v)} are $\dout$-close in inequality \ref{ineq:dout-close}, therefore the outputs will still be $\dout$-close.
-    
-    Note that if \texttt{exact\_cast} fails and causes the try-catch statement in line \ref{code:try-catch} to catch and return \texttt{max\_value} for both \texttt{len(u)} and \texttt{len(v)}, then the output for both \texttt{u} and \texttt{v} is \texttt{get\_max\_consecutive\_int(TO)}, resulting in an absolute distance of 0 between the outputs -- the smallest possible absolute distance -- so the outputs for \texttt{u} and \texttt{v} must be $\dout$-close.
-    
-    \item (Both \texttt{exact\_cast(len(u),TO)} and \texttt{exact\_cast(len(v),TO)} succeed). Because \texttt{TO} implements \texttt{ExactIntCast(usize)}, we know \texttt{exact\_cast}s from \texttt{len(u)} to \texttt{TO} will be exact. Therefore, the returned values will be \texttt{len(u)} and \texttt{len(v)}, except the values will now be of type \texttt{TO}. Since we showed that the \texttt{len(u)} and \texttt{len(v)} are $\dout$-close in inequality \ref{ineq:dout-close}, therefore the \texttt{exact\_cast}ed lengths will also be $\dout$-close.
-\end{enumerate}
-
-Because the outputs will always be $\dout$-close for inputs that follow the conditions specified in part 2 of theorem \ref{thrm:domain-and-stability}, we see that the stability guarantee is proven.
-
+    It is shown that \function(u), \function(v) are \dout-close under \texttt{output\_metric}.
 \end{proof}
 
 \end{document}

--- a/rust/src/transformations/count/make_count.tex
+++ b/rust/src/transformations/count/make_count.tex
@@ -2,7 +2,7 @@
 \input{../../mod.sty}
 
 \title{\texttt{fn make\_count}}
-\author{S\'ilvia Casacuberta, Grace Tian, Connor Wagaman -- wagaman@college.harvard.edu}
+\author{S\'ilvia Casacuberta, Grace Tian, Connor Wagaman}
 \date{}
 
 \begin{document}
@@ -10,22 +10,11 @@
 \maketitle
 
 \contrib
-Proves soundness of \texttt{fn make\_count} in \asOfCommit{mod.rs}{f5bb719}.
+Proves soundness of \rustdoc{transformations}{fn}{make\_count} in \asOfCommit{mod.rs}{f5bb719}.
 
 \section{Vetting history}
 \begin{itemize}
     \item \vettingPR{513}
-\end{itemize}
-
-\subsection{Versions of definitions documents}
-\label{sec:versioned-docs}
-
-When looking for definitions for terms that appear in this document, the following versions of the definitions documents should be used.
-
-\begin{itemize}
-    \item \textbf{Pseudocode definitions document:} This proof file uses the version of the pseudocode definitions document available as of September 23, 2021, which can be found at \href{https://github.com/opendp/whitepapers/blob/pseudocode-defns/pseudocode-defns/pseudocode_defns.pdf}{this link} (archived \href{https://web.archive.org/web/20210906201546/https://raw.githubusercontent.com/opendp/whitepapers/pseudocode-defns/pseudocode-defns/pseudocode_defns.pdf}{here}).
-    
-    \item \textbf{Proof definitions document:} This file uses the version of the proof definitions document available as of September 23, 2021, which can be found at \href{https://github.com/opendp/whitepapers/blob/proof-defns/proof-defns/proof_defns.pdf}{this link} (archived \href{https://web.archive.org/web/20210906201056/https://raw.githubusercontent.com/opendp/whitepapers/proof-defns/proof-defns/proof_defns.pdf}{here}). 
 \end{itemize}
 
 \section{Pseudocode}
@@ -35,21 +24,21 @@ When looking for definitions for terms that appear in this document, the followi
 \subsection*{Preconditions}
 \begin{itemize}
 
-    \item \texttt{TIA} (atomic input type) is a type with trait \texttt{Primitive}. \texttt{Primitive} implies \texttt{TIA} has the trait bound:
+    \item \texttt{TIA} (atomic input type) is a type with trait \rustdoc{traits}{trait}{Primitive}. \texttt{Primitive} implies \texttt{TIA} has the trait bound:
     \begin{itemize}
-        \item \texttt{CheckNull} so that \texttt{TIA} is a valid atomic type for \texttt{VectorDomain}
+        \item \rustdoc{traits}{trait}{CheckNull} so that \texttt{TIA} is a valid atomic type for \rustdoc{domains}{struct}{VectorDomain}
     \end{itemize}
 
-    \item \texttt{TO} (output type) is a type with trait \texttt{Number}. \texttt{Number} further implies \texttt{TO} has the trait bounds:
+    \item \texttt{TO} (output type) is a type with trait \rustdoc{traits}{trait}{Number}. \texttt{Number} further implies \texttt{TO} has the trait bounds:
     \begin{itemize}
         \item \texttt{CheckNull} so that \texttt{TO} is a valid atomic type for \texttt{AllDomain}
-        \item \texttt{ExactIntCast<usize>} for casting a vector length index of type \texttt{usize} to \texttt{TO}. \texttt{ExactIntCast} further implies \texttt{TO} has the trait bound:
+        \item \rustdoc{traits}{trait}{ExactIntCast} for casting a vector length index of type \texttt{usize} to \texttt{TO}. \texttt{ExactIntCast} further implies \texttt{TO} has the trait bound:
         \begin{itemize}
-            \item \texttt{ExactIntBounds}, which gives the \texttt{MAX\_CONSECUTIVE} value of type \texttt{TO}
+            \item \rustdoc{traits}{trait}{ExactIntBounds}, which gives the \texttt{MAX\_CONSECUTIVE} value of type \texttt{TO}
         \end{itemize}
         
         \item \texttt{One} provides a way to retrieve \texttt{TO}'s representation of 1
-        \item \texttt{DistanceConstant<IntDistance>} to satisfy the preconditions of \texttt{new\_stability\_map\_from\_constant}
+        \item \rustdoc{traits}{trait}{DistanceConstant} to satisfy the preconditions of \texttt{new\_stability\_map\_from\_constant}
     \end{itemize}
 \end{itemize}
 
@@ -60,8 +49,9 @@ def make_count():
     output_domain = AllDomain(TO) |\label{line:output-domain}|
 
     def function(data: Vec[TIA]) -> TO:|\label{line:TO-output}|
+        size = input_domain.size(data)
         try: |\label{line:try-catch}|
-            return TO.exact_int_cast(len(data))
+            return TO.exact_int_cast(size)
         except FailedCast:
             return TO.MAX_CONSECUTIVE |\label{line:except-return}|
 
@@ -129,8 +119,12 @@ Before proceeding with proving the validity of the stability map, we provide a c
     Recall that the definition of \texttt{SymmetricDistance} states that $h_v(z)$ will return the number of occurrences of value $z$ in vector $v$.
     Therefore, $\sum_{z\in\mathcal{X}} h_v(z)$ is the sum of the number of occurrences of each unique value; 
     this is equivalent to the total number of items in the vector. 
-    By the definition of \texttt{len} available in the pseudocode definitions document linked in section \ref{sec:versioned-docs}, 
-    then, $\sum_{z\in\mathcal{X}} h_v(z)$ is equivalent to \texttt{len(v)}.
+
+    Since \rustdoc{domains}{trait}{CollectionDomain} is implemented for \texttt{VectorDomain<AllDomain<TIA>>}, 
+    we depend on the correctness of the implementation 
+    Conditioned on the correctness of the implementation of \texttt{CollectionDomain} for \texttt{VectorDomain<AllDomain<TIA>>},
+    the variable \texttt{size} is of type \texttt{usize} containing the number of elements in \texttt{arg}.
+    Therefore, $\sum_{z\in\mathcal{X}} h_v(z)$ is equivalent to \texttt{size}.
 \end{proof}
 
 \begin{proof} \textbf{(Part 3 -- stability map).} 

--- a/rust/src/transformations/count/make_count.tex
+++ b/rust/src/transformations/count/make_count.tex
@@ -22,7 +22,8 @@ the cast saturates at the maximum value of type \texttt{TO}.
     \item \vettingPR{513}
 \end{itemize}
 
-\section{Preconditions}
+\section{Hoare Triple}
+\subsection*{Precondition}
 \begin{itemize}
 
     \item \texttt{TIA} (atomic input type) is a type with trait \rustdoc{traits/trait}{Primitive}. \texttt{Primitive} implies \texttt{TIA} has the trait bound:
@@ -44,7 +45,7 @@ the cast saturates at the maximum value of type \texttt{TO}.
     \end{itemize}
 \end{itemize}
 
-\section{Pseudocode}
+\subsection*{Pseudocode}
 \begin{lstlisting}[language = Python, escapechar=|]
 def make_count():
     input_domain = VectorDomain(AllDomain(TIA))
@@ -67,10 +68,10 @@ def make_count():
         input_metric, output_metric, stability_map)
 \end{lstlisting}
 
-\section{Postcondition}
+\subsection*{Postcondition}
 \validTransformation{\texttt{(TIA, TO)}}{\texttt{make\_count}}
 
-\subsection*{Proofs}
+\section{Proofs}
 
 \begin{proof} \textbf{(Part 1 -- appropriate output domain).}
     The \texttt{output\_domain} is \texttt{AllDomain(TO)}, so it is sufficient to show that \texttt{function} always returns non-null values of type \texttt{TO}.

--- a/rust/src/transformations/count/make_count.tex
+++ b/rust/src/transformations/count/make_count.tex
@@ -10,7 +10,7 @@
 \maketitle
 
 \contrib
-Proves soundness of \rustdoc{transformations}{fn}{make\_count} in \asOfCommit{mod.rs}{f5bb719}.
+Proves soundness of \rustdoc{transformations/fn}{make\_count} in \asOfCommit{mod.rs}{f5bb719}.
 
 \texttt{make\_count} returns a Transformation that computes a count of the number of records in a vector.
 The length of the vector, of type \texttt{usize}, is exactly casted to a user specified output type \texttt{TO}.
@@ -25,22 +25,22 @@ the cast saturates at the maximum value of type \texttt{TO}.
 \section{Preconditions}
 \begin{itemize}
 
-    \item \texttt{TIA} (atomic input type) is a type with trait \rustdoc{traits}{trait}{Primitive}. \texttt{Primitive} implies \texttt{TIA} has the trait bound:
+    \item \texttt{TIA} (atomic input type) is a type with trait \rustdoc{traits/trait}{Primitive}. \texttt{Primitive} implies \texttt{TIA} has the trait bound:
     \begin{itemize}
-        \item \rustdoc{traits}{trait}{CheckNull} so that \texttt{TIA} is a valid atomic type for \rustdoc{domains}{struct}{AllDomain}
+        \item \rustdoc{traits/trait}{CheckNull} so that \texttt{TIA} is a valid atomic type for \rustdoc{domains/struct}{AllDomain}
     \end{itemize}
 
-    \item \texttt{TO} (output type) is a type with trait \rustdoc{traits}{trait}{Number}. \texttt{Number} further implies \texttt{TO} has the trait bounds:
+    \item \texttt{TO} (output type) is a type with trait \rustdoc{traits/trait}{Number}. \texttt{Number} further implies \texttt{TO} has the trait bounds:
     \begin{itemize}
-        \item \rustdoc{traits}{trait}{InfSub} so that the output domain is compatible with the output metric
+        \item \rustdoc{traits/trait}{InfSub} so that the output domain is compatible with the output metric
         \item \texttt{CheckNull} so that \texttt{TO} is a valid atomic type for \texttt{AllDomain}
-        \item \rustdoc{traits}{trait}{ExactIntCast} for casting a vector length index of type \texttt{usize} to \texttt{TO}. \texttt{ExactIntCast} further implies \texttt{TO} has the trait bound:
+        \item \rustdoc{traits/trait}{ExactIntCast} for casting a vector length index of type \texttt{usize} to \texttt{TO}. \texttt{ExactIntCast} further implies \texttt{TO} has the trait bound:
         \begin{itemize}
-            \item \rustdoc{traits}{trait}{ExactIntBounds}, which gives the \texttt{MAX\_CONSECUTIVE} value of type \texttt{TO}
+            \item \rustdoc{traits/trait}{ExactIntBounds}, which gives the \texttt{MAX\_CONSECUTIVE} value of type \texttt{TO}
         \end{itemize}
         
         \item \texttt{One} provides a way to retrieve \texttt{TO}'s representation of 1
-        \item \rustdoc{traits}{trait}{DistanceConstant} to satisfy the preconditions of \texttt{new\_stability\_map\_from\_constant}
+        \item \rustdoc{traits/trait}{DistanceConstant} to satisfy the preconditions of \texttt{new\_stability\_map\_from\_constant}
     \end{itemize}
 \end{itemize}
 
@@ -80,11 +80,11 @@ def make_count():
 \end{proof}
 
 \begin{proof} \textbf{(Part 2 -- domain-metric compatibility).}
-    Our \texttt{input\_metric} of \rustdoc{metrics}{struct}{SymmetricDistance} is compatible with any domain of the form \texttt{VectorDomain(inner\_domain)}, 
+    Our \texttt{input\_metric} of \rustdoc{metrics/struct}{SymmetricDistance} is compatible with any domain of the form \texttt{VectorDomain(inner\_domain)}, 
     and our \texttt{input\_domain} of \\\texttt{VectorDomain(AllDomain(TIA))} is of this form. 
     Therefore our \texttt{input\_domain} and \texttt{input\_metric} are compatible.
 
-    Our \texttt{output\_metric} of \rustdoc{metrics}{struct}{AbsoluteDistance} is compatible with any domain of the form \texttt{AllDomain(T)} where \texttt{T} has the trait \texttt{InfSub}, 
+    Our \texttt{output\_metric} of \rustdoc{metrics/struct}{AbsoluteDistance} is compatible with any domain of the form \texttt{AllDomain(T)} where \texttt{T} has the trait \texttt{InfSub}, 
     and our \texttt{output\_domain} of \texttt{AllDomain(TO)} is of this form and \texttt{TO} has the necessary trait.
     Therefore our \texttt{input\_domain} and \texttt{input\_metric} are compatible.
 \end{proof}
@@ -98,7 +98,7 @@ Before proceeding with proving the validity of the stability map, we provide a c
 \end{lemma}
 
 \begin{proof}
-    By \rustdoc{domains}{trait}{CollectionDomain}, we know \texttt{size} on line \ref{line:size} is of type \texttt{usize}, 
+    By \rustdoc{domains/trait}{CollectionDomain}, we know \texttt{size} on line \ref{line:size} is of type \texttt{usize}, 
     so it is non-negative and integral.
     Therefore, by the definition of \texttt{ExactIntCast}, 
     the invocation of \texttt{TO.exact\_int\_cast} on line \ref{line:exact-int-cast} can only fail if the argument is greater than \texttt{TO.MAX\_CONSECUTIVE}.
@@ -123,7 +123,7 @@ Before proceeding with proving the validity of the stability map, we provide a c
     Therefore, $\sum_{z\in\mathcal{X}} h_v(z)$ is the sum of the number of occurrences of each unique value; 
     this is equivalent to the total number of items in the vector. 
 
-    Since \rustdoc{domains}{trait}{CollectionDomain} is implemented for \texttt{VectorDomain<AllDomain<TIA>>}, 
+    Since \rustdoc{domains/trait}{CollectionDomain} is implemented for \texttt{VectorDomain<AllDomain<TIA>>}, 
     we depend on the correctness of the implementation 
     Conditioned on the correctness of the implementation of \texttt{CollectionDomain} for \texttt{VectorDomain<AllDomain<TIA>>},
     the variable \texttt{size} is of type \texttt{usize} containing the number of elements in \texttt{arg}.
@@ -140,10 +140,10 @@ Before proceeding with proving the validity of the stability map, we provide a c
         &= |\sum_{z\in \mathcal{X}} h_{\texttt{u}}(z) - \sum_{z\in \mathcal{X}} h_{\texttt{v}}(z)| &&\text{by } \ref{lemma:len-sum-equiv} \\
         &= |\sum_{z\in \mathcal{X}}\left(h_{\texttt{u}}(z) - h_{\texttt{v}}(z)\right)| &&\text{by algebra} \\
         &\leq \sum_{z\in \mathcal{X}}|h_{\texttt{u}}(z) - h_{\texttt{v}}(z)| &&\text{by triangle inequality} \\
-        &= d_{Sym}(u, v) &&\text{by } \rustdoc{metrics}{struct}{SymmetricDistance}\\
+        &= d_{Sym}(u, v) &&\text{by } \rustdoc{metrics/struct}{SymmetricDistance}\\
         &\leq \din &&\text{by the first assumption} \\
-        &\leq \texttt{TO.inf\_cast}(\din) &&\text{by } \rustdoc{traits}{trait}{InfCast} \\
-        &\leq \texttt{TO.one().inf\_mul(TO.inf\_cast(\din))} &&\text{by } \rustdoc{traits}{trait}{InfMul} \\
+        &\leq \texttt{TO.inf\_cast}(\din) &&\text{by } \rustdoc{traits/trait}{InfCast} \\
+        &\leq \texttt{TO.one().inf\_mul(TO.inf\_cast(\din))} &&\text{by } \rustdoc{traits/trait}{InfMul} \\
         &=\texttt{stability\_map}(\din) &&\text{by pseudocode line } \ref{line:stability-map} \\
         &\leq \dout &&\text{by the second assumption}
     \end{align*}

--- a/rust/src/transformations/count/make_count.tex
+++ b/rust/src/transformations/count/make_count.tex
@@ -12,6 +12,11 @@
 \contrib
 Proves soundness of \rustdoc{transformations}{fn}{make\_count} in \asOfCommit{mod.rs}{f5bb719}.
 
+\texttt{make\_count} returns a Transformation that computes a count of the number of records in a vector.
+The length of the vector, of type \texttt{usize}, is exactly casted to a user specified output type \texttt{TO}.
+If the length is too large to be represented exactly by \texttt{TO}, 
+the cast saturates at the maximum value of type \texttt{TO}.
+
 \section{Vetting history}
 \begin{itemize}
     \item \vettingPR{513}
@@ -26,11 +31,12 @@ Proves soundness of \rustdoc{transformations}{fn}{make\_count} in \asOfCommit{mo
 
     \item \texttt{TIA} (atomic input type) is a type with trait \rustdoc{traits}{trait}{Primitive}. \texttt{Primitive} implies \texttt{TIA} has the trait bound:
     \begin{itemize}
-        \item \rustdoc{traits}{trait}{CheckNull} so that \texttt{TIA} is a valid atomic type for \rustdoc{domains}{struct}{VectorDomain}
+        \item \rustdoc{traits}{trait}{CheckNull} so that \texttt{TIA} is a valid atomic type for \rustdoc{domains}{struct}{AllDomain}
     \end{itemize}
 
     \item \texttt{TO} (output type) is a type with trait \rustdoc{traits}{trait}{Number}. \texttt{Number} further implies \texttt{TO} has the trait bounds:
     \begin{itemize}
+        \item \rustdoc{traits}{trait}{InfSub} so that the output domain is compatible with the output metric
         \item \texttt{CheckNull} so that \texttt{TO} is a valid atomic type for \texttt{AllDomain}
         \item \rustdoc{traits}{trait}{ExactIntCast} for casting a vector length index of type \texttt{usize} to \texttt{TO}. \texttt{ExactIntCast} further implies \texttt{TO} has the trait bound:
         \begin{itemize}
@@ -49,9 +55,9 @@ def make_count():
     output_domain = AllDomain(TO) |\label{line:output-domain}|
 
     def function(data: Vec[TIA]) -> TO:|\label{line:TO-output}|
-        size = input_domain.size(data)
+        size = input_domain.size(data) |\label{line:size}|
         try: |\label{line:try-catch}|
-            return TO.exact_int_cast(size)
+            return TO.exact_int_cast(size) |\label{line:exact-int-cast}|
         except FailedCast:
             return TO.MAX_CONSECUTIVE |\label{line:except-return}|
 
@@ -98,8 +104,10 @@ Before proceeding with proving the validity of the stability map, we provide a c
 \end{lemma}
 
 \begin{proof}
-    In line \ref{line:try-catch}, we know the argument to \texttt{TO.exact\_int\_cast} is non-negative and integral.
-    Therefore, by the definition of \texttt{ExactIntCast}, the invocation of \texttt{TO.exact\_int\_cast} can only fail if the argument is greater than \texttt{TO.MAX\_CONSECUTIVE}.
+    By \rustdoc{domains}{trait}{CollectionDomain}, we know \texttt{size} on line \ref{line:size} is of type \texttt{usize}, 
+    so it is non-negative and integral.
+    Therefore, by the definition of \texttt{ExactIntCast}, 
+    the invocation of \texttt{TO.exact\_int\_cast} on line \ref{line:exact-int-cast} can only fail if the argument is greater than \texttt{TO.MAX\_CONSECUTIVE}.
     In this case, the value is replaced with \texttt{TO.MAX\_CONSECUTIVE}.
     Therefore, $\function(u) = min(\texttt{len(u)}, c)$, where $c = \texttt{TO.MAX\_CONSECUTIVE}$.
     We use this equality to prove the lemma:

--- a/rust/src/transformations/count/make_count.tex
+++ b/rust/src/transformations/count/make_count.tex
@@ -80,11 +80,11 @@ def make_count():
 \end{proof}
 
 \begin{proof} \textbf{(Part 2 -- domain-metric compatibility).}
-    Our \texttt{input\_metric} of \texttt{SymmetricDistance} is compatible with any domain of the form \texttt{VectorDomain(inner\_domain)}, 
+    Our \texttt{input\_metric} of \rustdoc{metrics}{struct}{SymmetricDistance} is compatible with any domain of the form \texttt{VectorDomain(inner\_domain)}, 
     and our \texttt{input\_domain} of \\\texttt{VectorDomain(AllDomain(TIA))} is of this form. 
     Therefore our \texttt{input\_domain} and \texttt{input\_metric} are compatible.
 
-    Our \texttt{output\_metric} of \texttt{AbsoluteDistance(TO)} is compatible with any domain of the form \texttt{AllDomain(T)} where \texttt{T} has the trait \texttt{InfSub}, 
+    Our \texttt{output\_metric} of \rustdoc{metrics}{struct}{AbsoluteDistance} is compatible with any domain of the form \texttt{AllDomain(T)} where \texttt{T} has the trait \texttt{InfSub}, 
     and our \texttt{output\_domain} of \texttt{AllDomain(TO)} is of this form and \texttt{TO} has the necessary trait.
     Therefore our \texttt{input\_domain} and \texttt{input\_metric} are compatible.
 \end{proof}
@@ -93,7 +93,8 @@ Before proceeding with proving the validity of the stability map, we provide a c
 
 \begin{lemma}
     \label{dsym-sens}
-    $|\function(u) - \function(v)| \leq |\texttt{len(u)} - \texttt{len(v)}|$.
+    $|\function(u) - \function(v)| \leq |\texttt{len(u)} - \texttt{len(v)}|$, 
+    where \texttt{len} is an alias for \\ \texttt{input\_domain.size}.
 \end{lemma}
 
 \begin{proof}
@@ -128,7 +129,7 @@ Before proceeding with proving the validity of the stability map, we provide a c
 \end{proof}
 
 \begin{proof} \textbf{(Part 3 -- stability map).} 
-    Take any two elements $u, v$ in the \texttt{input\_domain} and any pair $(\din, \dout)$, 
+    Take any two elements $u, v$ in the \\\texttt{input\_domain} and any pair $(\din, \dout)$, 
     where \din\ has the associated type for \texttt{input\_metric} and \dout\ has the associated type for \texttt{output\_metric}.
     Assume $u, v$ are \din-close under \texttt{input\_metric} and that $\texttt{stability\_map}(\din) \leq \dout$. 
     These assumptions are used to establish the following inequality:
@@ -137,10 +138,10 @@ Before proceeding with proving the validity of the stability map, we provide a c
         &= |\sum_{z\in \mathcal{X}} h_{\texttt{u}}(z) - \sum_{z\in \mathcal{X}} h_{\texttt{v}}(z)| &&\text{by } \ref{lemma:len-sum-equiv} \\
         &= |\sum_{z\in \mathcal{X}}\left(h_{\texttt{u}}(z) - h_{\texttt{v}}(z)\right)| &&\text{by algebra} \\
         &\leq \sum_{z\in \mathcal{X}}|h_{\texttt{u}}(z) - h_{\texttt{v}}(z)| &&\text{by triangle inequality} \\
-        &= d_{Sym}(u, v) &&\text{by } \texttt{SymmetricDistance}\\
+        &= d_{Sym}(u, v) &&\text{by } \rustdoc{metrics}{struct}{SymmetricDistance}\\
         &\leq \din &&\text{by the first assumption} \\
-        &\leq \texttt{TO.inf\_cast}(\din) &&\text{by } \texttt{InfCast} \\
-        &\leq \texttt{TO.one().inf\_mul(TO.inf\_cast(\din))} &&\text{by } \texttt{InfMul} \\
+        &\leq \texttt{TO.inf\_cast}(\din) &&\text{by } \rustdoc{traits}{trait}{InfCast} \\
+        &\leq \texttt{TO.one().inf\_mul(TO.inf\_cast(\din))} &&\text{by } \rustdoc{traits}{trait}{InfMul} \\
         &=\texttt{stability\_map}(\din) &&\text{by pseudocode line } \ref{line:stability-map} \\
         &\leq \dout &&\text{by the second assumption}
     \end{align*}

--- a/rust/src/transformations/count/mod.rs
+++ b/rust/src/transformations/count/mod.rs
@@ -9,9 +9,9 @@ use opendp_derive::bootstrap;
 
 use crate::core::{Function, Metric, StabilityMap, Transformation};
 use crate::metrics::{AbsoluteDistance, SymmetricDistance, LpDistance};
-use crate::domains::{AllDomain, MapDomain, VectorDomain, CollectionDomain};
+use crate::domains::{AllDomain, MapDomain, VectorDomain};
 use crate::error::*;
-use crate::traits::{Number, Hashable, Primitive, Float};
+use crate::traits::{Number, Hashable, Primitive, Float, CollectionSize};
 
 #[bootstrap(features("contrib"), generics(TO(default = "int")))]
 /// Make a Transformation that computes a count of the number of records in data.
@@ -32,7 +32,7 @@ pub fn make_count<TIA, TO>(
         // think of this as: min(arg.len(), TO::max_value())
         Function::new(move |arg: &Vec<TIA>| {
             // get size via the CollectionDomain trait
-            let size = VectorDomain::<AllDomain<TIA>>::size(arg);
+            let size = arg.size();
             
             // cast to TO, and if cast fails (due to overflow) fill with largest value
             TO::exact_int_cast(size).unwrap_or(TO::MAX_CONSECUTIVE)


### PR DESCRIPTION
Moving the proof for the count transformation from last summer's OpenDP Whitepapers repository (https://github.com/opendp/whitepapers/tree/make_count). The TeX file is the same one.

Port of the whitepapers repository PR: https://github.com/opendp/whitepapers/pull/3