### PR TITLE
fix 32-bit SMD Curve downcast

### DIFF
--- a/python/src/opendp/_data.py
+++ b/python/src/opendp/_data.py
@@ -236,8 +236,7 @@ def bool_free(
 
 def smd_curve_epsilon(
     curve: Any,
-    delta: Any,
-    T: RuntimeTypeDescriptor = None
+    delta: Any
 ) -> Any:
     """Internal function. Use an SMDCurve to find epsilon at a given `delta`.
     
@@ -245,25 +244,20 @@ def smd_curve_epsilon(
     :type curve: Any
     :param delta: 
     :type delta: Any
-    :param T: 
-    :type T: :ref:`RuntimeTypeDescriptor`
     :return: Epsilon at a given `delta`.
     :rtype: Any
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
     :raises OpenDPException: packaged error from the core OpenDP library
     """
-    # Standardize type arguments.
-    T = RuntimeType.parse_or_infer(type_name=T, public_example=delta)
-    
+    # No type arguments to standardize.
     # Convert arguments to c types.
     curve = py_to_c(curve, c_type=AnyObjectPtr)
-    delta = py_to_c(delta, c_type=AnyObjectPtr, type_name=T)
-    T = py_to_c(T, c_type=ctypes.c_char_p)
+    delta = py_to_c(delta, c_type=AnyObjectPtr, type_name=get_atom(object_type(curve)))
     
     # Call library function.
     function = lib.opendp_data__smd_curve_epsilon
-    function.argtypes = [AnyObjectPtr, AnyObjectPtr, ctypes.c_char_p]
+    function.argtypes = [AnyObjectPtr, AnyObjectPtr]
     function.restype = FfiResult
     
-    return c_to_py(unwrap(function(curve, delta, T), AnyObjectPtr))
+    return c_to_py(unwrap(function(curve, delta), AnyObjectPtr))

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -266,9 +266,9 @@ class SMDCurve(object):
     def __init__(self, curve):
         self.curve = curve
 
-    def epsilon(self, delta, T=None):
+    def epsilon(self, delta):
         from opendp._data import smd_curve_epsilon
-        return smd_curve_epsilon(self.curve, delta, T=T)
+        return smd_curve_epsilon(self.curve, delta)
 
 
 class UnknownTypeException(Exception):

--- a/rust/src/data/bootstrap.json
+++ b/rust/src/data/bootstrap.json
@@ -97,8 +97,21 @@
         "description": "Internal function. Use an SMDCurve to find epsilon at a given `delta`.",
         "args": [
             {"name": "curve", "c_type": "const AnyObject *"},
-            {"name": "delta", "c_type": "const AnyObject *", "rust_type": "T"},
-            {"name": "T", "is_type": true}
+            {
+                "name": "delta", 
+                "c_type": "const AnyObject *", 
+                "rust_type": {
+                    "function": "get_atom",
+                    "params": [
+                        {
+                            "function": "object_type",
+                            "params": [
+                                "curve"
+                            ]
+                        }
+                    ]
+                }
+            }
         ],
         "ret": {
             "c_type": "FfiResult<const AnyObject *>",

--- a/rust/src/traits/bounded/mod.rs
+++ b/rust/src/traits/bounded/mod.rs
@@ -9,5 +9,5 @@ macro_rules! impl_finite_bounds {
         const MIN_FINITE: Self = Self::MIN;
     })+)
 }
-impl_finite_bounds!(f64 f32 i8 i16 i32 i64 i128 u8 u16 u32 u64 u128);
+impl_finite_bounds!(f64 f32 i8 i16 i32 i64 i128 isize u8 u16 u32 u64 u128 usize);
 


### PR DESCRIPTION
Closes #522.

This adjusts the FFI for the SMD curve evaluation to introspect `T` from the curve struct itself. No additional FFI helpers added, invoking the map reuses `object_type` on the curve, and then retrieves the atom.