### PR TITLE
`make_is_equal` proof

### DIFF
--- a/python/src/opendp/transformations.py
+++ b/python/src/opendp/transformations.py
@@ -1715,6 +1715,10 @@ def make_is_equal(
     * Input Metric:   `M`
     * Output Metric:  `M`
     
+    **Proof Definition:**
+    
+    [(Proof Document)](https://docs.opendp.org/en/latest/proofs/rust/src/trans/manipulation/make_is_equal.pdf)
+    
     :param input_domain: 
     :param input_metric: 
     :param value: value to check against

--- a/rust/src/trans/manipulation/make_is_equal.tex
+++ b/rust/src/trans/manipulation/make_is_equal.tex
@@ -1,0 +1,127 @@
+\input{../../mod.sty}
+
+\newcommand{\silvia}[1]{{ {\color{blue}{(silvia)~#1}}}}
+\newcommand{\grace}[1]{{ {\color{purple}{(grace)~#1}}}}
+\newcommand{\connor}[1]{{ {\color{teal}{(connor)~#1}}}}
+\newcommand{\mike}[1]{{ {\color{green}{(mike)~#1}}}}
+\newcommand{\todo}{{\textcolor{red}{TODO }}}
+
+
+\title{Privacy Proofs for OpenDP: Is\_Equal Transformation}
+\author{Grace Tian}
+\date{Summer 2021}
+\begin{document}
+
+
+\maketitle
+\tableofcontents
+
+\section{Algorithm Implementation}
+\subsection{Code in Rust}
+The current OpenDP library contains the \texttt{make\_is\_equal} function implementing the is\_equal function. This is defined in lines 62-71 of the file \texttt{manipulation.rs} in the Git repository (\url{https://github.com/opendp/opendp/blob/21-impute/rust/opendp/src/trans/manipulation.rs#L62-L71}).
+
+\subsection{Pseudo Code in Python}\label{sec:pseudocode}
+
+\subsubsection*{Preconditions}
+To ensure the correctness of the output, we require the following preconditions:
+
+\begin{itemize}
+    \item \textbf{User-specified types:}
+    \begin{itemize}
+        \item Variable \texttt{\texttt{value}} must be of type \texttt{TI}
+        \item Type \texttt{T} must have trait \texttt{PartialEq}
+    \end{itemize}
+\end{itemize}
+
+\subsubsection*{Postconditions}
+
+\begin{itemize}
+    \item Either a valid \texttt{Transformation} is returned or an error is returned.
+\end{itemize}
+
+\begin{lstlisting}[language=Python, escapechar=|]
+def make_is_equal(value : TI):
+    input_domain = (VectorDomain(AllDomain(TI));
+    output_domain = (VectorDomain(AllDomain(bool));
+    input_metric = SymmetricDistance(); 
+    output_metric = SymmetricDistance();
+    
+    
+    def Relation(d_in: u32, d_out: u32) -> bool: |\label{line:rel}|
+        return d_out >= d_in*1
+        
+    def function(data: Vec(TI)) -> Vec(Bool): |\label{line:fn}|
+        return list(map(data == value)) |\label{line:map}|
+
+    return Transformation(input_domain, output_domain, function, input_metric, output_metric, Relation)
+\end{lstlisting}
+
+\grace{ For the next round of the updates, will need to change pseudocode so that it returns the result of a make row by row transformation (which the code does). }
+
+\subsection{Proof}
+\begin{theorem}
+
+
+For every setting of the input parameters \texttt{value} to \texttt{make\_is\_equal} such that the given preconditions hold, the transformation returned by \texttt{make\_is\_equal} has the following properties:
+\begin{enumerate}
+    \item \textup{(Appropriate output domain).} If vector $v$ is in the \texttt{input\_domain}, then \texttt{function(v)} is in the \texttt{output\_domain}.
+    \item \textup{(Domain-Metric Compatibility).} The domain \texttt{input\_domain} matches one of the possible domains listed in the definition of \texttt{input\_metric}, and likewise \texttt{output\_domain} matches one of the possible domains listed in the definition of \texttt{output\_metric}.
+    \item \textup{(Stability Guarantee).} For every pair of elements $v, w$ in \texttt{input\_domain} and for every pair $(\din, \dout)$, where $\din$ is of the associated type for \texttt{input\_metric} and $\dout$ is the associated type for \texttt{output\_metric}, if $v,w$ are $d_{in}$-close under \texttt{input\_metric} and $\Relation(\din, \dout) = \True$, then $\function(v), \function(w)$ are $d_{out}$-close under \texttt{output\_metric}.
+\end{enumerate}
+\end{theorem}
+\begin{proof}
+\begin{enumerate}
+\item \textbf{(Appropriate output domain).} In the case of \texttt{make\_is\_equal}, this corresponds to showing that for every vector $v$ of elements of type \texttt{TI}, \texttt{function}$(v)$ is a vector of elements of type \texttt{bool}.
+
+
+The $\function(v)$ has type \texttt{Vec(TI)} follows from the assumption that element $v$ is in \texttt{input\_domain} and from the type signature of \texttt{function} in line~\ref{line:fn} of the pseudocode (Section~\ref{sec:pseudocode}), which takes in an element of type \texttt{Vec(TI)} and returns an element of type \texttt{Vec(Bool)}. If the Rust code compiles correctly, then the type correctness follows from the definition of the type signature enforced by Rust. Otherwise, the code raises an exception for incorrect input type. 
+
+\item \textbf{(Domain-metric compatibility).} 
+
+Symmetric distance is compatible with \texttt{VectorDomain(AllDomain(TI))} for any generic type \texttt{TI}, as stated in \href{https://www.overleaf.com/project/60d215bf90b337ac02200a99}{``List of definitions used in the pseudocode"}. The theorem holds because for \texttt{make\_is\_equal}, the input domain is \texttt{VectorDomain(AllDomain(TI))} for generic type \texttt{TI} and the output domain is \texttt{VectorDomain(AllDomain(bool))}. 
+
+\item \textbf{(Stability guarantee).} 
+Because $\Relation(\din, \dout) = \texttt{True}$, it follows that $\din \leq \dout$ by the \texttt{is\_equal} stability relation defined in the pseduocode.
+
+Since vector inputs $v, w$ are $\din$-close, then the symmetric distance is bounded by $\din$ by definition the symmetric distance is bounded by $d_{in}$: $d_{Sym}(v, w) \leq \din$.
+
+We apply the histogram notation, as stated in \href{https://www.overleaf.com/project/60d215bf90b337ac02200a99}{``List of definitions used in the pseudocode"}, to rewrite the symmetric distance in terms of elements $z$ in $\texttt{function}(v)$ and $\texttt{function}(w)$
+$$d_{Sym}(v, w) = \norm{h_v - h_w}_1 = \sum_{z} \abs{h_v(z) - h_w(z)}.$$ 
+
+We now want to bound the symmetric distance of the transformed vectors:
+
+$$d_{Sym}(\function(v), \function(w)) = \sum_z \abs{h_{\function(v)}(z) - h_{\function(w)}(z)}.$$
+
+Since each function maps each element to boolean $\{ \T, \F\}$, we consider both cases. 
+\begin{enumerate}
+    \item $z = \T$:\\
+    $$\abs{h_{\function(v)}(\T) - h_{\function(w)}(\T)} = \abs{h_v(\texttt{value}) - h_w(\texttt{value})}$$
+    
+    \item $z = \F$:\\
+    
+    Since any element $z \neq \texttt{value}$ maps to \F by definition of \texttt{is\_equal}, we consider all elements $z \neq val$:
+    $\abs{h_{\function(v)}(\F) - h_{\function(w)}(\F)} = \abs{\sum_{z \neq val} h_v(z) - h_w(z)}$
+    
+    By triangle inequality, we have 
+    $$\abs{h_{\function(v)}(\F) - h_{\function(w)}(\F)} \leq \sum_{z \neq val} \abs{h_v(z) - h_w(z)}$$
+\end{enumerate}
+
+
+Therefore, we can apply the first two cases respectively to the third line below. 
+
+\begin{align*}
+    d_{Sym}(\function(v), \function(w)) &= \sum_z \abs{h_{\function(v)}(z) - h_{\function(w)}(z)} \\
+    &= \abs{h_{\function(v)}(\T) - h_{\function(w)}(\T)} + \abs{h_{\function(v)}(\F) - h_{\function(w)}(\F)} \\ 
+    &\leq \abs{h_{v}(\texttt{value}) - h_{w}(\texttt{value})} + \sum_{z \neq \texttt{value}} \abs{h_{v}(z) - h_{w}(z)}\\
+    &= \sum_z \abs{h_{v}(z) - h_{w}(z)} \\
+    &= d_{Sym}(v, w)
+\end{align*}
+
+Since $d_{Sym}(\function(v), \function(w)) \leq d_{Sym}(v, w) \leq \din$ and $\din \leq \dout$, it follows that the transformations are \dout-close: $d_{Sym}(\function(v), \function(w)) \leq \dout$.
+\grace{TODO in the next round of edits, will use Salil's suggested proof outline with row by row transformation abstraction. This will get rid of casework?}
+
+
+\end{enumerate}
+\end{proof}
+
+\end{document}

--- a/rust/src/trans/manipulation/make_is_equal.tex
+++ b/rust/src/trans/manipulation/make_is_equal.tex
@@ -1,127 +1,82 @@
-\input{../../mod.sty}
+\documentclass{article}
+\input{../../lib.sty}
 
-\newcommand{\silvia}[1]{{ {\color{blue}{(silvia)~#1}}}}
-\newcommand{\grace}[1]{{ {\color{purple}{(grace)~#1}}}}
-\newcommand{\connor}[1]{{ {\color{teal}{(connor)~#1}}}}
-\newcommand{\mike}[1]{{ {\color{green}{(mike)~#1}}}}
-\newcommand{\todo}{{\textcolor{red}{TODO }}}
+\title{\texttt{fn make\_is\_equal}}
+\author{S\'ilvia Casacuberta}
+\date{}
 
-
-\title{Privacy Proofs for OpenDP: Is\_Equal Transformation}
-\author{Grace Tian}
-\date{Summer 2021}
 \begin{document}
 
-
 \maketitle
-\tableofcontents
 
-\section{Algorithm Implementation}
-\subsection{Code in Rust}
-The current OpenDP library contains the \texttt{make\_is\_equal} function implementing the is\_equal function. This is defined in lines 62-71 of the file \texttt{manipulation.rs} in the Git repository (\url{https://github.com/opendp/opendp/blob/21-impute/rust/opendp/src/trans/manipulation.rs#L62-L71}).
+\contrib
+Proves soundness of \texttt{fn make\_is\_equal} in \asOfCommit{mod.rs}{0db9c6036}.
 
-\subsection{Pseudo Code in Python}\label{sec:pseudocode}
+\subsection*{Vetting History}
+\begin{itemize}
+    \item \vettingPR{512}
+\end{itemize}
 
-\subsubsection*{Preconditions}
+\section{Hoare Triple}
+\subsection*{Precondition}
 To ensure the correctness of the output, we require the following preconditions:
 
 \begin{itemize}
-    \item \textbf{User-specified types:}
-    \begin{itemize}
-        \item Variable \texttt{\texttt{value}} must be of type \texttt{TI}
-        \item Type \texttt{T} must have trait \texttt{PartialEq}
-    \end{itemize}
+    \item Type \texttt{TIA} must have trait \texttt{PartialEq}.
+    \item Type \texttt{M} must have trait \texttt{DatasetMetric}.
+    \item \rustdoc{core/trait}{MetricSpace} is implemented for \texttt{(VectorDomain<AtomDomain<TIA>>, M)}. Therefore \texttt{M} is a valid metric on \texttt{VectorDomain<AtomDomain<TIA>>}.
+    \item \rustdoc{core/trait}{MetricSpace} is implemented for \texttt{(VectorDomain<AtomDomain<bool>>, M)}.
 \end{itemize}
 
-\subsubsection*{Postconditions}
+\subsection*{Pseudocode}
+\begin{lstlisting}[language=Python, escapechar=|] 
+def make_is_equal(
+    input_domain: VectorDomain[AtomDomain[TIA]], 
+    input_metric: M, 
+    value: TIA
+): |\label{line:def}|
+    output_row_domain = atom_domain(T=bool)
 
-\begin{itemize}
-    \item Either a valid \texttt{Transformation} is returned or an error is returned.
-\end{itemize}
+    def is_equal(arg: TA) -> TA: |\label{line:function}|
+        return value == arg
 
-\begin{lstlisting}[language=Python, escapechar=|]
-def make_is_equal(value : TI):
-    input_domain = (VectorDomain(AllDomain(TI));
-    output_domain = (VectorDomain(AllDomain(bool));
-    input_metric = SymmetricDistance(); 
-    output_metric = SymmetricDistance();
-    
-    
-    def Relation(d_in: u32, d_out: u32) -> bool: |\label{line:rel}|
-        return d_out >= d_in*1
-        
-    def function(data: Vec(TI)) -> Vec(Bool): |\label{line:fn}|
-        return list(map(data == value)) |\label{line:map}|
-
-    return Transformation(input_domain, output_domain, function, input_metric, output_metric, Relation)
+    return make_row_by_row( |\label{line:row-by-row}|
+        input_domain, 
+        input_metric, 
+        output_row_domain, 
+        is_equal
+    )
 \end{lstlisting}
 
-\grace{ For the next round of the updates, will need to change pseudocode so that it returns the result of a make row by row transformation (which the code does). }
+\subsubsection*{Postconditions}
+\validTransformation{\texttt{(input\_domain, input\_metric, value)}}{\texttt{make\_is\_equal}}
 
-\subsection{Proof}
-\begin{theorem}
+\section{Proof}
 
+\begin{lemma}
+    The invocation of \rustdoc{transformations/manipulation/fn}{make\_row\_by\_row} (line \ref{line:row-by-row}) satisfies its preconditions.
+\end{lemma}
 
-For every setting of the input parameters \texttt{value} to \texttt{make\_is\_equal} such that the given preconditions hold, the transformation returned by \texttt{make\_is\_equal} has the following properties:
-\begin{enumerate}
-    \item \textup{(Appropriate output domain).} If vector $v$ is in the \texttt{input\_domain}, then \texttt{function(v)} is in the \texttt{output\_domain}.
-    \item \textup{(Domain-Metric Compatibility).} The domain \texttt{input\_domain} matches one of the possible domains listed in the definition of \texttt{input\_metric}, and likewise \texttt{output\_domain} matches one of the possible domains listed in the definition of \texttt{output\_metric}.
-    \item \textup{(Stability Guarantee).} For every pair of elements $v, w$ in \texttt{input\_domain} and for every pair $(\din, \dout)$, where $\din$ is of the associated type for \texttt{input\_metric} and $\dout$ is the associated type for \texttt{output\_metric}, if $v,w$ are $d_{in}$-close under \texttt{input\_metric} and $\Relation(\din, \dout) = \True$, then $\function(v), \function(w)$ are $d_{out}$-close under \texttt{output\_metric}.
-\end{enumerate}
-\end{theorem}
 \begin{proof}
-\begin{enumerate}
-\item \textbf{(Appropriate output domain).} In the case of \texttt{make\_is\_equal}, this corresponds to showing that for every vector $v$ of elements of type \texttt{TI}, \texttt{function}$(v)$ is a vector of elements of type \texttt{bool}.
+    \label{lemma:row-by-row-precondition}
+    The preconditions of \texttt{make\_is\_equal} and pseudocode definition (line \ref{line:def}) ensure that the type preconditions of \texttt{make\_row\_by\_row} are satisfied. 
+    The remaining preconditions of \texttt{make\_row\_by\_row} are:
+    \begin{itemize}
+        \item \texttt{row\_function} has no side-effects.
+        \item If the input to \texttt{row\_function} is a member of \texttt{input\_domain}'s row domain, then the output is a member of \texttt{output\_row\_domain}.
+    \end{itemize}
 
+    The first precondition is satisfied by the definition of \texttt{is\_equal} (line \ref{line:function}) in the pseudocode.
 
-The $\function(v)$ has type \texttt{Vec(TI)} follows from the assumption that element $v$ is in \texttt{input\_domain} and from the type signature of \texttt{function} in line~\ref{line:fn} of the pseudocode (Section~\ref{sec:pseudocode}), which takes in an element of type \texttt{Vec(TI)} and returns an element of type \texttt{Vec(Bool)}. If the Rust code compiles correctly, then the type correctness follows from the definition of the type signature enforced by Rust. Otherwise, the code raises an exception for incorrect input type. 
+    For the second precondition, assume the input is a member of \texttt{input\_domain}'s row domain. 
+    By the definition of \texttt{PartialEq}, the output of \texttt{is\_equal} is boolean, and \texttt{AtomDomain<bool>} includes all booleans.
+    Therefore, the output is a member of \texttt{output\_row\_domain}.
+\end{proof}
 
-\item \textbf{(Domain-metric compatibility).} 
-
-Symmetric distance is compatible with \texttt{VectorDomain(AllDomain(TI))} for any generic type \texttt{TI}, as stated in \href{https://www.overleaf.com/project/60d215bf90b337ac02200a99}{``List of definitions used in the pseudocode"}. The theorem holds because for \texttt{make\_is\_equal}, the input domain is \texttt{VectorDomain(AllDomain(TI))} for generic type \texttt{TI} and the output domain is \texttt{VectorDomain(AllDomain(bool))}. 
-
-\item \textbf{(Stability guarantee).} 
-Because $\Relation(\din, \dout) = \texttt{True}$, it follows that $\din \leq \dout$ by the \texttt{is\_equal} stability relation defined in the pseduocode.
-
-Since vector inputs $v, w$ are $\din$-close, then the symmetric distance is bounded by $\din$ by definition the symmetric distance is bounded by $d_{in}$: $d_{Sym}(v, w) \leq \din$.
-
-We apply the histogram notation, as stated in \href{https://www.overleaf.com/project/60d215bf90b337ac02200a99}{``List of definitions used in the pseudocode"}, to rewrite the symmetric distance in terms of elements $z$ in $\texttt{function}(v)$ and $\texttt{function}(w)$
-$$d_{Sym}(v, w) = \norm{h_v - h_w}_1 = \sum_{z} \abs{h_v(z) - h_w(z)}.$$ 
-
-We now want to bound the symmetric distance of the transformed vectors:
-
-$$d_{Sym}(\function(v), \function(w)) = \sum_z \abs{h_{\function(v)}(z) - h_{\function(w)}(z)}.$$
-
-Since each function maps each element to boolean $\{ \T, \F\}$, we consider both cases. 
-\begin{enumerate}
-    \item $z = \T$:\\
-    $$\abs{h_{\function(v)}(\T) - h_{\function(w)}(\T)} = \abs{h_v(\texttt{value}) - h_w(\texttt{value})}$$
-    
-    \item $z = \F$:\\
-    
-    Since any element $z \neq \texttt{value}$ maps to \F by definition of \texttt{is\_equal}, we consider all elements $z \neq val$:
-    $\abs{h_{\function(v)}(\F) - h_{\function(w)}(\F)} = \abs{\sum_{z \neq val} h_v(z) - h_w(z)}$
-    
-    By triangle inequality, we have 
-    $$\abs{h_{\function(v)}(\F) - h_{\function(w)}(\F)} \leq \sum_{z \neq val} \abs{h_v(z) - h_w(z)}$$
-\end{enumerate}
-
-
-Therefore, we can apply the first two cases respectively to the third line below. 
-
-\begin{align*}
-    d_{Sym}(\function(v), \function(w)) &= \sum_z \abs{h_{\function(v)}(z) - h_{\function(w)}(z)} \\
-    &= \abs{h_{\function(v)}(\T) - h_{\function(w)}(\T)} + \abs{h_{\function(v)}(\F) - h_{\function(w)}(\F)} \\ 
-    &\leq \abs{h_{v}(\texttt{value}) - h_{w}(\texttt{value})} + \sum_{z \neq \texttt{value}} \abs{h_{v}(z) - h_{w}(z)}\\
-    &= \sum_z \abs{h_{v}(z) - h_{w}(z)} \\
-    &= d_{Sym}(v, w)
-\end{align*}
-
-Since $d_{Sym}(\function(v), \function(w)) \leq d_{Sym}(v, w) \leq \din$ and $\din \leq \dout$, it follows that the transformations are \dout-close: $d_{Sym}(\function(v), \function(w)) \leq \dout$.
-\grace{TODO in the next round of edits, will use Salil's suggested proof outline with row by row transformation abstraction. This will get rid of casework?}
-
-
-\end{enumerate}
+We now prove the postcondition of \texttt{make\_is\_equal}.
+\begin{proof}
+By \ref{lemma:row-by-row-precondition}, the preconditions of \rustdoc{transformations/manipulation/fn}{make\_row\_by\_row} are satisfied.
+Thus, by the definition of \\\texttt{make\_row\_by\_row}, the output is a valid transformation.
 \end{proof}
 
 \end{document}

--- a/rust/src/trans/manipulation/make_is_equal.tex
+++ b/rust/src/trans/manipulation/make_is_equal.tex
@@ -11,6 +11,8 @@
 
 \contrib
 Proves soundness of \texttt{fn make\_is\_equal} in \asOfCommit{mod.rs}{0db9c6036}.
+The transformation checks if each element in a vector dataset is equivalent to a given value,
+returning a vector of booleans.
 
 \subsection*{Vetting History}
 \begin{itemize}

--- a/rust/src/trans/manipulation/make_is_equal.tex
+++ b/rust/src/trans/manipulation/make_is_equal.tex
@@ -26,8 +26,8 @@ To ensure the correctness of the output, we require the following preconditions:
 \begin{itemize}
     \item Type \texttt{TIA} must have trait \texttt{PartialEq}.
     \item Type \texttt{M} must have trait \texttt{DatasetMetric}.
-    \item \rustdoc{core/trait}{MetricSpace} is implemented for \texttt{(VectorDomain<AtomDomain<TIA>>, M)}. Therefore \texttt{M} is a valid metric on \texttt{VectorDomain<AtomDomain<TIA>>}.
-    \item \rustdoc{core/trait}{MetricSpace} is implemented for \texttt{(VectorDomain<AtomDomain<bool>>, M)}.
+    \item \rustdoc{core/trait}{MetricSpace} is implemented for \texttt{(VectorDomain<AtomDomain<TIA>{}>, M)}. Therefore \texttt{M} is a valid metric on \texttt{VectorDomain<AtomDomain<TIA>{}>}.
+    \item \rustdoc{core/trait}{MetricSpace} is implemented for \texttt{(VectorDomain<AtomDomain<bool>{}>, M)}.
 \end{itemize}
 
 \subsection*{Pseudocode}


### PR DESCRIPTION
Moving the proof for the is_equal transformation from last summer's OpenDP Whitepapers repository (https://github.com/opendp/whitepapers/tree/is_equal). The TeX file is the same one.

Ported from the whitepapers repository PR: https://github.com/opendp/whitepapers/pull/2