### PR TITLE
integrate proofs into releases

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,21 +22,76 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Make sure we get all refs needed to build docs for different versions
           fetch-depth: 0
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
+
+      - name: Collect file listing
+        id: "collect"
+        run: |
+          shopt -s globstar
+          files=$(echo **/*.tex)
+
+          # escape list of .tex files
+          tex="${files//'%'/'%25'}"
+          tex="${tex//$'\n'/'%0A'}"
+          tex="${tex//$'\r'/'%0D'}"
+          echo "::set-output name=tex::$tex"
+
+          # escape list of .pdf files
+          pdf="${files//$'.tex'/.pdf}"
+          pdf="${pdf//'%'/'%25'}"
+          pdf="${pdf//$'\n'/'%0A'}"
+          pdf="${pdf//$'\r'/'%0D'}"
+          echo "::set-output name=pdf::$pdf"
+
+          # name the version
+          version=$(cat VERSION)
+          if [ "$version" == "0.0.0+development" ]; then
+              version=latest
+          else
+              version="v$version"
+          fi
+          echo "::set-output name=version::$pdf"
+
+      - name: Compile LaTeX documents
+        uses: xu-cheng/latex-action@v2
+        with:
+          root_file: ${{ steps.collect.outputs.tex }}
+          # so that cwd is relative to .tex file, not repository root
+          work_in_root_file_dir: true
+          # so that shell commands run in .tex files
+          latexmk_shell_escape: true
+          # git is necessary for some shell commands to run
+          extra_system_packages: git
+          # give permissions for git commands to run
+          pre_compile: git config --global --add safe.directory /github/workspace
+
+      - name: Push to artifacts repo
+        uses: opendp/pull-request-artifacts@main
+        with:
+          commit: ${{ github.sha }}
+          artifacts: ${{ steps.collect.outputs.pdf }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts-token: ${{ secrets.ARTIFACTS_REPO_TOKEN }}
+          artifacts-repo: opendp/artifacts
+          artifacts-dir: release/${{ steps.collect.outputs.version }}
+          inter-link: false
+          post-comment: false
+
+      - name: Build docs site
         run: |
           echo "Install Sphinx and deploy docs..."
           cd docs
           python --version
           python -m venv venv
           source venv/bin/activate
+          
           echo "Upgrade pip and install requirements."
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+
           echo "Create docs."
           make versions
           cp -r build /tmp
@@ -49,10 +104,32 @@ jobs:
           echo docs.opendp.org > CNAME
           echo "for underscore directories" > .nojekyll
           cp -r /tmp/build/html/* .
-          git add --all --force
+      
+      - name: Checkout artifacts
+        uses: actions/checkout@v3
+        with:
+          path: artifacts
+      
+      - name: Populate docs site with pdfs
+        run: |
+          # copy each folder over
+          for folder in en/*; do
+            source=artifacts/release/$folder
+            target=en/$folder/proofs
+
+            if [ -d "$source" ]; then
+              mkdir -p "$target";
+              mv "$source" "$target";
+            fi;
+          done
+          
+          # discard unused pdfs
+          rm -r artifacts
+
       - name: Push docs to gh-pages branch
         #if: success() && github.ref == 'refs/heads/main'
         run: |
+          git add --all --force
           echo "Push docs to gh-pages branch"
           git commit --allow-empty-message --message "$(git log $(git rev-parse origin/main) --oneline --format=%B -n1 | head -n1)"
           git remote set-url origin "https://$GITHUB_ACTOR:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 sphinx==4.1.2
 sphinx-prompt
+commonmark
 git+https://github.com/samtygier-stfc/sphinx-multiversion.git@prebuild_command
 pydata-sphinx-theme

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,6 +25,36 @@ extensions = [
     'sphinx_multiversion',
 ]
 
+# convert markdown to rst when rendering with sphinx
+import commonmark
+import re
+py_attr_re = re.compile(r"\:py\:\w+\:(``[^:`]+``)")
+
+def docstring(app, what, name, obj, options, lines):
+    path = name.split(".")
+    if len(path) > 1 and path[1] in {
+        "accuracy", 
+        "combinators", 
+        "core",
+        "measurements", 
+        "transformations", 
+    }:
+        ast = commonmark.Parser().parse('\n'.join(lines))
+        rst = commonmark.ReStructuredTextRenderer().render(ast)
+
+        # allow sphinx notation to pass through
+        indexes = set()
+        for match in py_attr_re.finditer(rst):
+            a, b = match.span(1)
+            indexes |= {a, b - 1}
+        rst = "".join(l for i, l in enumerate(rst) if i not in indexes)
+
+        lines.clear()
+        lines += rst.splitlines()
+
+def setup(app):
+    app.connect('autodoc-process-docstring', docstring)
+
 # This prevents the RuntimeTypeDescriptors from expanding and making the signatures on API docs unreadable
 autodoc_typehints = "description"
 

--- a/python/src/opendp/accuracy.py
+++ b/python/src/opendp/accuracy.py
@@ -22,7 +22,7 @@ def accuracy_to_gaussian_scale(
     :param accuracy: Desired accuracy. A tolerance for how far values may diverge from the input to the mechanism.
     :param alpha: Statistical significance, level-`alpha`, or (1. - `alpha`)100% confidence. Must be within (0, 1].
     :param T: Data type of `accuracy` and `alpha`
-    :type T: :ref:`RuntimeTypeDescriptor`
+    :type T: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Any
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -54,7 +54,7 @@ def accuracy_to_laplacian_scale(
     :param accuracy: Desired accuracy. A tolerance for how far values may diverge from the input to the mechanism.
     :param alpha: Statistical significance, level-`alpha`, or (1. - `alpha`)100% confidence. Must be within (0, 1].
     :param T: Data type of `accuracy` and `alpha`
-    :type T: :ref:`RuntimeTypeDescriptor`
+    :type T: :py:ref:`RuntimeTypeDescriptor`
     :return: Laplacian noise scale that meets the `accuracy` requirement at a given level-`alpha`.
     :rtype: Any
     :raises AssertionError: if an argument's type differs from the expected type
@@ -87,7 +87,7 @@ def gaussian_scale_to_accuracy(
     :param scale: Gaussian noise scale.
     :param alpha: Statistical significance, level-`alpha`, or (1. - `alpha`)100% confidence. Must be within (0, 1].
     :param T: Data type of `scale` and `alpha`
-    :type T: :ref:`RuntimeTypeDescriptor`
+    :type T: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Any
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -119,7 +119,7 @@ def laplacian_scale_to_accuracy(
     :param scale: Laplacian noise scale.
     :param alpha: Statistical significance, level-`alpha`, or (1. - `alpha`)100% confidence. Must be within (0, 1].
     :param T: Data type of `scale` and `alpha`
-    :type T: :ref:`RuntimeTypeDescriptor`
+    :type T: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Any
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse

--- a/python/src/opendp/combinators.py
+++ b/python/src/opendp/combinators.py
@@ -50,7 +50,7 @@ def make_chain_mt(
     transformation0: Transformation
 ) -> Measurement:
     """Construct the functional composition (`measurement1` ○ `transformation0`).
-    Returns a Measurement that when invoked, computes measurement1(transformation0(x)).
+    Returns a Measurement that when invoked, computes `measurement1(transformation0(x))`.
     
     :param measurement1: outer mechanism
     :type measurement1: Measurement
@@ -81,7 +81,7 @@ def make_chain_tm(
     measurement0: Measurement
 ) -> Measurement:
     """Construct the functional composition (`transformation1` ○ `measurement0`).
-    Returns a Measurement that when invoked, computes transformation1(measurement0(x)).
+    Returns a Measurement that when invoked, computes `transformation1(measurement0(x))`.
     Used to represent non-interactive postprocessing.
     
     :param transformation1: outer postprocessing transformation
@@ -113,7 +113,7 @@ def make_chain_tt(
     transformation0: Transformation
 ) -> Transformation:
     """Construct the functional composition (`transformation1` ○ `transformation0`).
-    Returns a Transformation that when invoked, computes transformation1(transformation0(x)).
+    Returns a Transformation that when invoked, computes `transformation1(transformation0(x))`.
     
     :param transformation1: outer transformation
     :type transformation1: Transformation
@@ -207,7 +207,7 @@ def make_zCDP_to_approxDP(
     measurement: Measurement
 ) -> Measurement:
     """Constructs a new output measurement where the output measure
-    is casted from ZeroConcentratedDivergence<QO> to SmoothedMaxDivergence<QO>.
+    is casted from `ZeroConcentratedDivergence<QO>` to `SmoothedMaxDivergence<QO>`.
     
     :param measurement: a measurement with a privacy curve to be casted
     :type measurement: Measurement

--- a/python/src/opendp/measurements.py
+++ b/python/src/opendp/measurements.py
@@ -25,13 +25,21 @@ def make_base_discrete_gaussian(
 ) -> Measurement:
     """Make a Measurement that adds noise from the discrete_gaussian(`scale`) distribution to the input.
     
-    Set `D` to change the input data type:
+    Set `D` to change the input data type and input metric:
     ```text
-    | `D`                        | input type |
-    | -------------------------- | ---------- | 
-    | AllDomain<T> (default)     | T          |
-    | VectorDomain<AllDomain<T>> | Vec<T>     |
+    | `D`                        | input type | `D::InputMetric`     |
+    | -------------------------- | ---------- | -------------------- |
+    | AllDomain<T> (default)     | T          | AbsoluteDistance<T>  |
+    | VectorDomain<AllDomain<T>> | Vec<T>     | L2Distance<T>        |
     ```
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `D`
+    * Output Domain:  `D`
+    * Input Metric:   `D::InputMetric`
+    * Output Measure: `MO`
     
     :param scale: Noise scale parameter for the gaussian distribution. `scale` == standard_deviation.
     :param D: Domain of the data type to be privatized. Valid values are `VectorDomain<AllDomain<T>>` or `AllDomain<T>`.
@@ -71,12 +79,12 @@ def make_base_discrete_laplace(
 ) -> Measurement:
     """Make a Measurement that adds noise from the discrete_laplace(`scale`) distribution to the input.
     
-    Set `D` to change the input data type:
+    Set `D` to change the input data type and input metric:
     ```text
-    | `D`                        | input type |
-    | -------------------------- | ---------- | 
-    | AllDomain<T> (default)     | T          |
-    | VectorDomain<AllDomain<T>> | Vec<T>     |
+    | `D`                        | input type | `D::InputMetric`     |
+    | -------------------------- | ---------- | -------------------- |
+    | AllDomain<T> (default)     | T          | AbsoluteDistance<T>  |
+    | VectorDomain<AllDomain<T>> | Vec<T>     | L1Distance<T>        |
     ```
     
     This uses `make_base_discrete_laplace_cks20` if scale is greater than 10, otherwise it uses `make_base_discrete_laplace_linear`.
@@ -85,6 +93,14 @@ def make_base_discrete_laplace(
     
     * [GRS12 Universally Utility-Maximizing Privacy Mechanisms](https://theory.stanford.edu/~tim/papers/priv.pdf)
     * [CKS20 The Discrete Gaussian for Differential Privacy](https://arxiv.org/pdf/2004.00010.pdf#subsection.5.2)
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `D`
+    * Output Domain:  `D`
+    * Input Metric:   `D::InputMetric`
+    * Output Measure: `MaxDivergence<QO>`
     
     :param scale: Noise scale parameter for the laplace distribution. `scale` == sqrt(2) * standard_deviation.
     :param D: Domain of the data type to be privatized. Valid values are `VectorDomain<AllDomain<T>>` or `AllDomain<T>`
@@ -123,18 +139,26 @@ def make_base_discrete_laplace_cks20(
     """Make a Measurement that adds noise from the discrete_laplace(`scale`) distribution to the input, 
     using an efficient algorithm on rational bignums.
     
-    Set `D` to change the input data type:
+    Set `D` to change the input data type and input metric:
     ```text
-    | `D`                        | input type |
-    | -------------------------- | ---------- | 
-    | AllDomain<T> (default)     | T          |
-    | VectorDomain<AllDomain<T>> | Vec<T>     |
+    | `D`                        | input type | `D::InputMetric`     |
+    | -------------------------- | ---------- | -------------------- |
+    | AllDomain<T> (default)     | T          | AbsoluteDistance<T>  |
+    | VectorDomain<AllDomain<T>> | Vec<T>     | L1Distance<T>        |
     ```
     
     
     **Citations:**
     
     * [CKS20 The Discrete Gaussian for Differential Privacy](https://arxiv.org/pdf/2004.00010.pdf#subsection.5.2)
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `D`
+    * Output Domain:  `D`
+    * Input Metric:   `D::InputMetric`
+    * Output Measure: `MaxDivergence<QO>`
     
     :param scale: Noise scale parameter for the laplace distribution. `scale` == sqrt(2) * standard_deviation.
     :param D: Domain of the data type to be privatized. Valid values are `VectorDomain<AllDomain<T>>` or `AllDomain<T>`
@@ -175,18 +199,26 @@ def make_base_discrete_laplace_linear(
     using a linear-time algorithm on finite data types.
     
     This algorithm can be executed in constant time if bounds are passed.
-    Set `D` to change the input data type:
+    Set `D` to change the input data type and input metric:
     ```text
-    | `D`                        | input type |
-    | -------------------------- | ---------- | 
-    | AllDomain<T> (default)     | T          |
-    | VectorDomain<AllDomain<T>> | Vec<T>     |
+    | `D`                        | input type | `D::InputMetric`     |
+    | -------------------------- | ---------- | -------------------- |
+    | AllDomain<T> (default)     | T          | AbsoluteDistance<T>  |
+    | VectorDomain<AllDomain<T>> | Vec<T>     | L1Distance<T>        |
     ```
     
     
     **Citations:**
     
     * [GRS12 Universally Utility-Maximizing Privacy Mechanisms](https://theory.stanford.edu/~tim/papers/priv.pdf)
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `D`
+    * Output Domain:  `D`
+    * Input Metric:   `D::InputMetric`
+    * Output Measure: `MaxDivergence<QO>`
     
     :param scale: Noise scale parameter for the distribution. `scale` == sqrt(2) * standard_deviation.
     :param bounds: Set bounds on the count to make the algorithm run in constant-time.
@@ -230,17 +262,25 @@ def make_base_gaussian(
 ) -> Measurement:
     """Make a Measurement that adds noise from the gaussian(`scale`) distribution to the input.
     
-    Set `D` to change the input data type:
+    Set `D` to change the input data type and input metric:
     ```text
-    | `D`                        | input type |
-    | -------------------------- | ---------- | 
-    | AllDomain<T> (default)     | T          |
-    | VectorDomain<AllDomain<T>> | Vec<T>     |
+    | `D`                        | input type | `D::InputMetric`     |
+    | -------------------------- | ---------- | -------------------- |
+    | AllDomain<T> (default)     | T          | AbsoluteDistance<T>  |
+    | VectorDomain<AllDomain<T>> | Vec<T>     | L2Distance<T>        |
     ```
     
     This function takes a noise granularity in terms of 2^k. 
     Larger granularities are more computationally efficient, but have a looser privacy map. 
     If k is not set, k defaults to the smallest granularity.
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `D`
+    * Output Domain:  `D`
+    * Input Metric:   `D::InputMetric`
+    * Output Measure: `MO`
     
     :param scale: Noise scale parameter for the gaussian distribution. `scale` == standard_deviation.
     :param k: The noise granularity.
@@ -287,6 +327,14 @@ def make_base_geometric(
     Use `make_base_discrete_laplace` instead (more efficient). 
     `make_base_discrete_laplace_linear` has a similar interface with the optional constant-time bounds.
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `D`
+    * Output Domain:  `D`
+    * Input Metric:   `D::InputMetric`
+    * Output Measure: `MaxDivergence<QO>`
+    
     :param scale: 
     :param bounds: 
     :type bounds: Any
@@ -328,17 +376,25 @@ def make_base_laplace(
 ) -> Measurement:
     """Make a Measurement that adds noise from the laplace(`scale`) distribution to a scalar value.
     
-    Set `D` to change the input data type:
+    Set `D` to change the input data type and input metric:
     ```text
-    | `D`                        | input type |
-    | -------------------------- | ---------- | 
-    | AllDomain<T> (default)     | T          |
-    | VectorDomain<AllDomain<T>> | Vec<T>     |
+    | `D`                        | input type | `D::InputMetric`     |
+    | -------------------------- | ---------- | -------------------- |
+    | AllDomain<T> (default)     | T          | AbsoluteDistance<T>  |
+    | VectorDomain<AllDomain<T>> | Vec<T>     | L1Distance<T>        |
     ```
     
     This function takes a noise granularity in terms of 2^k. 
     Larger granularities are more computationally efficient, but have a looser privacy map. 
     If k is not set, k defaults to the smallest granularity.
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `D`
+    * Output Domain:  `D`
+    * Input Metric:   `D::InputMetric`
+    * Output Measure: `MaxDivergence<D::Atom>`
     
     :param scale: Noise scale parameter for the laplace distribution. `scale` == sqrt(2) * standard_deviation.
     :param k: The noise granularity.
@@ -381,6 +437,13 @@ def make_base_ptr(
     This function takes a noise granularity in terms of 2^k. 
     Larger granularities are more computationally efficient, but have a looser privacy map. 
     If k is not set, k defaults to the smallest granularity.
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `MapDomain<AllDomain<TK>, AllDomain<TV>>`
+    * Output Domain:  `MapDomain<AllDomain<TK>, AllDomain<TV>>`
+    * Input Metric:   `L1Distance<TV>`
+    * Output Measure: `SmoothedMaxDivergence<TV>`
     
     :param scale: Noise scale parameter for the laplace distribution. `scale` == sqrt(2) * standard_deviation.
     :param threshold: Exclude counts that are less than this minimum value.
@@ -425,6 +488,13 @@ def make_randomized_response(
 ) -> Measurement:
     """Make a Measurement that implements randomized response on a categorical value.
     
+    **Supporting Elements:**
+    
+    * Input Domain:   `AllDomain<T>`
+    * Output Domain:  `AllDomain<T>`
+    * Input Metric:   `DiscreteDistance`
+    * Output Measure: `MaxDivergence<Q>`
+    
     :param categories: Set of valid outcomes
     :type categories: Any
     :param prob: Probability of returning the correct answer. Must be in [1/num_categories, 1)
@@ -466,6 +536,13 @@ def make_randomized_response_bool(
     Q: RuntimeTypeDescriptor = None
 ) -> Measurement:
     """Make a Measurement that implements randomized response on a boolean value.
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `AllDomain<bool>`
+    * Output Domain:  `AllDomain<bool>`
+    * Input Metric:   `DiscreteDistance`
+    * Output Measure: `MaxDivergence<Q>`
     
     :param prob: Probability of returning the correct answer. Must be in [0.5, 1)
     :param constant_time: Set to true to enable constant time. Slower.

--- a/python/src/opendp/transformations.py
+++ b/python/src/opendp/transformations.py
@@ -106,6 +106,14 @@ def make_b_ary_tree(
     """Expand a vector of counts into a b-ary tree of counts, 
     where each branch is the sum of its `b` immediate children.
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<AllDomain<TA>>`
+    * Output Domain:  `VectorDomain<AllDomain<TA>>`
+    * Input Metric:   `M`
+    * Output Metric:  `M`
+    
     :param leaf_count: The number of leaf nodes in the b-ary tree.
     :type leaf_count: int
     :param branching_factor: The number of children on each branch of the resulting tree. Larger branching factors result in shallower trees.
@@ -154,6 +162,14 @@ def make_bounded_float_checked_sum(
     * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
     * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<BoundedDomain<S::Item>>`
+    * Output Domain:  `AllDomain<S::Item>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `AbsoluteDistance<S::Item>`
+    
     :param size_limit: Upper bound on number of records to keep in the input data.
     :type size_limit: int
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
@@ -200,6 +216,14 @@ def make_bounded_float_ordered_sum(
     * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
     * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<BoundedDomain<S::Item>>`
+    * Output Domain:  `AllDomain<S::Item>`
+    * Input Metric:   `InsertDeleteDistance`
+    * Output Metric:  `AbsoluteDistance<S::Item>`
+    
     :param size_limit: Upper bound on the number of records in input data. Used to bound sensitivity.
     :type size_limit: int
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
@@ -244,6 +268,14 @@ def make_bounded_int_monotonic_sum(
     * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
     * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<BoundedDomain<T>>`
+    * Output Domain:  `AllDomain<T>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `AbsoluteDistance<T>`
+    
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
     :type bounds: Tuple[Any, Any]
     :param T: Atomic Input Type and Output Type
@@ -282,6 +314,14 @@ def make_bounded_int_ordered_sum(
     
     * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
     * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<BoundedDomain<T>>`
+    * Output Domain:  `AllDomain<T>`
+    * Input Metric:   `InsertDeleteDistance`
+    * Output Metric:  `AbsoluteDistance<T>`
     
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
     :type bounds: Tuple[Any, Any]
@@ -322,6 +362,14 @@ def make_bounded_int_split_sum(
     * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
     * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<BoundedDomain<T>>`
+    * Output Domain:  `AllDomain<T>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `AbsoluteDistance<T>`
+    
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
     :type bounds: Tuple[Any, Any]
     :param T: Atomic Input Type and Output Type
@@ -358,6 +406,14 @@ def make_bounded_resize(
 ) -> Transformation:
     """Make a Transformation that either truncates or imputes records 
     with `constant` in a Vec<`TA`> to match a provided `size`.
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<BoundedDomain<TA>>`
+    * Output Domain:  `SizedDomain<VectorDomain<BoundedDomain<TA>>>`
+    * Input Metric:   `MI`
+    * Output Metric:  `MO`
     
     :param size: Number of records in output data.
     :type size: int
@@ -450,6 +506,14 @@ def make_cast(
     """Make a Transformation that casts a vector of data from type `TIA` to type `TOA`.
     Failure to parse results in None, else Some<TOA>.
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<AllDomain<TIA>>`
+    * Output Domain:  `VectorDomain<OptionNullDomain<AllDomain<TOA>>>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `SymmetricDistance`
+    
     :param TIA: Atomic Input Type to cast from
     :type TIA: :py:ref:`RuntimeTypeDescriptor`
     :param TOA: Atomic Output Type to cast into
@@ -483,6 +547,14 @@ def make_cast_default(
 ) -> Transformation:
     """Make a Transformation that casts a vector of data from type `TIA` to type `TOA`. 
     If the cast fails, fill with default.
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<AllDomain<TIA>>`
+    * Output Domain:  `VectorDomain<AllDomain<TOA>>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `SymmetricDistance`
     
     :param TIA: Atomic Input Type to cast from
     :type TIA: :py:ref:`RuntimeTypeDescriptor`
@@ -518,6 +590,14 @@ def make_cast_inherent(
     """Make a Transformation that casts a vector of data from type `TI` to a type that can represent nullity `TO`. 
     If cast fails, fill with `TO`'s null value.
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<AllDomain<TIA>>`
+    * Output Domain:  `VectorDomain<InherentNullDomain<AllDomain<TOA>>>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `SymmetricDistance`
+    
     :param TIA: Atomic Input Type to cast from
     :type TIA: :py:ref:`RuntimeTypeDescriptor`
     :param TOA: Atomic Output Type to cast into
@@ -550,6 +630,14 @@ def make_cdf(
 ) -> Transformation:
     """Postprocess a noisy array of float summary counts into a cumulative distribution.
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<AllDomain<TA>>`
+    * Output Domain:  `VectorDomain<AllDomain<TA>>`
+    * Input Metric:   `AgnosticMetric`
+    * Output Metric:  `AgnosticMetric`
+    
     :param TA: Atomic Type. One of `f32` or `f64`
     :type TA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
@@ -580,6 +668,14 @@ def make_clamp(
     """Make a Transformation that clamps numeric data in Vec<`T`> to `bounds`.
     If datum is less than lower, let datum be lower. 
     If datum is greater than upper, let datum be upper.
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<AllDomain<TA>>`
+    * Output Domain:  `VectorDomain<BoundedDomain<TA>>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `SymmetricDistance`
     
     :param bounds: Tuple of inclusive lower and upper bounds.
     :type bounds: Tuple[Any, Any]
@@ -626,6 +722,14 @@ def make_consistent_b_ary_tree(
     
     * [HRMS09 Boosting the Accuracy of Differentially Private Histograms Through Consistency, section 4.1](https://arxiv.org/pdf/0904.0942.pdf)
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<AllDomain<TIA>>`
+    * Output Domain:  `VectorDomain<AllDomain<TOA>>`
+    * Input Metric:   `AgnosticMetric`
+    * Output Metric:  `AgnosticMetric`
+    
     :param branching_factor: 
     :type branching_factor: int
     :param TIA: Atomic type of the input data. Should be an integer type.
@@ -667,6 +771,14 @@ def make_count(
     
     * [GRS12 Universally Utility-Maximizing Privacy Mechanisms](https://theory.stanford.edu/~tim/papers/priv.pdf)
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<AllDomain<TIA>>`
+    * Output Domain:  `AllDomain<TO>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `AbsoluteDistance<TO>`
+    
     :param TIA: Atomic Input Type. Input data is expected to be of the form Vec<TIA>.
     :type TIA: :py:ref:`RuntimeTypeDescriptor`
     :param TO: 
@@ -706,6 +818,14 @@ def make_count_by(
     **Citations:**
     
     * [BV17 Differential Privacy on Finite Computers](https://arxiv.org/abs/1709.05396)
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<AllDomain<TK>>`
+    * Output Domain:  `MapDomain<AllDomain<TK>, AllDomain<TV>>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `MO`
     
     :param MO: Output Metric.
     :type MO: SensitivityMetric
@@ -754,6 +874,14 @@ def make_count_by_categories(
     
     * [GRS12 Universally Utility-Maximizing Privacy Mechanisms](https://theory.stanford.edu/~tim/papers/priv.pdf)
     * [BV17 Differential Privacy on Finite Computers](https://arxiv.org/abs/1709.05396)
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<AllDomain<TIA>>`
+    * Output Domain:  `VectorDomain<AllDomain<TOA>>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `MO`
     
     :param categories: The set of categories to compute counts for.
     :type categories: Any
@@ -804,6 +932,14 @@ def make_count_distinct(
     
     * [GRS12 Universally Utility-Maximizing Privacy Mechanisms](https://theory.stanford.edu/~tim/papers/priv.pdf)
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<AllDomain<TIA>>`
+    * Output Domain:  `AllDomain<TO>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `AbsoluteDistance<TO>`
+    
     :param TIA: Atomic Input Type. Input data is expected to be of the form Vec<TIA>.
     :type TIA: :py:ref:`RuntimeTypeDescriptor`
     :param TO: 
@@ -836,6 +972,14 @@ def make_create_dataframe(
     K: RuntimeTypeDescriptor = None
 ) -> Transformation:
     """Make a Transformation that constructs a dataframe from a `Vec<Vec<String>>` (a vector of records).
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<VectorDomain<AllDomain<String>>>`
+    * Output Domain:  `DataFrameDomain<K>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `SymmetricDistance`
     
     :param col_names: Column names for each record entry.
     :type col_names: Any
@@ -871,6 +1015,14 @@ def make_df_cast_default(
 ) -> Transformation:
     """Make a Transformation that casts the elements in a column in a dataframe from type `TIA` to type `TOA`. 
     If cast fails, fill with default.
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `DataFrameDomain<TK>`
+    * Output Domain:  `DataFrameDomain<TK>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `SymmetricDistance`
     
     :param column_name: column name to be transformed
     :type column_name: Any
@@ -914,6 +1066,14 @@ def make_df_is_equal(
 ) -> Transformation:
     """Make a Transformation that checks if each element in a column in a dataframe is equivalent to `value`
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `DataFrameDomain<TK>`
+    * Output Domain:  `DataFrameDomain<TK>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `SymmetricDistance`
+    
     :param column_name: Column name to be transformed
     :type column_name: Any
     :param value: 
@@ -953,6 +1113,14 @@ def make_drop_null(
     """Make a Transformation that drops null values.
     `DA` is one of `OptionNullDomain<AllDomain<TA>>` or `InherentNullDomain<AllDomain<TA>>`.
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<DA>`
+    * Output Domain:  `VectorDomain<AllDomain<DA::Imputed>>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `SymmetricDistance`
+    
     :param DA: atomic domain of input data that contains nulls.
     :type DA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
@@ -981,6 +1149,14 @@ def make_find(
     TIA: RuntimeTypeDescriptor = None
 ) -> Transformation:
     """Find the index of a data value in a set of categories.
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<AllDomain<TIA>>`
+    * Output Domain:  `VectorDomain<OptionNullDomain<AllDomain<usize>>>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `SymmetricDistance`
     
     :param categories: The set of categories to find indexes from.
     :type categories: Any
@@ -1014,6 +1190,14 @@ def make_find_bin(
 ) -> Transformation:
     """Make a transformation that finds the bin index in a monotonically increasing vector of edges.
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<AllDomain<TIA>>`
+    * Output Domain:  `VectorDomain<AllDomain<usize>>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `SymmetricDistance`
+    
     :param edges: The set of edges to split bins by.
     :type edges: Any
     :param TIA: Atomic Input Type that is numeric
@@ -1045,6 +1229,14 @@ def make_identity(
     M: RuntimeTypeDescriptor
 ) -> Transformation:
     """Make a Transformation representing the identity function.
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `D`
+    * Output Domain:  `D`
+    * Input Metric:   `M`
+    * Output Metric:  `M`
     
     :param D: Domain of the identity function. Must be `VectorDomain<AllDomain<T>>` or `AllDomain<T>`
     :type D: :py:ref:`RuntimeTypeDescriptor`
@@ -1089,6 +1281,14 @@ def make_impute_constant(
     | NullableDomain<AllDomain<T>> | Vec<T>         | Vec<T>      |
     ```
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<DA>`
+    * Output Domain:  `VectorDomain<AllDomain<DA::Imputed>>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `SymmetricDistance`
+    
     :param constant: Value to replace nulls with.
     :type constant: Any
     :param DA: Atomic Domain of data being imputed.
@@ -1124,6 +1324,14 @@ def make_impute_uniform_float(
     """Make a Transformation that replaces NaN values in Vec<`TA`> with uniformly distributed floats within `bounds`.
     Operates on `InherentNullDomain<AllDomain<TA>>`
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<InherentNullDomain<AllDomain<TA>>>`
+    * Output Domain:  `VectorDomain<AllDomain<TA>>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `SymmetricDistance`
+    
     :param bounds: Tuple of inclusive lower and upper bounds.
     :type bounds: Tuple[Any, Any]
     :param TA: Atomic Type of data being imputed. One of `f32` or `f64`
@@ -1156,6 +1364,14 @@ def make_index(
     TOA: RuntimeTypeDescriptor = None
 ) -> Transformation:
     """Make a transformation that treats each element as an index into a vector of categories.
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<AllDomain<usize>>`
+    * Output Domain:  `VectorDomain<AllDomain<TOA>>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `SymmetricDistance`
     
     :param categories: The set of categories to index into.
     :type categories: Any
@@ -1192,6 +1408,14 @@ def make_is_equal(
 ) -> Transformation:
     """Make a Transformation that checks if each element is equal to `value`.
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<AllDomain<TIA>>`
+    * Output Domain:  `VectorDomain<AllDomain<bool>>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `SymmetricDistance`
+    
     :param value: value to check against
     :type value: Any
     :param TIA: Atomic Input Type. Type of elements in the input vector
@@ -1222,6 +1446,14 @@ def make_is_null(
     DIA: RuntimeTypeDescriptor
 ) -> Transformation:
     """Make a Transformation that checks if each element in a vector is null.
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<DIA>`
+    * Output Domain:  `VectorDomain<AllDomain<bool>>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `SymmetricDistance`
     
     :param DIA: Atomic Input Domain. Can be any domain for which the carrier type has a notion of nullity.
     :type DIA: :py:ref:`RuntimeTypeDescriptor`
@@ -1254,6 +1486,14 @@ def make_lipschitz_float_mul(
 ) -> Transformation:
     """Make a transformation that multiplies an aggregate by a constant.
     The bounds clamp the input, in order to bound the increase in sensitivity from float rounding.
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `D`
+    * Output Domain:  `D`
+    * Input Metric:   `M`
+    * Output Metric:  `M`
     
     :param constant: The constant to multiply aggregates by.
     :param bounds: Tuple of inclusive lower and upper bounds.
@@ -1311,6 +1551,13 @@ def make_metric_bounded(
     | InsertDeleteDistance | HammingDistance   |
     ```
     
+    **Supporting Elements:**
+    
+    * Input Domain:   `SizedDomain<VectorDomain<AllDomain<TA>>>`
+    * Output Domain:  `SizedDomain<VectorDomain<AllDomain<TA>>>`
+    * Input Metric:   `MI`
+    * Output Metric:  `MI::BoundedMetric`
+    
     :param size: Number of records in input data.
     :type size: int
     :param MI: Input Metric.
@@ -1357,6 +1604,14 @@ def make_metric_unbounded(
     | HammingDistance   | InsertDeleteDistance |
     ```
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `SizedDomain<VectorDomain<AllDomain<TA>>>`
+    * Output Domain:  `SizedDomain<VectorDomain<AllDomain<TA>>>`
+    * Input Metric:   `MI`
+    * Output Metric:  `MI::UnboundedMetric`
+    
     :param size: Number of records in input data.
     :type size: int
     :param MI: Input Metric.
@@ -1395,6 +1650,13 @@ def make_ordered_random(
     Operates exclusively on VectorDomain<AllDomain<`TA`>>.
     The dataset metric is not generic over ChangeOneDistance because the dataset size is unknown.
     
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<AllDomain<TA>>`
+    * Output Domain:  `VectorDomain<AllDomain<TA>>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `InsertDeleteDistance`
+    
     :param TA: Atomic Type.
     :type TA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
@@ -1426,6 +1688,14 @@ def make_quantiles_from_counts(
     F: RuntimeTypeDescriptor = "float"
 ) -> Transformation:
     """Postprocess a noisy array of summary counts into quantiles.
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<AllDomain<TA>>`
+    * Output Domain:  `VectorDomain<AllDomain<TA>>`
+    * Input Metric:   `AgnosticMetric`
+    * Output Metric:  `AgnosticMetric`
     
     :param bin_edges: The edges that the input data was binned into before counting.
     :type bin_edges: Any
@@ -1473,6 +1743,14 @@ def make_resize(
     """Make a Transformation that either truncates or imputes records 
     with `constant` in a Vec<`TA`> to match a provided `size`.
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<AllDomain<TA>>`
+    * Output Domain:  `SizedDomain<VectorDomain<AllDomain<TA>>>`
+    * Input Metric:   `MI`
+    * Output Metric:  `MO`
+    
     :param size: Number of records in output data.
     :type size: int
     :param constant: Value to impute with.
@@ -1518,6 +1796,14 @@ def make_select_column(
 ) -> Transformation:
     """Make a Transformation that retrieves the column `key` from a dataframe as Vec<`TOA`>.
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `DataFrameDomain<K>`
+    * Output Domain:  `VectorDomain<AllDomain<TOA>>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `SymmetricDistance`
+    
     :param key: categorical/hashable data type of the key/column name
     :type key: Any
     :param K: data type of key
@@ -1561,6 +1847,14 @@ def make_sized_bounded_float_checked_sum(
     
     * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf) 
     * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `SizedDomain<VectorDomain<BoundedDomain<S::Item>>>`
+    * Output Domain:  `AllDomain<S::Item>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `AbsoluteDistance<S::Item>`
     
     :param size: Number of records in input data.
     :type size: int
@@ -1608,6 +1902,14 @@ def make_sized_bounded_float_ordered_sum(
     * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
     * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `SizedDomain<VectorDomain<BoundedDomain<S::Item>>>`
+    * Output Domain:  `AllDomain<S::Item>`
+    * Input Metric:   `InsertDeleteDistance`
+    * Output Metric:  `AbsoluteDistance<S::Item>`
+    
     :param size: Number of records in input data.
     :type size: int
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
@@ -1653,6 +1955,14 @@ def make_sized_bounded_int_checked_sum(
     * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
     * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `SizedDomain<VectorDomain<BoundedDomain<T>>>`
+    * Output Domain:  `AllDomain<T>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `AbsoluteDistance<T>`
+    
     :param size: Number of records in input data.
     :type size: int
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
@@ -1695,6 +2005,14 @@ def make_sized_bounded_int_monotonic_sum(
     
     * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
     * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `SizedDomain<VectorDomain<BoundedDomain<T>>>`
+    * Output Domain:  `AllDomain<T>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `AbsoluteDistance<T>`
     
     :param size: Number of records in input data.
     :type size: int
@@ -1740,6 +2058,14 @@ def make_sized_bounded_int_ordered_sum(
     * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
     * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `SizedDomain<VectorDomain<BoundedDomain<T>>>`
+    * Output Domain:  `AllDomain<T>`
+    * Input Metric:   `InsertDeleteDistance`
+    * Output Metric:  `AbsoluteDistance<T>`
+    
     :param size: Number of records in input data.
     :type size: int
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
@@ -1784,6 +2110,14 @@ def make_sized_bounded_int_split_sum(
     * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
     * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `SizedDomain<VectorDomain<BoundedDomain<T>>>`
+    * Output Domain:  `AllDomain<T>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `AbsoluteDistance<T>`
+    
     :param size: Number of records in input data.
     :type size: int
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
@@ -1822,6 +2156,13 @@ def make_sized_bounded_mean(
     """Make a Transformation that computes the mean of bounded data.
     This uses a restricted-sensitivity proof that takes advantage of known dataset size.
     Use `make_clamp` to bound data and `make_bounded_resize` to establish dataset size.
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `SizedDomain<VectorDomain<BoundedDomain<T>>>`
+    * Output Domain:  `AllDomain<T>`
+    * Input Metric:   `MI`
+    * Output Metric:  `AbsoluteDistance<T>`
     
     :param size: Number of records in input data.
     :type size: int
@@ -1871,6 +2212,14 @@ def make_sized_bounded_ordered_random(
     | SymmetricDistance | InsertDeleteDistance |
     | ChangeOneDistance | HammingDistance      |
     ```
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `SizedDomain<VectorDomain<BoundedDomain<TA>>>`
+    * Output Domain:  `SizedDomain<VectorDomain<BoundedDomain<TA>>>`
+    * Input Metric:   `MI`
+    * Output Metric:  `MI::OrderedMetric`
     
     :param size: Number of records in input data.
     :type size: int
@@ -1969,6 +2318,14 @@ def make_sized_bounded_sum_of_squared_deviations(
     * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
     * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `SizedDomain<VectorDomain<BoundedDomain<S::Item>>>`
+    * Output Domain:  `AllDomain<S::Item>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `AbsoluteDistance<S::Item>`
+    
     :param size: Number of records in input data.
     :type size: int
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
@@ -2015,6 +2372,13 @@ def make_sized_bounded_unordered(
     | InsertDeleteDistance | SymmetricDistance  |
     | HammingDistance      | ChangeOneDistance  |
     ```
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `SizedDomain<VectorDomain<BoundedDomain<TA>>>`
+    * Output Domain:  `SizedDomain<VectorDomain<BoundedDomain<TA>>>`
+    * Input Metric:   `MI`
+    * Output Metric:  `MI::UnorderedMetric`
     
     :param size: Number of records in input data.
     :type size: int
@@ -2063,6 +2427,14 @@ def make_sized_bounded_variance(
     **Citations:**
     
     * [DHK15 Differential Privacy for Social Science Inference](http://hona.kr/papers/files/DOrazioHonakerKingPrivacy.pdf)
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `SizedDomain<VectorDomain<BoundedDomain<S::Item>>>`
+    * Output Domain:  `AllDomain<S::Item>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `AbsoluteDistance<S::Item>`
     
     :param size: Number of records in input data.
     :type size: int
@@ -2113,6 +2485,14 @@ def make_sized_ordered_random(
     | ChangeOneDistance | HammingDistance      |
     ```
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `SizedDomain<VectorDomain<AllDomain<TA>>>`
+    * Output Domain:  `SizedDomain<VectorDomain<AllDomain<TA>>>`
+    * Input Metric:   `MI`
+    * Output Metric:  `MI::OrderedMetric`
+    
     :param size: Number of records in input data.
     :type size: int
     :param MI: Input Metric.
@@ -2158,6 +2538,13 @@ def make_sized_unordered(
     | HammingDistance      | ChangeOneDistance  |
     ```
     
+    **Supporting Elements:**
+    
+    * Input Domain:   `SizedDomain<VectorDomain<AllDomain<TA>>>`
+    * Output Domain:  `SizedDomain<VectorDomain<AllDomain<TA>>>`
+    * Input Metric:   `MI`
+    * Output Metric:  `MI::UnorderedMetric`
+    
     :param size: Number of records in input data.
     :type size: int
     :param MI: Input Metric.
@@ -2196,6 +2583,14 @@ def make_split_dataframe(
     """Make a Transformation that splits each record in a String into a `Vec<Vec<String>>`,
     and loads the resulting table into a dataframe keyed by `col_names`.
     
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `AllDomain<String>`
+    * Output Domain:  `DataFrameDomain<K>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `SymmetricDistance`
+    
     :param separator: The token(s) that separate entries in each record.
     :type separator: str
     :param col_names: Column names for each record entry.
@@ -2230,6 +2625,13 @@ def make_split_lines(
 ) -> Transformation:
     """Make a Transformation that takes a string and splits it into a `Vec<String>` of its lines.
     
+    **Supporting Elements:**
+    
+    * Input Domain:   `AllDomain<String>`
+    * Output Domain:  `VectorDomain<AllDomain<String>>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `SymmetricDistance`
+    
     
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
@@ -2252,6 +2654,14 @@ def make_split_records(
     separator: str
 ) -> Transformation:
     """Make a Transformation that splits each record in a `Vec<String>` into a `Vec<Vec<String>>`.
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<AllDomain<String>>`
+    * Output Domain:  `VectorDomain<VectorDomain<AllDomain<String>>>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `SymmetricDistance`
     
     :param separator: The token(s) that separate entries in each record.
     :type separator: str
@@ -2280,6 +2690,14 @@ def make_subset_by(
     TK: RuntimeTypeDescriptor = None
 ) -> Transformation:
     """Make a Transformation that subsets a dataframe by a boolean column.
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `DataFrameDomain<TK>`
+    * Output Domain:  `DataFrameDomain<TK>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `SymmetricDistance`
     
     :param indicator_column: name of the boolean column that indicates inclusion in the subset
     :type indicator_column: Any
@@ -2316,6 +2734,14 @@ def make_unclamp(
 ) -> Transformation:
     """Make a Transformation that unclamps numeric data in Vec<`T`>.
     Used to convert a `VectorDomain<BoundedDomain<T>>` to a `VectorDomain<AllDomain<T>>`.
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<BoundedDomain<TA>>`
+    * Output Domain:  `VectorDomain<AllDomain<TA>>`
+    * Input Metric:   `SymmetricDistance`
+    * Output Metric:  `SymmetricDistance`
     
     :param bounds: Tuple of lower and upper bounds.
     :type bounds: Tuple[Any, Any]
@@ -2356,6 +2782,14 @@ def make_unordered(
     | -------------------- | -------------------- |
     | InsertDeleteDistance | SymmetricDistance    |
     ```
+    
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<AllDomain<TA>>`
+    * Output Domain:  `VectorDomain<AllDomain<TA>>`
+    * Input Metric:   `InsertDeleteDistance`
+    * Output Metric:  `SymmetricDistance`
     
     :param TA: Atomic Type.
     :type TA: :py:ref:`RuntimeTypeDescriptor`

--- a/python/src/opendp/transformations.py
+++ b/python/src/opendp/transformations.py
@@ -72,11 +72,10 @@ def choose_branching_factor(
     """Returns an approximation to the ideal `branching_factor` for a dataset of a given size, 
     that minimizes error in cdf and quantile estimates based on b-ary trees.
     
-    **Citations**
     
-    * QYL13, Understanding Hierarchical Methods for Differentially Private Histograms
+    **Citations:**
     
-       * Proposition 1: <http://www.vldb.org/pvldb/vol6/p1954-qardaji.pdf>
+    * [QYL13 Understanding Hierarchical Methods for Differentially Private Histograms](http://www.vldb.org/pvldb/vol6/p1954-qardaji.pdf)
     
     :param size_guess: A guess at the size of your dataset.
     :type size_guess: int
@@ -112,9 +111,9 @@ def make_b_ary_tree(
     :param branching_factor: The number of children on each branch of the resulting tree. Larger branching factors result in shallower trees.
     :type branching_factor: int
     :param M: Metric. Must be L1Distance<Q> or L2Distance<Q>
-    :type M: :ref:`RuntimeTypeDescriptor`
+    :type M: :py:ref:`RuntimeTypeDescriptor`
     :param TA: Atomic Type of the input data.
-    :type TA: :ref:`RuntimeTypeDescriptor`
+    :type TA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -149,22 +148,18 @@ def make_bounded_float_checked_sum(
     This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility. 
     Use `make_clamp` to bound data and `make_bounded_resize` to establish dataset size.
     
-    **Citations**
     
-    * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
+    **Citations:**
     
-        * <https://arxiv.org/pdf/2207.10635.pdf>
-    
-    * Calibrating Noise to Sensitivity in Private Data Analysis
-        
-        * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+    * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+    * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
     :param size_limit: Upper bound on number of records to keep in the input data.
     :type size_limit: int
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
     :type bounds: Tuple[Any, Any]
-    :param S: Summation algorithm to use on data type T. One of Sequential<T> or Pairwise<T>.
-    :type S: :ref:`RuntimeTypeDescriptor`
+    :param S: Summation algorithm to use on data type `T`. One of `Sequential<T>` or `Pairwise<T>`.
+    :type S: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -199,22 +194,18 @@ def make_bounded_float_ordered_sum(
     You may need to use `make_ordered_random` to impose an ordering on the data.
     The utility loss from overestimating the `size_limit` is small.
     
-    **Citations**
     
-    * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
+    **Citations:**
     
-        * <https://arxiv.org/pdf/2207.10635.pdf>
-    
-    * Calibrating Noise to Sensitivity in Private Data Analysis
-        
-        * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+    * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+    * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
     :param size_limit: Upper bound on the number of records in input data. Used to bound sensitivity.
     :type size_limit: int
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
     :type bounds: Tuple[Any, Any]
-    :param S: Summation algorithm to use on data type T. One of Sequential<T> or Pairwise<T>.
-    :type S: :ref:`RuntimeTypeDescriptor`
+    :param S: Summation algorithm to use on data type `T`. One of `Sequential<T>` or `Pairwise<T>`.
+    :type S: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -247,20 +238,16 @@ def make_bounded_int_monotonic_sum(
     """Make a Transformation that computes the sum of bounded ints, 
     where all values share the same sign.
     
-    **Citations**
     
-    * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
+    **Citations:**
     
-        * <https://arxiv.org/pdf/2207.10635.pdf>
-    
-    * Calibrating Noise to Sensitivity in Private Data Analysis
-        
-        * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+    * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+    * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
     :type bounds: Tuple[Any, Any]
     :param T: Atomic Input Type and Output Type
-    :type T: :ref:`RuntimeTypeDescriptor`
+    :type T: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -290,20 +277,16 @@ def make_bounded_int_ordered_sum(
     """Make a Transformation that computes the sum of bounded ints.
     You may need to use `make_ordered_random` to impose an ordering on the data.
     
-    **Citations**
     
-    * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
+    **Citations:**
     
-        * <https://arxiv.org/pdf/2207.10635.pdf>
-    
-    * Calibrating Noise to Sensitivity in Private Data Analysis
-        
-        * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+    * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+    * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
     :type bounds: Tuple[Any, Any]
     :param T: Atomic Input Type and Output Type
-    :type T: :ref:`RuntimeTypeDescriptor`
+    :type T: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -333,20 +316,16 @@ def make_bounded_int_split_sum(
     """Make a Transformation that computes the sum of bounded ints. 
     Adds the saturating sum of the positives to the saturating sum of the negatives.
     
-    **Citations**
     
-    * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
+    **Citations:**
     
-        * <https://arxiv.org/pdf/2207.10635.pdf>
-    
-    * Calibrating Noise to Sensitivity in Private Data Analysis
-        
-        * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+    * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+    * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
     :type bounds: Tuple[Any, Any]
     :param T: Atomic Input Type and Output Type
-    :type T: :ref:`RuntimeTypeDescriptor`
+    :type T: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -386,11 +365,11 @@ def make_bounded_resize(
     :type bounds: Tuple[Any, Any]
     :param constant: Value to impute with.
     :param MI: Input Metric. One of `InsertDeleteDistance` or `SymmetricDistance`
-    :type MI: :ref:`RuntimeTypeDescriptor`
+    :type MI: :py:ref:`RuntimeTypeDescriptor`
     :param MO: Output Metric. One of `InsertDeleteDistance` or `SymmetricDistance`
-    :type MO: :ref:`RuntimeTypeDescriptor`
+    :type MO: :py:ref:`RuntimeTypeDescriptor`
     :param TA: Atomic type. If not passed, TA is inferred from the lower bound
-    :type TA: :ref:`RuntimeTypeDescriptor`
+    :type TA: :py:ref:`RuntimeTypeDescriptor`
     :return: A vector of the same type `TA`, but with the provided `size`.
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
@@ -428,22 +407,18 @@ def make_bounded_sum(
     """Make a Transformation that computes the sum of bounded data. 
     Use `make_clamp` to bound data.
     
-    **Citations**
     
-    * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
+    **Citations:**
     
-        * <https://arxiv.org/pdf/2207.10635.pdf>
-    
-    * Calibrating Noise to Sensitivity in Private Data Analysis
-        
-        * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+    * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+    * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
     :type bounds: Tuple[Any, Any]
     :param MI: Input Metric. One of `SymmetricDistance` or `InsertDeleteDistance`.
-    :type MI: :ref:`RuntimeTypeDescriptor`
+    :type MI: :py:ref:`RuntimeTypeDescriptor`
     :param T: Atomic Input Type and Output Type.
-    :type T: :ref:`RuntimeTypeDescriptor`
+    :type T: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -476,9 +451,9 @@ def make_cast(
     Failure to parse results in None, else Some<TOA>.
     
     :param TIA: Atomic Input Type to cast from
-    :type TIA: :ref:`RuntimeTypeDescriptor`
+    :type TIA: :py:ref:`RuntimeTypeDescriptor`
     :param TOA: Atomic Output Type to cast into
-    :type TOA: :ref:`RuntimeTypeDescriptor`
+    :type TOA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -510,9 +485,9 @@ def make_cast_default(
     If the cast fails, fill with default.
     
     :param TIA: Atomic Input Type to cast from
-    :type TIA: :ref:`RuntimeTypeDescriptor`
+    :type TIA: :py:ref:`RuntimeTypeDescriptor`
     :param TOA: Atomic Output Type to cast into
-    :type TOA: :ref:`RuntimeTypeDescriptor`
+    :type TOA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -544,9 +519,9 @@ def make_cast_inherent(
     If cast fails, fill with `TO`'s null value.
     
     :param TIA: Atomic Input Type to cast from
-    :type TIA: :ref:`RuntimeTypeDescriptor`
+    :type TIA: :py:ref:`RuntimeTypeDescriptor`
     :param TOA: Atomic Output Type to cast into
-    :type TOA: :ref:`RuntimeTypeDescriptor`
+    :type TOA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -575,8 +550,8 @@ def make_cdf(
 ) -> Transformation:
     """Postprocess a noisy array of float summary counts into a cumulative distribution.
     
-    :param TA: Atomic Type. One of f32 or f64
-    :type TA: :ref:`RuntimeTypeDescriptor`
+    :param TA: Atomic Type. One of `f32` or `f64`
+    :type TA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -609,7 +584,7 @@ def make_clamp(
     :param bounds: Tuple of inclusive lower and upper bounds.
     :type bounds: Tuple[Any, Any]
     :param TA: Atomic Type
-    :type TA: :ref:`RuntimeTypeDescriptor`
+    :type TA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -646,18 +621,17 @@ def make_consistent_b_ary_tree(
     The output remains consistent even when leaf nodes are missing.
     This is due to an adjustment to the original algorithm to apportion corrections to children relative to their variance.
     
-    **Citations**
     
-    * HRMS09, Boosting the Accuracy of Differentially Private Histograms Through Consistency
-      
-       * Section 4.1: <https://arxiv.org/pdf/0904.0942.pdf>
+    **Citations:**
+    
+    * [HRMS09 Boosting the Accuracy of Differentially Private Histograms Through Consistency, section 4.1](https://arxiv.org/pdf/0904.0942.pdf)
     
     :param branching_factor: 
     :type branching_factor: int
     :param TIA: Atomic type of the input data. Should be an integer type.
-    :type TIA: :ref:`RuntimeTypeDescriptor`
+    :type TIA: :py:ref:`RuntimeTypeDescriptor`
     :param TOA: Atomic type of the output data. Should be a float type.
-    :type TOA: :ref:`RuntimeTypeDescriptor`
+    :type TOA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -688,16 +662,15 @@ def make_count(
 ) -> Transformation:
     """Make a Transformation that computes a count of the number of records in data.
     
-    **Citations**
     
-    * GRS12, Universally Utility-Maximizing Privacy Mechanisms
+    **Citations:**
     
-        * <https://theory.stanford.edu/~tim/papers/priv.pdf>
+    * [GRS12 Universally Utility-Maximizing Privacy Mechanisms](https://theory.stanford.edu/~tim/papers/priv.pdf)
     
     :param TIA: Atomic Input Type. Input data is expected to be of the form Vec<TIA>.
-    :type TIA: :ref:`RuntimeTypeDescriptor`
+    :type TIA: :py:ref:`RuntimeTypeDescriptor`
     :param TO: 
-    :type TO: :ref:`RuntimeTypeDescriptor`
+    :type TO: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -729,19 +702,18 @@ def make_count_by(
     """Make a Transformation that computes the count of each unique value in data. 
     This assumes that the category set is unknown.
     
-    **Citations**
     
-    * BV17, Differential Privacy on Finite Computers
+    **Citations:**
     
-        * <https://arxiv.org/abs/1709.05396>
+    * [BV17 Differential Privacy on Finite Computers](https://arxiv.org/abs/1709.05396)
     
     :param MO: Output Metric.
     :type MO: SensitivityMetric
     :param TK: Type of Key. Categorical/hashable input data type. Input data must be Vec<TK>.
-    :type TK: :ref:`RuntimeTypeDescriptor`
+    :type TK: :py:ref:`RuntimeTypeDescriptor`
     :param TV: 
-    :type TV: :ref:`RuntimeTypeDescriptor`
-    :return: The carrier type is HashMap<TK, TV>, a hashmap of the count (TV) for each unique data input (TK).
+    :type TV: :py:ref:`RuntimeTypeDescriptor`
+    :return: The carrier type is `HashMap<TK, TV>`, a hashmap of the count (`TV`) for each unique data input (`TK`).
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -777,15 +749,11 @@ def make_count_by_categories(
     """Make a Transformation that computes the number of times each category appears in the data. 
     This assumes that the category set is known.
     
-    **Citations**
     
-    * GRS12, Universally Utility-Maximizing Privacy Mechanisms
+    **Citations:**
     
-        * <https://theory.stanford.edu/~tim/papers/priv.pdf>
-    
-    * BV17, Differential Privacy on Finite Computers
-    
-        * <https://arxiv.org/abs/1709.05396>
+    * [GRS12 Universally Utility-Maximizing Privacy Mechanisms](https://theory.stanford.edu/~tim/papers/priv.pdf)
+    * [BV17 Differential Privacy on Finite Computers](https://arxiv.org/abs/1709.05396)
     
     :param categories: The set of categories to compute counts for.
     :type categories: Any
@@ -794,10 +762,10 @@ def make_count_by_categories(
     :param MO: Output Metric.
     :type MO: SensitivityMetric
     :param TIA: Atomic Input Type that is categorical/hashable. Input data must be Vec<TIA>
-    :type TIA: :ref:`RuntimeTypeDescriptor`
+    :type TIA: :py:ref:`RuntimeTypeDescriptor`
     :param TOA: Atomic Output Type that is numeric.
-    :type TOA: :ref:`RuntimeTypeDescriptor`
-    :return: The carrier type is HashMap<TK, TV>, a hashmap of the count (TV) for each unique data input (TK).
+    :type TOA: :py:ref:`RuntimeTypeDescriptor`
+    :return: The carrier type is `HashMap<TK, TV>`, a hashmap of the count (`TV`) for each unique data input (`TK`).
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -831,16 +799,15 @@ def make_count_distinct(
 ) -> Transformation:
     """Make a Transformation that computes a count of the number of unique, distinct records in data.
     
-    **Citations**
     
-    * GRS12, Universally Utility-Maximizing Privacy Mechanisms
+    **Citations:**
     
-        * <https://theory.stanford.edu/~tim/papers/priv.pdf>
+    * [GRS12 Universally Utility-Maximizing Privacy Mechanisms](https://theory.stanford.edu/~tim/papers/priv.pdf)
     
     :param TIA: Atomic Input Type. Input data is expected to be of the form Vec<TIA>.
-    :type TIA: :ref:`RuntimeTypeDescriptor`
+    :type TIA: :py:ref:`RuntimeTypeDescriptor`
     :param TO: 
-    :type TO: :ref:`RuntimeTypeDescriptor`
+    :type TO: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -868,12 +835,12 @@ def make_create_dataframe(
     col_names: Any,
     K: RuntimeTypeDescriptor = None
 ) -> Transformation:
-    """Make a Transformation that constructs a dataframe from a Vec<Vec<String>> (a vector of records).
+    """Make a Transformation that constructs a dataframe from a `Vec<Vec<String>>` (a vector of records).
     
     :param col_names: Column names for each record entry.
     :type col_names: Any
     :param K: categorical/hashable data type of column names
-    :type K: :ref:`RuntimeTypeDescriptor`
+    :type K: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -908,11 +875,11 @@ def make_df_cast_default(
     :param column_name: column name to be transformed
     :type column_name: Any
     :param TK: Type of the column name
-    :type TK: :ref:`RuntimeTypeDescriptor`
+    :type TK: :py:ref:`RuntimeTypeDescriptor`
     :param TIA: Atomic Input Type to cast from
-    :type TIA: :ref:`RuntimeTypeDescriptor`
+    :type TIA: :py:ref:`RuntimeTypeDescriptor`
     :param TOA: Atomic Output Type to cast into
-    :type TOA: :ref:`RuntimeTypeDescriptor`
+    :type TOA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -952,9 +919,9 @@ def make_df_is_equal(
     :param value: 
     :type value: Any
     :param TK: Type of the column name
-    :type TK: :ref:`RuntimeTypeDescriptor`
+    :type TK: :py:ref:`RuntimeTypeDescriptor`
     :param TIA: Atomic Input Type to cast from
-    :type TIA: :ref:`RuntimeTypeDescriptor`
+    :type TIA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -984,10 +951,10 @@ def make_drop_null(
     DA: RuntimeTypeDescriptor
 ) -> Transformation:
     """Make a Transformation that drops null values.
-    Operates on OptionNullDomain<AllDomain<TA>> or InherentNullDomain<AllDomain<TA>>.
+    `DA` is one of `OptionNullDomain<AllDomain<TA>>` or `InherentNullDomain<AllDomain<TA>>`.
     
     :param DA: atomic domain of input data that contains nulls.
-    :type DA: :ref:`RuntimeTypeDescriptor`
+    :type DA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1018,7 +985,7 @@ def make_find(
     :param categories: The set of categories to find indexes from.
     :type categories: Any
     :param TIA: Atomic Input Type that is categorical/hashable
-    :type TIA: :ref:`RuntimeTypeDescriptor`
+    :type TIA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1050,7 +1017,7 @@ def make_find_bin(
     :param edges: The set of edges to split bins by.
     :type edges: Any
     :param TIA: Atomic Input Type that is numeric
-    :type TIA: :ref:`RuntimeTypeDescriptor`
+    :type TIA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1079,10 +1046,10 @@ def make_identity(
 ) -> Transformation:
     """Make a Transformation representing the identity function.
     
-    :param D: Domain of the identity function. Must be VectorDomain<AllDomain<_>> or AllDomain<_>
-    :type D: :ref:`RuntimeTypeDescriptor`
+    :param D: Domain of the identity function. Must be `VectorDomain<AllDomain<T>>` or `AllDomain<T>`
+    :type D: :py:ref:`RuntimeTypeDescriptor`
     :param M: Metric. Must be a dataset metric if D is a VectorDomain or a sensitivity metric if D is an AllDomain
-    :type M: :ref:`RuntimeTypeDescriptor`
+    :type M: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1111,17 +1078,21 @@ def make_impute_constant(
     DA: RuntimeTypeDescriptor = "OptionNullDomain<AllDomain<TA>>"
 ) -> Transformation:
     """Make a Transformation that replaces null/None data with `constant`.
-    By default, the input type is Vec<Option<TA>>, as emitted by make_cast.
-    Set `DA` to InherentNullDomain<AllDomain<TA>> for imputing on types 
+    By default, the input type is `Vec<Option<TA>>`, as emitted by make_cast.
+    Set `DA` to `InherentNullDomain<AllDomain<TA>>` for imputing on types 
     that have an inherent representation of nullity, like floats.
     
-    Maps a Vec<Option<T>> -> Vec<T> if input domain is AllDomain<Option<T>>,
-        or Vec<T> -> Vec<T> if input domain is NullableDomain<AllDomain<T>>
+    ```text
+    | Input Domain `DI`            |  Input Type    | Output Type |
+    | ---------------------------- | -------------- | ----------- |
+    | AllDomain<Option<T>>         | Vec<Option<T>> | Vec<T>      |
+    | NullableDomain<AllDomain<T>> | Vec<T>         | Vec<T>      |
+    ```
     
     :param constant: Value to replace nulls with.
     :type constant: Any
-    :param DA: Atomic Domain of data being imputed. This is OptionNullDomain<AllDomain<TA>> or InherentNullDomain<AllDomain<TA>>
-    :type DA: :ref:`RuntimeTypeDescriptor`
+    :param DA: Atomic Domain of data being imputed.
+    :type DA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1151,12 +1122,12 @@ def make_impute_uniform_float(
     TA: RuntimeTypeDescriptor = None
 ) -> Transformation:
     """Make a Transformation that replaces NaN values in Vec<`TA`> with uniformly distributed floats within `bounds`.
-    Operates on InherentNullDomain<AllDomain<TA>>
+    Operates on `InherentNullDomain<AllDomain<TA>>`
     
     :param bounds: Tuple of inclusive lower and upper bounds.
     :type bounds: Tuple[Any, Any]
-    :param TA: Atomic Type of data being imputed. One of f32 or f64
-    :type TA: :ref:`RuntimeTypeDescriptor`
+    :param TA: Atomic Type of data being imputed. One of `f32` or `f64`
+    :type TA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1191,7 +1162,7 @@ def make_index(
     :param null: Category to return if the index is out-of-range of the category set.
     :type null: Any
     :param TOA: 
-    :type TOA: :ref:`RuntimeTypeDescriptor`
+    :type TOA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1224,7 +1195,7 @@ def make_is_equal(
     :param value: value to check against
     :type value: Any
     :param TIA: Atomic Input Type. Type of elements in the input vector
-    :type TIA: :ref:`RuntimeTypeDescriptor`
+    :type TIA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1253,7 +1224,7 @@ def make_is_null(
     """Make a Transformation that checks if each element in a vector is null.
     
     :param DIA: Atomic Input Domain. Can be any domain for which the carrier type has a notion of nullity.
-    :type DIA: :ref:`RuntimeTypeDescriptor`
+    :type DIA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1288,9 +1259,9 @@ def make_lipschitz_float_mul(
     :param bounds: Tuple of inclusive lower and upper bounds.
     :type bounds: Tuple[Any, Any]
     :param D: Domain of the function. Must be AllDomain<T> or VectorDomain<AllDomain<T>>
-    :type D: :ref:`RuntimeTypeDescriptor`
+    :type D: :py:ref:`RuntimeTypeDescriptor`
     :param M: Metric. Must be AbsoluteDistance<T>, L1Distance<T> or L2Distance<T>
-    :type M: :ref:`RuntimeTypeDescriptor`
+    :type M: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1333,15 +1304,19 @@ def make_metric_bounded(
     
     While it is valid to operate with bounded data, there is no constructor for it in Python.
     
-    If MI is "SymmetricDistance", then output metric is "ChangeOneDistance", 
-    and respectively "InsertDeleteDistance" maps to "HammingDistance".
+    ```text
+    | `MI`                 | output metric     |
+    | -------------------- | ----------------- |
+    | SymmetricDistance    | ChangeOneDistance |
+    | InsertDeleteDistance | HammingDistance   |
+    ```
     
     :param size: Number of records in input data.
     :type size: int
-    :param MI: Input Metric. One of "SymmetricDistance" or "InsertDeleteDistance"
+    :param MI: Input Metric.
     :type MI: DatasetMetric
     :param TA: Atomic Type.
-    :type TA: :ref:`RuntimeTypeDescriptor`
+    :type TA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1375,15 +1350,19 @@ def make_metric_unbounded(
     to the respective unbounded dataset metric with a no-op. 
     Operates exclusively on SizedDomain<VectorDomain<AllDomain<`TA`>>>.
     
-    If "ChangeOneDistance", then output metric is "SymmetricDistance", 
-    and respectively "HammingDistance" maps to "InsertDeleteDistance".
+    ```text
+    | `MI`              | output metric        |
+    | ----------------- | -------------------- |
+    | ChangeOneDistance | SymmetricDistance    |
+    | HammingDistance   | InsertDeleteDistance |
+    ```
     
     :param size: Number of records in input data.
     :type size: int
-    :param MI: Input Metric. One of "ChangeOneDistance" or "HammingDistance"
+    :param MI: Input Metric.
     :type MI: DatasetMetric
     :param TA: Atomic Type.
-    :type TA: :ref:`RuntimeTypeDescriptor`
+    :type TA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1417,7 +1396,7 @@ def make_ordered_random(
     The dataset metric is not generic over ChangeOneDistance because the dataset size is unknown.
     
     :param TA: Atomic Type.
-    :type TA: :ref:`RuntimeTypeDescriptor`
+    :type TA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1455,9 +1434,9 @@ def make_quantiles_from_counts(
     :param interpolation: Must be one of `linear` or `nearest`
     :type interpolation: str
     :param TA: Atomic Type of the bin edges and data.
-    :type TA: :ref:`RuntimeTypeDescriptor`
-    :param F: Float type of the alpha argument. One of f32 or f64
-    :type F: :ref:`RuntimeTypeDescriptor`
+    :type TA: :py:ref:`RuntimeTypeDescriptor`
+    :param F: Float type of the alpha argument. One of `f32` or `f64`
+    :type F: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1499,11 +1478,11 @@ def make_resize(
     :param constant: Value to impute with.
     :type constant: Any
     :param MI: Input Metric. One of `InsertDeleteDistance` or `SymmetricDistance`
-    :type MI: :ref:`RuntimeTypeDescriptor`
+    :type MI: :py:ref:`RuntimeTypeDescriptor`
     :param MO: Output Metric. One of `InsertDeleteDistance` or `SymmetricDistance`
-    :type MO: :ref:`RuntimeTypeDescriptor`
+    :type MO: :py:ref:`RuntimeTypeDescriptor`
     :param TA: Atomic type. If not passed, TA is inferred from the lower bound
-    :type TA: :ref:`RuntimeTypeDescriptor`
+    :type TA: :py:ref:`RuntimeTypeDescriptor`
     :return: A vector of the same type `TA`, but with the provided `size`.
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
@@ -1542,9 +1521,9 @@ def make_select_column(
     :param key: categorical/hashable data type of the key/column name
     :type key: Any
     :param K: data type of key
-    :type K: :ref:`RuntimeTypeDescriptor`
+    :type K: :py:ref:`RuntimeTypeDescriptor`
     :param TOA: Atomic Output Type to downcast vector to
-    :type TOA: :ref:`RuntimeTypeDescriptor`
+    :type TOA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1577,22 +1556,18 @@ def make_sized_bounded_float_checked_sum(
     """Make a Transformation that computes the sum of bounded floats with known dataset size. 
     This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility.
     
-    **Citations**
     
-    * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
+    **Citations:**
     
-        * <https://arxiv.org/pdf/2207.10635.pdf>
-    
-    * Calibrating Noise to Sensitivity in Private Data Analysis
-        
-        * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+    * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf) 
+    * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
     :param size: Number of records in input data.
     :type size: int
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
     :type bounds: Tuple[Any, Any]
-    :param S: Summation algorithm to use on data type T. One of Sequential<T> or Pairwise<T>.
-    :type S: :ref:`RuntimeTypeDescriptor`
+    :param S: Summation algorithm to use on data type `T`. One of `Sequential<T>` or `Pairwise<T>`.
+    :type S: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1627,22 +1602,18 @@ def make_sized_bounded_float_ordered_sum(
     This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility. 
     You may need to use `make_ordered_random` to impose an ordering on the data.
     
-    **Citations**
     
-    * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
+    **Citations:**
     
-        * <https://arxiv.org/pdf/2207.10635.pdf>
-    
-    * Calibrating Noise to Sensitivity in Private Data Analysis
-        
-        * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+    * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+    * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
     :param size: Number of records in input data.
     :type size: int
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
     :type bounds: Tuple[Any, Any]
-    :param S: Summation algorithm to use on data type T. One of Sequential<T> or Pairwise<T>.
-    :type S: :ref:`RuntimeTypeDescriptor`
+    :param S: Summation algorithm to use on data type `T`. One of `Sequential<T>` or `Pairwise<T>`.
+    :type S: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1676,22 +1647,18 @@ def make_sized_bounded_int_checked_sum(
     """Make a Transformation that computes the sum of bounded ints. 
     The effective range is reduced, as (bounds * size) must not overflow.
     
-    **Citations**
     
-    * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
+    **Citations:**
     
-        * <https://arxiv.org/pdf/2207.10635.pdf>
-    
-    * Calibrating Noise to Sensitivity in Private Data Analysis
-        
-        * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+    * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+    * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
     :param size: Number of records in input data.
     :type size: int
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
     :type bounds: Tuple[Any, Any]
     :param T: Atomic Input Type and Output Type
-    :type T: :ref:`RuntimeTypeDescriptor`
+    :type T: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1723,22 +1690,18 @@ def make_sized_bounded_int_monotonic_sum(
     """Make a Transformation that computes the sum of bounded ints, 
     where all values share the same sign.
     
-    **Citations**
     
-    * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
+    **Citations:**
     
-        * <https://arxiv.org/pdf/2207.10635.pdf>
-    
-    * Calibrating Noise to Sensitivity in Private Data Analysis
-        
-        * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+    * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+    * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
     :param size: Number of records in input data.
     :type size: int
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
     :type bounds: Tuple[Any, Any]
     :param T: Atomic Input Type and Output Type
-    :type T: :ref:`RuntimeTypeDescriptor`
+    :type T: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1771,22 +1734,18 @@ def make_sized_bounded_int_ordered_sum(
     This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility. 
     You may need to use `make_ordered_random` to impose an ordering on the data.
     
-    **Citations**
     
-    * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
+    **Citations:**
     
-        * <https://arxiv.org/pdf/2207.10635.pdf>
-    
-    * Calibrating Noise to Sensitivity in Private Data Analysis
-        
-        * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+    * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+    * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
     :param size: Number of records in input data.
     :type size: int
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
     :type bounds: Tuple[Any, Any]
     :param T: Atomic Input Type and Output Type
-    :type T: :ref:`RuntimeTypeDescriptor`
+    :type T: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1819,22 +1778,18 @@ def make_sized_bounded_int_split_sum(
     This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility. 
     Adds the saturating sum of the positives to the saturating sum of the negatives.
     
-    **Citations**
     
-    * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
+    **Citations:**
     
-        * <https://arxiv.org/pdf/2207.10635.pdf>
-    
-    * Calibrating Noise to Sensitivity in Private Data Analysis
-        
-        * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+    * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+    * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
     :param size: Number of records in input data.
     :type size: int
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
     :type bounds: Tuple[Any, Any]
     :param T: Atomic Input Type and Output Type
-    :type T: :ref:`RuntimeTypeDescriptor`
+    :type T: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1873,9 +1828,9 @@ def make_sized_bounded_mean(
     :param bounds: Tuple of inclusive lower and upper bounds.
     :type bounds: Tuple[Any, Any]
     :param MI: Input Metric. One of `SymmetricDistance` or `InsertDeleteDistance`
-    :type MI: :ref:`RuntimeTypeDescriptor`
+    :type MI: :py:ref:`RuntimeTypeDescriptor`
     :param T: Atomic Input Type and Output Type.
-    :type T: :ref:`RuntimeTypeDescriptor`
+    :type T: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1910,17 +1865,21 @@ def make_sized_bounded_ordered_random(
     """Make a Transformation that converts the unordered dataset metric `MI`
     to the respective ordered dataset metric by assigning a random permutatation.
     Operates exclusively on SizedDomain<VectorDomain<BoundedDomain<`TA`>>>.
-    If `MI` is "SymmetricDistance", then output metric is "InsertDeleteDistance",
-    and respectively "ChangeOneDistance" maps to "HammingDistance".
+    ```text
+    | `MI`              | output metric        |
+    | ----------------- | -------------------- |
+    | SymmetricDistance | InsertDeleteDistance |
+    | ChangeOneDistance | HammingDistance      |
+    ```
     
     :param size: Number of records in input data.
     :type size: int
     :param bounds: Tuple of inclusive lower and upper bounds.
     :type bounds: Tuple[Any, Any]
-    :param MI: Input Metric. One of "SymmetricDistance" or "ChangeOneDistance"
+    :param MI: Input Metric.
     :type MI: DatasetMetric
     :param TA: Atomic Type.
-    :type TA: :ref:`RuntimeTypeDescriptor`
+    :type TA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -1956,24 +1915,20 @@ def make_sized_bounded_sum(
     This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility. 
     Use `make_clamp` to bound data and `make_bounded_resize` to establish dataset size.
     
-    **Citations**
     
-    * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
+    **Citations:**
     
-        * <https://arxiv.org/pdf/2207.10635.pdf>
-    
-    * Calibrating Noise to Sensitivity in Private Data Analysis
-        
-        * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+    * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+    * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
     :param size: Number of records in input data.
     :type size: int
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
     :type bounds: Tuple[Any, Any]
     :param MI: Input Metric. One of `SymmetricDistance` or `InsertDeleteDistance`.
-    :type MI: :ref:`RuntimeTypeDescriptor`
+    :type MI: :py:ref:`RuntimeTypeDescriptor`
     :param T: Atomic Input Type and Output Type.
-    :type T: :ref:`RuntimeTypeDescriptor`
+    :type T: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -2008,22 +1963,18 @@ def make_sized_bounded_sum_of_squared_deviations(
     This uses a restricted-sensitivity proof that takes advantage of known dataset size. 
     Use `make_clamp` to bound data and `make_bounded_resize` to establish dataset size.
     
-    **Citations**
     
-    * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
+    **Citations:**
     
-        * <https://arxiv.org/pdf/2207.10635.pdf>
-    
-    * Calibrating Noise to Sensitivity in Private Data Analysis
-        
-        * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+    * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+    * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
     :param size: Number of records in input data.
     :type size: int
     :param bounds: Tuple of lower and upper bounds for data in the input domain.
     :type bounds: Tuple[Any, Any]
-    :param S: Summation algorithm to use on data type T. One of Sequential<T> or Pairwise<T>.
-    :type S: :ref:`RuntimeTypeDescriptor`
+    :param S: Summation algorithm to use on data type `T`. One of `Sequential<T>` or `Pairwise<T>`.
+    :type S: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -2058,17 +2009,21 @@ def make_sized_bounded_unordered(
     """Make a Transformation that converts the ordered dataset metric `MI`
     to the respective unordered dataset metric via a no-op.
     Operates exclusively on SizedDomain<VectorDomain<BoundedDomain<`TA`>>>.
-    If `MI` is "InsertDeleteDistance", then output metric is "SymmetricDistance",
-    and respectively "HammingDistance" maps to "ChangeOneDistance".
+    ```text
+    | `MI`                 | output metric      |
+    | -------------------- | ------------------ |
+    | InsertDeleteDistance | SymmetricDistance  |
+    | HammingDistance      | ChangeOneDistance  |
+    ```
     
     :param size: Number of records in input data.
     :type size: int
     :param bounds: Tuple of inclusive lower and upper bounds.
     :type bounds: Tuple[Any, Any]
-    :param MI: Input Metric. One of "InsertDeleteDistance" or "HammingDistance"
+    :param MI: Input Metric.
     :type MI: DatasetMetric
     :param TA: Atomic Type.
-    :type TA: :ref:`RuntimeTypeDescriptor`
+    :type TA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -2104,11 +2059,10 @@ def make_sized_bounded_variance(
     This uses a restricted-sensitivity proof that takes advantage of known dataset size. 
     Use `make_clamp` to bound data and `make_bounded_resize` to establish dataset size.
     
-    **Citations**
     
-    * DHK15, Differential Privacy for Social Science Inference
+    **Citations:**
     
-        * <http://hona.kr/papers/files/DOrazioHonakerKingPrivacy.pdf>
+    * [DHK15 Differential Privacy for Social Science Inference](http://hona.kr/papers/files/DOrazioHonakerKingPrivacy.pdf)
     
     :param size: Number of records in input data.
     :type size: int
@@ -2116,8 +2070,8 @@ def make_sized_bounded_variance(
     :type bounds: Tuple[Any, Any]
     :param ddof: Delta degrees of freedom. Set to 0 if not a sample, 1 for sample estimate.
     :type ddof: int
-    :param S: Summation algorithm to use on data type T. One of Sequential<T> or Pairwise<T>.
-    :type S: :ref:`RuntimeTypeDescriptor`
+    :param S: Summation algorithm to use on data type `T`. One of `Sequential<T>` or `Pairwise<T>`.
+    :type S: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -2152,15 +2106,19 @@ def make_sized_ordered_random(
     """Make a Transformation that converts the unordered dataset metric `MI`
     to the respective ordered dataset metric by assigning a random permutatation.
     Operates exclusively on SizedDomain<VectorDomain<AllDomain<`TA`>>>.
-    If `MI` is "SymmetricDistance", then output metric is "InsertDeleteDistance",
-    and respectively "ChangeOneDistance" maps to "HammingDistance".
+    ```text
+    | `MI`              | output metric        |
+    | ----------------- | -------------------- |
+    | SymmetricDistance | InsertDeleteDistance |
+    | ChangeOneDistance | HammingDistance      |
+    ```
     
     :param size: Number of records in input data.
     :type size: int
-    :param MI: Input Metric. One of "SymmetricDistance" or "ChangeOneDistance"
+    :param MI: Input Metric.
     :type MI: DatasetMetric
     :param TA: Atomic Type.
-    :type TA: :ref:`RuntimeTypeDescriptor`
+    :type TA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -2193,15 +2151,19 @@ def make_sized_unordered(
     """Make a Transformation that converts the ordered dataset metric `MI`
     to the respective unordered dataset metric via a no-op.
     Operates exclusively on SizedDomain<VectorDomain<AllDomain<`TA`>>>.
-    If `MI` is "InsertDeleteDistance", then output metric is "SymmetricDistance",
-    and respectively "HammingDistance" maps to "ChangeOneDistance".
+    ```text
+    | `MI`                 | output metric      |
+    | -------------------- | ------------------ |
+    | InsertDeleteDistance | SymmetricDistance  |
+    | HammingDistance      | ChangeOneDistance  |
+    ```
     
     :param size: Number of records in input data.
     :type size: int
-    :param MI: Input Metric. One of "InsertDeleteDistance" or "HammingDistance"
+    :param MI: Input Metric.
     :type MI: DatasetMetric
     :param TA: Atomic Type.
-    :type TA: :ref:`RuntimeTypeDescriptor`
+    :type TA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -2231,7 +2193,7 @@ def make_split_dataframe(
     col_names: Any,
     K: RuntimeTypeDescriptor = None
 ) -> Transformation:
-    """Make a Transformation that splits each record in a String into a Vec<Vec<String>>,
+    """Make a Transformation that splits each record in a String into a `Vec<Vec<String>>`,
     and loads the resulting table into a dataframe keyed by `col_names`.
     
     :param separator: The token(s) that separate entries in each record.
@@ -2239,7 +2201,7 @@ def make_split_dataframe(
     :param col_names: Column names for each record entry.
     :type col_names: Any
     :param K: categorical/hashable data type of column names
-    :type K: :ref:`RuntimeTypeDescriptor`
+    :type K: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -2266,7 +2228,7 @@ def make_split_dataframe(
 def make_split_lines(
     
 ) -> Transformation:
-    """Make a Transformation that takes a string and splits it into a Vec<String> of its lines.
+    """Make a Transformation that takes a string and splits it into a `Vec<String>` of its lines.
     
     
     :rtype: Transformation
@@ -2289,7 +2251,7 @@ def make_split_lines(
 def make_split_records(
     separator: str
 ) -> Transformation:
-    """Make a Transformation that splits each record in a Vec<String> into a Vec<Vec<String>>.
+    """Make a Transformation that splits each record in a `Vec<String>` into a `Vec<Vec<String>>`.
     
     :param separator: The token(s) that separate entries in each record.
     :type separator: str
@@ -2324,7 +2286,7 @@ def make_subset_by(
     :param keep_columns: list of column names to apply subset to
     :type keep_columns: Any
     :param TK: Type of the column name
-    :type TK: :ref:`RuntimeTypeDescriptor`
+    :type TK: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -2353,12 +2315,12 @@ def make_unclamp(
     TA: RuntimeTypeDescriptor = None
 ) -> Transformation:
     """Make a Transformation that unclamps numeric data in Vec<`T`>.
-    Used to convert a VectorDomain<BoundedDomain<T>> to a VectorDomain<AllDomain<T>>.
+    Used to convert a `VectorDomain<BoundedDomain<T>>` to a `VectorDomain<AllDomain<T>>`.
     
     :param bounds: Tuple of lower and upper bounds.
     :type bounds: Tuple[Any, Any]
     :param TA: Atomic Type
-    :type TA: :ref:`RuntimeTypeDescriptor`
+    :type TA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse
@@ -2389,8 +2351,14 @@ def make_unordered(
     Operates exclusively on VectorDomain<AllDomain<`TA`>>.
     The dataset metric is not generic over HammingDistance because the dataset size is unknown.
     
+    ```text
+    | input metric         | output metric        |
+    | -------------------- | -------------------- |
+    | InsertDeleteDistance | SymmetricDistance    |
+    ```
+    
     :param TA: Atomic Type.
-    :type TA: :ref:`RuntimeTypeDescriptor`
+    :type TA: :py:ref:`RuntimeTypeDescriptor`
     :rtype: Transformation
     :raises AssertionError: if an argument's type differs from the expected type
     :raises UnknownTypeError: if a type-argument fails to parse

--- a/rust/build/codegen/python.rs
+++ b/rust/build/codegen/python.rs
@@ -123,17 +123,11 @@ fn generate_input_argument(arg: &Argument, func: &Function, hierarchy: &HashMap<
 /// generate a docstring for the current function, with the function description, args, and return
 /// in Sphinx format: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
 fn generate_docstring(func: &Function, hierarchy: &HashMap<String, Vec<String>>) -> String {
-    let mut description = func.description.as_ref()
+    let description = func.description.as_ref()
         .map(|v| format!("{}\n", v))
         .unwrap_or_else(String::new);
-    if let Some(proof) = &func.proof {
-        description = format!(r#"{description}
 
-`This constructor is supported by the linked proof. <{proof}>`_
-"#,
-        description=description,
-        proof=proof);
-    }
+    println!("{description}");
 
     let doc_args = func.args.iter()
         .map(|v| generate_docstring_arg(v, hierarchy))

--- a/rust/build/codegen/python.rs
+++ b/rust/build/codegen/python.rs
@@ -163,7 +163,7 @@ fn generate_docstring_arg(arg: &Argument, hierarchy: &HashMap<String, Vec<String
     format!(r#":param {name}: {description}{type_}"#,
             name = name,
             type_ = arg.python_type_hint(hierarchy)
-                .map(|v| if v.as_str() == "RuntimeTypeDescriptor" {":ref:`RuntimeTypeDescriptor`".to_string()} else {v})
+                .map(|v| if v.as_str() == "RuntimeTypeDescriptor" {":py:ref:`RuntimeTypeDescriptor`".to_string()} else {v})
                 .map(|v| format!("\n:type {}: {}", name, v))
                 .unwrap_or_default(),
             description = arg.description.clone().unwrap_or_default())

--- a/rust/opendp_bootstrap/src/parse/docstring.rs
+++ b/rust/opendp_bootstrap/src/parse/docstring.rs
@@ -19,7 +19,7 @@ impl Docstring {
 
         let mut insert_section = |section_name: &str| {
             doc_sections.remove(section_name).map(|section| {
-                description.push(format!("**{section_name}**\n"));
+                description.push(format!("\n**{section_name}:**\n"));
                 description.extend(section)
             })
         };

--- a/rust/opendp_bootstrap/src/parse/docstring.rs
+++ b/rust/opendp_bootstrap/src/parse/docstring.rs
@@ -16,7 +16,6 @@ impl Docstring {
         let mut doc_sections = parse_docstring_sections(attrs)?;
 
         if let Some(sup_elements) = parse_sig_output(output)? {
-            println!("{sup_elements:?}");
             doc_sections.insert("Supporting Elements".to_string(), sup_elements);
         }
 

--- a/rust/opendp_bootstrap/src/parse/mod.rs
+++ b/rust/opendp_bootstrap/src/parse/mod.rs
@@ -30,7 +30,7 @@ impl Function {
         }
 
         // aggregate info from all sources
-        let function = reconcile_function(bootstrap, Docstring::from_attrs(attrs)?, sig)?;
+        let function = reconcile_function(bootstrap, Docstring::from_attrs(attrs, &sig.output)?, sig)?;
 
         Ok((func_name, function))
     }

--- a/rust/opendp_derive/src/lib.rs
+++ b/rust/opendp_derive/src/lib.rs
@@ -32,7 +32,7 @@ pub fn bootstrap(attr_args: TokenStream, input: TokenStream) -> TokenStream {
     let ItemFn { attrs, sig, .. } = parse_macro_input!(input as ItemFn);
 
     // attempt to parse docstring to detect formatting errors
-    let docstrings = try_!(Docstring::from_attrs(attrs), original_input);
+    let docstrings = try_!(Docstring::from_attrs(attrs, &sig.output), original_input);
 
     // parse bootstrap arguments
     let attr_args = parse_macro_input!(attr_args as AttributeArgs);

--- a/rust/src/combinators/amplify/mod.rs
+++ b/rust/src/combinators/amplify/mod.rs
@@ -35,7 +35,7 @@ impl<Q> AmplifiableMeasure for FixedSmoothedMaxDivergence<Q>
 /// This measurement does not perform any sampling. 
 /// It is useful when you have a dataset on-hand that is a simple random sample from a larger population.
 /// 
-/// The DIA, DO, MI and MO between the input measurement and amplified output measurement all match.
+/// The `DIA`, `DO`, `MI` and `MO` between the input measurement and amplified output measurement all match.
 /// 
 /// # Arguments
 /// * `measurement` - the computation to apply privacy amplification to

--- a/rust/src/combinators/chain/ffi.rs
+++ b/rust/src/combinators/chain/ffi.rs
@@ -10,7 +10,7 @@ use crate::ffi::any::{AnyMeasurement, AnyTransformation};
     arguments(measurement1(rust_type()), transformation0(rust_type()))
 )]
 /// Construct the functional composition (`measurement1` ○ `transformation0`).
-/// Returns a Measurement that when invoked, computes measurement1(transformation0(x)).
+/// Returns a Measurement that when invoked, computes `measurement1(transformation0(x))`.
 ///
 /// # Arguments
 /// * `measurement1` - outer mechanism
@@ -37,7 +37,7 @@ pub extern "C" fn opendp_combinators__make_chain_mt(
     arguments(transformation1(rust_type()), transformation0(rust_type()))
 )]
 /// Construct the functional composition (`transformation1` ○ `transformation0`).
-/// Returns a Transformation that when invoked, computes transformation1(transformation0(x)).
+/// Returns a Transformation that when invoked, computes `transformation1(transformation0(x))`.
 ///
 /// # Arguments
 /// * `transformation1` - outer transformation
@@ -63,7 +63,7 @@ pub extern "C" fn opendp_combinators__make_chain_tt(
     arguments(transformation1(rust_type()), measurement0(rust_type()))
 )]
 /// Construct the functional composition (`transformation1` ○ `measurement0`).
-/// Returns a Measurement that when invoked, computes transformation1(measurement0(x)).
+/// Returns a Measurement that when invoked, computes `transformation1(measurement0(x))`.
 /// Used to represent non-interactive postprocessing.
 ///
 /// # Arguments

--- a/rust/src/combinators/chain/mod.rs
+++ b/rust/src/combinators/chain/mod.rs
@@ -21,7 +21,7 @@ fn mismatch_message<T1: Debug, T2: Debug>(mode: &str, struct1: &T1, struct2: &T2
 }
 
 /// Construct the functional composition (`measurement1` ○ `transformation0`).
-/// Returns a Measurement that when invoked, computes measurement1(transformation0(x)).
+/// Returns a Measurement that when invoked, computes `measurement1(transformation0(x))`.
 /// 
 /// # Arguments
 /// * `measurement1` - outer measurement/mechanism
@@ -62,7 +62,7 @@ pub fn make_chain_mt<DI, DX, DO, MI, MX, MO>(
 }
 
 /// Construct the functional composition (`transformation1` ○ `transformation0`).
-/// Returns a Measurement that when invoked, computes transformation1(transformation0(x)).
+/// Returns a Measurement that when invoked, computes `transformation1(transformation0(x))`.
 /// 
 /// # Arguments
 /// * `transformation1` - outer transformation
@@ -103,7 +103,7 @@ pub fn make_chain_tt<DI, DX, DO, MI, MX, MO>(
 }
 
 /// Construct the functional composition (`transformation1` ○ `measurement0`).
-/// Returns a Measurement that when invoked, computes transformation1(measurement0(x)).
+/// Returns a Measurement that when invoked, computes `transformation1(measurement0(x))`.
 /// Used to represent non-interactive postprocessing.
 /// 
 /// # Arguments

--- a/rust/src/combinators/measure_cast/zCDP_to_approxDP/ffi.rs
+++ b/rust/src/combinators/measure_cast/zCDP_to_approxDP/ffi.rs
@@ -10,7 +10,7 @@ use crate::{
 
 #[bootstrap(features("contrib"))]
 /// Constructs a new output measurement where the output measure
-/// is casted from ZeroConcentratedDivergence<QO> to SmoothedMaxDivergence<QO>.
+/// is casted from `ZeroConcentratedDivergence<QO>` to `SmoothedMaxDivergence<QO>`.
 ///
 /// # Arguments
 /// * `measurement` - a measurement with a privacy curve to be casted

--- a/rust/src/combinators/measure_cast/zCDP_to_approxDP/mod.rs
+++ b/rust/src/combinators/measure_cast/zCDP_to_approxDP/mod.rs
@@ -13,7 +13,7 @@ mod ffi;
 mod cks20;
 
 /// Constructs a new output measurement where the output measure 
-/// is casted from ZeroConcentratedDivergence<QO> to SmoothedMaxDivergence<QO>.
+/// is casted from `ZeroConcentratedDivergence<QO>` to `SmoothedMaxDivergence<QO>`.
 /// 
 /// # Arguments
 /// * `meas` - a measurement with a privacy curve to be casted
@@ -22,7 +22,7 @@ mod cks20;
 /// * `DI` - Input Domain
 /// * `DO` - Output Domain
 /// * `MI` - Input Metric
-/// * `QO` - Output distance type. One of f32 or f64.
+/// * `QO` - Output distance type. One of `f32` or `f64`.
 pub fn make_zCDP_to_approxDP<DI, DO, MI, QO>(
     meas: Measurement<DI, DO, MI, ZeroConcentratedDivergence<QO>>,
 ) -> Fallible<Measurement<DI, DO, MI, SmoothedMaxDivergence<QO>>>

--- a/rust/src/combinators/mod.rs
+++ b/rust/src/combinators/mod.rs
@@ -1,26 +1,26 @@
 #[cfg(feature="contrib")]
-pub mod amplify;
+mod amplify;
 #[cfg(feature="contrib")]
 pub use crate::combinators::amplify::*;
 
 #[cfg(feature="contrib")]
-pub mod chain;
+mod chain;
 #[cfg(feature="contrib")]
 pub use crate::combinators::chain::*;
 
 #[cfg(feature="contrib")]
-pub mod compose;
+mod compose;
 #[cfg(feature="contrib")]
 pub use crate::combinators::compose::*;
 
 #[cfg(feature="contrib")]
-pub mod measure_cast;
+mod measure_cast;
 #[cfg(feature="contrib")]
 pub use crate::combinators::measure_cast::*;
 
 
 #[cfg(feature="contrib")]
-pub mod fix_delta;
+mod fix_delta;
 #[cfg(feature="contrib")]
 pub use crate::combinators::fix_delta::*;
 

--- a/rust/src/measurements/alp/mod.rs
+++ b/rust/src/measurements/alp/mod.rs
@@ -30,6 +30,8 @@ type SparseDomain<K, C> = MapDomain<AllDomain<K>, AllDomain<C>>;
 type BitVector = Vec<bool>;
 type HashFunctions<K> = Vec<Rc<dyn Fn(&K) -> usize>>;
 #[derive(Clone)]
+
+#[doc(hidden)]
 pub struct AlpState<K, T>{
     alpha: T,
     scale: T,
@@ -145,7 +147,9 @@ fn compute_estimate<K, T>(state: &AlpState<K, T>, key: &K) -> T
     estimate_unary::<T>(&v) * T::from(state.alpha).unwrap() / state.scale
 }
 
-/// Measurement to compute a DP projection of bounded sparse data. See arxiv.org/abs/2106.10068 (Algorithm 4).
+/// Measurement to compute a DP projection of bounded sparse data. 
+/// 
+/// See arxiv.org/abs/2106.10068 (Algorithm 4).
 /// This function allows the user to create custom hash functions. The mechanism provides no utility guarantees 
 /// if hash functions are chosen poorly. It is recommended to use make_base_alp.
 /// 
@@ -191,7 +195,9 @@ pub fn make_base_alp_with_hashers<K, C, T>(alpha: T, scale: T, s: usize, h: Hash
     ))
 }
 
-/// Measurement to compute a DP projection of bounded sparse data. See arxiv.org/abs/2106.10068 (Algorithm 4).
+/// Measurement to compute a DP projection of bounded sparse data. 
+/// 
+/// See arxiv.org/abs/2106.10068 (Algorithm 4).
 /// The size of the projection is O(total * size_factor * scale / alpha).
 /// The evaluation time of post-processing is O(beta * scale / alpha). 
 ///
@@ -240,7 +246,7 @@ pub fn post_process<K, T>(state: AlpState<K, T>) -> Queryable<AlpState<K, T>, K,
     })
 }
 
-/// Wrapper Measurement. See post_process above
+/// Wrapper Measurement. See [`post_process`].
 pub fn make_alp_histogram_post_process<K, C, T>(
     m: &Measurement<SparseDomain<K, C>, AlpDomain<K, T>, L1Distance<C>, MaxDivergence<T>>
 ) -> Fallible<Measurement<SparseDomain<K, C>, AllDomain<Queryable<AlpState<K, T>, K, T>>, L1Distance<C>, MaxDivergence<T>>>

--- a/rust/src/measurements/discrete_gaussian/mod.rs
+++ b/rust/src/measurements/discrete_gaussian/mod.rs
@@ -78,12 +78,12 @@ where
 )]
 /// Make a Measurement that adds noise from the discrete_gaussian(`scale`) distribution to the input.
 /// 
-/// Set `D` to change the input data type:
+/// Set `D` to change the input data type and input metric:
 /// ```text
-/// | `D`                        | input type |
-/// | -------------------------- | ---------- | 
-/// | AllDomain<T> (default)     | T          |
-/// | VectorDomain<AllDomain<T>> | Vec<T>     |
+/// | `D`                        | input type | `D::InputMetric`     |
+/// | -------------------------- | ---------- | -------------------- |
+/// | AllDomain<T> (default)     | T          | AbsoluteDistance<T>  |
+/// | VectorDomain<AllDomain<T>> | Vec<T>     | L2Distance<T>        |
 /// ```
 /// 
 /// # Arguments

--- a/rust/src/measurements/discrete_gaussian/mod.rs
+++ b/rust/src/measurements/discrete_gaussian/mod.rs
@@ -19,6 +19,7 @@ mod ffi;
 
 use super::MappableDomain;
 
+#[doc(hidden)]
 pub trait DiscreteGaussianDomain<Q>: MappableDomain + Default {
     type InputMetric: SensitivityMetric<Distance = Q> + Default;
 }
@@ -29,6 +30,7 @@ impl<T: Clone + CheckNull, Q> DiscreteGaussianDomain<Q> for VectorDomain<AllDoma
     type InputMetric = L2Distance<Q>;
 }
 
+#[doc(hidden)]
 pub trait DiscreteGaussianMeasure<DI>: Measure + Default
 where
     DI: DiscreteGaussianDomain<Self::Atom>,
@@ -75,14 +77,21 @@ where
     derived_types(Q(get_atom_or_infer("MO", "scale")))
 )]
 /// Make a Measurement that adds noise from the discrete_gaussian(`scale`) distribution to the input.
-/// Adjust D to noise vector-valued data.
+/// 
+/// Set `D` to change the input data type:
+/// ```text
+/// | `D`                        | input type |
+/// | -------------------------- | ---------- | 
+/// | AllDomain<T> (default)     | T          |
+/// | VectorDomain<AllDomain<T>> | Vec<T>     |
+/// ```
 /// 
 /// # Arguments
 /// * `scale` - Noise scale parameter for the gaussian distribution. `scale` == standard_deviation.
 /// * `k` - The noise granularity.
 /// 
 /// # Generics
-/// * `D` - Domain of the data type to be privatized. Valid values are VectorDomain<AllDomain<T>> or AllDomain<T>.
+/// * `D` - Domain of the data type to be privatized. Valid values are `VectorDomain<AllDomain<T>>` or `AllDomain<T>`.
 /// * `MO` - Output measure. The only valid measure is ZeroConcentratedDivergence<Q>, but Q can be f32 or f64
 pub fn make_base_discrete_gaussian<D, MO>(
     scale: MO::Atom,

--- a/rust/src/measurements/discrete_laplace/cks20/mod.rs
+++ b/rust/src/measurements/discrete_laplace/cks20/mod.rs
@@ -21,19 +21,25 @@ mod ffi;
     arguments(scale(c_type = "void *")),
     generics(D(default = "AllDomain<int>"))
 )]
-/// Make a Measurement that adds noise from the discrete_laplace(`scale`) distribution to the input.
-/// Adjust D to noise vector-valued data.
+/// Make a Measurement that adds noise from the discrete_laplace(`scale`) distribution to the input, 
+/// using an efficient algorithm on rational bignums.
+/// 
+/// Set `D` to change the input data type:
+/// ```text
+/// | `D`                        | input type |
+/// | -------------------------- | ---------- | 
+/// | AllDomain<T> (default)     | T          |
+/// | VectorDomain<AllDomain<T>> | Vec<T>     |
+/// ```
 /// 
 /// # Citations
-/// * CKS20, The Discrete Gaussian for Differential Privacy
-/// 
-///     * Based on Section 5.2 <https://arxiv.org/pdf/2004.00010.pdf#subsection.5.2>
+/// * [CKS20 The Discrete Gaussian for Differential Privacy](https://arxiv.org/pdf/2004.00010.pdf#subsection.5.2)
 /// 
 /// # Arguments
 /// * `scale` - Noise scale parameter for the laplace distribution. `scale` == sqrt(2) * standard_deviation.
 /// 
 /// # Generics
-/// * `D` - Domain of the data type to be privatized. Valid values are VectorDomain<AllDomain<T>> or AllDomain<T>
+/// * `D` - Domain of the data type to be privatized. Valid values are `VectorDomain<AllDomain<T>>` or `AllDomain<T>`
 /// * `QO` - Data type of the output distance and scale.
 pub fn make_base_discrete_laplace_cks20<D, QO>(
     scale: QO,

--- a/rust/src/measurements/discrete_laplace/cks20/mod.rs
+++ b/rust/src/measurements/discrete_laplace/cks20/mod.rs
@@ -24,12 +24,12 @@ mod ffi;
 /// Make a Measurement that adds noise from the discrete_laplace(`scale`) distribution to the input, 
 /// using an efficient algorithm on rational bignums.
 /// 
-/// Set `D` to change the input data type:
+/// Set `D` to change the input data type and input metric:
 /// ```text
-/// | `D`                        | input type |
-/// | -------------------------- | ---------- | 
-/// | AllDomain<T> (default)     | T          |
-/// | VectorDomain<AllDomain<T>> | Vec<T>     |
+/// | `D`                        | input type | `D::InputMetric`     |
+/// | -------------------------- | ---------- | -------------------- |
+/// | AllDomain<T> (default)     | T          | AbsoluteDistance<T>  |
+/// | VectorDomain<AllDomain<T>> | Vec<T>     | L1Distance<T>        |
 /// ```
 /// 
 /// # Citations

--- a/rust/src/measurements/discrete_laplace/linear/mod.rs
+++ b/rust/src/measurements/discrete_laplace/linear/mod.rs
@@ -26,12 +26,12 @@ use super::DiscreteLaplaceDomain;
 /// using a linear-time algorithm on finite data types.
 /// 
 /// This algorithm can be executed in constant time if bounds are passed.
-/// Set `D` to change the input data type:
+/// Set `D` to change the input data type and input metric:
 /// ```text
-/// | `D`                        | input type |
-/// | -------------------------- | ---------- | 
-/// | AllDomain<T> (default)     | T          |
-/// | VectorDomain<AllDomain<T>> | Vec<T>     |
+/// | `D`                        | input type | `D::InputMetric`     |
+/// | -------------------------- | ---------- | -------------------- |
+/// | AllDomain<T> (default)     | T          | AbsoluteDistance<T>  |
+/// | VectorDomain<AllDomain<T>> | Vec<T>     | L1Distance<T>        |
 /// ```
 /// 
 /// # Citations

--- a/rust/src/measurements/discrete_laplace/linear/mod.rs
+++ b/rust/src/measurements/discrete_laplace/linear/mod.rs
@@ -22,21 +22,27 @@ use super::DiscreteLaplaceDomain;
         T(get_atom("D")),
         OptionT(id = "Option<(T, T)>"))
 )]
-/// Make a Measurement that adds noise from the discrete_laplace(`scale`) distribution to the input.
+/// Make a Measurement that adds noise from the discrete_laplace(`scale`) distribution to the input, 
+/// using a linear-time algorithm on finite data types.
+/// 
 /// This algorithm can be executed in constant time if bounds are passed.
-/// Adjust D to noise vector-valued data.
+/// Set `D` to change the input data type:
+/// ```text
+/// | `D`                        | input type |
+/// | -------------------------- | ---------- | 
+/// | AllDomain<T> (default)     | T          |
+/// | VectorDomain<AllDomain<T>> | Vec<T>     |
+/// ```
 /// 
 /// # Citations
-/// * GRS12, Universally Utility-Maximizing Privacy Mechanisms
-/// 
-///     * <https://theory.stanford.edu/~tim/papers/priv.pdf>
+/// * [GRS12 Universally Utility-Maximizing Privacy Mechanisms](https://theory.stanford.edu/~tim/papers/priv.pdf)
 /// 
 /// # Arguments
 /// * `scale` - Noise scale parameter for the distribution. `scale` == sqrt(2) * standard_deviation.
 /// * `bounds` - Set bounds on the count to make the algorithm run in constant-time.
 /// 
-/// # Arguments
-/// * `D` - Domain of the data type to be privatized. Valid values are VectorDomain<AllDomain<T>> or AllDomain<T>
+/// # Generics
+/// * `D` - Domain of the data type to be privatized. Valid values are `VectorDomain<AllDomain<T>>` or `AllDomain<T>`
 /// * `QO` - Data type of the scale and output distance.
 pub fn make_base_discrete_laplace_linear<D, QO>(
     scale: QO,
@@ -103,7 +109,7 @@ where
 /// * `bounds` - Set bounds on the count to make the algorithm run in constant-time.
 /// 
 /// # Arguments
-/// * `D` - Domain of the data type to be privatized. Valid values are VectorDomain<AllDomain<T>> or AllDomain<T>
+/// * `D` - Domain of the data type to be privatized. Valid values are `VectorDomain<AllDomain<T>>` or `AllDomain<T>`
 /// * `QO` - Data type of the scale and output distance
 #[deprecated(
     since = "0.5.0",

--- a/rust/src/measurements/discrete_laplace/mod.rs
+++ b/rust/src/measurements/discrete_laplace/mod.rs
@@ -76,12 +76,12 @@ impl<T: Clone + CheckNull> DiscreteLaplaceDomain for VectorDomain<AllDomain<T>> 
 )]
 /// Make a Measurement that adds noise from the discrete_laplace(`scale`) distribution to the input.
 /// 
-/// Set `D` to change the input data type:
+/// Set `D` to change the input data type and input metric:
 /// ```text
-/// | `D`                        | input type |
-/// | -------------------------- | ---------- | 
-/// | AllDomain<T> (default)     | T          |
-/// | VectorDomain<AllDomain<T>> | Vec<T>     |
+/// | `D`                        | input type | `D::InputMetric`     |
+/// | -------------------------- | ---------- | -------------------- |
+/// | AllDomain<T> (default)     | T          | AbsoluteDistance<T>  |
+/// | VectorDomain<AllDomain<T>> | Vec<T>     | L1Distance<T>        |
 /// ```
 /// 
 /// This uses `make_base_discrete_laplace_cks20` if scale is greater than 10, otherwise it uses `make_base_discrete_laplace_linear`.

--- a/rust/src/measurements/discrete_laplace/mod.rs
+++ b/rust/src/measurements/discrete_laplace/mod.rs
@@ -24,6 +24,7 @@ pub use cks20::*;
 mod linear;
 pub use linear::*;
 
+#[doc(hidden)]
 pub trait MappableDomain: Domain {
     type Atom: Clone;
     fn map_over(
@@ -57,6 +58,7 @@ impl<D: MappableDomain> MappableDomain for VectorDomain<D> {
     }
 }
 
+#[doc(hidden)]
 pub trait DiscreteLaplaceDomain: MappableDomain + Default {
     type InputMetric: SensitivityMetric<Distance = Self::Atom> + Default;
 }
@@ -73,23 +75,26 @@ impl<T: Clone + CheckNull> DiscreteLaplaceDomain for VectorDomain<AllDomain<T>> 
     generics(D(default = "AllDomain<int>"))
 )]
 /// Make a Measurement that adds noise from the discrete_laplace(`scale`) distribution to the input.
-/// Adjust D to noise vector-valued data.
+/// 
+/// Set `D` to change the input data type:
+/// ```text
+/// | `D`                        | input type |
+/// | -------------------------- | ---------- | 
+/// | AllDomain<T> (default)     | T          |
+/// | VectorDomain<AllDomain<T>> | Vec<T>     |
+/// ```
+/// 
 /// This uses `make_base_discrete_laplace_cks20` if scale is greater than 10, otherwise it uses `make_base_discrete_laplace_linear`.
 ///
 /// # Citations
-/// * GRS12, Universally Utility-Maximizing Privacy Mechanisms
-/// 
-///     * <https://theory.stanford.edu/~tim/papers/priv.pdf>
-/// 
-/// * CKS20, The Discrete Gaussian for Differential Privacy
-/// 
-///     * Based on Section 5.2 <https://arxiv.org/pdf/2004.00010.pdf#subsection.5.2>
+/// * [GRS12 Universally Utility-Maximizing Privacy Mechanisms](https://theory.stanford.edu/~tim/papers/priv.pdf)
+/// * [CKS20 The Discrete Gaussian for Differential Privacy](https://arxiv.org/pdf/2004.00010.pdf#subsection.5.2)
 /// 
 /// # Arguments
 /// * `scale` - Noise scale parameter for the laplace distribution. `scale` == sqrt(2) * standard_deviation.
 /// 
 /// # Generics
-/// * `D` - Domain of the data type to be privatized. Valid values are VectorDomain<AllDomain<T>> or AllDomain<T>
+/// * `D` - Domain of the data type to be privatized. Valid values are `VectorDomain<AllDomain<T>>` or `AllDomain<T>`
 /// * `QO` - Data type of the output distance and scale.
 #[cfg(feature = "use-mpfr")]
 pub fn make_base_discrete_laplace<D, QO>(
@@ -136,11 +141,6 @@ where
     }
 }
 
-#[bootstrap(
-    features("contrib"),
-    arguments(scale(c_type = "void *")),
-    generics(D(default = "AllDomain<int>"))
-)]
 #[cfg(not(feature = "use-mpfr"))]
 pub fn make_base_discrete_laplace<D, QO>(
     scale: QO,

--- a/rust/src/measurements/gaussian/mod.rs
+++ b/rust/src/measurements/gaussian/mod.rs
@@ -67,12 +67,12 @@ where
 )]
 /// Make a Measurement that adds noise from the gaussian(`scale`) distribution to the input.
 /// 
-/// Set `D` to change the input data type:
+/// Set `D` to change the input data type and input metric:
 /// ```text
-/// | `D`                        | input type |
-/// | -------------------------- | ---------- | 
-/// | AllDomain<T> (default)     | T          |
-/// | VectorDomain<AllDomain<T>> | Vec<T>     |
+/// | `D`                        | input type | `D::InputMetric`     |
+/// | -------------------------- | ---------- | -------------------- |
+/// | AllDomain<T> (default)     | T          | AbsoluteDistance<T>  |
+/// | VectorDomain<AllDomain<T>> | Vec<T>     | L2Distance<T>        |
 /// ```
 /// 
 /// This function takes a noise granularity in terms of 2^k. 

--- a/rust/src/measurements/gaussian/mod.rs
+++ b/rust/src/measurements/gaussian/mod.rs
@@ -15,6 +15,7 @@ use super::{get_discretization_consts, MappableDomain};
 #[cfg(feature = "ffi")]
 mod ffi;
 
+#[doc(hidden)]
 pub trait GaussianDomain: MappableDomain + Default {
     type InputMetric: SensitivityMetric<Distance = Self::Atom> + Default;
 }
@@ -25,6 +26,7 @@ impl<T: Clone + CheckNull> GaussianDomain for VectorDomain<AllDomain<T>> {
     type InputMetric = L2Distance<T>;
 }
 
+#[doc(hidden)]
 pub trait GaussianMeasure<DI: GaussianDomain>: Measure + Default {
     fn new_forward_map(scale: DI::Atom, relaxation: DI::Atom) -> PrivacyMap<DI::InputMetric, Self>;
 }
@@ -64,7 +66,14 @@ where
     derived_types(T(get_atom_or_infer("D", "scale")))
 )]
 /// Make a Measurement that adds noise from the gaussian(`scale`) distribution to the input.
-/// Adjust D to noise vector-valued data.
+/// 
+/// Set `D` to change the input data type:
+/// ```text
+/// | `D`                        | input type |
+/// | -------------------------- | ---------- | 
+/// | AllDomain<T> (default)     | T          |
+/// | VectorDomain<AllDomain<T>> | Vec<T>     |
+/// ```
 /// 
 /// This function takes a noise granularity in terms of 2^k. 
 /// Larger granularities are more computationally efficient, but have a looser privacy map. 
@@ -75,7 +84,7 @@ where
 /// * `k` - The noise granularity.
 /// 
 /// # Generics
-/// * `D` - Domain of the data type to be privatized. Valid values are VectorDomain<AllDomain<T>> or AllDomain<T>.
+/// * `D` - Domain of the data type to be privatized. Valid values are `VectorDomain<AllDomain<T>>` or `AllDomain<T>`.
 /// * `MO` - Output Measure. The only valid measure is ZeroConcentratedDivergence<T>.
 pub fn make_base_gaussian<D, MO>(scale: D::Atom, k: Option<i32>) -> Fallible<Measurement<D, D, D::InputMetric, MO>>
 where

--- a/rust/src/measurements/laplace/mod.rs
+++ b/rust/src/measurements/laplace/mod.rs
@@ -36,12 +36,12 @@ impl<T: Clone + CheckNull> LaplaceDomain for VectorDomain<AllDomain<T>> {
 )]
 /// Make a Measurement that adds noise from the laplace(`scale`) distribution to a scalar value.
 /// 
-/// Set `D` to change the input data type:
+/// Set `D` to change the input data type and input metric:
 /// ```text
-/// | `D`                        | input type |
-/// | -------------------------- | ---------- | 
-/// | AllDomain<T> (default)     | T          |
-/// | VectorDomain<AllDomain<T>> | Vec<T>     |
+/// | `D`                        | input type | `D::InputMetric`     |
+/// | -------------------------- | ---------- | -------------------- |
+/// | AllDomain<T> (default)     | T          | AbsoluteDistance<T>  |
+/// | VectorDomain<AllDomain<T>> | Vec<T>     | L1Distance<T>        |
 /// ```
 /// 
 /// This function takes a noise granularity in terms of 2^k. 

--- a/rust/src/measurements/laplace/mod.rs
+++ b/rust/src/measurements/laplace/mod.rs
@@ -13,6 +13,8 @@ use crate::traits::samplers::SampleDiscreteLaplaceZ2k;
 use crate::traits::{InfDiv, Float, InfAdd, ExactIntCast, FloatBits, CheckNull};
 
 use super::MappableDomain;
+
+#[doc(hidden)]
 pub trait LaplaceDomain: MappableDomain + Default {
     type InputMetric: SensitivityMetric<Distance = Self::Atom> + Default;
 }
@@ -33,7 +35,14 @@ impl<T: Clone + CheckNull> LaplaceDomain for VectorDomain<AllDomain<T>> {
     derived_types(T(get_atom_or_infer("D", "scale")))
 )]
 /// Make a Measurement that adds noise from the laplace(`scale`) distribution to a scalar value.
-/// Adjust D to noise vector-valued data.
+/// 
+/// Set `D` to change the input data type:
+/// ```text
+/// | `D`                        | input type |
+/// | -------------------------- | ---------- | 
+/// | AllDomain<T> (default)     | T          |
+/// | VectorDomain<AllDomain<T>> | Vec<T>     |
+/// ```
 /// 
 /// This function takes a noise granularity in terms of 2^k. 
 /// Larger granularities are more computationally efficient, but have a looser privacy map. 
@@ -44,7 +53,7 @@ impl<T: Clone + CheckNull> LaplaceDomain for VectorDomain<AllDomain<T>> {
 /// * `k` - The noise granularity.
 /// 
 /// # Generics
-/// * `D` - Domain of the data type to be privatized. Valid values are VectorDomain<AllDomain<T>> or AllDomain<T>
+/// * `D` - Domain of the data type to be privatized. Valid values are `VectorDomain<AllDomain<T>>` or `AllDomain<T>`
 pub fn make_base_laplace<D>(scale: D::Atom, k: Option<i32>) -> Fallible<Measurement<D, D, D::InputMetric, MaxDivergence<D::Atom>>>
     where D: LaplaceDomain,
           D::Atom: Float + SampleDiscreteLaplaceZ2k,

--- a/rust/src/measurements/mod.rs
+++ b/rust/src/measurements/mod.rs
@@ -3,36 +3,36 @@
 //! The different [`crate::core::Measurement`] implementations in this module are accessed by calling the appropriate constructor function.
 //! Constructors are named in the form `make_xxx()`, where `xxx` indicates what the resulting `Measurement` does.
 #[cfg(all(feature="use-mpfr", feature="contrib"))]
-pub mod discrete_gaussian;
+mod discrete_gaussian;
 #[cfg(all(feature="use-mpfr", feature="contrib"))]
 pub use crate::measurements::discrete_gaussian::*;
 
 #[cfg(feature="contrib")]
-pub mod discrete_laplace;
+mod discrete_laplace;
 #[cfg(feature="contrib")]
 pub use crate::measurements::discrete_laplace::*;
 
 #[cfg(all(feature="floating-point", feature="contrib"))]
-pub mod laplace;
+mod laplace;
 #[cfg(all(feature="floating-point", feature="contrib"))]
 pub use crate::measurements::laplace::*;
 
 #[cfg(all(feature="floating-point", feature="contrib", feature="use-mpfr"))]
-pub mod gaussian;
+mod gaussian;
 #[cfg(all(feature="floating-point", feature="contrib", feature="use-mpfr"))]
 pub use crate::measurements::gaussian::*;
 
 #[cfg(all(feature="floating-point", feature="contrib"))]
-pub mod ptr;
+mod ptr;
 #[cfg(all(feature="floating-point", feature="contrib"))]
 pub use crate::measurements::ptr::*;
 
 #[cfg(feature="contrib")]
-pub mod randomized_response;
+mod randomized_response;
 #[cfg(feature="contrib")]
 pub use crate::measurements::randomized_response::*;
 
 #[cfg(all(feature="use-mpfr", feature="floating-point", feature="contrib"))]
-pub mod alp;
+mod alp;
 #[cfg(all(feature="use-mpfr", feature="floating-point", feature="contrib"))]
 pub use crate::measurements::alp::*;

--- a/rust/src/transformations/b_ary_tree/consistency_postprocessor/mod.rs
+++ b/rust/src/transformations/b_ary_tree/consistency_postprocessor/mod.rs
@@ -22,9 +22,7 @@ mod ffi;
 /// This is due to an adjustment to the original algorithm to apportion corrections to children relative to their variance.
 /// 
 /// # Citations
-/// * HRMS09, Boosting the Accuracy of Differentially Private Histograms Through Consistency
-///   
-///    * Section 4.1: <https://arxiv.org/pdf/0904.0942.pdf>
+/// * [HRMS09 Boosting the Accuracy of Differentially Private Histograms Through Consistency, section 4.1](https://arxiv.org/pdf/0904.0942.pdf)
 /// 
 /// # Arguments
 /// * `branching factor` - the maximum number of children

--- a/rust/src/transformations/b_ary_tree/mod.rs
+++ b/rust/src/transformations/b_ary_tree/mod.rs
@@ -123,9 +123,7 @@ impl<const P: usize, T> BAryTreeMetric for LpDistance<P, T> {}
 /// that minimizes error in cdf and quantile estimates based on b-ary trees.
 /// 
 /// # Citations
-/// * QYL13, Understanding Hierarchical Methods for Differentially Private Histograms
-/// 
-///    * Proposition 1: <http://www.vldb.org/pvldb/vol6/p1954-qardaji.pdf>
+/// * [QYL13 Understanding Hierarchical Methods for Differentially Private Histograms](http://www.vldb.org/pvldb/vol6/p1954-qardaji.pdf)
 ///
 /// # Arguments
 /// * `size_guess` - A guess at the size of your dataset.

--- a/rust/src/transformations/cast_metric/ffi.rs
+++ b/rust/src/transformations/cast_metric/ffi.rs
@@ -63,14 +63,18 @@ pub extern "C" fn opendp_transformations__make_ordered_random(
 /// to the respective ordered dataset metric by assigning a random permutatation.
 /// Operates exclusively on SizedDomain<VectorDomain<AllDomain<`TA`>>>.
 ///
-/// If `MI` is "SymmetricDistance", then output metric is "InsertDeleteDistance",
-/// and respectively "ChangeOneDistance" maps to "HammingDistance".
-///
+/// ```text
+/// | `MI`              | output metric        |
+/// | ----------------- | -------------------- |
+/// | SymmetricDistance | InsertDeleteDistance |
+/// | ChangeOneDistance | HammingDistance      |
+/// ```
+/// 
 /// # Arguments
 /// * `size` - Number of records in input data.
 /// 
 /// # Generics
-/// * `MI` - Input Metric. One of "SymmetricDistance" or "ChangeOneDistance"
+/// * `MI` - Input Metric.
 /// * `TA` - Atomic Type.
 fn make_sized_ordered_random<MI, TA>(
     size: usize
@@ -122,15 +126,19 @@ pub extern "C" fn opendp_transformations__make_sized_ordered_random(
 /// to the respective ordered dataset metric by assigning a random permutatation.
 /// Operates exclusively on SizedDomain<VectorDomain<BoundedDomain<`TA`>>>.
 ///
-/// If `MI` is "SymmetricDistance", then output metric is "InsertDeleteDistance",
-/// and respectively "ChangeOneDistance" maps to "HammingDistance".
+/// ```text
+/// | `MI`              | output metric        |
+/// | ----------------- | -------------------- |
+/// | SymmetricDistance | InsertDeleteDistance |
+/// | ChangeOneDistance | HammingDistance      |
+/// ```
 /// 
 /// # Arguments
 /// * `size` - Number of records in input data.
 /// * `bounds` - Tuple of inclusive lower and upper bounds.
 /// 
 /// # Generics
-/// * `MI` - Input Metric. One of "SymmetricDistance" or "ChangeOneDistance"
+/// * `MI` - Input Metric.
 /// * `TA` - Atomic Type.
 fn make_sized_bounded_ordered_random<MI, TA>(
     size: usize,
@@ -188,6 +196,12 @@ pub extern "C" fn opendp_transformations__make_sized_bounded_ordered_random(
 ///
 /// The dataset metric is not generic over HammingDistance because the dataset size is unknown.
 /// 
+/// ```text
+/// | input metric         | output metric        |
+/// | -------------------- | -------------------- |
+/// | InsertDeleteDistance | SymmetricDistance    |
+/// ```
+/// 
 /// # Generics
 /// * `TA` - Atomic Type.
 fn make_unordered<TA: Clone + CheckNull>() -> Fallible<
@@ -224,14 +238,18 @@ pub extern "C" fn opendp_transformations__make_unordered(
 /// to the respective unordered dataset metric via a no-op.
 /// Operates exclusively on SizedDomain<VectorDomain<AllDomain<`TA`>>>.
 ///
-/// If `MI` is "InsertDeleteDistance", then output metric is "SymmetricDistance",
-/// and respectively "HammingDistance" maps to "ChangeOneDistance".
+/// ```text
+/// | `MI`                 | output metric      |
+/// | -------------------- | ------------------ |
+/// | InsertDeleteDistance | SymmetricDistance  |
+/// | HammingDistance      | ChangeOneDistance  |
+/// ```
 ///
 /// # Arguments
 /// * `size` - Number of records in input data.
 /// 
 /// # Generics
-/// * `MI` - Input Metric. One of "InsertDeleteDistance" or "HammingDistance"
+/// * `MI` - Input Metric.
 /// * `TA` - Atomic Type.
 fn make_sized_unordered<MI, TA>(
     size: usize
@@ -283,15 +301,19 @@ pub extern "C" fn opendp_transformations__make_sized_unordered(
 /// to the respective unordered dataset metric via a no-op.
 /// Operates exclusively on SizedDomain<VectorDomain<BoundedDomain<`TA`>>>.
 ///
-/// If `MI` is "InsertDeleteDistance", then output metric is "SymmetricDistance",
-/// and respectively "HammingDistance" maps to "ChangeOneDistance".
+/// ```text
+/// | `MI`                 | output metric      |
+/// | -------------------- | ------------------ |
+/// | InsertDeleteDistance | SymmetricDistance  |
+/// | HammingDistance      | ChangeOneDistance  |
+/// ```
 ///
 /// # Arguments
 /// * `size` - Number of records in input data.
 /// * `bounds` - Tuple of inclusive lower and upper bounds.
 /// 
 /// # Generics
-/// * `MI` - Input Metric. One of "InsertDeleteDistance" or "HammingDistance"
+/// * `MI` - Input Metric.
 /// * `TA` - Atomic Type.
 fn make_sized_bounded_unordered<MI, TA>(
     size: usize,
@@ -352,14 +374,18 @@ pub extern "C" fn opendp_transformations__make_sized_bounded_unordered(
 /// 
 /// While it is valid to operate with bounded data, there is no constructor for it in Python.
 /// 
-/// If MI is "SymmetricDistance", then output metric is "ChangeOneDistance", 
-/// and respectively "InsertDeleteDistance" maps to "HammingDistance".
+/// ```text
+/// | `MI`                 | output metric     |
+/// | -------------------- | ----------------- |
+/// | SymmetricDistance    | ChangeOneDistance |
+/// | InsertDeleteDistance | HammingDistance   |
+/// ```
 ///
 /// # Arguments
 /// * `size` - Number of records in input data.
 /// 
 /// # Generics
-/// * `MI` - Input Metric. One of "SymmetricDistance" or "InsertDeleteDistance"
+/// * `MI` - Input Metric.
 /// * `TA` - Atomic Type.
 fn make_metric_bounded<MI, TA>(
     size: usize
@@ -412,14 +438,18 @@ pub extern "C" fn opendp_transformations__make_metric_bounded(
 /// to the respective unbounded dataset metric with a no-op. 
 /// Operates exclusively on SizedDomain<VectorDomain<AllDomain<`TA`>>>.
 /// 
-/// If "ChangeOneDistance", then output metric is "SymmetricDistance", 
-/// and respectively "HammingDistance" maps to "InsertDeleteDistance".
-///
+/// ```text
+/// | `MI`              | output metric        |
+/// | ----------------- | -------------------- |
+/// | ChangeOneDistance | SymmetricDistance    |
+/// | HammingDistance   | InsertDeleteDistance |
+/// ```
+/// 
 /// # Arguments
 /// * `size` - Number of records in input data.
 /// 
 /// # Generics
-/// * `MI` - Input Metric. One of "ChangeOneDistance" or "HammingDistance"
+/// * `MI` - Input Metric.
 /// * `TA` - Atomic Type.
 fn make_metric_unbounded<MI, TA>(
     size: usize

--- a/rust/src/transformations/clamp/mod.rs
+++ b/rust/src/transformations/clamp/mod.rs
@@ -40,7 +40,7 @@ pub fn make_clamp<TA: 'static + Clone + TotalOrd + CheckNull>(
     generics(TA(example(get_first("bounds")))),
 )]
 /// Make a Transformation that unclamps numeric data in Vec<`T`>.
-/// Used to convert a VectorDomain<BoundedDomain<T>> to a VectorDomain<AllDomain<T>>.
+/// Used to convert a `VectorDomain<BoundedDomain<T>>` to a `VectorDomain<AllDomain<T>>`.
 /// 
 /// # Arguments
 /// * `bounds` - Tuple of lower and upper bounds.

--- a/rust/src/transformations/count/mod.rs
+++ b/rust/src/transformations/count/mod.rs
@@ -17,9 +17,7 @@ use crate::traits::{Number, Hashable, Primitive, Float};
 /// Make a Transformation that computes a count of the number of records in data.
 /// 
 /// # Citations
-/// * GRS12, Universally Utility-Maximizing Privacy Mechanisms
-/// 
-///     * <https://theory.stanford.edu/~tim/papers/priv.pdf>
+/// * [GRS12 Universally Utility-Maximizing Privacy Mechanisms](https://theory.stanford.edu/~tim/papers/priv.pdf)
 /// 
 /// # Generics
 /// * `TIA` - Atomic Input Type. Input data is expected to be of the form Vec<TIA>.
@@ -44,9 +42,7 @@ pub fn make_count<TIA, TO>(
 /// Make a Transformation that computes a count of the number of unique, distinct records in data.
 /// 
 /// # Citations
-/// * GRS12, Universally Utility-Maximizing Privacy Mechanisms
-/// 
-///     * <https://theory.stanford.edu/~tim/papers/priv.pdf>
+/// * [GRS12 Universally Utility-Maximizing Privacy Mechanisms](https://theory.stanford.edu/~tim/papers/priv.pdf)
 /// 
 /// # Generics
 /// * `TIA` - Atomic Input Type. Input data is expected to be of the form Vec<TIA>.
@@ -86,13 +82,8 @@ impl<const P: usize, Q: One> CountByCategoriesConstant<Q> for LpDistance<P, Q> {
 /// This assumes that the category set is known.
 /// 
 /// # Citations
-/// * GRS12, Universally Utility-Maximizing Privacy Mechanisms
-/// 
-///     * <https://theory.stanford.edu/~tim/papers/priv.pdf>
-/// 
-/// * BV17, Differential Privacy on Finite Computers
-/// 
-///     * <https://arxiv.org/abs/1709.05396>
+/// * [GRS12 Universally Utility-Maximizing Privacy Mechanisms](https://theory.stanford.edu/~tim/papers/priv.pdf)
+/// * [BV17 Differential Privacy on Finite Computers](https://arxiv.org/abs/1709.05396)
 /// 
 /// # Arguments
 /// * `categories` - The set of categories to compute counts for.
@@ -104,7 +95,7 @@ impl<const P: usize, Q: One> CountByCategoriesConstant<Q> for LpDistance<P, Q> {
 /// * `TOA` - Atomic Output Type that is numeric.
 /// 
 /// # Returns
-/// The carrier type is HashMap<TK, TV>, a hashmap of the count (TV) for each unique data input (TK).
+/// The carrier type is `HashMap<TK, TV>`, a hashmap of the count (`TV`) for each unique data input (`TK`).
 pub fn make_count_by_categories<MO, TIA, TOA>(
     categories: Vec<TIA>,
     null_category: bool
@@ -162,9 +153,7 @@ impl<const P: usize, Q: One> CountByConstant<Q> for LpDistance<P, Q> {
 /// This assumes that the category set is unknown.
 /// 
 /// # Citations
-/// * BV17, Differential Privacy on Finite Computers
-/// 
-///     * <https://arxiv.org/abs/1709.05396>
+/// * [BV17 Differential Privacy on Finite Computers](https://arxiv.org/abs/1709.05396)
 /// 
 /// # Generics
 /// * `MO` - Output Metric.
@@ -172,7 +161,7 @@ impl<const P: usize, Q: One> CountByConstant<Q> for LpDistance<P, Q> {
 /// * `TV - Type of Value. Express counts in terms of this integral type.
 /// 
 /// # Returns
-/// The carrier type is HashMap<TK, TV>, a hashmap of the count (TV) for each unique data input (TK).
+/// The carrier type is `HashMap<TK, TV>`, a hashmap of the count (`TV`) for each unique data input (`TK`).
 pub fn make_count_by<MO, TK, TV>(
 ) -> Fallible<Transformation<VectorDomain<AllDomain<TK>>, MapDomain<AllDomain<TK>, AllDomain<TV>>, SymmetricDistance, MO>>
     where MO: CountByConstant<MO::Distance> + SensitivityMetric,

--- a/rust/src/transformations/count_cdf/mod.rs
+++ b/rust/src/transformations/count_cdf/mod.rs
@@ -20,7 +20,7 @@ mod ffi;
 /// Postprocess a noisy array of float summary counts into a cumulative distribution.
 /// 
 /// # Generics
-/// * `TA` - Atomic Type. One of f32 or f64
+/// * `TA` - Atomic Type. One of `f32` or `f64`
 pub fn make_cdf<TA>() -> Fallible<
     Transformation<
         VectorDomain<AllDomain<TA>>,
@@ -68,7 +68,7 @@ pub enum Interpolation {
 /// 
 /// # Generics
 /// * `TA` - Atomic Type of the bin edges and data.
-/// * `F` - Float type of the alpha argument. One of f32 or f64
+/// * `F` - Float type of the alpha argument. One of `f32` or `f64`
 pub fn make_quantiles_from_counts<TA, F>(
     bin_edges: Vec<TA>,
     alphas: Vec<F>,

--- a/rust/src/transformations/dataframe/create/mod.rs
+++ b/rust/src/transformations/dataframe/create/mod.rs
@@ -62,7 +62,7 @@ fn create_dataframe<K: Hashable>(col_names: Vec<K>, records: &[Vec<&str>]) -> Da
 }
 
 #[bootstrap(features("contrib"))]
-/// Make a Transformation that constructs a dataframe from a Vec<Vec<String>> (a vector of records).
+/// Make a Transformation that constructs a dataframe from a `Vec<Vec<String>>` (a vector of records).
 /// 
 /// # Arguments
 /// * `col_names` - Column names for each record entry.
@@ -106,7 +106,7 @@ fn split_dataframe<K: Hashable>(separator: &str, col_names: Vec<K>, s: &str) -> 
     features("contrib"), 
     arguments(separator(c_type = "char *", rust_type()))
 )]
-/// Make a Transformation that splits each record in a String into a Vec<Vec<String>>,
+/// Make a Transformation that splits each record in a String into a `Vec<Vec<String>>`,
 /// and loads the resulting table into a dataframe keyed by `col_names`.
 /// 
 /// # Arguments
@@ -148,7 +148,7 @@ fn split_lines(s: &str) -> Vec<&str> {
 }
 
 #[bootstrap(features("contrib"))]
-/// Make a Transformation that takes a string and splits it into a Vec<String> of its lines.
+/// Make a Transformation that takes a string and splits it into a `Vec<String>` of its lines.
 pub fn make_split_lines() -> Fallible<
     Transformation<
         AllDomain<String>,
@@ -183,7 +183,7 @@ fn split_records<'a>(separator: &str, lines: &[&'a str]) -> Vec<Vec<&'a str>> {
     features("contrib"), 
     arguments(separator(c_type = "char *", rust_type()))
 )]
-/// Make a Transformation that splits each record in a Vec<String> into a Vec<Vec<String>>.
+/// Make a Transformation that splits each record in a `Vec<String>` into a `Vec<Vec<String>>`.
 /// 
 /// # Arguments
 /// * `separator` - The token(s) that separate entries in each record.

--- a/rust/src/transformations/impute/mod.rs
+++ b/rust/src/transformations/impute/mod.rs
@@ -16,13 +16,13 @@ use crate::traits::{CheckNull, Float};
     generics(TA(example(get_first("bounds"))))
 )]
 /// Make a Transformation that replaces NaN values in Vec<`TA`> with uniformly distributed floats within `bounds`.
-/// Operates on InherentNullDomain<AllDomain<TA>>
+/// Operates on `InherentNullDomain<AllDomain<TA>>`
 /// 
 /// # Arguments
 /// * `bounds` - Tuple of inclusive lower and upper bounds.
 /// 
 /// # Generics
-/// * `TA` - Atomic Type of data being imputed. One of f32 or f64
+/// * `TA` - Atomic Type of data being imputed. One of `f32` or `f64`
 pub fn make_impute_uniform_float<TA>(
     bounds: (TA, TA)
 ) -> Fallible<Transformation<VectorDomain<InherentNullDomain<AllDomain<TA>>>, VectorDomain<AllDomain<TA>>, SymmetricDistance, SymmetricDistance>>
@@ -71,18 +71,22 @@ impl<T: InherentNull> ImputeConstantDomain for InherentNullDomain<AllDomain<T>> 
     derived_types(TA(get_atom_or_infer("DA", "constant")))
 )]
 /// Make a Transformation that replaces null/None data with `constant`.
-/// By default, the input type is Vec<Option<TA>>, as emitted by make_cast.
-/// Set `DA` to InherentNullDomain<AllDomain<TA>> for imputing on types 
+/// By default, the input type is `Vec<Option<TA>>`, as emitted by make_cast.
+/// Set `DA` to `InherentNullDomain<AllDomain<TA>>` for imputing on types 
 /// that have an inherent representation of nullity, like floats.
 /// 
-/// Maps a Vec<Option<T>> -> Vec<T> if input domain is AllDomain<Option<T>>,
-///     or Vec<T> -> Vec<T> if input domain is NullableDomain<AllDomain<T>>
+/// ```text
+/// | Input Domain `DI`            |  Input Type    | Output Type |
+/// | ---------------------------- | -------------- | ----------- |
+/// | AllDomain<Option<T>>         | Vec<Option<T>> | Vec<T>      |
+/// | NullableDomain<AllDomain<T>> | Vec<T>         | Vec<T>      |
+/// ```
 /// 
 /// # Arguments
 /// * `constant` - Value to replace nulls with.
 /// 
 /// # Generics
-/// * `DA` - Atomic Domain of data being imputed. This is OptionNullDomain<AllDomain<TA>> or InherentNullDomain<AllDomain<TA>>
+/// * `DA` - Atomic Domain of data being imputed.
 pub fn make_impute_constant<DA>(
     constant: DA::Imputed
 ) -> Fallible<Transformation<VectorDomain<DA>, VectorDomain<AllDomain<DA::Imputed>>, SymmetricDistance, SymmetricDistance>>
@@ -122,7 +126,7 @@ impl<T: InherentNull + Clone> DropNullDomain for InherentNullDomain<AllDomain<T>
 
 #[bootstrap(features("contrib"))]
 /// Make a Transformation that drops null values.
-/// Operates on OptionNullDomain<AllDomain<TA>> or InherentNullDomain<AllDomain<TA>>.
+/// `DA` is one of `OptionNullDomain<AllDomain<TA>>` or `InherentNullDomain<AllDomain<TA>>`.
 /// 
 /// # Generics
 /// * `DA` - atomic domain of input data that contains nulls.

--- a/rust/src/transformations/manipulation/ffi.rs
+++ b/rust/src/transformations/manipulation/ffi.rs
@@ -20,7 +20,7 @@ use crate::transformations::{make_is_equal, make_is_null};
 /// Make a Transformation representing the identity function.
 /// 
 /// # Generics
-/// * `D` - Domain of the identity function. Must be VectorDomain<AllDomain<_>> or AllDomain<_>
+/// * `D` - Domain of the identity function. Must be `VectorDomain<AllDomain<T>>` or `AllDomain<T>`
 /// * `M` - Metric. Must be a dataset metric if D is a VectorDomain or a sensitivity metric if D is an AllDomain
 fn make_identity<D, M>() -> Fallible<Transformation<D, D, M, M>>
     where D: Domain + Default, D::Carrier: Clone,

--- a/rust/src/transformations/mod.rs
+++ b/rust/src/transformations/mod.rs
@@ -4,92 +4,92 @@
 //! Constructors are named in the form `make_xxx()`, where `xxx` indicates what the resulting `Transformation` does.
 
 #[cfg(feature="contrib")]
-pub mod covariance;
+mod covariance;
 #[cfg(feature="contrib")]
 pub use crate::transformations::covariance::*;
 
 #[cfg(feature="contrib")]
-pub mod b_ary_tree;
+mod b_ary_tree;
 #[cfg(feature="contrib")]
 pub use crate::transformations::b_ary_tree::*;
 
 #[cfg(feature="contrib")]
-pub mod dataframe;
+mod dataframe;
 #[cfg(feature="contrib")]
 pub use crate::transformations::dataframe::*;
 
 #[cfg(feature="contrib")]
-pub(crate) mod postprocess;
+mod postprocess;
 #[cfg(feature="contrib")]
 pub(crate) use postprocess::*;
 
 #[cfg(feature="contrib")]
-pub mod manipulation;
+mod manipulation;
 #[cfg(feature="contrib")]
 pub use crate::transformations::manipulation::*;
 
 #[cfg(feature="contrib")]
-pub mod sum;
+mod sum;
 #[cfg(feature="contrib")]
 pub use crate::transformations::sum::*;
 
 #[cfg(feature="contrib")]
-pub mod sum_of_squared_deviations;
+mod sum_of_squared_deviations;
 #[cfg(feature="contrib")]
 pub use crate::transformations::sum_of_squared_deviations::*;
 
 #[cfg(feature="contrib")]
-pub mod count;
+mod count;
 #[cfg(feature="contrib")]
 pub use crate::transformations::count::*;
 
 #[cfg(feature="contrib")]
-pub mod count_cdf;
+mod count_cdf;
 #[cfg(feature="contrib")]
 pub use crate::transformations::count_cdf::*;
 
 #[cfg(feature="contrib")]
-pub mod mean;
+mod mean;
 #[cfg(feature="contrib")]
 pub use crate::transformations::mean::*;
 
 #[cfg(feature="contrib")]
-pub mod variance;
+mod variance;
 #[cfg(feature="contrib")]
 pub use crate::transformations::variance::*;
 
 #[cfg(feature="contrib")]
-pub mod impute;
+mod impute;
 #[cfg(feature="contrib")]
 pub use crate::transformations::impute::*;
 
 #[cfg(feature="contrib")]
-pub mod index;
+mod index;
 #[cfg(feature="contrib")]
 pub use crate::transformations::index::*;
 
 #[cfg(feature="contrib")]
-pub mod lipschitz_mul;
+mod lipschitz_mul;
 #[cfg(feature="contrib")]
 pub use crate::transformations::lipschitz_mul::*;
 
 #[cfg(feature="contrib")]
-pub mod clamp;
+mod clamp;
 #[cfg(feature="contrib")]
 pub use crate::transformations::clamp::*;
 
 #[cfg(feature="contrib")]
-pub mod cast;
+mod cast;
 #[cfg(feature="contrib")]
 pub use crate::transformations::cast::*;
 
 #[cfg(feature="contrib")]
-pub mod cast_metric;
+mod cast_metric;
 #[cfg(feature="contrib")]
 pub use crate::transformations::cast_metric::*;
 
 #[cfg(feature="contrib")]
-pub mod resize;
+mod resize;
 #[cfg(feature="contrib")]
 pub use crate::transformations::resize::*;
 

--- a/rust/src/transformations/sum/float/checked/mod.rs
+++ b/rust/src/transformations/sum/float/checked/mod.rs
@@ -27,20 +27,15 @@ mod ffi;
 /// Use `make_clamp` to bound data and `make_bounded_resize` to establish dataset size.
 /// 
 /// # Citations
-/// * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
-/// 
-///     * <https://arxiv.org/pdf/2207.10635.pdf>
-/// 
-/// * Calibrating Noise to Sensitivity in Private Data Analysis
-///     
-///     * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+/// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+/// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
 /// 
 /// # Arguments
 /// * `size_limit` - Upper bound on number of records to keep in the input data.
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
 /// 
 /// # Generics
-/// * `S` - Summation algorithm to use on data type T. One of Sequential<T> or Pairwise<T>.
+/// * `S` - Summation algorithm to use on data type `T`. One of `Sequential<T>` or `Pairwise<T>`.
 pub fn make_bounded_float_checked_sum<S>(
     size_limit: usize,
     bounds: (S::Item, S::Item),
@@ -102,20 +97,15 @@ where
 /// This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility.
 /// 
 /// # Citations
-/// * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
-/// 
-///     * <https://arxiv.org/pdf/2207.10635.pdf>
-/// 
-/// * Calibrating Noise to Sensitivity in Private Data Analysis
-///     
-///     * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+/// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf) 
+/// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
 /// 
 /// # Arguments
 /// * `size` - Number of records in input data.
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
 /// 
 /// # Generics
-/// * `S` - Summation algorithm to use on data type T. One of Sequential<T> or Pairwise<T>.
+/// * `S` - Summation algorithm to use on data type `T`. One of `Sequential<T>` or `Pairwise<T>`.
 pub fn make_sized_bounded_float_checked_sum<S>(
     size: usize,
     bounds: (S::Item, S::Item),

--- a/rust/src/transformations/sum/float/ordered/mod.rs
+++ b/rust/src/transformations/sum/float/ordered/mod.rs
@@ -24,20 +24,15 @@ mod ffi;
 /// The utility loss from overestimating the `size_limit` is small.
 /// 
 /// # Citations
-/// * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
-/// 
-///     * <https://arxiv.org/pdf/2207.10635.pdf>
-/// 
-/// * Calibrating Noise to Sensitivity in Private Data Analysis
-///     
-///     * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+/// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+/// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
 /// 
 /// # Arguments
 /// * `size_limit` - Upper bound on the number of records in input data. Used to bound sensitivity.
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
 /// 
 /// # Generics
-/// * `S` - Summation algorithm to use on data type T. One of Sequential<T> or Pairwise<T>.
+/// * `S` - Summation algorithm to use on data type `T`. One of `Sequential<T>` or `Pairwise<T>`.
 pub fn make_bounded_float_ordered_sum<S>(
     size_limit: usize,
     bounds: (S::Item, S::Item),
@@ -88,20 +83,15 @@ where
 /// You may need to use `make_ordered_random` to impose an ordering on the data.
 /// 
 /// # Citations
-/// * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
-/// 
-///     * <https://arxiv.org/pdf/2207.10635.pdf>
-/// 
-/// * Calibrating Noise to Sensitivity in Private Data Analysis
-///     
-///     * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+/// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+/// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
 /// 
 /// # Arguments
 /// * `size` - Number of records in input data.
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
 /// 
 /// # Generics
-/// * `S` - Summation algorithm to use on data type T. One of Sequential<T> or Pairwise<T>.
+/// * `S` - Summation algorithm to use on data type `T`. One of `Sequential<T>` or `Pairwise<T>`.
 pub fn make_sized_bounded_float_ordered_sum<S>(
     size: usize,
     bounds: (S::Item, S::Item),

--- a/rust/src/transformations/sum/int/checked/mod.rs
+++ b/rust/src/transformations/sum/int/checked/mod.rs
@@ -24,13 +24,8 @@ mod ffi;
 /// The effective range is reduced, as (bounds * size) must not overflow.
 /// 
 /// # Citations
-/// * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
-/// 
-///     * <https://arxiv.org/pdf/2207.10635.pdf>
-/// 
-/// * Calibrating Noise to Sensitivity in Private Data Analysis
-///     
-///     * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+/// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+/// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
 /// 
 /// # Arguments
 /// * `size` - Number of records in input data.

--- a/rust/src/transformations/sum/int/monotonic/mod.rs
+++ b/rust/src/transformations/sum/int/monotonic/mod.rs
@@ -22,13 +22,8 @@ mod ffi;
 /// where all values share the same sign.
 /// 
 /// # Citations
-/// * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
-/// 
-///     * <https://arxiv.org/pdf/2207.10635.pdf>
-/// 
-/// * Calibrating Noise to Sensitivity in Private Data Analysis
-///     
-///     * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+/// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+/// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
 /// 
 /// # Arguments
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
@@ -81,13 +76,8 @@ where
 /// where all values share the same sign.
 /// 
 /// # Citations
-/// * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
-/// 
-///     * <https://arxiv.org/pdf/2207.10635.pdf>
-/// 
-/// * Calibrating Noise to Sensitivity in Private Data Analysis
-///     
-///     * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+/// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+/// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
 /// 
 /// # Arguments
 /// * `size` - Number of records in input data.

--- a/rust/src/transformations/sum/int/ordered/mod.rs
+++ b/rust/src/transformations/sum/int/ordered/mod.rs
@@ -23,13 +23,8 @@ mod ffi;
 /// You may need to use `make_ordered_random` to impose an ordering on the data.
 /// 
 /// # Citations
-/// * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
-/// 
-///     * <https://arxiv.org/pdf/2207.10635.pdf>
-/// 
-/// * Calibrating Noise to Sensitivity in Private Data Analysis
-///     
-///     * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+/// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+/// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
 /// 
 /// # Arguments
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
@@ -69,13 +64,8 @@ where
 /// You may need to use `make_ordered_random` to impose an ordering on the data.
 /// 
 /// # Citations
-/// * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
-/// 
-///     * <https://arxiv.org/pdf/2207.10635.pdf>
-/// 
-/// * Calibrating Noise to Sensitivity in Private Data Analysis
-///     
-///     * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+/// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+/// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
 /// 
 /// # Arguments
 /// * `size` - Number of records in input data.

--- a/rust/src/transformations/sum/int/split/mod.rs
+++ b/rust/src/transformations/sum/int/split/mod.rs
@@ -56,13 +56,8 @@ impl___signed_int_split_sat_sum! { i8 i16 i32 i64 i128 isize }
 /// Adds the saturating sum of the positives to the saturating sum of the negatives.
 /// 
 /// # Citations
-/// * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
-/// 
-///     * <https://arxiv.org/pdf/2207.10635.pdf>
-/// 
-/// * Calibrating Noise to Sensitivity in Private Data Analysis
-///     
-///     * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+/// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+/// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
 /// 
 /// # Arguments
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
@@ -104,13 +99,8 @@ where
 /// Adds the saturating sum of the positives to the saturating sum of the negatives.
 /// 
 /// # Citations
-/// * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
-/// 
-///     * <https://arxiv.org/pdf/2207.10635.pdf>
-/// 
-/// * Calibrating Noise to Sensitivity in Private Data Analysis
-///     
-///     * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+/// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+/// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
 /// 
 /// # Arguments
 /// * `size` - Number of records in input data.

--- a/rust/src/transformations/sum/mod.rs
+++ b/rust/src/transformations/sum/mod.rs
@@ -26,13 +26,8 @@ use crate::transformations::{make_ordered_random, make_unordered};
 /// Use `make_clamp` to bound data.
 /// 
 /// # Citations
-/// * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
-/// 
-///     * <https://arxiv.org/pdf/2207.10635.pdf>
-/// 
-/// * Calibrating Noise to Sensitivity in Private Data Analysis
-///     
-///     * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+/// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+/// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
 /// 
 /// # Arguments
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
@@ -61,13 +56,8 @@ where
 /// Use `make_clamp` to bound data and `make_bounded_resize` to establish dataset size.
 /// 
 /// # Citations
-/// * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
-/// 
-///     * <https://arxiv.org/pdf/2207.10635.pdf>
-/// 
-/// * Calibrating Noise to Sensitivity in Private Data Analysis
-///     
-///     * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+/// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+/// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
 /// 
 /// # Arguments
 /// * `size` - Number of records in input data.

--- a/rust/src/transformations/sum_of_squared_deviations/mod.rs
+++ b/rust/src/transformations/sum_of_squared_deviations/mod.rs
@@ -23,20 +23,15 @@ use super::UncheckedSum;
 /// Use `make_clamp` to bound data and `make_bounded_resize` to establish dataset size.
 /// 
 /// # Citations
-/// * Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It
-/// 
-///     * <https://arxiv.org/pdf/2207.10635.pdf>
-/// 
-/// * Calibrating Noise to Sensitivity in Private Data Analysis
-///     
-///     * <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>
+/// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
+/// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
 /// 
 /// # Arguments
 /// * `size` - Number of records in input data.
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
 /// 
 /// # Generics
-/// * `S` - Summation algorithm to use on data type T. One of Sequential<T> or Pairwise<T>.
+/// * `S` - Summation algorithm to use on data type `T`. One of `Sequential<T>` or `Pairwise<T>`.
 pub fn make_sized_bounded_sum_of_squared_deviations<S>(
     size: usize,
     bounds: (S::Item, S::Item),

--- a/rust/src/transformations/variance/mod.rs
+++ b/rust/src/transformations/variance/mod.rs
@@ -28,9 +28,7 @@ use super::{
 /// Use `make_clamp` to bound data and `make_bounded_resize` to establish dataset size.
 /// 
 /// # Citations
-/// * DHK15, Differential Privacy for Social Science Inference
-/// 
-///     * <http://hona.kr/papers/files/DOrazioHonakerKingPrivacy.pdf>
+/// * [DHK15 Differential Privacy for Social Science Inference](http://hona.kr/papers/files/DOrazioHonakerKingPrivacy.pdf)
 /// 
 /// # Arguments
 /// * `size` - Number of records in input data.
@@ -38,7 +36,7 @@ use super::{
 /// * `ddof` - Delta degrees of freedom. Set to 0 if not a sample, 1 for sample estimate.
 /// 
 /// # Generics
-/// * `S` - Summation algorithm to use on data type T. One of Sequential<T> or Pairwise<T>.
+/// * `S` - Summation algorithm to use on data type `T`. One of `Sequential<T>` or `Pairwise<T>`.
 pub fn make_sized_bounded_variance<S>(
     size: usize,
     bounds: (S::Item, S::Item),


### PR DESCRIPTION
Closes #56 

* updated docs.yml workflow to generate all proof pdfs and upload to `opendp/artifacts` upon merge to main or release
* updated docs.yml to copy proof artifacts to gh-pages docs site's multiversion folders
* (wip) latex macro for generating a link to either pdf file or rust doc


This should give us all the pieces we need to continuously browse proofs/documentation across python, rust and latex, with versioned links and support for offline builds.
