### PR TITLE
support user-supplied callbacks in client code

### DIFF
--- a/docs/source/developer/development-environment.rst
+++ b/docs/source/developer/development-environment.rst
@@ -10,7 +10,7 @@ Follow the steps below to get an OpenDP development environment set up, includin
 * Install `Python version 3.7 or higher <https://www.python.org>`_.
 
 If you have already installed Rust, make sure that you have installed a version at least as new as the `rust-version` specified in 
-[rust/Cargo.toml](https://github.com/opendp/opendp/blob/main/rust/Cargo.toml).
+`rust/Cargo.toml <https://github.com/opendp/opendp/blob/main/rust/Cargo.toml>`_.
 
 
 Clone the OpenDP Repo

--- a/docs/source/user/constructors/combinators.rst
+++ b/docs/source/user/constructors/combinators.rst
@@ -246,11 +246,11 @@ It is possible to construct Transformations, Measurements and Postprocessors on 
    * - Component
      - Constructor
    * - Transformation
-     - :func:`opendp.combinators.make_default_transformation`
+     - :func:`opendp.combinators.make_default_user_transformation`
    * - Measurement
-     - :func:`opendp.combinators.make_default_measurement`
+     - :func:`opendp.combinators.make_default_user_measurement`
    * - Postprocessor
-     - :func:`opendp.combinators.make_default_postprocessor`
+     - :func:`opendp.combinators.make_default_user_postprocessor`
 
 .. note::
 
@@ -272,7 +272,7 @@ In this example, we mock the typical API of the OpenDP library:
 
 .. doctest::
 
-    >>> from opendp.combinators import make_default_transformation
+    >>> from opendp.combinators import make_default_user_transformation
     >>> from opendp.typing import *
     ...
     >>> def make_repeat(multiplicity):
@@ -285,7 +285,7 @@ In this example, we mock the typical API of the OpenDP library:
     ...         # they can now influence `d_in` * `multiplicity` records
     ...         return d_in * multiplicity
     ...
-    ...     return make_default_transformation(
+    ...     return make_default_user_transformation(
     ...         function,
     ...         stability_map,
     ...         DI=VectorDomain[AllDomain[int]],

--- a/docs/source/user/constructors/combinators.rst
+++ b/docs/source/user/constructors/combinators.rst
@@ -193,11 +193,13 @@ If your dataset is a simple sample from a larger population,
 you can make the privacy relation more permissive by wrapping your measurement with a privacy amplification combinator:
 :func:`opendp.combinators.make_population_amplification`.
 
-The amplifier requires a looser trust model, as the population size can be set arbitrarily.
+.. note::
 
-.. doctest::
+    The amplifier requires a looser trust model, as the population size can be set arbitrarily.
 
-    >>> enable_features("honest-but-curious")
+    .. doctest::
+
+        >>> enable_features("honest-but-curious")
 
 
 In order to demonstrate this API, we'll first create a measurement with a sized input domain.
@@ -237,27 +239,34 @@ User-Defined Callbacks
 ----------------------
 
 It is possible to construct Transformations, Measurements and Postprocessors on your own via Python functions.
-This API is currently limited to domains that have a notion of a default value. 
-That is, ``SizedDomain`` and ``BoundedDomain``, which require runtime arguments to construct, are not currently supported.
 
 .. list-table::
    :header-rows: 1
 
    * - Component
-     - Function
+     - Constructor
    * - Transformation
-     - :func:`make_default_transformation <opendp.combinators.make_default_transformation>`
+     - :func:`opendp.combinators.make_default_transformation`
    * - Measurement
-     - :func:`make_default_measurement <opendp.combinators.make_default_measurement>`
+     - :func:`opendp.combinators.make_default_measurement`
    * - Postprocessor
-     - :func:`make_default_postprocessor <opendp.combinators.make_default_postprocessor>`
+     - :func:`opendp.combinators.make_default_postprocessor`
 
+.. note::
 
-This requires a looser trust model, as we cannot verify any correctness properties of user-defined functions.
+    This API is currently limited to domains that have a default. 
+    Domains that carry state do not have a default:
+    ``SizedDomain`` carries a size parameter, and ``BoundedDomain`` carries bounds, so they are not currently supported.
+    The output domain of ``make_basic_composition`` suffers from the same issue.
+    This restriction may be lifted after `#232 <https://github.com/opendp/opendp/issues/232>`_.
 
-.. doctest::
+.. note::
 
-    >>> enable_features("honest-but-curious")
+    This requires a looser trust model, as we cannot verify any correctness properties of user-defined functions.
+
+    .. doctest::
+
+        >>> enable_features("honest-but-curious")
 
 In this example, we mock the typical API of the OpenDP library:
 

--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -61,6 +61,9 @@ def py_to_c(value: Any, c_type, type_name: Union[RuntimeType, str] = None):
     if isinstance(value, c_type):
         return value
 
+    if c_type == CallbackFn:
+        return _wrap_py_func(value, type_name)
+
     # check that the type name is consistent with the value
     if type_name is not None:
         RuntimeType.assert_is_similar(RuntimeType.parse(type_name), RuntimeType.infer(value))
@@ -364,3 +367,41 @@ def _slice_to_hashmap(raw: FfiSlicePtr) -> Dict[Any, Any]:
 
 def _wrap_in_slice(ptr, len_: int) -> FfiSlicePtr:
     return FfiSlicePtr(FfiSlice(ctypes.cast(ptr, ctypes.c_void_p), len_))
+
+
+#                            (output         , input       )
+CallbackFn = ctypes.CFUNCTYPE(ctypes.c_void_p, AnyObjectPtr)
+
+def _wrap_py_func(func, TO):
+    from opendp._convert import c_to_py, py_to_c
+
+    def wrapper_func(c_arg):
+        try:
+            # 1. convert AnyObject to Python type
+            py_arg = c_to_py(c_arg)
+            # don't free c_arg, because it is owned by Rust
+            c_arg.__class__ = ctypes.POINTER(AnyObject)
+
+            # 2. invoke the user-supplied function
+            py_out = func(py_arg)
+
+            # 3. convert back to an AnyObject
+            c_out = py_to_c(py_out, c_type=AnyObjectPtr, type_name=TO)
+            # don't free c_out, because we are giving ownership to Rust
+            c_out.__class__ = ctypes.POINTER(AnyObject)
+
+            # 4. pack up into an FfiResult
+            lib.ffiresult_ok.argtypes = [ctypes.c_void_p]
+            lib.ffiresult_ok.restype = ctypes.c_void_p
+            return lib.ffiresult_ok(ctypes.addressof(c_out.contents))
+
+        except Exception:
+            import traceback
+            lib.ffiresult_err.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+            lib.ffiresult_err.restype = ctypes.c_void_p
+            return lib.ffiresult_err(
+                ctypes.c_char_p(f"Continued stack trace from Exception in user-defined function".encode()),
+                ctypes.c_char_p(traceback.format_exc().encode()),
+            )
+
+    return CallbackFn(wrapper_func)

--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -369,6 +369,8 @@ def _wrap_in_slice(ptr, len_: int) -> FfiSlicePtr:
     return FfiSlicePtr(FfiSlice(ctypes.cast(ptr, ctypes.c_void_p), len_))
 
 
+# The result type cannot be an `ctypes.POINTER(FfiResult)` due to:
+#   https://bugs.python.org/issue5710#msg85731
 #                            (output         , input       )
 CallbackFn = ctypes.CFUNCTYPE(ctypes.c_void_p, AnyObjectPtr)
 

--- a/python/src/opendp/_data.py
+++ b/python/src/opendp/_data.py
@@ -32,13 +32,17 @@ def bool_free(
     :raises OpenDPException: packaged error from the core OpenDP library
     """
     # No type arguments to standardize.
-    # No arguments to convert to c types.
-    # Call library function.
-    function = lib.opendp_data__bool_free
-    function.argtypes = [BoolPtr]
-    function.restype = FfiResult
+    # Convert arguments to c types.
+    c_this = this
     
-    return c_to_py(unwrap(function(this), ctypes.c_void_p))
+    # Call library function.
+    lib_function = lib.opendp_data__bool_free
+    lib_function.argtypes = [BoolPtr]
+    lib_function.restype = FfiResult
+    
+    output = c_to_py(unwrap(lib_function(c_this), ctypes.c_void_p))
+    
+    return output
 
 
 def ffislice_of_anyobjectptrs(
@@ -57,14 +61,16 @@ def ffislice_of_anyobjectptrs(
     """
     # No type arguments to standardize.
     # Convert arguments to c types.
-    raw = py_to_c(raw, c_type=FfiSlicePtr, type_name=None)
+    c_raw = py_to_c(raw, c_type=FfiSlicePtr, type_name=None)
     
     # Call library function.
-    function = lib.opendp_data__ffislice_of_anyobjectptrs
-    function.argtypes = [FfiSlicePtr]
-    function.restype = FfiResult
+    lib_function = lib.opendp_data__ffislice_of_anyobjectptrs
+    lib_function.argtypes = [FfiSlicePtr]
+    lib_function.restype = FfiResult
     
-    return unwrap(function(raw), FfiSlicePtr)
+    output = unwrap(lib_function(c_raw), FfiSlicePtr)
+    
+    return output
 
 
 def object_as_slice(
@@ -84,14 +90,16 @@ def object_as_slice(
     """
     # No type arguments to standardize.
     # Convert arguments to c types.
-    obj = py_to_c(obj, c_type=AnyObjectPtr, type_name=None)
+    c_obj = py_to_c(obj, c_type=AnyObjectPtr, type_name=None)
     
     # Call library function.
-    function = lib.opendp_data__object_as_slice
-    function.argtypes = [AnyObjectPtr]
-    function.restype = FfiResult
+    lib_function = lib.opendp_data__object_as_slice
+    lib_function.argtypes = [AnyObjectPtr]
+    lib_function.restype = FfiResult
     
-    return unwrap(function(obj), FfiSlicePtr)
+    output = unwrap(lib_function(c_obj), FfiSlicePtr)
+    
+    return output
 
 
 def object_free(
@@ -108,13 +116,17 @@ def object_free(
     :raises OpenDPException: packaged error from the core OpenDP library
     """
     # No type arguments to standardize.
-    # No arguments to convert to c types.
-    # Call library function.
-    function = lib.opendp_data__object_free
-    function.argtypes = [AnyObjectPtr]
-    function.restype = FfiResult
+    # Convert arguments to c types.
+    c_this = this
     
-    return c_to_py(unwrap(function(this), ctypes.c_void_p))
+    # Call library function.
+    lib_function = lib.opendp_data__object_free
+    lib_function.argtypes = [AnyObjectPtr]
+    lib_function.restype = FfiResult
+    
+    output = c_to_py(unwrap(lib_function(c_this), ctypes.c_void_p))
+    
+    return output
 
 
 def object_type(
@@ -133,14 +145,16 @@ def object_type(
     """
     # No type arguments to standardize.
     # Convert arguments to c types.
-    this = py_to_c(this, c_type=AnyObjectPtr, type_name=None)
+    c_this = py_to_c(this, c_type=AnyObjectPtr, type_name=None)
     
     # Call library function.
-    function = lib.opendp_data__object_type
-    function.argtypes = [AnyObjectPtr]
-    function.restype = FfiResult
+    lib_function = lib.opendp_data__object_type
+    lib_function.argtypes = [AnyObjectPtr]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(this), ctypes.c_char_p))
+    output = c_to_py(unwrap(lib_function(c_this), ctypes.c_char_p))
+    
+    return output
 
 
 def slice_as_object(
@@ -166,15 +180,17 @@ def slice_as_object(
     T = parse_or_infer(T, raw)
     
     # Convert arguments to c types.
-    raw = py_to_c(raw, c_type=FfiSlicePtr, type_name=T)
-    T = py_to_c(T, c_type=ctypes.c_char_p, type_name=None)
+    c_raw = py_to_c(raw, c_type=FfiSlicePtr, type_name=T)
+    c_T = py_to_c(T, c_type=ctypes.c_char_p, type_name=None)
     
     # Call library function.
-    function = lib.opendp_data__slice_as_object
-    function.argtypes = [FfiSlicePtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_data__slice_as_object
+    lib_function.argtypes = [FfiSlicePtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return unwrap(function(raw, T), AnyObjectPtr)
+    output = unwrap(lib_function(c_raw, c_T), AnyObjectPtr)
+    
+    return output
 
 
 def slice_free(
@@ -193,13 +209,17 @@ def slice_free(
     :raises OpenDPException: packaged error from the core OpenDP library
     """
     # No type arguments to standardize.
-    # No arguments to convert to c types.
-    # Call library function.
-    function = lib.opendp_data__slice_free
-    function.argtypes = [FfiSlicePtr]
-    function.restype = FfiResult
+    # Convert arguments to c types.
+    c_this = this
     
-    return c_to_py(unwrap(function(this), ctypes.c_void_p))
+    # Call library function.
+    lib_function = lib.opendp_data__slice_free
+    lib_function.argtypes = [FfiSlicePtr]
+    lib_function.restype = FfiResult
+    
+    output = c_to_py(unwrap(lib_function(c_this), ctypes.c_void_p))
+    
+    return output
 
 
 def smd_curve_epsilon(
@@ -222,15 +242,17 @@ def smd_curve_epsilon(
     """
     # No type arguments to standardize.
     # Convert arguments to c types.
-    curve = py_to_c(curve, c_type=AnyObjectPtr, type_name=None)
-    delta = py_to_c(delta, c_type=AnyObjectPtr, type_name=get_atom(object_type(curve)))
+    c_curve = py_to_c(curve, c_type=AnyObjectPtr, type_name=None)
+    c_delta = py_to_c(delta, c_type=AnyObjectPtr, type_name=get_atom(object_type(curve)))
     
     # Call library function.
-    function = lib.opendp_data__smd_curve_epsilon
-    function.argtypes = [AnyObjectPtr, AnyObjectPtr]
-    function.restype = FfiResult
+    lib_function = lib.opendp_data__smd_curve_epsilon
+    lib_function.argtypes = [AnyObjectPtr, AnyObjectPtr]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(curve, delta), AnyObjectPtr))
+    output = c_to_py(unwrap(lib_function(c_curve, c_delta), AnyObjectPtr))
+    
+    return output
 
 
 def str_free(
@@ -248,13 +270,17 @@ def str_free(
     :raises OpenDPException: packaged error from the core OpenDP library
     """
     # No type arguments to standardize.
-    # No arguments to convert to c types.
-    # Call library function.
-    function = lib.opendp_data__str_free
-    function.argtypes = [ctypes.c_char_p]
-    function.restype = FfiResult
+    # Convert arguments to c types.
+    c_this = this
     
-    return c_to_py(unwrap(function(this), ctypes.c_void_p))
+    # Call library function.
+    lib_function = lib.opendp_data__str_free
+    lib_function.argtypes = [ctypes.c_char_p]
+    lib_function.restype = FfiResult
+    
+    output = c_to_py(unwrap(lib_function(c_this), ctypes.c_void_p))
+    
+    return output
 
 
 def to_string(
@@ -273,11 +299,13 @@ def to_string(
     """
     # No type arguments to standardize.
     # Convert arguments to c types.
-    this = py_to_c(this, c_type=AnyObjectPtr, type_name=None)
+    c_this = py_to_c(this, c_type=AnyObjectPtr, type_name=None)
     
     # Call library function.
-    function = lib.opendp_data__to_string
-    function.argtypes = [AnyObjectPtr]
-    function.restype = FfiResult
+    lib_function = lib.opendp_data__to_string
+    lib_function.argtypes = [AnyObjectPtr]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(this), ctypes.c_char_p))
+    output = c_to_py(unwrap(lib_function(c_this), ctypes.c_char_p))
+    
+    return output

--- a/python/src/opendp/accuracy.py
+++ b/python/src/opendp/accuracy.py
@@ -42,16 +42,18 @@ def accuracy_to_discrete_gaussian_scale(
     T = RuntimeType.parse_or_infer(type_name=T, public_example=accuracy)
     
     # Convert arguments to c types.
-    accuracy = py_to_c(accuracy, c_type=ctypes.c_void_p, type_name=T)
-    alpha = py_to_c(alpha, c_type=ctypes.c_void_p, type_name=T)
-    T = py_to_c(T, c_type=ctypes.c_char_p)
+    c_accuracy = py_to_c(accuracy, c_type=ctypes.c_void_p, type_name=T)
+    c_alpha = py_to_c(alpha, c_type=ctypes.c_void_p, type_name=T)
+    c_T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_accuracy__accuracy_to_discrete_gaussian_scale
-    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_accuracy__accuracy_to_discrete_gaussian_scale
+    lib_function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(accuracy, alpha, T), AnyObjectPtr))
+    output = c_to_py(unwrap(lib_function(c_accuracy, c_alpha, c_T), AnyObjectPtr))
+    
+    return output
 
 
 def accuracy_to_discrete_laplacian_scale(
@@ -81,16 +83,18 @@ def accuracy_to_discrete_laplacian_scale(
     T = RuntimeType.parse_or_infer(type_name=T, public_example=accuracy)
     
     # Convert arguments to c types.
-    accuracy = py_to_c(accuracy, c_type=ctypes.c_void_p, type_name=T)
-    alpha = py_to_c(alpha, c_type=ctypes.c_void_p, type_name=T)
-    T = py_to_c(T, c_type=ctypes.c_char_p)
+    c_accuracy = py_to_c(accuracy, c_type=ctypes.c_void_p, type_name=T)
+    c_alpha = py_to_c(alpha, c_type=ctypes.c_void_p, type_name=T)
+    c_T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_accuracy__accuracy_to_discrete_laplacian_scale
-    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_accuracy__accuracy_to_discrete_laplacian_scale
+    lib_function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(accuracy, alpha, T), AnyObjectPtr))
+    output = c_to_py(unwrap(lib_function(c_accuracy, c_alpha, c_T), AnyObjectPtr))
+    
+    return output
 
 
 def accuracy_to_gaussian_scale(
@@ -115,16 +119,18 @@ def accuracy_to_gaussian_scale(
     T = RuntimeType.parse_or_infer(type_name=T, public_example=accuracy)
     
     # Convert arguments to c types.
-    accuracy = py_to_c(accuracy, c_type=ctypes.c_void_p, type_name=T)
-    alpha = py_to_c(alpha, c_type=ctypes.c_void_p, type_name=T)
-    T = py_to_c(T, c_type=ctypes.c_char_p)
+    c_accuracy = py_to_c(accuracy, c_type=ctypes.c_void_p, type_name=T)
+    c_alpha = py_to_c(alpha, c_type=ctypes.c_void_p, type_name=T)
+    c_T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_accuracy__accuracy_to_gaussian_scale
-    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_accuracy__accuracy_to_gaussian_scale
+    lib_function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(accuracy, alpha, T), AnyObjectPtr))
+    output = c_to_py(unwrap(lib_function(c_accuracy, c_alpha, c_T), AnyObjectPtr))
+    
+    return output
 
 
 def accuracy_to_laplacian_scale(
@@ -150,16 +156,18 @@ def accuracy_to_laplacian_scale(
     T = RuntimeType.parse_or_infer(type_name=T, public_example=accuracy)
     
     # Convert arguments to c types.
-    accuracy = py_to_c(accuracy, c_type=ctypes.c_void_p, type_name=T)
-    alpha = py_to_c(alpha, c_type=ctypes.c_void_p, type_name=T)
-    T = py_to_c(T, c_type=ctypes.c_char_p)
+    c_accuracy = py_to_c(accuracy, c_type=ctypes.c_void_p, type_name=T)
+    c_alpha = py_to_c(alpha, c_type=ctypes.c_void_p, type_name=T)
+    c_T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_accuracy__accuracy_to_laplacian_scale
-    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_accuracy__accuracy_to_laplacian_scale
+    lib_function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(accuracy, alpha, T), AnyObjectPtr))
+    output = c_to_py(unwrap(lib_function(c_accuracy, c_alpha, c_T), AnyObjectPtr))
+    
+    return output
 
 
 def discrete_gaussian_scale_to_accuracy(
@@ -188,16 +196,18 @@ def discrete_gaussian_scale_to_accuracy(
     T = RuntimeType.parse_or_infer(type_name=T, public_example=scale)
     
     # Convert arguments to c types.
-    scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=T)
-    alpha = py_to_c(alpha, c_type=ctypes.c_void_p, type_name=T)
-    T = py_to_c(T, c_type=ctypes.c_char_p)
+    c_scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=T)
+    c_alpha = py_to_c(alpha, c_type=ctypes.c_void_p, type_name=T)
+    c_T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_accuracy__discrete_gaussian_scale_to_accuracy
-    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_accuracy__discrete_gaussian_scale_to_accuracy
+    lib_function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(scale, alpha, T), AnyObjectPtr))
+    output = c_to_py(unwrap(lib_function(c_scale, c_alpha, c_T), AnyObjectPtr))
+    
+    return output
 
 
 def discrete_laplacian_scale_to_accuracy(
@@ -232,16 +242,18 @@ def discrete_laplacian_scale_to_accuracy(
     T = RuntimeType.parse_or_infer(type_name=T, public_example=scale)
     
     # Convert arguments to c types.
-    scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=T)
-    alpha = py_to_c(alpha, c_type=ctypes.c_void_p, type_name=T)
-    T = py_to_c(T, c_type=ctypes.c_char_p)
+    c_scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=T)
+    c_alpha = py_to_c(alpha, c_type=ctypes.c_void_p, type_name=T)
+    c_T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_accuracy__discrete_laplacian_scale_to_accuracy
-    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_accuracy__discrete_laplacian_scale_to_accuracy
+    lib_function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(scale, alpha, T), AnyObjectPtr))
+    output = c_to_py(unwrap(lib_function(c_scale, c_alpha, c_T), AnyObjectPtr))
+    
+    return output
 
 
 def gaussian_scale_to_accuracy(
@@ -266,16 +278,18 @@ def gaussian_scale_to_accuracy(
     T = RuntimeType.parse_or_infer(type_name=T, public_example=scale)
     
     # Convert arguments to c types.
-    scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=T)
-    alpha = py_to_c(alpha, c_type=ctypes.c_void_p, type_name=T)
-    T = py_to_c(T, c_type=ctypes.c_char_p)
+    c_scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=T)
+    c_alpha = py_to_c(alpha, c_type=ctypes.c_void_p, type_name=T)
+    c_T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_accuracy__gaussian_scale_to_accuracy
-    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_accuracy__gaussian_scale_to_accuracy
+    lib_function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(scale, alpha, T), AnyObjectPtr))
+    output = c_to_py(unwrap(lib_function(c_scale, c_alpha, c_T), AnyObjectPtr))
+    
+    return output
 
 
 def laplacian_scale_to_accuracy(
@@ -300,13 +314,15 @@ def laplacian_scale_to_accuracy(
     T = RuntimeType.parse_or_infer(type_name=T, public_example=scale)
     
     # Convert arguments to c types.
-    scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=T)
-    alpha = py_to_c(alpha, c_type=ctypes.c_void_p, type_name=T)
-    T = py_to_c(T, c_type=ctypes.c_char_p)
+    c_scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=T)
+    c_alpha = py_to_c(alpha, c_type=ctypes.c_void_p, type_name=T)
+    c_T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_accuracy__laplacian_scale_to_accuracy
-    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_accuracy__laplacian_scale_to_accuracy
+    lib_function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(scale, alpha, T), AnyObjectPtr))
+    output = c_to_py(unwrap(lib_function(c_scale, c_alpha, c_T), AnyObjectPtr))
+    
+    return output

--- a/python/src/opendp/combinators.py
+++ b/python/src/opendp/combinators.py
@@ -10,9 +10,9 @@ __all__ = [
     "make_chain_mt",
     "make_chain_tm",
     "make_chain_tt",
-    "make_default_measurement",
-    "make_default_postprocessor",
-    "make_default_transformation",
+    "make_default_user_measurement",
+    "make_default_user_postprocessor",
+    "make_default_user_transformation",
     "make_fix_delta",
     "make_population_amplification",
     "make_pureDP_to_fixed_approxDP",
@@ -160,7 +160,7 @@ def make_chain_tt(
     return output
 
 
-def make_default_measurement(
+def make_default_user_measurement(
     function,
     privacy_map,
     DI: RuntimeTypeDescriptor,
@@ -192,7 +192,7 @@ def make_default_measurement(
     * `FixedSmoothedMaxDivergence<_>`
     * `ZeroConcentratedDivergence<_>`
     
-    [make_default_measurement in Rust documentation.](https://docs.rs/opendp/latest/opendp/combinators/fn.make_default_measurement.html)
+    [make_default_user_measurement in Rust documentation.](https://docs.rs/opendp/latest/opendp/combinators/fn.make_default_user_measurement.html)
     
     :param function: A function mapping data from `DI` to `DO`.
     :param privacy_map: A function mapping distances from `MI` to `MO`.
@@ -221,7 +221,7 @@ def make_default_measurement(
     c_MO = py_to_c(MO, c_type=ctypes.c_char_p, type_name=None)
     
     # Call library function.
-    lib_function = lib.opendp_combinators__make_default_measurement
+    lib_function = lib.opendp_combinators__make_default_user_measurement
     lib_function.argtypes = [CallbackFn, CallbackFn, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
     lib_function.restype = FfiResult
     
@@ -230,7 +230,7 @@ def make_default_measurement(
     return output
 
 
-def make_default_postprocessor(
+def make_default_user_postprocessor(
     function,
     DI: RuntimeTypeDescriptor,
     DO: RuntimeTypeDescriptor
@@ -242,7 +242,7 @@ def make_default_postprocessor(
     * `VectorDomain<AllDomain<_>>`
     * `AllDomain<_>`
     
-    [make_default_postprocessor in Rust documentation.](https://docs.rs/opendp/latest/opendp/combinators/fn.make_default_postprocessor.html)
+    [make_default_user_postprocessor in Rust documentation.](https://docs.rs/opendp/latest/opendp/combinators/fn.make_default_user_postprocessor.html)
     
     :param function: A function mapping data from `DI` to `DO`.
     :param DI: Input Domain. See Supported Domains
@@ -263,7 +263,7 @@ def make_default_postprocessor(
     c_DO = py_to_c(DO, c_type=ctypes.c_char_p, type_name=None)
     
     # Call library function.
-    lib_function = lib.opendp_combinators__make_default_postprocessor
+    lib_function = lib.opendp_combinators__make_default_user_postprocessor
     lib_function.argtypes = [CallbackFn, ctypes.c_char_p, ctypes.c_char_p]
     lib_function.restype = FfiResult
     
@@ -272,7 +272,7 @@ def make_default_postprocessor(
     return output
 
 
-def make_default_transformation(
+def make_default_user_transformation(
     function,
     stability_map,
     DI: RuntimeTypeDescriptor,
@@ -298,7 +298,7 @@ def make_default_transformation(
     * `L1Distance<_>`
     * `L2Distance<_>`
     
-    [make_default_transformation in Rust documentation.](https://docs.rs/opendp/latest/opendp/combinators/fn.make_default_transformation.html)
+    [make_default_user_transformation in Rust documentation.](https://docs.rs/opendp/latest/opendp/combinators/fn.make_default_user_transformation.html)
     
     :param function: A function mapping data from `DI` to `DO`.
     :param stability_map: A function mapping distances from `MI` to `MO`.
@@ -327,7 +327,7 @@ def make_default_transformation(
     c_MO = py_to_c(MO, c_type=ctypes.c_char_p, type_name=None)
     
     # Call library function.
-    lib_function = lib.opendp_combinators__make_default_transformation
+    lib_function = lib.opendp_combinators__make_default_user_transformation
     lib_function.argtypes = [CallbackFn, CallbackFn, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
     lib_function.restype = FfiResult
     

--- a/python/src/opendp/combinators.py
+++ b/python/src/opendp/combinators.py
@@ -10,6 +10,9 @@ __all__ = [
     "make_chain_mt",
     "make_chain_tm",
     "make_chain_tt",
+    "make_default_measurement",
+    "make_default_postprocessor",
+    "make_default_transformation",
     "make_fix_delta",
     "make_population_amplification",
     "make_pureDP_to_fixed_approxDP",
@@ -39,14 +42,16 @@ def make_basic_composition(
     
     # No type arguments to standardize.
     # Convert arguments to c types.
-    measurements = py_to_c(measurements, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[AnyMeasurementPtr]))
+    c_measurements = py_to_c(measurements, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[AnyMeasurementPtr]))
     
     # Call library function.
-    function = lib.opendp_combinators__make_basic_composition
-    function.argtypes = [AnyObjectPtr]
-    function.restype = FfiResult
+    lib_function = lib.opendp_combinators__make_basic_composition
+    lib_function.argtypes = [AnyObjectPtr]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(measurements), Measurement))
+    output = c_to_py(unwrap(lib_function(c_measurements), Measurement))
+    output._depends_on(get_dependencies_iterable(measurements))
+    return output
 
 
 def make_chain_mt(
@@ -71,15 +76,17 @@ def make_chain_mt(
     
     # No type arguments to standardize.
     # Convert arguments to c types.
-    measurement1 = py_to_c(measurement1, c_type=Measurement, type_name=None)
-    transformation0 = py_to_c(transformation0, c_type=Transformation, type_name=None)
+    c_measurement1 = py_to_c(measurement1, c_type=Measurement, type_name=None)
+    c_transformation0 = py_to_c(transformation0, c_type=Transformation, type_name=None)
     
     # Call library function.
-    function = lib.opendp_combinators__make_chain_mt
-    function.argtypes = [Measurement, Transformation]
-    function.restype = FfiResult
+    lib_function = lib.opendp_combinators__make_chain_mt
+    lib_function.argtypes = [Measurement, Transformation]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(measurement1, transformation0), Measurement))
+    output = c_to_py(unwrap(lib_function(c_measurement1, c_transformation0), Measurement))
+    output._depends_on(get_dependencies(measurement1), get_dependencies(transformation0))
+    return output
 
 
 def make_chain_tm(
@@ -105,15 +112,17 @@ def make_chain_tm(
     
     # No type arguments to standardize.
     # Convert arguments to c types.
-    transformation1 = py_to_c(transformation1, c_type=Transformation, type_name=None)
-    measurement0 = py_to_c(measurement0, c_type=Measurement, type_name=None)
+    c_transformation1 = py_to_c(transformation1, c_type=Transformation, type_name=None)
+    c_measurement0 = py_to_c(measurement0, c_type=Measurement, type_name=None)
     
     # Call library function.
-    function = lib.opendp_combinators__make_chain_tm
-    function.argtypes = [Transformation, Measurement]
-    function.restype = FfiResult
+    lib_function = lib.opendp_combinators__make_chain_tm
+    lib_function.argtypes = [Transformation, Measurement]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(transformation1, measurement0), Measurement))
+    output = c_to_py(unwrap(lib_function(c_transformation1, c_measurement0), Measurement))
+    output._depends_on(get_dependencies(transformation1), get_dependencies(measurement0))
+    return output
 
 
 def make_chain_tt(
@@ -138,15 +147,193 @@ def make_chain_tt(
     
     # No type arguments to standardize.
     # Convert arguments to c types.
-    transformation1 = py_to_c(transformation1, c_type=Transformation, type_name=None)
-    transformation0 = py_to_c(transformation0, c_type=Transformation, type_name=None)
+    c_transformation1 = py_to_c(transformation1, c_type=Transformation, type_name=None)
+    c_transformation0 = py_to_c(transformation0, c_type=Transformation, type_name=None)
     
     # Call library function.
-    function = lib.opendp_combinators__make_chain_tt
-    function.argtypes = [Transformation, Transformation]
-    function.restype = FfiResult
+    lib_function = lib.opendp_combinators__make_chain_tt
+    lib_function.argtypes = [Transformation, Transformation]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(transformation1, transformation0), Transformation))
+    output = c_to_py(unwrap(lib_function(c_transformation1, c_transformation0), Transformation))
+    output._depends_on(get_dependencies(transformation1), get_dependencies(transformation0))
+    return output
+
+
+def make_default_measurement(
+    function,
+    privacy_map,
+    DI: RuntimeTypeDescriptor,
+    DO: RuntimeTypeDescriptor,
+    MI: RuntimeTypeDescriptor,
+    MO: RuntimeTypeDescriptor
+) -> Measurement:
+    """Construct a Measurement from user-defined callbacks.
+    
+    **Supported Domains:**
+    
+    * `VectorDomain<AllDomain<_>>`
+    * `AllDomain<_>`
+    
+    **Supported Metrics:**
+    
+    * `SymmetricDistance`
+    * `InsertDeleteDistance`
+    * `ChangeOneDistance`
+    * `HammingDistance`
+    * `DiscreteDistance`
+    * `AbsoluteDistance<_>`
+    * `L1Distance<_>`
+    * `L2Distance<_>`
+    
+    **Supported Measures:**
+    
+    * `MaxDivergence<_>`
+    * `FixedSmoothedMaxDivergence<_>`
+    * `ZeroConcentratedDivergence<_>`
+    
+    [make_default_measurement in Rust documentation.](https://docs.rs/opendp/latest/opendp/combinators/fn.make_default_measurement.html)
+    
+    :param function: A function mapping data from `DI` to `DO`.
+    :param privacy_map: A function mapping distances from `MI` to `MO`.
+    :param DI: Input Domain. See Supported Domains
+    :type DI: :py:ref:`RuntimeTypeDescriptor`
+    :param DO: Output Domain. See Supported Domains
+    :type DO: :py:ref:`RuntimeTypeDescriptor`
+    :param MI: Input Metric. See Supported Metrics
+    :type MI: :py:ref:`RuntimeTypeDescriptor`
+    :param MO: Output Measure. See Supported Measures
+    :type MO: :py:ref:`RuntimeTypeDescriptor`
+    :rtype: Measurement
+    :raises TypeError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    assert_features("contrib", "honest-but-curious")
+    
+    # No type arguments to standardize.
+    # Convert arguments to c types.
+    c_function = py_to_c(function, c_type=CallbackFn, type_name=domain_carrier_type(DO))
+    c_privacy_map = py_to_c(privacy_map, c_type=CallbackFn, type_name=measure_distance_type(MO))
+    c_DI = py_to_c(DI, c_type=ctypes.c_char_p, type_name=None)
+    c_DO = py_to_c(DO, c_type=ctypes.c_char_p, type_name=None)
+    c_MI = py_to_c(MI, c_type=ctypes.c_char_p, type_name=None)
+    c_MO = py_to_c(MO, c_type=ctypes.c_char_p, type_name=None)
+    
+    # Call library function.
+    lib_function = lib.opendp_combinators__make_default_measurement
+    lib_function.argtypes = [CallbackFn, CallbackFn, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
+    
+    output = c_to_py(unwrap(lib_function(c_function, c_privacy_map, c_DI, c_DO, c_MI, c_MO), Measurement))
+    output._depends_on(c_function, c_privacy_map)
+    return output
+
+
+def make_default_postprocessor(
+    function,
+    DI: RuntimeTypeDescriptor,
+    DO: RuntimeTypeDescriptor
+) -> Transformation:
+    """Construct a Postprocessor from user-defined callbacks.
+    
+    **Supported Domains:**
+    
+    * `VectorDomain<AllDomain<_>>`
+    * `AllDomain<_>`
+    
+    [make_default_postprocessor in Rust documentation.](https://docs.rs/opendp/latest/opendp/combinators/fn.make_default_postprocessor.html)
+    
+    :param function: A function mapping data from `DI` to `DO`.
+    :param DI: Input Domain. See Supported Domains
+    :type DI: :py:ref:`RuntimeTypeDescriptor`
+    :param DO: Output Domain. See Supported Domains
+    :type DO: :py:ref:`RuntimeTypeDescriptor`
+    :rtype: Transformation
+    :raises TypeError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    assert_features("contrib")
+    
+    # No type arguments to standardize.
+    # Convert arguments to c types.
+    c_function = py_to_c(function, c_type=CallbackFn, type_name=domain_carrier_type(DO))
+    c_DI = py_to_c(DI, c_type=ctypes.c_char_p, type_name=None)
+    c_DO = py_to_c(DO, c_type=ctypes.c_char_p, type_name=None)
+    
+    # Call library function.
+    lib_function = lib.opendp_combinators__make_default_postprocessor
+    lib_function.argtypes = [CallbackFn, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
+    
+    output = c_to_py(unwrap(lib_function(c_function, c_DI, c_DO), Transformation))
+    output._depends_on(c_function)
+    return output
+
+
+def make_default_transformation(
+    function,
+    stability_map,
+    DI: RuntimeTypeDescriptor,
+    DO: RuntimeTypeDescriptor,
+    MI: RuntimeTypeDescriptor,
+    MO: RuntimeTypeDescriptor
+) -> Transformation:
+    """Construct a Transformation from user-defined callbacks.
+    
+    **Supported Domains:**
+    
+    * `VectorDomain<AllDomain<_>>`
+    * `AllDomain<_>`
+    
+    **Supported Metrics:**
+    
+    * `SymmetricDistance`
+    * `InsertDeleteDistance`
+    * `ChangeOneDistance`
+    * `HammingDistance`
+    * `DiscreteDistance`
+    * `AbsoluteDistance<_>`
+    * `L1Distance<_>`
+    * `L2Distance<_>`
+    
+    [make_default_transformation in Rust documentation.](https://docs.rs/opendp/latest/opendp/combinators/fn.make_default_transformation.html)
+    
+    :param function: A function mapping data from `DI` to `DO`.
+    :param stability_map: A function mapping distances from `MI` to `MO`.
+    :param DI: Input Domain. See Supported Domains
+    :type DI: :py:ref:`RuntimeTypeDescriptor`
+    :param DO: Output Domain. See Supported Domains
+    :type DO: :py:ref:`RuntimeTypeDescriptor`
+    :param MI: Input Metric. See Supported Metrics
+    :type MI: :py:ref:`RuntimeTypeDescriptor`
+    :param MO: Output Metric. See Supported Metrics
+    :type MO: :py:ref:`RuntimeTypeDescriptor`
+    :rtype: Transformation
+    :raises TypeError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    assert_features("contrib", "honest-but-curious")
+    
+    # No type arguments to standardize.
+    # Convert arguments to c types.
+    c_function = py_to_c(function, c_type=CallbackFn, type_name=domain_carrier_type(DO))
+    c_stability_map = py_to_c(stability_map, c_type=CallbackFn, type_name=metric_distance_type(MO))
+    c_DI = py_to_c(DI, c_type=ctypes.c_char_p, type_name=None)
+    c_DO = py_to_c(DO, c_type=ctypes.c_char_p, type_name=None)
+    c_MI = py_to_c(MI, c_type=ctypes.c_char_p, type_name=None)
+    c_MO = py_to_c(MO, c_type=ctypes.c_char_p, type_name=None)
+    
+    # Call library function.
+    lib_function = lib.opendp_combinators__make_default_transformation
+    lib_function.argtypes = [CallbackFn, CallbackFn, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
+    
+    output = c_to_py(unwrap(lib_function(c_function, c_stability_map, c_DI, c_DO, c_MI, c_MO), Transformation))
+    output._depends_on(c_function, c_stability_map)
+    return output
 
 
 def make_fix_delta(
@@ -170,15 +357,17 @@ def make_fix_delta(
     
     # No type arguments to standardize.
     # Convert arguments to c types.
-    measurement = py_to_c(measurement, c_type=Measurement, type_name=None)
-    delta = py_to_c(delta, c_type=AnyObjectPtr, type_name=get_atom(measurement_output_distance_type(measurement)))
+    c_measurement = py_to_c(measurement, c_type=Measurement, type_name=None)
+    c_delta = py_to_c(delta, c_type=AnyObjectPtr, type_name=get_atom(measurement_output_distance_type(measurement)))
     
     # Call library function.
-    function = lib.opendp_combinators__make_fix_delta
-    function.argtypes = [Measurement, AnyObjectPtr]
-    function.restype = FfiResult
+    lib_function = lib.opendp_combinators__make_fix_delta
+    lib_function.argtypes = [Measurement, AnyObjectPtr]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(measurement, delta), Measurement))
+    output = c_to_py(unwrap(lib_function(c_measurement, c_delta), Measurement))
+    output._depends_on(get_dependencies(measurement))
+    return output
 
 
 def make_population_amplification(
@@ -209,15 +398,17 @@ def make_population_amplification(
     
     # No type arguments to standardize.
     # Convert arguments to c types.
-    measurement = py_to_c(measurement, c_type=Measurement, type_name=AnyMeasurement)
-    population_size = py_to_c(population_size, c_type=ctypes.c_size_t, type_name=usize)
+    c_measurement = py_to_c(measurement, c_type=Measurement, type_name=AnyMeasurement)
+    c_population_size = py_to_c(population_size, c_type=ctypes.c_size_t, type_name=usize)
     
     # Call library function.
-    function = lib.opendp_combinators__make_population_amplification
-    function.argtypes = [Measurement, ctypes.c_size_t]
-    function.restype = FfiResult
+    lib_function = lib.opendp_combinators__make_population_amplification
+    lib_function.argtypes = [Measurement, ctypes.c_size_t]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(measurement, population_size), Measurement))
+    output = c_to_py(unwrap(lib_function(c_measurement, c_population_size), Measurement))
+    output._depends_on(get_dependencies(measurement))
+    return output
 
 
 def make_pureDP_to_fixed_approxDP(
@@ -239,14 +430,16 @@ def make_pureDP_to_fixed_approxDP(
     
     # No type arguments to standardize.
     # Convert arguments to c types.
-    measurement = py_to_c(measurement, c_type=Measurement, type_name=AnyMeasurement)
+    c_measurement = py_to_c(measurement, c_type=Measurement, type_name=AnyMeasurement)
     
     # Call library function.
-    function = lib.opendp_combinators__make_pureDP_to_fixed_approxDP
-    function.argtypes = [Measurement]
-    function.restype = FfiResult
+    lib_function = lib.opendp_combinators__make_pureDP_to_fixed_approxDP
+    lib_function.argtypes = [Measurement]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(measurement), Measurement))
+    output = c_to_py(unwrap(lib_function(c_measurement), Measurement))
+    
+    return output
 
 
 def make_pureDP_to_zCDP(
@@ -272,14 +465,16 @@ def make_pureDP_to_zCDP(
     
     # No type arguments to standardize.
     # Convert arguments to c types.
-    measurement = py_to_c(measurement, c_type=Measurement, type_name=AnyMeasurement)
+    c_measurement = py_to_c(measurement, c_type=Measurement, type_name=AnyMeasurement)
     
     # Call library function.
-    function = lib.opendp_combinators__make_pureDP_to_zCDP
-    function.argtypes = [Measurement]
-    function.restype = FfiResult
+    lib_function = lib.opendp_combinators__make_pureDP_to_zCDP
+    lib_function.argtypes = [Measurement]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(measurement), Measurement))
+    output = c_to_py(unwrap(lib_function(c_measurement), Measurement))
+    
+    return output
 
 
 def make_zCDP_to_approxDP(
@@ -301,11 +496,13 @@ def make_zCDP_to_approxDP(
     
     # No type arguments to standardize.
     # Convert arguments to c types.
-    measurement = py_to_c(measurement, c_type=Measurement, type_name=AnyMeasurement)
+    c_measurement = py_to_c(measurement, c_type=Measurement, type_name=AnyMeasurement)
     
     # Call library function.
-    function = lib.opendp_combinators__make_zCDP_to_approxDP
-    function.argtypes = [Measurement]
-    function.restype = FfiResult
+    lib_function = lib.opendp_combinators__make_zCDP_to_approxDP
+    lib_function.argtypes = [Measurement]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(measurement), Measurement))
+    output = c_to_py(unwrap(lib_function(c_measurement), Measurement))
+    output._depends_on(get_dependencies(measurement))
+    return output

--- a/python/src/opendp/core.py
+++ b/python/src/opendp/core.py
@@ -8,12 +8,15 @@ __all__ = [
     "_error_free",
     "_measurement_free",
     "_transformation_free",
+    "domain_carrier_type",
+    "measure_distance_type",
     "measurement_check",
     "measurement_input_carrier_type",
     "measurement_input_distance_type",
     "measurement_invoke",
     "measurement_map",
     "measurement_output_distance_type",
+    "metric_distance_type",
     "transformation_check",
     "transformation_input_carrier_type",
     "transformation_input_distance_type",
@@ -38,13 +41,17 @@ def _error_free(
     :raises UnknownTypeError: if a type argument fails to parse
     """
     # No type arguments to standardize.
-    # No arguments to convert to c types.
-    # Call library function.
-    function = lib.opendp_core___error_free
-    function.argtypes = [ctypes.POINTER(FfiError)]
-    function.restype = ctypes.c_bool
+    # Convert arguments to c types.
+    c_this = this
     
-    return c_to_py(function(this))
+    # Call library function.
+    lib_function = lib.opendp_core___error_free
+    lib_function.argtypes = [ctypes.POINTER(FfiError)]
+    lib_function.restype = ctypes.c_bool
+    
+    output = c_to_py(lib_function(c_this))
+    
+    return output
 
 
 def _measurement_free(
@@ -61,13 +68,17 @@ def _measurement_free(
     :raises OpenDPException: packaged error from the core OpenDP library
     """
     # No type arguments to standardize.
-    # No arguments to convert to c types.
-    # Call library function.
-    function = lib.opendp_core___measurement_free
-    function.argtypes = [Measurement]
-    function.restype = FfiResult
+    # Convert arguments to c types.
+    c_this = this
     
-    return c_to_py(unwrap(function(this), ctypes.c_void_p))
+    # Call library function.
+    lib_function = lib.opendp_core___measurement_free
+    lib_function.argtypes = [Measurement]
+    lib_function.restype = FfiResult
+    
+    output = c_to_py(unwrap(lib_function(c_this), ctypes.c_void_p))
+    
+    return output
 
 
 def _transformation_free(
@@ -84,13 +95,73 @@ def _transformation_free(
     :raises OpenDPException: packaged error from the core OpenDP library
     """
     # No type arguments to standardize.
-    # No arguments to convert to c types.
-    # Call library function.
-    function = lib.opendp_core___transformation_free
-    function.argtypes = [Transformation]
-    function.restype = FfiResult
+    # Convert arguments to c types.
+    c_this = this
     
-    return c_to_py(unwrap(function(this), ctypes.c_void_p))
+    # Call library function.
+    lib_function = lib.opendp_core___transformation_free
+    lib_function.argtypes = [Transformation]
+    lib_function.restype = FfiResult
+    
+    output = c_to_py(unwrap(lib_function(c_this), ctypes.c_void_p))
+    
+    return output
+
+
+def domain_carrier_type(
+    D: str
+) -> str:
+    """Get the carrier type associated with a domain descriptor
+    
+    [domain_carrier_type in Rust documentation.](https://docs.rs/opendp/latest/opendp/core/fn.domain_carrier_type.html)
+    
+    :param D: The domain to get the carrier type from.
+    :type D: str
+    :rtype: str
+    :raises TypeError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # No type arguments to standardize.
+    # Convert arguments to c types.
+    c_D = py_to_c(D, c_type=ctypes.c_char_p, type_name=None)
+    
+    # Call library function.
+    lib_function = lib.opendp_core__domain_carrier_type
+    lib_function.argtypes = [ctypes.c_char_p]
+    lib_function.restype = FfiResult
+    
+    output = c_to_py(unwrap(lib_function(c_D), ctypes.c_char_p))
+    
+    return output
+
+
+def measure_distance_type(
+    M: str
+) -> str:
+    """Get the distance type associated with a measure descriptor
+    
+    [measure_distance_type in Rust documentation.](https://docs.rs/opendp/latest/opendp/core/fn.measure_distance_type.html)
+    
+    :param M: The measure to get the distance type from.
+    :type M: str
+    :rtype: str
+    :raises TypeError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # No type arguments to standardize.
+    # Convert arguments to c types.
+    c_M = py_to_c(M, c_type=ctypes.c_char_p, type_name=None)
+    
+    # Call library function.
+    lib_function = lib.opendp_core__measure_distance_type
+    lib_function.argtypes = [ctypes.c_char_p]
+    lib_function.restype = FfiResult
+    
+    output = c_to_py(unwrap(lib_function(c_M), ctypes.c_char_p))
+    
+    return output
 
 
 def measurement_check(
@@ -115,16 +186,18 @@ def measurement_check(
     """
     # No type arguments to standardize.
     # Convert arguments to c types.
-    measurement = py_to_c(measurement, c_type=Measurement, type_name=None)
-    distance_in = py_to_c(distance_in, c_type=AnyObjectPtr, type_name=measurement_input_distance_type(measurement))
-    distance_out = py_to_c(distance_out, c_type=AnyObjectPtr, type_name=measurement_output_distance_type(measurement))
+    c_measurement = py_to_c(measurement, c_type=Measurement, type_name=None)
+    c_distance_in = py_to_c(distance_in, c_type=AnyObjectPtr, type_name=measurement_input_distance_type(measurement))
+    c_distance_out = py_to_c(distance_out, c_type=AnyObjectPtr, type_name=measurement_output_distance_type(measurement))
     
     # Call library function.
-    function = lib.opendp_core__measurement_check
-    function.argtypes = [Measurement, AnyObjectPtr, AnyObjectPtr]
-    function.restype = FfiResult
+    lib_function = lib.opendp_core__measurement_check
+    lib_function.argtypes = [Measurement, AnyObjectPtr, AnyObjectPtr]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(measurement, distance_in, distance_out), BoolPtr))
+    output = c_to_py(unwrap(lib_function(c_measurement, c_distance_in, c_distance_out), BoolPtr))
+    
+    return output
 
 
 def measurement_input_carrier_type(
@@ -143,14 +216,16 @@ def measurement_input_carrier_type(
     """
     # No type arguments to standardize.
     # Convert arguments to c types.
-    this = py_to_c(this, c_type=Measurement, type_name=None)
+    c_this = py_to_c(this, c_type=Measurement, type_name=None)
     
     # Call library function.
-    function = lib.opendp_core__measurement_input_carrier_type
-    function.argtypes = [Measurement]
-    function.restype = FfiResult
+    lib_function = lib.opendp_core__measurement_input_carrier_type
+    lib_function.argtypes = [Measurement]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(this), ctypes.c_char_p))
+    output = c_to_py(unwrap(lib_function(c_this), ctypes.c_char_p))
+    
+    return output
 
 
 def measurement_input_distance_type(
@@ -169,14 +244,16 @@ def measurement_input_distance_type(
     """
     # No type arguments to standardize.
     # Convert arguments to c types.
-    this = py_to_c(this, c_type=Measurement, type_name=None)
+    c_this = py_to_c(this, c_type=Measurement, type_name=None)
     
     # Call library function.
-    function = lib.opendp_core__measurement_input_distance_type
-    function.argtypes = [Measurement]
-    function.restype = FfiResult
+    lib_function = lib.opendp_core__measurement_input_distance_type
+    lib_function.argtypes = [Measurement]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(this), ctypes.c_char_p))
+    output = c_to_py(unwrap(lib_function(c_this), ctypes.c_char_p))
+    
+    return output
 
 
 def measurement_invoke(
@@ -198,15 +275,17 @@ def measurement_invoke(
     """
     # No type arguments to standardize.
     # Convert arguments to c types.
-    this = py_to_c(this, c_type=Measurement, type_name=None)
-    arg = py_to_c(arg, c_type=AnyObjectPtr, type_name=measurement_input_carrier_type(this))
+    c_this = py_to_c(this, c_type=Measurement, type_name=None)
+    c_arg = py_to_c(arg, c_type=AnyObjectPtr, type_name=measurement_input_carrier_type(this))
     
     # Call library function.
-    function = lib.opendp_core__measurement_invoke
-    function.argtypes = [Measurement, AnyObjectPtr]
-    function.restype = FfiResult
+    lib_function = lib.opendp_core__measurement_invoke
+    lib_function.argtypes = [Measurement, AnyObjectPtr]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(this, arg), AnyObjectPtr))
+    output = c_to_py(unwrap(lib_function(c_this, c_arg), AnyObjectPtr))
+    
+    return output
 
 
 def measurement_map(
@@ -228,15 +307,17 @@ def measurement_map(
     """
     # No type arguments to standardize.
     # Convert arguments to c types.
-    measurement = py_to_c(measurement, c_type=Measurement, type_name=None)
-    distance_in = py_to_c(distance_in, c_type=AnyObjectPtr, type_name=measurement_input_distance_type(measurement))
+    c_measurement = py_to_c(measurement, c_type=Measurement, type_name=None)
+    c_distance_in = py_to_c(distance_in, c_type=AnyObjectPtr, type_name=measurement_input_distance_type(measurement))
     
     # Call library function.
-    function = lib.opendp_core__measurement_map
-    function.argtypes = [Measurement, AnyObjectPtr]
-    function.restype = FfiResult
+    lib_function = lib.opendp_core__measurement_map
+    lib_function.argtypes = [Measurement, AnyObjectPtr]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(measurement, distance_in), AnyObjectPtr))
+    output = c_to_py(unwrap(lib_function(c_measurement, c_distance_in), AnyObjectPtr))
+    
+    return output
 
 
 def measurement_output_distance_type(
@@ -255,14 +336,44 @@ def measurement_output_distance_type(
     """
     # No type arguments to standardize.
     # Convert arguments to c types.
-    this = py_to_c(this, c_type=Measurement, type_name=None)
+    c_this = py_to_c(this, c_type=Measurement, type_name=None)
     
     # Call library function.
-    function = lib.opendp_core__measurement_output_distance_type
-    function.argtypes = [Measurement]
-    function.restype = FfiResult
+    lib_function = lib.opendp_core__measurement_output_distance_type
+    lib_function.argtypes = [Measurement]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(this), ctypes.c_char_p))
+    output = c_to_py(unwrap(lib_function(c_this), ctypes.c_char_p))
+    
+    return output
+
+
+def metric_distance_type(
+    M: str
+) -> str:
+    """Get the distance type associated with a metric descriptor
+    
+    [metric_distance_type in Rust documentation.](https://docs.rs/opendp/latest/opendp/core/fn.metric_distance_type.html)
+    
+    :param M: The metric to get the distance type from.
+    :type M: str
+    :rtype: str
+    :raises TypeError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # No type arguments to standardize.
+    # Convert arguments to c types.
+    c_M = py_to_c(M, c_type=ctypes.c_char_p, type_name=None)
+    
+    # Call library function.
+    lib_function = lib.opendp_core__metric_distance_type
+    lib_function.argtypes = [ctypes.c_char_p]
+    lib_function.restype = FfiResult
+    
+    output = c_to_py(unwrap(lib_function(c_M), ctypes.c_char_p))
+    
+    return output
 
 
 def transformation_check(
@@ -287,16 +398,18 @@ def transformation_check(
     """
     # No type arguments to standardize.
     # Convert arguments to c types.
-    transformation = py_to_c(transformation, c_type=Transformation, type_name=None)
-    distance_in = py_to_c(distance_in, c_type=AnyObjectPtr, type_name=transformation_input_distance_type(transformation))
-    distance_out = py_to_c(distance_out, c_type=AnyObjectPtr, type_name=transformation_output_distance_type(transformation))
+    c_transformation = py_to_c(transformation, c_type=Transformation, type_name=None)
+    c_distance_in = py_to_c(distance_in, c_type=AnyObjectPtr, type_name=transformation_input_distance_type(transformation))
+    c_distance_out = py_to_c(distance_out, c_type=AnyObjectPtr, type_name=transformation_output_distance_type(transformation))
     
     # Call library function.
-    function = lib.opendp_core__transformation_check
-    function.argtypes = [Transformation, AnyObjectPtr, AnyObjectPtr]
-    function.restype = FfiResult
+    lib_function = lib.opendp_core__transformation_check
+    lib_function.argtypes = [Transformation, AnyObjectPtr, AnyObjectPtr]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(transformation, distance_in, distance_out), BoolPtr))
+    output = c_to_py(unwrap(lib_function(c_transformation, c_distance_in, c_distance_out), BoolPtr))
+    
+    return output
 
 
 def transformation_input_carrier_type(
@@ -315,14 +428,16 @@ def transformation_input_carrier_type(
     """
     # No type arguments to standardize.
     # Convert arguments to c types.
-    this = py_to_c(this, c_type=Transformation, type_name=None)
+    c_this = py_to_c(this, c_type=Transformation, type_name=None)
     
     # Call library function.
-    function = lib.opendp_core__transformation_input_carrier_type
-    function.argtypes = [Transformation]
-    function.restype = FfiResult
+    lib_function = lib.opendp_core__transformation_input_carrier_type
+    lib_function.argtypes = [Transformation]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(this), ctypes.c_char_p))
+    output = c_to_py(unwrap(lib_function(c_this), ctypes.c_char_p))
+    
+    return output
 
 
 def transformation_input_distance_type(
@@ -341,14 +456,16 @@ def transformation_input_distance_type(
     """
     # No type arguments to standardize.
     # Convert arguments to c types.
-    this = py_to_c(this, c_type=Transformation, type_name=None)
+    c_this = py_to_c(this, c_type=Transformation, type_name=None)
     
     # Call library function.
-    function = lib.opendp_core__transformation_input_distance_type
-    function.argtypes = [Transformation]
-    function.restype = FfiResult
+    lib_function = lib.opendp_core__transformation_input_distance_type
+    lib_function.argtypes = [Transformation]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(this), ctypes.c_char_p))
+    output = c_to_py(unwrap(lib_function(c_this), ctypes.c_char_p))
+    
+    return output
 
 
 def transformation_invoke(
@@ -370,15 +487,17 @@ def transformation_invoke(
     """
     # No type arguments to standardize.
     # Convert arguments to c types.
-    this = py_to_c(this, c_type=Transformation, type_name=None)
-    arg = py_to_c(arg, c_type=AnyObjectPtr, type_name=transformation_input_carrier_type(this))
+    c_this = py_to_c(this, c_type=Transformation, type_name=None)
+    c_arg = py_to_c(arg, c_type=AnyObjectPtr, type_name=transformation_input_carrier_type(this))
     
     # Call library function.
-    function = lib.opendp_core__transformation_invoke
-    function.argtypes = [Transformation, AnyObjectPtr]
-    function.restype = FfiResult
+    lib_function = lib.opendp_core__transformation_invoke
+    lib_function.argtypes = [Transformation, AnyObjectPtr]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(this, arg), AnyObjectPtr))
+    output = c_to_py(unwrap(lib_function(c_this, c_arg), AnyObjectPtr))
+    
+    return output
 
 
 def transformation_map(
@@ -400,15 +519,17 @@ def transformation_map(
     """
     # No type arguments to standardize.
     # Convert arguments to c types.
-    transformation = py_to_c(transformation, c_type=Transformation, type_name=None)
-    distance_in = py_to_c(distance_in, c_type=AnyObjectPtr, type_name=transformation_input_distance_type(transformation))
+    c_transformation = py_to_c(transformation, c_type=Transformation, type_name=None)
+    c_distance_in = py_to_c(distance_in, c_type=AnyObjectPtr, type_name=transformation_input_distance_type(transformation))
     
     # Call library function.
-    function = lib.opendp_core__transformation_map
-    function.argtypes = [Transformation, AnyObjectPtr]
-    function.restype = FfiResult
+    lib_function = lib.opendp_core__transformation_map
+    lib_function.argtypes = [Transformation, AnyObjectPtr]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(transformation, distance_in), AnyObjectPtr))
+    output = c_to_py(unwrap(lib_function(c_transformation, c_distance_in), AnyObjectPtr))
+    
+    return output
 
 
 def transformation_output_distance_type(
@@ -427,11 +548,13 @@ def transformation_output_distance_type(
     """
     # No type arguments to standardize.
     # Convert arguments to c types.
-    this = py_to_c(this, c_type=Transformation, type_name=None)
+    c_this = py_to_c(this, c_type=Transformation, type_name=None)
     
     # Call library function.
-    function = lib.opendp_core__transformation_output_distance_type
-    function.argtypes = [Transformation]
-    function.restype = FfiResult
+    lib_function = lib.opendp_core__transformation_output_distance_type
+    lib_function.argtypes = [Transformation]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(this), ctypes.c_char_p))
+    output = c_to_py(unwrap(lib_function(c_this), ctypes.c_char_p))
+    
+    return output

--- a/python/src/opendp/measurements.py
+++ b/python/src/opendp/measurements.py
@@ -64,17 +64,19 @@ def make_base_discrete_gaussian(
     MO = MO.substitute(QO=QO)
     
     # Convert arguments to c types.
-    scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=QO)
-    D = py_to_c(D, c_type=ctypes.c_char_p)
-    MO = py_to_c(MO, c_type=ctypes.c_char_p)
-    QI = py_to_c(QI, c_type=ctypes.c_char_p)
+    c_scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=QO)
+    c_D = py_to_c(D, c_type=ctypes.c_char_p)
+    c_MO = py_to_c(MO, c_type=ctypes.c_char_p)
+    c_QI = py_to_c(QI, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_measurements__make_base_discrete_gaussian
-    function.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_measurements__make_base_discrete_gaussian
+    lib_function.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(scale, D, MO, QI), Measurement))
+    output = c_to_py(unwrap(lib_function(c_scale, c_D, c_MO, c_QI), Measurement))
+    
+    return output
 
 
 def make_base_discrete_laplace(
@@ -124,16 +126,18 @@ def make_base_discrete_laplace(
     QO = RuntimeType.parse_or_infer(type_name=QO, public_example=scale)
     
     # Convert arguments to c types.
-    scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=QO)
-    D = py_to_c(D, c_type=ctypes.c_char_p)
-    QO = py_to_c(QO, c_type=ctypes.c_char_p)
+    c_scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=QO)
+    c_D = py_to_c(D, c_type=ctypes.c_char_p)
+    c_QO = py_to_c(QO, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_measurements__make_base_discrete_laplace
-    function.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_measurements__make_base_discrete_laplace
+    lib_function.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(scale, D, QO), Measurement))
+    output = c_to_py(unwrap(lib_function(c_scale, c_D, c_QO), Measurement))
+    
+    return output
 
 
 def make_base_discrete_laplace_cks20(
@@ -181,16 +185,18 @@ def make_base_discrete_laplace_cks20(
     QO = RuntimeType.parse_or_infer(type_name=QO, public_example=scale)
     
     # Convert arguments to c types.
-    scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=QO)
-    D = py_to_c(D, c_type=ctypes.c_char_p)
-    QO = py_to_c(QO, c_type=ctypes.c_char_p)
+    c_scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=QO)
+    c_D = py_to_c(D, c_type=ctypes.c_char_p)
+    c_QO = py_to_c(QO, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_measurements__make_base_discrete_laplace_cks20
-    function.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_measurements__make_base_discrete_laplace_cks20
+    lib_function.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(scale, D, QO), Measurement))
+    output = c_to_py(unwrap(lib_function(c_scale, c_D, c_QO), Measurement))
+    
+    return output
 
 
 def make_base_discrete_laplace_linear(
@@ -244,17 +250,19 @@ def make_base_discrete_laplace_linear(
     OptionT = RuntimeType(origin='Option', args=[RuntimeType(origin='Tuple', args=[T, T])])
     
     # Convert arguments to c types.
-    scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=QO)
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=OptionT)
-    D = py_to_c(D, c_type=ctypes.c_char_p)
-    QO = py_to_c(QO, c_type=ctypes.c_char_p)
+    c_scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=QO)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=OptionT)
+    c_D = py_to_c(D, c_type=ctypes.c_char_p)
+    c_QO = py_to_c(QO, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_measurements__make_base_discrete_laplace_linear
-    function.argtypes = [ctypes.c_void_p, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_measurements__make_base_discrete_laplace_linear
+    lib_function.argtypes = [ctypes.c_void_p, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(scale, bounds, D, QO), Measurement))
+    output = c_to_py(unwrap(lib_function(c_scale, c_bounds, c_D, c_QO), Measurement))
+    
+    return output
 
 
 def make_base_gaussian(
@@ -307,17 +315,19 @@ def make_base_gaussian(
     MO = MO.substitute(T=T)
     
     # Convert arguments to c types.
-    scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=T)
-    k = py_to_c(k, c_type=ctypes.c_uint32, type_name=i32)
-    D = py_to_c(D, c_type=ctypes.c_char_p)
-    MO = py_to_c(MO, c_type=ctypes.c_char_p)
+    c_scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=T)
+    c_k = py_to_c(k, c_type=ctypes.c_uint32, type_name=i32)
+    c_D = py_to_c(D, c_type=ctypes.c_char_p)
+    c_MO = py_to_c(MO, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_measurements__make_base_gaussian
-    function.argtypes = [ctypes.c_void_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_measurements__make_base_gaussian
+    lib_function.argtypes = [ctypes.c_void_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(scale, k, D, MO), Measurement))
+    output = c_to_py(unwrap(lib_function(c_scale, c_k, c_D, c_MO), Measurement))
+    
+    return output
 
 
 def make_base_geometric(
@@ -360,17 +370,19 @@ def make_base_geometric(
     OptionT = RuntimeType(origin='Option', args=[RuntimeType(origin='Tuple', args=[T, T])])
     
     # Convert arguments to c types.
-    scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=QO)
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=OptionT)
-    D = py_to_c(D, c_type=ctypes.c_char_p)
-    QO = py_to_c(QO, c_type=ctypes.c_char_p)
+    c_scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=QO)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=OptionT)
+    c_D = py_to_c(D, c_type=ctypes.c_char_p)
+    c_QO = py_to_c(QO, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_measurements__make_base_geometric
-    function.argtypes = [ctypes.c_void_p, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_measurements__make_base_geometric
+    lib_function.argtypes = [ctypes.c_void_p, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(scale, bounds, D, QO), Measurement))
+    output = c_to_py(unwrap(lib_function(c_scale, c_bounds, c_D, c_QO), Measurement))
+    
+    return output
 
 
 def make_base_laplace(
@@ -419,16 +431,18 @@ def make_base_laplace(
     D = D.substitute(T=T)
     
     # Convert arguments to c types.
-    scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=T)
-    k = py_to_c(k, c_type=ctypes.c_uint32, type_name=i32)
-    D = py_to_c(D, c_type=ctypes.c_char_p)
+    c_scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=T)
+    c_k = py_to_c(k, c_type=ctypes.c_uint32, type_name=i32)
+    c_D = py_to_c(D, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_measurements__make_base_laplace
-    function.argtypes = [ctypes.c_void_p, ctypes.c_uint32, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_measurements__make_base_laplace
+    lib_function.argtypes = [ctypes.c_void_p, ctypes.c_uint32, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(scale, k, D), Measurement))
+    output = c_to_py(unwrap(lib_function(c_scale, c_k, c_D), Measurement))
+    
+    return output
 
 
 def make_base_ptr(
@@ -472,18 +486,20 @@ def make_base_ptr(
     TV = RuntimeType.parse_or_infer(type_name=TV, public_example=scale)
     
     # Convert arguments to c types.
-    scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=TV)
-    threshold = py_to_c(threshold, c_type=ctypes.c_void_p, type_name=TV)
-    k = py_to_c(k, c_type=ctypes.c_uint32, type_name=i32)
-    TK = py_to_c(TK, c_type=ctypes.c_char_p)
-    TV = py_to_c(TV, c_type=ctypes.c_char_p)
+    c_scale = py_to_c(scale, c_type=ctypes.c_void_p, type_name=TV)
+    c_threshold = py_to_c(threshold, c_type=ctypes.c_void_p, type_name=TV)
+    c_k = py_to_c(k, c_type=ctypes.c_uint32, type_name=i32)
+    c_TK = py_to_c(TK, c_type=ctypes.c_char_p)
+    c_TV = py_to_c(TV, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_measurements__make_base_ptr
-    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_measurements__make_base_ptr
+    lib_function.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(scale, threshold, k, TK, TV), Measurement))
+    output = c_to_py(unwrap(lib_function(c_scale, c_threshold, c_k, c_TK, c_TV), Measurement))
+    
+    return output
 
 
 def make_randomized_response(
@@ -525,18 +541,20 @@ def make_randomized_response(
     QO = RuntimeType.parse_or_infer(type_name=QO, public_example=prob)
     
     # Convert arguments to c types.
-    categories = py_to_c(categories, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[T]))
-    prob = py_to_c(prob, c_type=ctypes.c_void_p, type_name=QO)
-    constant_time = py_to_c(constant_time, c_type=ctypes.c_bool, type_name=bool)
-    T = py_to_c(T, c_type=ctypes.c_char_p)
-    QO = py_to_c(QO, c_type=ctypes.c_char_p)
+    c_categories = py_to_c(categories, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[T]))
+    c_prob = py_to_c(prob, c_type=ctypes.c_void_p, type_name=QO)
+    c_constant_time = py_to_c(constant_time, c_type=ctypes.c_bool, type_name=bool)
+    c_T = py_to_c(T, c_type=ctypes.c_char_p)
+    c_QO = py_to_c(QO, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_measurements__make_randomized_response
-    function.argtypes = [AnyObjectPtr, ctypes.c_void_p, ctypes.c_bool, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_measurements__make_randomized_response
+    lib_function.argtypes = [AnyObjectPtr, ctypes.c_void_p, ctypes.c_bool, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(categories, prob, constant_time, T, QO), Measurement))
+    output = c_to_py(unwrap(lib_function(c_categories, c_prob, c_constant_time, c_T, c_QO), Measurement))
+    
+    return output
 
 
 def make_randomized_response_bool(
@@ -571,13 +589,15 @@ def make_randomized_response_bool(
     QO = RuntimeType.parse_or_infer(type_name=QO, public_example=prob)
     
     # Convert arguments to c types.
-    prob = py_to_c(prob, c_type=ctypes.c_void_p, type_name=QO)
-    constant_time = py_to_c(constant_time, c_type=ctypes.c_bool, type_name=bool)
-    QO = py_to_c(QO, c_type=ctypes.c_char_p)
+    c_prob = py_to_c(prob, c_type=ctypes.c_void_p, type_name=QO)
+    c_constant_time = py_to_c(constant_time, c_type=ctypes.c_bool, type_name=bool)
+    c_QO = py_to_c(QO, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_measurements__make_randomized_response_bool
-    function.argtypes = [ctypes.c_void_p, ctypes.c_bool, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_measurements__make_randomized_response_bool
+    lib_function.argtypes = [ctypes.c_void_p, ctypes.c_bool, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(prob, constant_time, QO), Measurement))
+    output = c_to_py(unwrap(lib_function(c_prob, c_constant_time, c_QO), Measurement))
+    
+    return output

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -126,6 +126,10 @@ class Measurement(ctypes.POINTER(AnyMeasurement)):
         from opendp.typing import RuntimeType
         return RuntimeType.parse(measurement_input_carrier_type(self))
 
+    def _depends_on(self, *args):
+        """Extends the memory lifetime of args to the lifetime of self."""
+        setattr(self, "_dependencies", args)
+
     def __del__(self):
         try:
             from opendp.core import _measurement_free
@@ -259,6 +263,10 @@ class Transformation(ctypes.POINTER(AnyTransformation)):
         from opendp.core import transformation_input_carrier_type
         from opendp.typing import RuntimeType
         return RuntimeType.parse(transformation_input_carrier_type(self))
+
+    def _depends_on(self, *args):
+        """Extends the memory lifetime of args to the lifetime of self."""
+        setattr(self, "_dependencies", args)
 
     def __del__(self):
         try:

--- a/python/src/opendp/transformations.py
+++ b/python/src/opendp/transformations.py
@@ -88,14 +88,16 @@ def choose_branching_factor(
     
     # No type arguments to standardize.
     # Convert arguments to c types.
-    size_guess = py_to_c(size_guess, c_type=ctypes.c_size_t, type_name=usize)
+    c_size_guess = py_to_c(size_guess, c_type=ctypes.c_size_t, type_name=usize)
     
     # Call library function.
-    function = lib.opendp_transformations__choose_branching_factor
-    function.argtypes = [ctypes.c_size_t]
-    function.restype = ctypes.c_size_t
+    lib_function = lib.opendp_transformations__choose_branching_factor
+    lib_function.argtypes = [ctypes.c_size_t]
+    lib_function.restype = ctypes.c_size_t
     
-    return c_to_py(function(size_guess))
+    output = c_to_py(lib_function(c_size_guess))
+    
+    return output
 
 
 def make_b_ary_tree(
@@ -136,17 +138,19 @@ def make_b_ary_tree(
     TA = RuntimeType.parse(type_name=TA)
     
     # Convert arguments to c types.
-    leaf_count = py_to_c(leaf_count, c_type=ctypes.c_size_t, type_name=usize)
-    branching_factor = py_to_c(branching_factor, c_type=ctypes.c_size_t, type_name=usize)
-    M = py_to_c(M, c_type=ctypes.c_char_p)
-    TA = py_to_c(TA, c_type=ctypes.c_char_p)
+    c_leaf_count = py_to_c(leaf_count, c_type=ctypes.c_size_t, type_name=usize)
+    c_branching_factor = py_to_c(branching_factor, c_type=ctypes.c_size_t, type_name=usize)
+    c_M = py_to_c(M, c_type=ctypes.c_char_p)
+    c_TA = py_to_c(TA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_b_ary_tree
-    function.argtypes = [ctypes.c_size_t, ctypes.c_size_t, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_b_ary_tree
+    lib_function.argtypes = [ctypes.c_size_t, ctypes.c_size_t, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(leaf_count, branching_factor, M, TA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_leaf_count, c_branching_factor, c_M, c_TA), Transformation))
+    
+    return output
 
 
 def make_bounded_float_checked_sum(
@@ -203,16 +207,18 @@ def make_bounded_float_checked_sum(
     S = S.substitute(T=T)
     
     # Convert arguments to c types.
-    size_limit = py_to_c(size_limit, c_type=ctypes.c_size_t, type_name=usize)
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
-    S = py_to_c(S, c_type=ctypes.c_char_p)
+    c_size_limit = py_to_c(size_limit, c_type=ctypes.c_size_t, type_name=usize)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
+    c_S = py_to_c(S, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_bounded_float_checked_sum
-    function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_bounded_float_checked_sum
+    lib_function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size_limit, bounds, S), Transformation))
+    output = c_to_py(unwrap(lib_function(c_size_limit, c_bounds, c_S), Transformation))
+    
+    return output
 
 
 def make_bounded_float_ordered_sum(
@@ -270,16 +276,18 @@ def make_bounded_float_ordered_sum(
     S = S.substitute(T=T)
     
     # Convert arguments to c types.
-    size_limit = py_to_c(size_limit, c_type=ctypes.c_size_t, type_name=usize)
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
-    S = py_to_c(S, c_type=ctypes.c_char_p)
+    c_size_limit = py_to_c(size_limit, c_type=ctypes.c_size_t, type_name=usize)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
+    c_S = py_to_c(S, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_bounded_float_ordered_sum
-    function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_bounded_float_ordered_sum
+    lib_function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size_limit, bounds, S), Transformation))
+    output = c_to_py(unwrap(lib_function(c_size_limit, c_bounds, c_S), Transformation))
+    
+    return output
 
 
 def make_bounded_int_monotonic_sum(
@@ -318,15 +326,17 @@ def make_bounded_int_monotonic_sum(
     T = RuntimeType.parse_or_infer(type_name=T, public_example=get_first(bounds))
     
     # Convert arguments to c types.
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
-    T = py_to_c(T, c_type=ctypes.c_char_p)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
+    c_T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_bounded_int_monotonic_sum
-    function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_bounded_int_monotonic_sum
+    lib_function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(bounds, T), Transformation))
+    output = c_to_py(unwrap(lib_function(c_bounds, c_T), Transformation))
+    
+    return output
 
 
 def make_bounded_int_ordered_sum(
@@ -365,15 +375,17 @@ def make_bounded_int_ordered_sum(
     T = RuntimeType.parse_or_infer(type_name=T, public_example=get_first(bounds))
     
     # Convert arguments to c types.
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
-    T = py_to_c(T, c_type=ctypes.c_char_p)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
+    c_T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_bounded_int_ordered_sum
-    function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_bounded_int_ordered_sum
+    lib_function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(bounds, T), Transformation))
+    output = c_to_py(unwrap(lib_function(c_bounds, c_T), Transformation))
+    
+    return output
 
 
 def make_bounded_int_split_sum(
@@ -412,15 +424,17 @@ def make_bounded_int_split_sum(
     T = RuntimeType.parse_or_infer(type_name=T, public_example=get_first(bounds))
     
     # Convert arguments to c types.
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
-    T = py_to_c(T, c_type=ctypes.c_char_p)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
+    c_T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_bounded_int_split_sum
-    function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_bounded_int_split_sum
+    lib_function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(bounds, T), Transformation))
+    output = c_to_py(unwrap(lib_function(c_bounds, c_T), Transformation))
+    
+    return output
 
 
 def make_bounded_resize(
@@ -468,19 +482,21 @@ def make_bounded_resize(
     TA = RuntimeType.parse_or_infer(type_name=TA, public_example=get_first(bounds))
     
     # Convert arguments to c types.
-    size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[TA, TA]))
-    constant = py_to_c(constant, c_type=ctypes.c_void_p, type_name=TA)
-    MI = py_to_c(MI, c_type=ctypes.c_char_p)
-    MO = py_to_c(MO, c_type=ctypes.c_char_p)
-    TA = py_to_c(TA, c_type=ctypes.c_char_p)
+    c_size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[TA, TA]))
+    c_constant = py_to_c(constant, c_type=ctypes.c_void_p, type_name=TA)
+    c_MI = py_to_c(MI, c_type=ctypes.c_char_p)
+    c_MO = py_to_c(MO, c_type=ctypes.c_char_p)
+    c_TA = py_to_c(TA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_bounded_resize
-    function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_bounded_resize
+    lib_function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, bounds, constant, MI, MO, TA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_size, c_bounds, c_constant, c_MI, c_MO, c_TA), Transformation))
+    
+    return output
 
 
 def make_bounded_sum(
@@ -516,16 +532,18 @@ def make_bounded_sum(
     T = RuntimeType.parse_or_infer(type_name=T, public_example=get_first(bounds))
     
     # Convert arguments to c types.
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
-    MI = py_to_c(MI, c_type=ctypes.c_char_p)
-    T = py_to_c(T, c_type=ctypes.c_char_p)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
+    c_MI = py_to_c(MI, c_type=ctypes.c_char_p)
+    c_T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_bounded_sum
-    function.argtypes = [AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_bounded_sum
+    lib_function.argtypes = [AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(bounds, MI, T), Transformation))
+    output = c_to_py(unwrap(lib_function(c_bounds, c_MI, c_T), Transformation))
+    
+    return output
 
 
 def make_cast(
@@ -562,15 +580,17 @@ def make_cast(
     TOA = RuntimeType.parse(type_name=TOA)
     
     # Convert arguments to c types.
-    TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
-    TOA = py_to_c(TOA, c_type=ctypes.c_char_p)
+    c_TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
+    c_TOA = py_to_c(TOA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_cast
-    function.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_cast
+    lib_function.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(TIA, TOA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_TIA, c_TOA), Transformation))
+    
+    return output
 
 
 def make_cast_default(
@@ -613,15 +633,17 @@ def make_cast_default(
     TOA = RuntimeType.parse(type_name=TOA)
     
     # Convert arguments to c types.
-    TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
-    TOA = py_to_c(TOA, c_type=ctypes.c_char_p)
+    c_TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
+    c_TOA = py_to_c(TOA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_cast_default
-    function.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_cast_default
+    lib_function.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(TIA, TOA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_TIA, c_TOA), Transformation))
+    
+    return output
 
 
 def make_cast_inherent(
@@ -660,15 +682,17 @@ def make_cast_inherent(
     TOA = RuntimeType.parse(type_name=TOA)
     
     # Convert arguments to c types.
-    TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
-    TOA = py_to_c(TOA, c_type=ctypes.c_char_p)
+    c_TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
+    c_TOA = py_to_c(TOA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_cast_inherent
-    function.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_cast_inherent
+    lib_function.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(TIA, TOA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_TIA, c_TOA), Transformation))
+    
+    return output
 
 
 def make_cdf(
@@ -698,14 +722,16 @@ def make_cdf(
     TA = RuntimeType.parse(type_name=TA)
     
     # Convert arguments to c types.
-    TA = py_to_c(TA, c_type=ctypes.c_char_p)
+    c_TA = py_to_c(TA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_cdf
-    function.argtypes = [ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_cdf
+    lib_function.argtypes = [ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(TA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_TA), Transformation))
+    
+    return output
 
 
 def make_clamp(
@@ -741,15 +767,17 @@ def make_clamp(
     TA = RuntimeType.parse_or_infer(type_name=TA, public_example=get_first(bounds))
     
     # Convert arguments to c types.
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[TA, TA]))
-    TA = py_to_c(TA, c_type=ctypes.c_char_p)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[TA, TA]))
+    c_TA = py_to_c(TA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_clamp
-    function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_clamp
+    lib_function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(bounds, TA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_bounds, c_TA), Transformation))
+    
+    return output
 
 
 def make_consistent_b_ary_tree(
@@ -797,16 +825,18 @@ def make_consistent_b_ary_tree(
     TOA = RuntimeType.parse(type_name=TOA)
     
     # Convert arguments to c types.
-    branching_factor = py_to_c(branching_factor, c_type=ctypes.c_size_t, type_name=usize)
-    TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
-    TOA = py_to_c(TOA, c_type=ctypes.c_char_p)
+    c_branching_factor = py_to_c(branching_factor, c_type=ctypes.c_size_t, type_name=usize)
+    c_TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
+    c_TOA = py_to_c(TOA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_consistent_b_ary_tree
-    function.argtypes = [ctypes.c_size_t, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_consistent_b_ary_tree
+    lib_function.argtypes = [ctypes.c_size_t, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(branching_factor, TIA, TOA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_branching_factor, c_TIA, c_TOA), Transformation))
+    
+    return output
 
 
 def make_count(
@@ -848,15 +878,17 @@ def make_count(
     TO = RuntimeType.parse(type_name=TO)
     
     # Convert arguments to c types.
-    TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
-    TO = py_to_c(TO, c_type=ctypes.c_char_p)
+    c_TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
+    c_TO = py_to_c(TO, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_count
-    function.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_count
+    lib_function.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(TIA, TO), Transformation))
+    output = c_to_py(unwrap(lib_function(c_TIA, c_TO), Transformation))
+    
+    return output
 
 
 def make_count_by(
@@ -900,16 +932,18 @@ def make_count_by(
     TV = RuntimeType.parse(type_name=TV)
     
     # Convert arguments to c types.
-    MO = py_to_c(MO, c_type=ctypes.c_char_p)
-    TK = py_to_c(TK, c_type=ctypes.c_char_p)
-    TV = py_to_c(TV, c_type=ctypes.c_char_p)
+    c_MO = py_to_c(MO, c_type=ctypes.c_char_p)
+    c_TK = py_to_c(TK, c_type=ctypes.c_char_p)
+    c_TV = py_to_c(TV, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_count_by
-    function.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_count_by
+    lib_function.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(MO, TK, TV), Transformation))
+    output = c_to_py(unwrap(lib_function(c_MO, c_TK, c_TV), Transformation))
+    
+    return output
 
 
 def make_count_by_categories(
@@ -960,18 +994,20 @@ def make_count_by_categories(
     TOA = RuntimeType.parse(type_name=TOA)
     
     # Convert arguments to c types.
-    categories = py_to_c(categories, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[TIA]))
-    null_category = py_to_c(null_category, c_type=ctypes.c_bool, type_name=bool)
-    MO = py_to_c(MO, c_type=ctypes.c_char_p)
-    TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
-    TOA = py_to_c(TOA, c_type=ctypes.c_char_p)
+    c_categories = py_to_c(categories, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[TIA]))
+    c_null_category = py_to_c(null_category, c_type=ctypes.c_bool, type_name=bool)
+    c_MO = py_to_c(MO, c_type=ctypes.c_char_p)
+    c_TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
+    c_TOA = py_to_c(TOA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_count_by_categories
-    function.argtypes = [AnyObjectPtr, ctypes.c_bool, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_count_by_categories
+    lib_function.argtypes = [AnyObjectPtr, ctypes.c_bool, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(categories, null_category, MO, TIA, TOA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_categories, c_null_category, c_MO, c_TIA, c_TOA), Transformation))
+    
+    return output
 
 
 def make_count_distinct(
@@ -1009,15 +1045,17 @@ def make_count_distinct(
     TO = RuntimeType.parse(type_name=TO)
     
     # Convert arguments to c types.
-    TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
-    TO = py_to_c(TO, c_type=ctypes.c_char_p)
+    c_TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
+    c_TO = py_to_c(TO, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_count_distinct
-    function.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_count_distinct
+    lib_function.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(TIA, TO), Transformation))
+    output = c_to_py(unwrap(lib_function(c_TIA, c_TO), Transformation))
+    
+    return output
 
 
 def make_create_dataframe(
@@ -1050,15 +1088,17 @@ def make_create_dataframe(
     K = RuntimeType.parse_or_infer(type_name=K, public_example=get_first(col_names))
     
     # Convert arguments to c types.
-    col_names = py_to_c(col_names, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[K]))
-    K = py_to_c(K, c_type=ctypes.c_char_p)
+    c_col_names = py_to_c(col_names, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[K]))
+    c_K = py_to_c(K, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_create_dataframe
-    function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_create_dataframe
+    lib_function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(col_names, K), Transformation))
+    output = c_to_py(unwrap(lib_function(c_col_names, c_K), Transformation))
+    
+    return output
 
 
 def make_df_cast_default(
@@ -1108,17 +1148,19 @@ def make_df_cast_default(
     TOA = RuntimeType.parse(type_name=TOA)
     
     # Convert arguments to c types.
-    column_name = py_to_c(column_name, c_type=AnyObjectPtr, type_name=TK)
-    TK = py_to_c(TK, c_type=ctypes.c_char_p)
-    TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
-    TOA = py_to_c(TOA, c_type=ctypes.c_char_p)
+    c_column_name = py_to_c(column_name, c_type=AnyObjectPtr, type_name=TK)
+    c_TK = py_to_c(TK, c_type=ctypes.c_char_p)
+    c_TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
+    c_TOA = py_to_c(TOA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_df_cast_default
-    function.argtypes = [AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_df_cast_default
+    lib_function.argtypes = [AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(column_name, TK, TIA, TOA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_column_name, c_TK, c_TIA, c_TOA), Transformation))
+    
+    return output
 
 
 def make_df_is_equal(
@@ -1158,17 +1200,19 @@ def make_df_is_equal(
     TIA = RuntimeType.parse_or_infer(type_name=TIA, public_example=value)
     
     # Convert arguments to c types.
-    column_name = py_to_c(column_name, c_type=AnyObjectPtr, type_name=TK)
-    value = py_to_c(value, c_type=AnyObjectPtr, type_name=TIA)
-    TK = py_to_c(TK, c_type=ctypes.c_char_p)
-    TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
+    c_column_name = py_to_c(column_name, c_type=AnyObjectPtr, type_name=TK)
+    c_value = py_to_c(value, c_type=AnyObjectPtr, type_name=TIA)
+    c_TK = py_to_c(TK, c_type=ctypes.c_char_p)
+    c_TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_df_is_equal
-    function.argtypes = [AnyObjectPtr, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_df_is_equal
+    lib_function.argtypes = [AnyObjectPtr, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(column_name, value, TK, TIA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_column_name, c_value, c_TK, c_TIA), Transformation))
+    
+    return output
 
 
 def make_drop_null(
@@ -1204,14 +1248,16 @@ def make_drop_null(
     DA = RuntimeType.parse(type_name=DA)
     
     # Convert arguments to c types.
-    DA = py_to_c(DA, c_type=ctypes.c_char_p)
+    c_DA = py_to_c(DA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_drop_null
-    function.argtypes = [ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_drop_null
+    lib_function.argtypes = [ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(DA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_DA), Transformation))
+    
+    return output
 
 
 def make_find(
@@ -1248,15 +1294,17 @@ def make_find(
     TIA = RuntimeType.parse_or_infer(type_name=TIA, public_example=get_first(categories))
     
     # Convert arguments to c types.
-    categories = py_to_c(categories, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[TIA]))
-    TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
+    c_categories = py_to_c(categories, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[TIA]))
+    c_TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_find
-    function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_find
+    lib_function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(categories, TIA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_categories, c_TIA), Transformation))
+    
+    return output
 
 
 def make_find_bin(
@@ -1297,15 +1345,17 @@ def make_find_bin(
     TIA = RuntimeType.parse_or_infer(type_name=TIA, public_example=get_first(edges))
     
     # Convert arguments to c types.
-    edges = py_to_c(edges, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[TIA]))
-    TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
+    c_edges = py_to_c(edges, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[TIA]))
+    c_TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_find_bin
-    function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_find_bin
+    lib_function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(edges, TIA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_edges, c_TIA), Transformation))
+    
+    return output
 
 
 def make_identity(
@@ -1339,15 +1389,17 @@ def make_identity(
     M = RuntimeType.parse(type_name=M)
     
     # Convert arguments to c types.
-    D = py_to_c(D, c_type=ctypes.c_char_p)
-    M = py_to_c(M, c_type=ctypes.c_char_p)
+    c_D = py_to_c(D, c_type=ctypes.c_char_p)
+    c_M = py_to_c(M, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_identity
-    function.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_identity
+    lib_function.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(D, M), Transformation))
+    output = c_to_py(unwrap(lib_function(c_D, c_M), Transformation))
+    
+    return output
 
 
 def make_impute_constant(
@@ -1391,15 +1443,17 @@ def make_impute_constant(
     DIA = DIA.substitute(TA=TA)
     
     # Convert arguments to c types.
-    constant = py_to_c(constant, c_type=AnyObjectPtr, type_name=TA)
-    DIA = py_to_c(DIA, c_type=ctypes.c_char_p)
+    c_constant = py_to_c(constant, c_type=AnyObjectPtr, type_name=TA)
+    c_DIA = py_to_c(DIA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_impute_constant
-    function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_impute_constant
+    lib_function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(constant, DIA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_constant, c_DIA), Transformation))
+    
+    return output
 
 
 def make_impute_uniform_float(
@@ -1432,15 +1486,17 @@ def make_impute_uniform_float(
     TA = RuntimeType.parse_or_infer(type_name=TA, public_example=get_first(bounds))
     
     # Convert arguments to c types.
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[TA, TA]))
-    TA = py_to_c(TA, c_type=ctypes.c_char_p)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[TA, TA]))
+    c_TA = py_to_c(TA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_impute_uniform_float
-    function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_impute_uniform_float
+    lib_function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(bounds, TA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_bounds, c_TA), Transformation))
+    
+    return output
 
 
 def make_index(
@@ -1476,16 +1532,18 @@ def make_index(
     TOA = RuntimeType.parse_or_infer(type_name=TOA, public_example=get_first(categories))
     
     # Convert arguments to c types.
-    categories = py_to_c(categories, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[TOA]))
-    null = py_to_c(null, c_type=AnyObjectPtr, type_name=TOA)
-    TOA = py_to_c(TOA, c_type=ctypes.c_char_p)
+    c_categories = py_to_c(categories, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[TOA]))
+    c_null = py_to_c(null, c_type=AnyObjectPtr, type_name=TOA)
+    c_TOA = py_to_c(TOA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_index
-    function.argtypes = [AnyObjectPtr, AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_index
+    lib_function.argtypes = [AnyObjectPtr, AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(categories, null, TOA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_categories, c_null, c_TOA), Transformation))
+    
+    return output
 
 
 def make_is_equal(
@@ -1518,15 +1576,17 @@ def make_is_equal(
     TIA = RuntimeType.parse_or_infer(type_name=TIA, public_example=value)
     
     # Convert arguments to c types.
-    value = py_to_c(value, c_type=AnyObjectPtr, type_name=TIA)
-    TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
+    c_value = py_to_c(value, c_type=AnyObjectPtr, type_name=TIA)
+    c_TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_is_equal
-    function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_is_equal
+    lib_function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(value, TIA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_value, c_TIA), Transformation))
+    
+    return output
 
 
 def make_is_null(
@@ -1556,14 +1616,16 @@ def make_is_null(
     DIA = RuntimeType.parse(type_name=DIA)
     
     # Convert arguments to c types.
-    DIA = py_to_c(DIA, c_type=ctypes.c_char_p)
+    c_DIA = py_to_c(DIA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_is_null
-    function.argtypes = [ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_is_null
+    lib_function.argtypes = [ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(DIA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_DIA), Transformation))
+    
+    return output
 
 
 def make_lipschitz_float_mul(
@@ -1607,17 +1669,19 @@ def make_lipschitz_float_mul(
     M = M.substitute(T=T)
     
     # Convert arguments to c types.
-    constant = py_to_c(constant, c_type=ctypes.c_void_p, type_name=T)
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
-    D = py_to_c(D, c_type=ctypes.c_char_p)
-    M = py_to_c(M, c_type=ctypes.c_char_p)
+    c_constant = py_to_c(constant, c_type=ctypes.c_void_p, type_name=T)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
+    c_D = py_to_c(D, c_type=ctypes.c_char_p)
+    c_M = py_to_c(M, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_lipschitz_float_mul
-    function.argtypes = [ctypes.c_void_p, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_lipschitz_float_mul
+    lib_function.argtypes = [ctypes.c_void_p, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(constant, bounds, D, M), Transformation))
+    output = c_to_py(unwrap(lib_function(c_constant, c_bounds, c_D, c_M), Transformation))
+    
+    return output
 
 
 def make_metric_bounded(
@@ -1665,16 +1729,18 @@ def make_metric_bounded(
     TA = RuntimeType.parse(type_name=TA)
     
     # Convert arguments to c types.
-    size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
-    MI = py_to_c(MI, c_type=ctypes.c_char_p)
-    TA = py_to_c(TA, c_type=ctypes.c_char_p)
+    c_size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
+    c_MI = py_to_c(MI, c_type=ctypes.c_char_p)
+    c_TA = py_to_c(TA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_metric_bounded
-    function.argtypes = [ctypes.c_size_t, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_metric_bounded
+    lib_function.argtypes = [ctypes.c_size_t, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, MI, TA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_size, c_MI, c_TA), Transformation))
+    
+    return output
 
 
 def make_metric_unbounded(
@@ -1717,16 +1783,18 @@ def make_metric_unbounded(
     TA = RuntimeType.parse(type_name=TA)
     
     # Convert arguments to c types.
-    size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
-    MI = py_to_c(MI, c_type=ctypes.c_char_p)
-    TA = py_to_c(TA, c_type=ctypes.c_char_p)
+    c_size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
+    c_MI = py_to_c(MI, c_type=ctypes.c_char_p)
+    c_TA = py_to_c(TA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_metric_unbounded
-    function.argtypes = [ctypes.c_size_t, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_metric_unbounded
+    lib_function.argtypes = [ctypes.c_size_t, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, MI, TA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_size, c_MI, c_TA), Transformation))
+    
+    return output
 
 
 def make_ordered_random(
@@ -1760,14 +1828,16 @@ def make_ordered_random(
     TA = RuntimeType.parse(type_name=TA)
     
     # Convert arguments to c types.
-    TA = py_to_c(TA, c_type=ctypes.c_char_p)
+    c_TA = py_to_c(TA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_ordered_random
-    function.argtypes = [ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_ordered_random
+    lib_function.argtypes = [ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(TA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_TA), Transformation))
+    
+    return output
 
 
 def make_quantiles_from_counts(
@@ -1810,18 +1880,20 @@ def make_quantiles_from_counts(
     F = RuntimeType.parse_or_infer(type_name=F, public_example=get_first(alphas))
     
     # Convert arguments to c types.
-    bin_edges = py_to_c(bin_edges, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[TA]))
-    alphas = py_to_c(alphas, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[F]))
-    interpolation = py_to_c(interpolation, c_type=ctypes.c_char_p, type_name=String)
-    TA = py_to_c(TA, c_type=ctypes.c_char_p)
-    F = py_to_c(F, c_type=ctypes.c_char_p)
+    c_bin_edges = py_to_c(bin_edges, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[TA]))
+    c_alphas = py_to_c(alphas, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[F]))
+    c_interpolation = py_to_c(interpolation, c_type=ctypes.c_char_p, type_name=String)
+    c_TA = py_to_c(TA, c_type=ctypes.c_char_p)
+    c_F = py_to_c(F, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_quantiles_from_counts
-    function.argtypes = [AnyObjectPtr, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_quantiles_from_counts
+    lib_function.argtypes = [AnyObjectPtr, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(bin_edges, alphas, interpolation, TA, F), Transformation))
+    output = c_to_py(unwrap(lib_function(c_bin_edges, c_alphas, c_interpolation, c_TA, c_F), Transformation))
+    
+    return output
 
 
 def make_resize(
@@ -1867,18 +1939,20 @@ def make_resize(
     TA = RuntimeType.parse_or_infer(type_name=TA, public_example=constant)
     
     # Convert arguments to c types.
-    size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
-    constant = py_to_c(constant, c_type=AnyObjectPtr, type_name=TA)
-    MI = py_to_c(MI, c_type=ctypes.c_char_p)
-    MO = py_to_c(MO, c_type=ctypes.c_char_p)
-    TA = py_to_c(TA, c_type=ctypes.c_char_p)
+    c_size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
+    c_constant = py_to_c(constant, c_type=AnyObjectPtr, type_name=TA)
+    c_MI = py_to_c(MI, c_type=ctypes.c_char_p)
+    c_MO = py_to_c(MO, c_type=ctypes.c_char_p)
+    c_TA = py_to_c(TA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_resize
-    function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_resize
+    lib_function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, constant, MI, MO, TA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_size, c_constant, c_MI, c_MO, c_TA), Transformation))
+    
+    return output
 
 
 def make_select_column(
@@ -1915,16 +1989,18 @@ def make_select_column(
     TOA = RuntimeType.parse(type_name=TOA)
     
     # Convert arguments to c types.
-    key = py_to_c(key, c_type=AnyObjectPtr, type_name=K)
-    K = py_to_c(K, c_type=ctypes.c_char_p)
-    TOA = py_to_c(TOA, c_type=ctypes.c_char_p)
+    c_key = py_to_c(key, c_type=AnyObjectPtr, type_name=K)
+    c_K = py_to_c(K, c_type=ctypes.c_char_p)
+    c_TOA = py_to_c(TOA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_select_column
-    function.argtypes = [AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_select_column
+    lib_function.argtypes = [AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(key, K, TOA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_key, c_K, c_TOA), Transformation))
+    
+    return output
 
 
 def make_sized_bounded_float_checked_sum(
@@ -1980,16 +2056,18 @@ def make_sized_bounded_float_checked_sum(
     S = S.substitute(T=T)
     
     # Convert arguments to c types.
-    size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
-    S = py_to_c(S, c_type=ctypes.c_char_p)
+    c_size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
+    c_S = py_to_c(S, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_sized_bounded_float_checked_sum
-    function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_sized_bounded_float_checked_sum
+    lib_function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, bounds, S), Transformation))
+    output = c_to_py(unwrap(lib_function(c_size, c_bounds, c_S), Transformation))
+    
+    return output
 
 
 def make_sized_bounded_float_ordered_sum(
@@ -2047,16 +2125,18 @@ def make_sized_bounded_float_ordered_sum(
     S = S.substitute(T=T)
     
     # Convert arguments to c types.
-    size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
-    S = py_to_c(S, c_type=ctypes.c_char_p)
+    c_size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
+    c_S = py_to_c(S, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_sized_bounded_float_ordered_sum
-    function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_sized_bounded_float_ordered_sum
+    lib_function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, bounds, S), Transformation))
+    output = c_to_py(unwrap(lib_function(c_size, c_bounds, c_S), Transformation))
+    
+    return output
 
 
 def make_sized_bounded_int_checked_sum(
@@ -2098,16 +2178,18 @@ def make_sized_bounded_int_checked_sum(
     T = RuntimeType.parse_or_infer(type_name=T, public_example=get_first(bounds))
     
     # Convert arguments to c types.
-    size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
-    T = py_to_c(T, c_type=ctypes.c_char_p)
+    c_size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
+    c_T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_sized_bounded_int_checked_sum
-    function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_sized_bounded_int_checked_sum
+    lib_function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, bounds, T), Transformation))
+    output = c_to_py(unwrap(lib_function(c_size, c_bounds, c_T), Transformation))
+    
+    return output
 
 
 def make_sized_bounded_int_monotonic_sum(
@@ -2149,16 +2231,18 @@ def make_sized_bounded_int_monotonic_sum(
     T = RuntimeType.parse_or_infer(type_name=T, public_example=get_first(bounds))
     
     # Convert arguments to c types.
-    size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
-    T = py_to_c(T, c_type=ctypes.c_char_p)
+    c_size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
+    c_T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_sized_bounded_int_monotonic_sum
-    function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_sized_bounded_int_monotonic_sum
+    lib_function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, bounds, T), Transformation))
+    output = c_to_py(unwrap(lib_function(c_size, c_bounds, c_T), Transformation))
+    
+    return output
 
 
 def make_sized_bounded_int_ordered_sum(
@@ -2202,16 +2286,18 @@ def make_sized_bounded_int_ordered_sum(
     T = RuntimeType.parse_or_infer(type_name=T, public_example=get_first(bounds))
     
     # Convert arguments to c types.
-    size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
-    T = py_to_c(T, c_type=ctypes.c_char_p)
+    c_size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
+    c_T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_sized_bounded_int_ordered_sum
-    function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_sized_bounded_int_ordered_sum
+    lib_function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, bounds, T), Transformation))
+    output = c_to_py(unwrap(lib_function(c_size, c_bounds, c_T), Transformation))
+    
+    return output
 
 
 def make_sized_bounded_int_split_sum(
@@ -2255,16 +2341,18 @@ def make_sized_bounded_int_split_sum(
     T = RuntimeType.parse_or_infer(type_name=T, public_example=get_first(bounds))
     
     # Convert arguments to c types.
-    size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
-    T = py_to_c(T, c_type=ctypes.c_char_p)
+    c_size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
+    c_T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_sized_bounded_int_split_sum
-    function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_sized_bounded_int_split_sum
+    lib_function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, bounds, T), Transformation))
+    output = c_to_py(unwrap(lib_function(c_size, c_bounds, c_T), Transformation))
+    
+    return output
 
 
 def make_sized_bounded_mean(
@@ -2307,17 +2395,19 @@ def make_sized_bounded_mean(
     T = RuntimeType.parse_or_infer(type_name=T, public_example=get_first(bounds))
     
     # Convert arguments to c types.
-    size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
-    MI = py_to_c(MI, c_type=ctypes.c_char_p)
-    T = py_to_c(T, c_type=ctypes.c_char_p)
+    c_size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
+    c_MI = py_to_c(MI, c_type=ctypes.c_char_p)
+    c_T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_sized_bounded_mean
-    function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_sized_bounded_mean
+    lib_function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, bounds, MI, T), Transformation))
+    output = c_to_py(unwrap(lib_function(c_size, c_bounds, c_MI, c_T), Transformation))
+    
+    return output
 
 
 def make_sized_bounded_ordered_random(
@@ -2363,17 +2453,19 @@ def make_sized_bounded_ordered_random(
     TA = RuntimeType.parse(type_name=TA)
     
     # Convert arguments to c types.
-    size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[TA, TA]))
-    MI = py_to_c(MI, c_type=ctypes.c_char_p)
-    TA = py_to_c(TA, c_type=ctypes.c_char_p)
+    c_size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[TA, TA]))
+    c_MI = py_to_c(MI, c_type=ctypes.c_char_p)
+    c_TA = py_to_c(TA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_sized_bounded_ordered_random
-    function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_sized_bounded_ordered_random
+    lib_function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, bounds, MI, TA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_size, c_bounds, c_MI, c_TA), Transformation))
+    
+    return output
 
 
 def make_sized_bounded_sum(
@@ -2414,17 +2506,19 @@ def make_sized_bounded_sum(
     T = RuntimeType.parse_or_infer(type_name=T, public_example=get_first(bounds))
     
     # Convert arguments to c types.
-    size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
-    MI = py_to_c(MI, c_type=ctypes.c_char_p)
-    T = py_to_c(T, c_type=ctypes.c_char_p)
+    c_size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
+    c_MI = py_to_c(MI, c_type=ctypes.c_char_p)
+    c_T = py_to_c(T, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_sized_bounded_sum
-    function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_sized_bounded_sum
+    lib_function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, bounds, MI, T), Transformation))
+    output = c_to_py(unwrap(lib_function(c_size, c_bounds, c_MI, c_T), Transformation))
+    
+    return output
 
 
 def make_sized_bounded_sum_of_squared_deviations(
@@ -2480,16 +2574,18 @@ def make_sized_bounded_sum_of_squared_deviations(
     S = S.substitute(T=T)
     
     # Convert arguments to c types.
-    size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
-    S = py_to_c(S, c_type=ctypes.c_char_p)
+    c_size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
+    c_S = py_to_c(S, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_sized_bounded_sum_of_squared_deviations
-    function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_sized_bounded_sum_of_squared_deviations
+    lib_function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, bounds, S), Transformation))
+    output = c_to_py(unwrap(lib_function(c_size, c_bounds, c_S), Transformation))
+    
+    return output
 
 
 def make_sized_bounded_unordered(
@@ -2535,17 +2631,19 @@ def make_sized_bounded_unordered(
     TA = RuntimeType.parse(type_name=TA)
     
     # Convert arguments to c types.
-    size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[TA, TA]))
-    MI = py_to_c(MI, c_type=ctypes.c_char_p)
-    TA = py_to_c(TA, c_type=ctypes.c_char_p)
+    c_size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[TA, TA]))
+    c_MI = py_to_c(MI, c_type=ctypes.c_char_p)
+    c_TA = py_to_c(TA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_sized_bounded_unordered
-    function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_sized_bounded_unordered
+    lib_function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, bounds, MI, TA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_size, c_bounds, c_MI, c_TA), Transformation))
+    
+    return output
 
 
 def make_sized_bounded_variance(
@@ -2593,17 +2691,19 @@ def make_sized_bounded_variance(
     S = S.substitute(T=T)
     
     # Convert arguments to c types.
-    size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
-    ddof = py_to_c(ddof, c_type=ctypes.c_size_t, type_name=usize)
-    S = py_to_c(S, c_type=ctypes.c_char_p)
+    c_size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[T, T]))
+    c_ddof = py_to_c(ddof, c_type=ctypes.c_size_t, type_name=usize)
+    c_S = py_to_c(S, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_sized_bounded_variance
-    function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_size_t, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_sized_bounded_variance
+    lib_function.argtypes = [ctypes.c_size_t, AnyObjectPtr, ctypes.c_size_t, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, bounds, ddof, S), Transformation))
+    output = c_to_py(unwrap(lib_function(c_size, c_bounds, c_ddof, c_S), Transformation))
+    
+    return output
 
 
 def make_sized_ordered_random(
@@ -2646,16 +2746,18 @@ def make_sized_ordered_random(
     TA = RuntimeType.parse(type_name=TA)
     
     # Convert arguments to c types.
-    size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
-    MI = py_to_c(MI, c_type=ctypes.c_char_p)
-    TA = py_to_c(TA, c_type=ctypes.c_char_p)
+    c_size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
+    c_MI = py_to_c(MI, c_type=ctypes.c_char_p)
+    c_TA = py_to_c(TA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_sized_ordered_random
-    function.argtypes = [ctypes.c_size_t, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_sized_ordered_random
+    lib_function.argtypes = [ctypes.c_size_t, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, MI, TA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_size, c_MI, c_TA), Transformation))
+    
+    return output
 
 
 def make_sized_unordered(
@@ -2698,16 +2800,18 @@ def make_sized_unordered(
     TA = RuntimeType.parse(type_name=TA)
     
     # Convert arguments to c types.
-    size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
-    MI = py_to_c(MI, c_type=ctypes.c_char_p)
-    TA = py_to_c(TA, c_type=ctypes.c_char_p)
+    c_size = py_to_c(size, c_type=ctypes.c_size_t, type_name=usize)
+    c_MI = py_to_c(MI, c_type=ctypes.c_char_p)
+    c_TA = py_to_c(TA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_sized_unordered
-    function.argtypes = [ctypes.c_size_t, ctypes.c_char_p, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_sized_unordered
+    lib_function.argtypes = [ctypes.c_size_t, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(size, MI, TA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_size, c_MI, c_TA), Transformation))
+    
+    return output
 
 
 def make_split_dataframe(
@@ -2744,16 +2848,18 @@ def make_split_dataframe(
     K = RuntimeType.parse_or_infer(type_name=K, public_example=get_first(col_names))
     
     # Convert arguments to c types.
-    separator = py_to_c(separator, c_type=ctypes.c_char_p, type_name=None)
-    col_names = py_to_c(col_names, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[K]))
-    K = py_to_c(K, c_type=ctypes.c_char_p)
+    c_separator = py_to_c(separator, c_type=ctypes.c_char_p, type_name=None)
+    c_col_names = py_to_c(col_names, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[K]))
+    c_K = py_to_c(K, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_split_dataframe
-    function.argtypes = [ctypes.c_char_p, AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_split_dataframe
+    lib_function.argtypes = [ctypes.c_char_p, AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(separator, col_names, K), Transformation))
+    output = c_to_py(unwrap(lib_function(c_separator, c_col_names, c_K), Transformation))
+    
+    return output
 
 
 def make_split_lines(
@@ -2781,11 +2887,13 @@ def make_split_lines(
     # No type arguments to standardize.
     # No arguments to convert to c types.
     # Call library function.
-    function = lib.opendp_transformations__make_split_lines
-    function.argtypes = []
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_split_lines
+    lib_function.argtypes = []
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(), Transformation))
+    output = c_to_py(unwrap(lib_function(), Transformation))
+    
+    return output
 
 
 def make_split_records(
@@ -2813,14 +2921,16 @@ def make_split_records(
     
     # No type arguments to standardize.
     # Convert arguments to c types.
-    separator = py_to_c(separator, c_type=ctypes.c_char_p, type_name=None)
+    c_separator = py_to_c(separator, c_type=ctypes.c_char_p, type_name=None)
     
     # Call library function.
-    function = lib.opendp_transformations__make_split_records
-    function.argtypes = [ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_split_records
+    lib_function.argtypes = [ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(separator), Transformation))
+    output = c_to_py(unwrap(lib_function(c_separator), Transformation))
+    
+    return output
 
 
 def make_subset_by(
@@ -2856,16 +2966,18 @@ def make_subset_by(
     TK = RuntimeType.parse_or_infer(type_name=TK, public_example=indicator_column)
     
     # Convert arguments to c types.
-    indicator_column = py_to_c(indicator_column, c_type=AnyObjectPtr, type_name=TK)
-    keep_columns = py_to_c(keep_columns, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[TK]))
-    TK = py_to_c(TK, c_type=ctypes.c_char_p)
+    c_indicator_column = py_to_c(indicator_column, c_type=AnyObjectPtr, type_name=TK)
+    c_keep_columns = py_to_c(keep_columns, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Vec', args=[TK]))
+    c_TK = py_to_c(TK, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_subset_by
-    function.argtypes = [AnyObjectPtr, AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_subset_by
+    lib_function.argtypes = [AnyObjectPtr, AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(indicator_column, keep_columns, TK), Transformation))
+    output = c_to_py(unwrap(lib_function(c_indicator_column, c_keep_columns, c_TK), Transformation))
+    
+    return output
 
 
 def make_unclamp(
@@ -2900,15 +3012,17 @@ def make_unclamp(
     TA = RuntimeType.parse_or_infer(type_name=TA, public_example=get_first(bounds))
     
     # Convert arguments to c types.
-    bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[TA, TA]))
-    TA = py_to_c(TA, c_type=ctypes.c_char_p)
+    c_bounds = py_to_c(bounds, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Tuple', args=[TA, TA]))
+    c_TA = py_to_c(TA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_unclamp
-    function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_unclamp
+    lib_function.argtypes = [AnyObjectPtr, ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(bounds, TA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_bounds, c_TA), Transformation))
+    
+    return output
 
 
 def make_unordered(
@@ -2940,11 +3054,13 @@ def make_unordered(
     TA = RuntimeType.parse(type_name=TA)
     
     # Convert arguments to c types.
-    TA = py_to_c(TA, c_type=ctypes.c_char_p)
+    c_TA = py_to_c(TA, c_type=ctypes.c_char_p)
     
     # Call library function.
-    function = lib.opendp_transformations__make_unordered
-    function.argtypes = [ctypes.c_char_p]
-    function.restype = FfiResult
+    lib_function = lib.opendp_transformations__make_unordered
+    lib_function.argtypes = [ctypes.c_char_p]
+    lib_function.restype = FfiResult
     
-    return c_to_py(unwrap(function(TA), Transformation))
+    output = c_to_py(unwrap(lib_function(c_TA), Transformation))
+    
+    return output

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -411,6 +411,7 @@ class PrivacyMeasure(RuntimeType):
 
 MaxDivergence = PrivacyMeasure('MaxDivergence')
 SmoothedMaxDivergence = PrivacyMeasure('SmoothedMaxDivergence')
+FixedSmoothedMaxDivergence = PrivacyMeasure('FixedSmoothedMaxDivergence')
 ZeroConcentratedDivergence = PrivacyMeasure('ZeroConcentratedDivergence')
 
 class Carrier(RuntimeType):

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -281,6 +281,9 @@ class RuntimeType(object):
 
         if public_example is None:
             return RuntimeType('Option', [UnknownType("Constructed Option from a None variant")])
+        
+        if callable(public_example):
+            return "CallbackFn"
 
         raise UnknownTypeException(type(public_example))
 
@@ -470,3 +473,9 @@ def get_first(value):
 
 def parse_or_infer(type_name: RuntimeType, example):
     return RuntimeType.parse_or_infer(type_name, example)
+
+def get_dependencies(value):
+    return getattr(value, "_dependencies", None)
+
+def get_dependencies_iterable(value):
+    return list(map(get_dependencies, value))

--- a/python/test/test_user_transform.py
+++ b/python/test/test_user_transform.py
@@ -11,7 +11,7 @@ def make_duplicate(multiplicity, raises=False):
     """An example user-defined transformation from Python"""
     def function(arg):
         if raises:
-            raise ValueError("boohoohoo")
+            raise ValueError("test that error propagates")
         return [elem + 1 for elem in arg] * multiplicity
 
     def stability_map(d_in):
@@ -83,10 +83,3 @@ def make_postprocess_frac():
 def test_make_default_postprocessor():
     mech = make_postprocess_frac()
     print(mech([12., 100.]))
-
-
-if __name__ == "__main__":
-    test_make_default_transformation()
-    test_make_custom_transformation_error()
-    test_make_default_measurement()
-    test_make_default_postprocessor()

--- a/python/test/test_user_transform.py
+++ b/python/test/test_user_transform.py
@@ -17,7 +17,7 @@ def make_duplicate(multiplicity, raises=False):
     def stability_map(d_in):
         return d_in * multiplicity
 
-    return make_custom_transformation_with_defaults(
+    return make_default_transformation(
         function,
         stability_map,
         DI=VectorDomain[AllDomain[i32]],
@@ -26,7 +26,7 @@ def make_duplicate(multiplicity, raises=False):
         MO=SymmetricDistance,
     )
 
-def test_make_custom_transformation_with_defaults():
+def test_make_default_transformation():
     trans = (
         make_cast_default(TIA=str, TOA=int)
         >> make_duplicate(2)
@@ -53,7 +53,7 @@ def make_constant_mechanism(constant):
     def stability_map(_d_in):
         return 0.
 
-    return make_custom_measurement_with_defaults(
+    return make_default_measurement(
         function,
         stability_map,
         DI=AllDomain[i32],
@@ -62,7 +62,7 @@ def make_constant_mechanism(constant):
         MO=MaxDivergence[f64],
     )
 
-def test_make_custom_measurement_with_defaults():
+def test_make_default_measurement():
     mech = make_constant_mechanism(23)
     print(mech(1))
 
@@ -74,19 +74,19 @@ def make_postprocess_frac():
     def function(arg):
         return arg[0] / arg[1]
 
-    return make_custom_postprocessor_with_defaults(
+    return make_default_postprocessor(
         function,
         DI=VectorDomain[AllDomain[f64]],
         DO=AllDomain[f64],
     )
 
-def test_make_custom_postprocessor_with_defaults():
+def test_make_default_postprocessor():
     mech = make_postprocess_frac()
     print(mech([12., 100.]))
 
 
 if __name__ == "__main__":
-    test_make_custom_transformation_with_defaults()
+    test_make_default_transformation()
     test_make_custom_transformation_error()
-    test_make_custom_measurement_with_defaults()
-    test_make_custom_postprocessor_with_defaults()
+    test_make_default_measurement()
+    test_make_default_postprocessor()

--- a/python/test/test_user_transform.py
+++ b/python/test/test_user_transform.py
@@ -1,0 +1,92 @@
+from opendp.transformations import make_cast_default, make_clamp, make_bounded_sum
+from opendp.measurements import make_base_discrete_laplace
+from opendp.combinators import *
+from opendp.mod import enable_features
+from opendp.typing import *
+
+enable_features("contrib", "honest-but-curious")
+
+
+def make_duplicate(multiplicity, raises=False):
+    """An example user-defined transformation from Python"""
+    def function(arg):
+        if raises:
+            raise ValueError("boohoohoo")
+        return [elem + 1 for elem in arg] * multiplicity
+
+    def stability_map(d_in):
+        return d_in * multiplicity
+
+    return make_custom_transformation_with_defaults(
+        function,
+        stability_map,
+        DI=VectorDomain[AllDomain[i32]],
+        DO=VectorDomain[AllDomain[i32]],
+        MI=SymmetricDistance,
+        MO=SymmetricDistance,
+    )
+
+def test_make_custom_transformation_with_defaults():
+    trans = (
+        make_cast_default(TIA=str, TOA=int)
+        >> make_duplicate(2)
+        >> make_clamp((1, 2))
+        >> make_bounded_sum((1, 2))
+        >> make_base_discrete_laplace(1.0)
+    )
+
+    print(trans(["0", "1", "2", "3"]))
+    print(trans.map(1))
+
+
+def test_make_custom_transformation_error():
+    import pytest
+    with pytest.raises(Exception):
+        make_duplicate(2, raises=True)([1, 2, 3])
+
+
+def make_constant_mechanism(constant):
+    """An example user-defined measurement from Python"""
+    def function(_arg):
+        return constant
+
+    def stability_map(_d_in):
+        return 0.
+
+    return make_custom_measurement_with_defaults(
+        function,
+        stability_map,
+        DI=AllDomain[i32],
+        DO=AllDomain[i32],
+        MI=AbsoluteDistance[i32],
+        MO=MaxDivergence[f64],
+    )
+
+def test_make_custom_measurement_with_defaults():
+    mech = make_constant_mechanism(23)
+    print(mech(1))
+
+    assert mech.map(200) == 0.
+
+
+def make_postprocess_frac():
+    """An example user-defined postprocessor from Python"""
+    def function(arg):
+        return arg[0] / arg[1]
+
+    return make_custom_postprocessor_with_defaults(
+        function,
+        DI=VectorDomain[AllDomain[f64]],
+        DO=AllDomain[f64],
+    )
+
+def test_make_custom_postprocessor_with_defaults():
+    mech = make_postprocess_frac()
+    print(mech([12., 100.]))
+
+
+if __name__ == "__main__":
+    # test_make_custom_transformation_with_defaults()
+    # test_make_custom_transformation_error()
+    # test_make_custom_measurement_with_defaults()
+    test_make_custom_postprocessor_with_defaults()

--- a/python/test/test_user_transform.py
+++ b/python/test/test_user_transform.py
@@ -86,7 +86,7 @@ def test_make_custom_postprocessor_with_defaults():
 
 
 if __name__ == "__main__":
-    # test_make_custom_transformation_with_defaults()
-    # test_make_custom_transformation_error()
-    # test_make_custom_measurement_with_defaults()
+    test_make_custom_transformation_with_defaults()
+    test_make_custom_transformation_error()
+    test_make_custom_measurement_with_defaults()
     test_make_custom_postprocessor_with_defaults()

--- a/python/test/test_user_transform.py
+++ b/python/test/test_user_transform.py
@@ -17,7 +17,7 @@ def make_duplicate(multiplicity, raises=False):
     def stability_map(d_in):
         return d_in * multiplicity
 
-    return make_default_transformation(
+    return make_default_user_transformation(
         function,
         stability_map,
         DI=VectorDomain[AllDomain[i32]],
@@ -26,7 +26,7 @@ def make_duplicate(multiplicity, raises=False):
         MO=SymmetricDistance,
     )
 
-def test_make_default_transformation():
+def test_make_default_user_transformation():
     trans = (
         make_cast_default(TIA=str, TOA=int)
         >> make_duplicate(2)
@@ -53,7 +53,7 @@ def make_constant_mechanism(constant):
     def stability_map(_d_in):
         return 0.
 
-    return make_default_measurement(
+    return make_default_user_measurement(
         function,
         stability_map,
         DI=AllDomain[i32],
@@ -62,7 +62,7 @@ def make_constant_mechanism(constant):
         MO=MaxDivergence[f64],
     )
 
-def test_make_default_measurement():
+def test_make_default_user_measurement():
     mech = make_constant_mechanism(23)
     print(mech(1))
 
@@ -74,12 +74,12 @@ def make_postprocess_frac():
     def function(arg):
         return arg[0] / arg[1]
 
-    return make_default_postprocessor(
+    return make_default_user_postprocessor(
         function,
         DI=VectorDomain[AllDomain[f64]],
         DO=AllDomain[f64],
     )
 
-def test_make_default_postprocessor():
+def test_make_default_user_postprocessor():
     mech = make_postprocess_frac()
     print(mech([12., 100.]))

--- a/rust/build/derive.rs
+++ b/rust/build/derive.rs
@@ -159,7 +159,7 @@ fn parse_file(
             }
 
             // use the bootstrap crate to parse a Function
-            Function::from_ast(attr_args, item_fn, Some(module_name)).ok()
+            Some(Function::from_ast(attr_args, item_fn, Some(module_name)).unwrap())
         })
         .collect()
 }

--- a/rust/build/derive.rs
+++ b/rust/build/derive.rs
@@ -159,7 +159,7 @@ fn parse_file(
             }
 
             // use the bootstrap crate to parse a Function
-            Some(Function::from_ast(attr_args, item_fn, Some(module_name)).unwrap())
+            Function::from_ast(attr_args, item_fn, Some(module_name)).ok()
         })
         .collect()
 }

--- a/rust/opendp_tooling/src/bootstrap/arguments.rs
+++ b/rust/opendp_tooling/src/bootstrap/arguments.rs
@@ -23,6 +23,8 @@ pub struct BootstrapArguments {
     pub arguments: BootTypeHashMap,
     pub derived_types: Option<DerivedTypes>,
     pub returns: Option<BootType>,
+    #[darling(default)]
+    pub dependencies: Dependencies,
 }
 
 impl BootstrapArguments {
@@ -201,5 +203,18 @@ impl FromMeta for DefaultGenerics {
         } else {
             Err(Error::custom("expected string").with_span(lit))
         }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Dependencies(pub Vec<TypeRecipe>);
+
+impl FromMeta for Dependencies {
+    fn from_list(items: &[NestedMeta]) -> Result<Self> {
+        items
+            .iter()
+            .map(TypeRecipe::from_nested_meta)
+            .collect::<Result<Vec<_>>>()
+            .map(Dependencies)
     }
 }

--- a/rust/opendp_tooling/src/bootstrap/mod.rs
+++ b/rust/opendp_tooling/src/bootstrap/mod.rs
@@ -65,6 +65,7 @@ pub fn reconcile_function(
             signature.output_c_type,
         )?,
         derived_types: reconcile_derived_types(bootstrap.derived_types),
+        dependencies: bootstrap.dependencies.0,
     })
 }
 

--- a/rust/opendp_tooling/src/bootstrap/signature.rs
+++ b/rust/opendp_tooling/src/bootstrap/signature.rs
@@ -163,7 +163,8 @@ fn syn_type_to_c_type(ty: Type, generics: &HashSet<String>) -> Result<String> {
                         _ => "void *".to_string(),
                     }
                 }
-                i if i == "String" || i == "c_char" => "AnyObject *".to_string(),
+                i if i == "String" => "AnyObject *".to_string(),
+                i if i == "c_char" => "char *".to_string(),
                 i if i == "AnyObject" => "AnyObject *".to_string(),
                 i if i == "Vec" => "AnyObject *".to_string(),
                 i if i == "HashSet" => "AnyObject *".to_string(),

--- a/rust/opendp_tooling/src/bootstrap/signature.rs
+++ b/rust/opendp_tooling/src/bootstrap/signature.rs
@@ -185,6 +185,7 @@ fn syn_type_to_c_type(ty: Type, generics: &HashSet<String>) -> Result<String> {
                 i if i == "Postprocessor" => "AnyTransformation *".to_string(),
                 i if i == "AnyTransformation" => "AnyTransformation *".to_string(),
                 i if i == "AnyMeasurement" => "AnyMeasurement *".to_string(),
+                i if i == "CallbackFn" => "CallbackFn".to_string(),
                 i if i == "Fallible" || i == "FfiResult" => {
                     let args = match &segment.arguments {
                         PathArguments::AngleBracketed(ref ab) => &ab.args,

--- a/rust/opendp_tooling/src/codegen/python.rs
+++ b/rust/opendp_tooling/src/codegen/python.rs
@@ -363,11 +363,13 @@ fn generate_data_converter(func: &Function, typemap: &HashMap<String, String>) -
     let data_converter: String = func
         .args
         .iter()
-        .filter(|arg| !arg.do_not_convert)
         .map(|arg| {
+            let name = arg.name();
+            if arg.do_not_convert {
+                return format!("c_{name} = {name}")
+            };
             format!(
-                r#"{name} = py_to_c({name}, c_type={c_type}{rust_type_arg})"#,
-                name = arg.name(),
+                r#"c_{name} = py_to_c({name}, c_type={c_type}{rust_type_arg})"#,
                 c_type = arg.python_origin_ctype(typemap),
                 rust_type_arg = arg
                     .rust_type
@@ -407,8 +409,7 @@ fn generate_call(
         args = func
             .args
             .iter()
-            // .chain(func.type_args.iter())
-            .map(|arg| arg.name())
+            .map(|arg| format!("c_{}", arg.name()))
             .collect::<Vec<_>>()
             .join(", ")
     );

--- a/rust/opendp_tooling/src/codegen/python.rs
+++ b/rust/opendp_tooling/src/codegen/python.rs
@@ -239,10 +239,13 @@ fn generate_body(
     format!(
         r#"{flag_checker}{type_arg_formatter}
 {data_converter}
-{make_call}"#,
+{make_call}
+{set_dependencies}
+return output"#,
         flag_checker = generate_flag_check(&func.features),
         type_arg_formatter = generate_type_arg_formatter(func),
         data_converter = generate_data_converter(func, typemap),
+        set_dependencies = set_dependencies(&func.dependencies),
         make_call = generate_call(module_name, func, typemap)
     )
 }
@@ -400,7 +403,7 @@ fn generate_call(
     typemap: &HashMap<String, String>,
 ) -> String {
     let mut call = format!(
-        r#"function({args})"#,
+        r#"lib_function({args})"#,
         args = func
             .args
             .iter()
@@ -422,11 +425,11 @@ fn generate_call(
     }
     format!(
         r#"# Call library function.
-function = lib.opendp_{module_name}__{func_name}
-function.argtypes = [{ctype_args}]
-function.restype = {ctype_restype}
+lib_function = lib.opendp_{module_name}__{func_name}
+lib_function.argtypes = [{ctype_args}]
+lib_function.restype = {ctype_restype}
 
-return {call}"#,
+output = {call}"#,
         module_name = module_name,
         func_name = func.name,
         ctype_args = func
@@ -438,4 +441,16 @@ return {call}"#,
         ctype_restype = ctype_restype,
         call = call
     )
+}
+
+
+fn set_dependencies(
+    dependencies: &Vec<TypeRecipe>
+) -> String {
+    if dependencies.is_empty() {
+        String::new()
+    } else {
+        let dependencies = dependencies.iter().map(|dep| dep.to_python()).collect::<Vec<String>>().join(", ");
+        format!("output._depends_on({dependencies})")
+    }
 }

--- a/rust/opendp_tooling/src/codegen/python_typemap.json
+++ b/rust/opendp_tooling/src/codegen/python_typemap.json
@@ -29,5 +29,6 @@
     "const AnyTransformation *": "Transformation",
     "FfiError *": "ctypes.POINTER(FfiError)",
     "const FfiError *": "ctypes.POINTER(FfiError)",
-    "FfiResult": "FfiResult"
+    "FfiResult": "FfiResult",
+    "CallbackFn": "CallbackFn"
 }

--- a/rust/opendp_tooling/src/lib.rs
+++ b/rust/opendp_tooling/src/lib.rs
@@ -21,6 +21,8 @@ pub struct Function {
     pub derived_types: Vec<Argument>,
     // metadata for return type
     pub ret: Argument,
+    // references to values that should share the same lifetime
+    pub dependencies: Vec<TypeRecipe>
 }
 
 // Metadata for function arguments, derived types and returns.

--- a/rust/src/combinators/amplify/ffi.rs
+++ b/rust/src/combinators/amplify/ffi.rs
@@ -60,7 +60,10 @@ impl IsSizedDomain for AnyDomain {
     }
 }
 
-#[bootstrap(features("contrib", "honest-but-curious"))]
+#[bootstrap(
+    features("contrib", "honest-but-curious"),
+    dependencies("$get_dependencies(measurement)")
+)]
 /// Construct an amplified measurement from a `measurement` with privacy amplification by subsampling.
 /// This measurement does not perform any sampling. 
 /// It is useful when you have a dataset on-hand that is a simple random sample from a larger population.

--- a/rust/src/combinators/chain/ffi.rs
+++ b/rust/src/combinators/chain/ffi.rs
@@ -7,7 +7,8 @@ use crate::ffi::any::{AnyMeasurement, AnyTransformation};
 
 #[bootstrap(
     features("contrib"),
-    arguments(measurement1(rust_type = b"null"), transformation0(rust_type = b"null"))
+    arguments(measurement1(rust_type = b"null"), transformation0(rust_type = b"null")),
+    dependencies("$get_dependencies(measurement1)", "$get_dependencies(transformation0)")
 )]
 /// Construct the functional composition (`measurement1` ○ `transformation0`).
 /// Returns a Measurement that when invoked, computes `measurement1(transformation0(x))`.
@@ -34,7 +35,8 @@ pub extern "C" fn opendp_combinators__make_chain_mt(
 
 #[bootstrap(
     features("contrib"),
-    arguments(transformation1(rust_type = b"null"), transformation0(rust_type = b"null"))
+    arguments(transformation1(rust_type = b"null"), transformation0(rust_type = b"null")),
+    dependencies("$get_dependencies(transformation1)", "$get_dependencies(transformation0)")
 )]
 /// Construct the functional composition (`transformation1` ○ `transformation0`).
 /// Returns a Transformation that when invoked, computes `transformation1(transformation0(x))`.
@@ -60,7 +62,8 @@ pub extern "C" fn opendp_combinators__make_chain_tt(
 
 #[bootstrap(
     features("contrib"),
-    arguments(transformation1(rust_type = b"null"), measurement0(rust_type = b"null"))
+    arguments(transformation1(rust_type = b"null"), measurement0(rust_type = b"null")),
+    dependencies("$get_dependencies(transformation1)", "$get_dependencies(measurement0)")
 )]
 /// Construct the functional composition (`transformation1` ○ `measurement0`).
 /// Returns a Measurement that when invoked, computes `transformation1(measurement0(x))`.

--- a/rust/src/combinators/compose/ffi.rs
+++ b/rust/src/combinators/compose/ffi.rs
@@ -13,7 +13,8 @@ use super::BasicCompositionMeasure;
 
 #[bootstrap(
     features("contrib"),
-    arguments(measurements(rust_type = "Vec<AnyMeasurementPtr>"))
+    arguments(measurements(rust_type = "Vec<AnyMeasurementPtr>")),
+    dependencies("$get_dependencies_iterable(measurements)")
 )]
 /// Construct the DP composition [`measurement0`, `measurement1`, ...]. 
 /// Returns a Measurement that when invoked, computes `[measurement0(x), measurement1(x), ...]`

--- a/rust/src/combinators/fix_delta/ffi.rs
+++ b/rust/src/combinators/fix_delta/ffi.rs
@@ -16,7 +16,8 @@ use super::FixDeltaMeasure;
     features("contrib"),
     arguments(
         measurement(rust_type = b"null"),
-        delta(rust_type = "$get_atom(measurement_output_distance_type(measurement))"))
+        delta(rust_type = "$get_atom(measurement_output_distance_type(measurement))")),
+    dependencies("$get_dependencies(measurement)")
 )]
 /// Fix the delta parameter in the privacy map of a `measurement` with a SmoothedMaxDivergence output measure.
 ///

--- a/rust/src/combinators/measure_cast/zCDP_to_approxDP/ffi.rs
+++ b/rust/src/combinators/measure_cast/zCDP_to_approxDP/ffi.rs
@@ -8,7 +8,10 @@ use crate::{
     traits::Float,
 };
 
-#[bootstrap(features("contrib"))]
+#[bootstrap(
+    features("contrib"),
+    dependencies("$get_dependencies(measurement)")
+)]
 /// Constructs a new output measurement where the output measure
 /// is casted from `ZeroConcentratedDivergence<QO>` to `SmoothedMaxDivergence<QO>`.
 ///

--- a/rust/src/combinators/mod.rs
+++ b/rust/src/combinators/mod.rs
@@ -20,6 +20,10 @@ mod measure_cast;
 #[cfg(feature="contrib")]
 pub use crate::combinators::measure_cast::*;
 
+#[cfg(feature="contrib")]
+mod user_defined;
+#[cfg(feature="contrib")]
+pub use crate::combinators::user_defined::*;
 
 #[cfg(feature="contrib")]
 mod fix_delta;

--- a/rust/src/combinators/mod.rs
+++ b/rust/src/combinators/mod.rs
@@ -20,10 +20,10 @@ mod measure_cast;
 #[cfg(feature="contrib")]
 pub use crate::combinators::measure_cast::*;
 
-#[cfg(feature="contrib")]
+#[cfg(all(feature="contrib", feature="ffi"))]
 mod user_defined;
-#[cfg(feature="contrib")]
-pub use crate::combinators::user_defined::*;
+#[cfg(all(feature="contrib", feature="ffi"))]
+pub(crate) use crate::combinators::user_defined::*;
 
 #[cfg(feature="contrib")]
 mod fix_delta;

--- a/rust/src/combinators/user_defined/ffi.rs
+++ b/rust/src/combinators/user_defined/ffi.rs
@@ -116,13 +116,38 @@ pub(crate) fn default_measure(M: Type) -> Fallible<AnyMeasure> {
     arguments(
         function(rust_type = "$domain_carrier_type(DO)"),
         stability_map(rust_type = "$metric_distance_type(MO)"),
-        DI(rust_type = b"null"),
-        DO(rust_type = b"null"),
-        MI(rust_type = b"null"),
-        MO(rust_type = b"null"),
+        DI(rust_type = b"null", hint = "RuntimeTypeDescriptor"),
+        DO(rust_type = b"null", hint = "RuntimeTypeDescriptor"),
+        MI(rust_type = b"null", hint = "RuntimeTypeDescriptor"),
+        MO(rust_type = b"null", hint = "RuntimeTypeDescriptor"),
     ),
     dependencies("c_function", "c_stability_map")
 )]
+/// Construct a Transformation from user-defined callbacks.
+/// 
+/// **Supported Domains:**
+/// 
+/// * `VectorDomain<AllDomain<_>>`
+/// * `AllDomain<_>`
+/// 
+/// **Supported Metrics:**
+/// 
+/// * `SymmetricDistance`
+/// * `InsertDeleteDistance`
+/// * `ChangeOneDistance`
+/// * `HammingDistance`
+/// * `DiscreteDistance`
+/// * `AbsoluteDistance<_>`
+/// * `L1Distance<_>`
+/// * `L2Distance<_>`
+/// 
+/// # Arguments
+/// * `function` - A function mapping data from `DI` to `DO`.
+/// * `stability_map` - A function mapping distances from `MI` to `MO`.
+/// * `DI` - Input Domain. See Supported Domains
+/// * `DO` - Output Domain. See Supported Domains
+/// * `MI` - Input Metric. See Supported Metrics
+/// * `MO` - Output Metric. See Supported Metrics
 #[no_mangle]
 pub extern "C" fn opendp_combinators__make_custom_transformation_with_defaults(
     function: CallbackFn,
@@ -153,13 +178,44 @@ pub extern "C" fn opendp_combinators__make_custom_transformation_with_defaults(
     arguments(
         function(rust_type = "$domain_carrier_type(DO)"),
         privacy_map(rust_type = "$measure_distance_type(MO)"),
-        DI(rust_type = b"null"),
-        DO(rust_type = b"null"),
-        MI(rust_type = b"null"),
-        MO(rust_type = b"null"),
+        DI(rust_type = b"null", hint = "RuntimeTypeDescriptor"),
+        DO(rust_type = b"null", hint = "RuntimeTypeDescriptor"),
+        MI(rust_type = b"null", hint = "RuntimeTypeDescriptor"),
+        MO(rust_type = b"null", hint = "RuntimeTypeDescriptor"),
     ),
     dependencies("c_function", "c_privacy_map")
 )]
+/// Construct a Measurement from user-defined callbacks.
+/// 
+/// **Supported Domains:**
+/// 
+/// * `VectorDomain<AllDomain<_>>`
+/// * `AllDomain<_>`
+/// 
+/// **Supported Metrics:**
+/// 
+/// * `SymmetricDistance`
+/// * `InsertDeleteDistance`
+/// * `ChangeOneDistance`
+/// * `HammingDistance`
+/// * `DiscreteDistance`
+/// * `AbsoluteDistance<_>`
+/// * `L1Distance<_>`
+/// * `L2Distance<_>`
+/// 
+/// **Supported Measures:**
+/// 
+/// * `MaxDivergence<_>`
+/// * `FixedSmoothedMaxDivergence<_>`
+/// * `ZeroConcentratedDivergence<_>`
+/// 
+/// # Arguments
+/// * `function` - A function mapping data from `DI` to `DO`.
+/// * `privacy_map` - A function mapping distances from `MI` to `MO`.
+/// * `DI` - Input Domain. See Supported Domains
+/// * `DO` - Output Domain. See Supported Domains
+/// * `MI` - Input Metric. See Supported Metrics
+/// * `MO` - Output Measure. See Supported Measures
 #[no_mangle]
 pub extern "C" fn opendp_combinators__make_custom_measurement_with_defaults(
     function: CallbackFn,
@@ -189,11 +245,22 @@ pub extern "C" fn opendp_combinators__make_custom_measurement_with_defaults(
     features("contrib"),
     arguments(
         function(rust_type = "$domain_carrier_type(DO)"),
-        DI(rust_type = b"null"),
-        DO(rust_type = b"null"),
+        DI(rust_type = b"null", hint = "RuntimeTypeDescriptor"),
+        DO(rust_type = b"null", hint = "RuntimeTypeDescriptor"),
     ),
     dependencies("c_function")
 )]
+/// Construct a Postprocessor from user-defined callbacks.
+/// 
+/// **Supported Domains:**
+/// 
+/// * `VectorDomain<AllDomain<_>>`
+/// * `AllDomain<_>`
+/// 
+/// # Arguments
+/// * `function` - A function mapping data from `DI` to `DO`.
+/// * `DI` - Input Domain. See Supported Domains
+/// * `DO` - Output Domain. See Supported Domains
 #[no_mangle]
 pub extern "C" fn opendp_combinators__make_custom_postprocessor_with_defaults(
     function: CallbackFn,

--- a/rust/src/combinators/user_defined/ffi.rs
+++ b/rust/src/combinators/user_defined/ffi.rs
@@ -111,7 +111,7 @@ pub(crate) fn default_measure(M: Type) -> Fallible<AnyMeasure> {
 }
 
 #[bootstrap(
-    name = "make_default_transformation",
+    name = "make_default_user_transformation",
     features("contrib", "honest-but-curious"),
     arguments(
         function(rust_type = "$domain_carrier_type(DO)"),
@@ -149,7 +149,7 @@ pub(crate) fn default_measure(M: Type) -> Fallible<AnyMeasure> {
 /// * `MI` - Input Metric. See Supported Metrics
 /// * `MO` - Output Metric. See Supported Metrics
 #[no_mangle]
-pub extern "C" fn opendp_combinators__make_default_transformation(
+pub extern "C" fn opendp_combinators__make_default_user_transformation(
     function: CallbackFn,
     stability_map: CallbackFn,
     DI: *const c_char,
@@ -173,7 +173,7 @@ pub extern "C" fn opendp_combinators__make_default_transformation(
 }
 
 #[bootstrap(
-    name = "make_default_measurement",
+    name = "make_default_user_measurement",
     features("contrib", "honest-but-curious"),
     arguments(
         function(rust_type = "$domain_carrier_type(DO)"),
@@ -217,7 +217,7 @@ pub extern "C" fn opendp_combinators__make_default_transformation(
 /// * `MI` - Input Metric. See Supported Metrics
 /// * `MO` - Output Measure. See Supported Measures
 #[no_mangle]
-pub extern "C" fn opendp_combinators__make_default_measurement(
+pub extern "C" fn opendp_combinators__make_default_user_measurement(
     function: CallbackFn,
     privacy_map: CallbackFn,
     DI: *const c_char,
@@ -241,7 +241,7 @@ pub extern "C" fn opendp_combinators__make_default_measurement(
 }
 
 #[bootstrap(
-    name = "make_default_postprocessor",
+    name = "make_default_user_postprocessor",
     features("contrib"),
     arguments(
         function(rust_type = "$domain_carrier_type(DO)"),
@@ -262,7 +262,7 @@ pub extern "C" fn opendp_combinators__make_default_measurement(
 /// * `DI` - Input Domain. See Supported Domains
 /// * `DO` - Output Domain. See Supported Domains
 #[no_mangle]
-pub extern "C" fn opendp_combinators__make_default_postprocessor(
+pub extern "C" fn opendp_combinators__make_default_user_postprocessor(
     function: CallbackFn,
     DI: *const c_char,
     DO: *const c_char,

--- a/rust/src/combinators/user_defined/ffi.rs
+++ b/rust/src/combinators/user_defined/ffi.rs
@@ -1,0 +1,185 @@
+use std::ffi::c_char;
+
+use opendp_derive::bootstrap;
+
+use crate::{
+    core::{Domain, FfiResult, Function, Metric, StabilityMap, Transformation, Measure, PrivacyMap, Measurement},
+    domains::{AllDomain, VectorDomain},
+    error::Fallible,
+    ffi::{
+        any::{AnyDomain, AnyMetric, AnyObject, AnyTransformation, AnyMeasurement, AnyMeasure, IntoAnyStabilityMapExt},
+        util::{self, Type},
+    },
+    metrics::{SymmetricDistance, AgnosticMetric, AbsoluteDistance}, 
+    measures::MaxDivergence,
+};
+
+type CallbackFn = extern "C" fn(*const AnyObject) -> *mut FfiResult<*mut AnyObject>;
+
+#[bootstrap(
+    name = "make_custom_transformation_with_defaults",
+    features("contrib", "honest-but-curious"),
+    arguments(
+        function(rust_type = "$domain_carrier_type(DO)"),
+        stability_map(rust_type = "$metric_distance_type(MO)"),
+        DI(c_type = "char *", rust_type = b"null"),
+        DO(c_type = "char *", rust_type = b"null"),
+        MI(c_type = "char *", rust_type = b"null"),
+        MO(c_type = "char *", rust_type = b"null"),
+    ),
+    dependencies("function", "stability_map")
+)]
+#[no_mangle]
+pub extern "C" fn opendp_combinators__make_custom_transformation_with_defaults(
+    function: CallbackFn,
+    stability_map: CallbackFn,
+    DI: *const c_char,
+    DO: *const c_char,
+    MI: *const c_char,
+    MO: *const c_char,
+) -> FfiResult<*mut AnyTransformation> {
+    fn monomorphize<DI, DO, MI, MO>(
+        function: CallbackFn,
+        stability_map: CallbackFn,
+    ) -> FfiResult<*mut AnyTransformation>
+    where
+        DI: 'static + Domain + Default,
+        DO: 'static + Domain + Default,
+        MI: 'static + Metric + Default,
+        MO: 'static + Metric + Default,
+    {
+        fn wrap_func(func: CallbackFn) -> impl Fn(&AnyObject) -> Fallible<AnyObject> {
+            move |arg: &AnyObject| -> Fallible<AnyObject> {
+                util::into_owned(func(arg as *const AnyObject))?.into()
+            }
+        }
+        FfiResult::Ok(util::into_raw(Transformation::new(
+            AnyDomain::new(DI::default()),
+            AnyDomain::new(DO::default()),
+            Function::new_fallible(wrap_func(function)),
+            AnyMetric::new(MI::default()),
+            AnyMetric::new(MO::default()),
+            StabilityMap::new_fallible(wrap_func(stability_map)),
+        )))
+    }
+    let DI = try_!(Type::try_from(DI));
+    let DO = try_!(Type::try_from(DO));
+    let MI = try_!(Type::try_from(MI));
+    let MO = try_!(Type::try_from(MO));
+
+    dispatch!(monomorphize, [
+        (DI, [AllDomain<i32>, VectorDomain<AllDomain<i32>>]),
+        (DO, [AllDomain<i32>, VectorDomain<AllDomain<i32>>]),
+        (MI, [SymmetricDistance]),
+        (MO, [SymmetricDistance])
+    ], (function, stability_map))
+}
+
+
+
+#[bootstrap(
+    name = "make_custom_measurement_with_defaults",
+    features("contrib", "honest-but-curious"),
+    arguments(
+        function(rust_type = "$domain_carrier_type(DO)"),
+        privacy_map(rust_type = "$measure_distance_type(MO)"),
+        DI(c_type = "char *", rust_type = b"null"),
+        DO(c_type = "char *", rust_type = b"null"),
+        MI(c_type = "char *", rust_type = b"null"),
+        MO(c_type = "char *", rust_type = b"null"),
+    ),
+    dependencies("function", "privacy_map")
+)]
+#[no_mangle]
+pub extern "C" fn opendp_combinators__make_custom_measurement_with_defaults(
+    function: CallbackFn,
+    privacy_map: CallbackFn,
+    DI: *const c_char,
+    DO: *const c_char,
+    MI: *const c_char,
+    MO: *const c_char,
+) -> FfiResult<*mut AnyMeasurement> {
+    fn monomorphize<DI, DO, MI, MO>(
+        function: CallbackFn,
+        privacy_map: CallbackFn,
+    ) -> FfiResult<*mut AnyMeasurement>
+    where
+        DI: 'static + Domain + Default,
+        DO: 'static + Domain + Default,
+        MI: 'static + Metric + Default,
+        MO: 'static + Measure + Default,
+    {
+        fn wrap_func(func: CallbackFn) -> impl Fn(&AnyObject) -> Fallible<AnyObject> {
+            move |arg: &AnyObject| -> Fallible<AnyObject> {
+                util::into_owned(func(arg as *const AnyObject))?.into()
+            }
+        }
+        FfiResult::Ok(util::into_raw(Measurement::new(
+            AnyDomain::new(DI::default()),
+            AnyDomain::new(DO::default()),
+            Function::new_fallible(wrap_func(function)),
+            AnyMetric::new(MI::default()),
+            AnyMeasure::new(MO::default()),
+            PrivacyMap::new_fallible(wrap_func(privacy_map)),
+        )))
+    }
+    let DI = try_!(Type::try_from(DI));
+    let DO = try_!(Type::try_from(DO));
+    let MI = try_!(Type::try_from(MI));
+    let MO = try_!(Type::try_from(MO));
+
+    dispatch!(monomorphize, [
+        (DI, [AllDomain<i32>, VectorDomain<AllDomain<i32>>]),
+        (DO, [AllDomain<i32>, VectorDomain<AllDomain<i32>>]),
+        (MI, [AbsoluteDistance<i32>]),
+        (MO, [MaxDivergence<f64>])
+    ], (function, privacy_map))
+}
+
+
+
+#[bootstrap(
+    name = "make_custom_postprocessor_with_defaults",
+    features("contrib"),
+    arguments(
+        function(rust_type = "$domain_carrier_type(DO)"),
+        DI(c_type = "char *", rust_type = b"null"),
+        DO(c_type = "char *", rust_type = b"null"),
+    ),
+    dependencies("function")
+)]
+#[no_mangle]
+pub extern "C" fn opendp_combinators__make_custom_postprocessor_with_defaults(
+    function: CallbackFn,
+    DI: *const c_char,
+    DO: *const c_char,
+) -> FfiResult<*mut AnyTransformation> {
+    fn monomorphize<DI, DO>(
+        function: CallbackFn,
+    ) -> FfiResult<*mut AnyTransformation>
+    where
+        DI: 'static + Domain + Default,
+        DO: 'static + Domain + Default,
+    {
+        fn wrap_func(func: CallbackFn) -> impl Fn(&AnyObject) -> Fallible<AnyObject> {
+            move |arg: &AnyObject| -> Fallible<AnyObject> {
+                util::into_owned(func(arg as *const AnyObject))?.into()
+            }
+        }
+        FfiResult::Ok(util::into_raw( Transformation::new(
+            AnyDomain::new(DI::default()),
+            AnyDomain::new(DO::default()),
+            Function::new_fallible(wrap_func(function)),
+            AnyMetric::new(AgnosticMetric::default()),
+            AnyMetric::new(AgnosticMetric::default()),
+            StabilityMap::<AgnosticMetric, AgnosticMetric>::new(|_| ()).into_any()
+        )))
+    }
+    let DI = try_!(Type::try_from(DI));
+    let DO = try_!(Type::try_from(DO));
+
+    dispatch!(monomorphize, [
+        (DI, [AllDomain<f64>, VectorDomain<AllDomain<f64>>]),
+        (DO, [AllDomain<f64>, VectorDomain<AllDomain<f64>>])
+    ], (function))
+}

--- a/rust/src/combinators/user_defined/ffi.rs
+++ b/rust/src/combinators/user_defined/ffi.rs
@@ -27,7 +27,7 @@ type CallbackFn = extern "C" fn(*const AnyObject) -> *mut FfiResult<*mut AnyObje
         MI(c_type = "char *", rust_type = b"null"),
         MO(c_type = "char *", rust_type = b"null"),
     ),
-    dependencies("function", "stability_map")
+    dependencies("c_function", "c_stability_map")
 )]
 #[no_mangle]
 pub extern "C" fn opendp_combinators__make_custom_transformation_with_defaults(
@@ -88,7 +88,7 @@ pub extern "C" fn opendp_combinators__make_custom_transformation_with_defaults(
         MI(c_type = "char *", rust_type = b"null"),
         MO(c_type = "char *", rust_type = b"null"),
     ),
-    dependencies("function", "privacy_map")
+    dependencies("c_function", "c_privacy_map")
 )]
 #[no_mangle]
 pub extern "C" fn opendp_combinators__make_custom_measurement_with_defaults(
@@ -146,7 +146,7 @@ pub extern "C" fn opendp_combinators__make_custom_measurement_with_defaults(
         DI(c_type = "char *", rust_type = b"null"),
         DO(c_type = "char *", rust_type = b"null"),
     ),
-    dependencies("function")
+    dependencies("c_function")
 )]
 #[no_mangle]
 pub extern "C" fn opendp_combinators__make_custom_postprocessor_with_defaults(

--- a/rust/src/combinators/user_defined/ffi.rs
+++ b/rust/src/combinators/user_defined/ffi.rs
@@ -3,18 +3,112 @@ use std::ffi::c_char;
 use opendp_derive::bootstrap;
 
 use crate::{
-    core::{Domain, FfiResult, Function, Metric, StabilityMap, Transformation, Measure, PrivacyMap, Measurement},
+    core::{
+        Domain, FfiResult, Function, Measure, Measurement, Metric, PrivacyMap, StabilityMap,
+        Transformation,
+    },
     domains::{AllDomain, VectorDomain},
     error::Fallible,
     ffi::{
-        any::{AnyDomain, AnyMetric, AnyObject, AnyTransformation, AnyMeasurement, AnyMeasure, IntoAnyStabilityMapExt},
-        util::{self, Type},
+        any::{
+            AnyDomain, AnyMeasure, AnyMeasurement, AnyMetric, AnyObject, AnyTransformation,
+            IntoAnyStabilityMapExt,
+        },
+        util::{self, Type, TypeContents},
     },
-    metrics::{SymmetricDistance, AgnosticMetric, AbsoluteDistance}, 
-    measures::MaxDivergence,
+    measures::{FixedSmoothedMaxDivergence, MaxDivergence, ZeroConcentratedDivergence},
+    metrics::{
+        AbsoluteDistance, AgnosticMetric, ChangeOneDistance, DiscreteDistance, HammingDistance,
+        InsertDeleteDistance, L1Distance, L2Distance, SymmetricDistance,
+    },
+    traits::CheckNull,
 };
 
 type CallbackFn = extern "C" fn(*const AnyObject) -> *mut FfiResult<*mut AnyObject>;
+
+// wrap a CallbackFn in a closure, so that it can be used in transformations and measurements
+fn wrap_func(func: CallbackFn) -> impl Fn(&AnyObject) -> Fallible<AnyObject> {
+    move |arg: &AnyObject| -> Fallible<AnyObject> {
+        util::into_owned(func(arg as *const AnyObject))?.into()
+    }
+}
+
+pub(crate) fn default_domain(D: Type) -> Fallible<AnyDomain> {
+    let TA = D.get_atom()?;
+    fn monomorphize<TA>(D: Type) -> Fallible<AnyDomain>
+    where
+        TA: 'static + CheckNull,
+    {
+        fn monomorphize<D>() -> Fallible<AnyDomain>
+        where
+            D: 'static + Domain + Default,
+        {
+            Ok(AnyDomain::new(D::default()))
+        }
+        dispatch!(monomorphize, [(D, [AllDomain<TA>, VectorDomain<AllDomain<TA>>])], ())
+    }
+    dispatch!(monomorphize, [(TA, @primitives)], (D))
+}
+
+pub(crate) fn default_metric(M: Type) -> Fallible<AnyMetric> {
+    match &M.contents {
+        TypeContents::PLAIN(_) => {
+            fn monomorphize<M>() -> Fallible<AnyMetric>
+            where
+                M: 'static + Metric + Default,
+            {
+                Ok(AnyMetric::new(M::default()))
+            }
+            dispatch!(
+                monomorphize,
+                [(
+                    M,
+                    [
+                        SymmetricDistance,
+                        InsertDeleteDistance,
+                        ChangeOneDistance,
+                        HammingDistance,
+                        DiscreteDistance
+                    ]
+                )],
+                ()
+            )
+        }
+        TypeContents::GENERIC { .. } => {
+            let QA = M.get_atom()?;
+            fn monomorphize<QA>(M: Type) -> Fallible<AnyMetric>
+            where
+                QA: 'static + CheckNull,
+            {
+                fn monomorphize<M>() -> Fallible<AnyMetric>
+                where
+                    M: 'static + Metric + Default,
+                {
+                    Ok(AnyMetric::new(M::default()))
+                }
+                dispatch!(monomorphize, [(M, [AbsoluteDistance<QA>, L1Distance<QA>, L2Distance<QA>])], ())
+            }
+            dispatch!(monomorphize, [(QA, @numbers)], (M))
+        }
+        _ => fallible!(FFI, "unrecognized metric: {}", M.to_string()),
+    }
+}
+pub(crate) fn default_measure(M: Type) -> Fallible<AnyMeasure> {
+    let QA = M.get_atom()?;
+    fn monomorphize<QA>(M: Type) -> Fallible<AnyMeasure>
+    where
+        QA: 'static + CheckNull,
+    {
+        fn monomorphize<M>() -> Fallible<AnyMeasure>
+        where
+            M: 'static + Measure + Default,
+        {
+            Ok(AnyMeasure::new(M::default()))
+        }
+        dispatch!(monomorphize, [(M, [MaxDivergence<QA>, FixedSmoothedMaxDivergence<QA>, ZeroConcentratedDivergence<QA>])], ())
+    }
+    dispatch!(monomorphize, [(QA, @numbers)], (M))
+}
 
 #[bootstrap(
     name = "make_custom_transformation_with_defaults",
@@ -22,10 +116,10 @@ type CallbackFn = extern "C" fn(*const AnyObject) -> *mut FfiResult<*mut AnyObje
     arguments(
         function(rust_type = "$domain_carrier_type(DO)"),
         stability_map(rust_type = "$metric_distance_type(MO)"),
-        DI(c_type = "char *", rust_type = b"null"),
-        DO(c_type = "char *", rust_type = b"null"),
-        MI(c_type = "char *", rust_type = b"null"),
-        MO(c_type = "char *", rust_type = b"null"),
+        DI(rust_type = b"null"),
+        DO(rust_type = b"null"),
+        MI(rust_type = b"null"),
+        MO(rust_type = b"null"),
     ),
     dependencies("c_function", "c_stability_map")
 )]
@@ -38,44 +132,20 @@ pub extern "C" fn opendp_combinators__make_custom_transformation_with_defaults(
     MI: *const c_char,
     MO: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<DI, DO, MI, MO>(
-        function: CallbackFn,
-        stability_map: CallbackFn,
-    ) -> FfiResult<*mut AnyTransformation>
-    where
-        DI: 'static + Domain + Default,
-        DO: 'static + Domain + Default,
-        MI: 'static + Metric + Default,
-        MO: 'static + Metric + Default,
-    {
-        fn wrap_func(func: CallbackFn) -> impl Fn(&AnyObject) -> Fallible<AnyObject> {
-            move |arg: &AnyObject| -> Fallible<AnyObject> {
-                util::into_owned(func(arg as *const AnyObject))?.into()
-            }
-        }
-        FfiResult::Ok(util::into_raw(Transformation::new(
-            AnyDomain::new(DI::default()),
-            AnyDomain::new(DO::default()),
-            Function::new_fallible(wrap_func(function)),
-            AnyMetric::new(MI::default()),
-            AnyMetric::new(MO::default()),
-            StabilityMap::new_fallible(wrap_func(stability_map)),
-        )))
-    }
     let DI = try_!(Type::try_from(DI));
     let DO = try_!(Type::try_from(DO));
     let MI = try_!(Type::try_from(MI));
     let MO = try_!(Type::try_from(MO));
 
-    dispatch!(monomorphize, [
-        (DI, [AllDomain<i32>, VectorDomain<AllDomain<i32>>]),
-        (DO, [AllDomain<i32>, VectorDomain<AllDomain<i32>>]),
-        (MI, [SymmetricDistance]),
-        (MO, [SymmetricDistance])
-    ], (function, stability_map))
+    FfiResult::Ok(util::into_raw(Transformation::new(
+        try_!(default_domain(DI)),
+        try_!(default_domain(DO)),
+        Function::new_fallible(wrap_func(function)),
+        try_!(default_metric(MI)),
+        try_!(default_metric(MO)),
+        StabilityMap::new_fallible(wrap_func(stability_map)),
+    )))
 }
-
-
 
 #[bootstrap(
     name = "make_custom_measurement_with_defaults",
@@ -83,10 +153,10 @@ pub extern "C" fn opendp_combinators__make_custom_transformation_with_defaults(
     arguments(
         function(rust_type = "$domain_carrier_type(DO)"),
         privacy_map(rust_type = "$measure_distance_type(MO)"),
-        DI(c_type = "char *", rust_type = b"null"),
-        DO(c_type = "char *", rust_type = b"null"),
-        MI(c_type = "char *", rust_type = b"null"),
-        MO(c_type = "char *", rust_type = b"null"),
+        DI(rust_type = b"null"),
+        DO(rust_type = b"null"),
+        MI(rust_type = b"null"),
+        MO(rust_type = b"null"),
     ),
     dependencies("c_function", "c_privacy_map")
 )]
@@ -99,52 +169,28 @@ pub extern "C" fn opendp_combinators__make_custom_measurement_with_defaults(
     MI: *const c_char,
     MO: *const c_char,
 ) -> FfiResult<*mut AnyMeasurement> {
-    fn monomorphize<DI, DO, MI, MO>(
-        function: CallbackFn,
-        privacy_map: CallbackFn,
-    ) -> FfiResult<*mut AnyMeasurement>
-    where
-        DI: 'static + Domain + Default,
-        DO: 'static + Domain + Default,
-        MI: 'static + Metric + Default,
-        MO: 'static + Measure + Default,
-    {
-        fn wrap_func(func: CallbackFn) -> impl Fn(&AnyObject) -> Fallible<AnyObject> {
-            move |arg: &AnyObject| -> Fallible<AnyObject> {
-                util::into_owned(func(arg as *const AnyObject))?.into()
-            }
-        }
-        FfiResult::Ok(util::into_raw(Measurement::new(
-            AnyDomain::new(DI::default()),
-            AnyDomain::new(DO::default()),
-            Function::new_fallible(wrap_func(function)),
-            AnyMetric::new(MI::default()),
-            AnyMeasure::new(MO::default()),
-            PrivacyMap::new_fallible(wrap_func(privacy_map)),
-        )))
-    }
     let DI = try_!(Type::try_from(DI));
     let DO = try_!(Type::try_from(DO));
     let MI = try_!(Type::try_from(MI));
     let MO = try_!(Type::try_from(MO));
 
-    dispatch!(monomorphize, [
-        (DI, [AllDomain<i32>, VectorDomain<AllDomain<i32>>]),
-        (DO, [AllDomain<i32>, VectorDomain<AllDomain<i32>>]),
-        (MI, [AbsoluteDistance<i32>]),
-        (MO, [MaxDivergence<f64>])
-    ], (function, privacy_map))
+    FfiResult::Ok(util::into_raw(Measurement::new(
+        try_!(default_domain(DI)),
+        try_!(default_domain(DO)),
+        Function::new_fallible(wrap_func(function)),
+        try_!(default_metric(MI)),
+        try_!(default_measure(MO)),
+        PrivacyMap::new_fallible(wrap_func(privacy_map)),
+    )))
 }
-
-
 
 #[bootstrap(
     name = "make_custom_postprocessor_with_defaults",
     features("contrib"),
     arguments(
         function(rust_type = "$domain_carrier_type(DO)"),
-        DI(c_type = "char *", rust_type = b"null"),
-        DO(c_type = "char *", rust_type = b"null"),
+        DI(rust_type = b"null"),
+        DO(rust_type = b"null"),
     ),
     dependencies("c_function")
 )]
@@ -154,32 +200,15 @@ pub extern "C" fn opendp_combinators__make_custom_postprocessor_with_defaults(
     DI: *const c_char,
     DO: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<DI, DO>(
-        function: CallbackFn,
-    ) -> FfiResult<*mut AnyTransformation>
-    where
-        DI: 'static + Domain + Default,
-        DO: 'static + Domain + Default,
-    {
-        fn wrap_func(func: CallbackFn) -> impl Fn(&AnyObject) -> Fallible<AnyObject> {
-            move |arg: &AnyObject| -> Fallible<AnyObject> {
-                util::into_owned(func(arg as *const AnyObject))?.into()
-            }
-        }
-        FfiResult::Ok(util::into_raw( Transformation::new(
-            AnyDomain::new(DI::default()),
-            AnyDomain::new(DO::default()),
-            Function::new_fallible(wrap_func(function)),
-            AnyMetric::new(AgnosticMetric::default()),
-            AnyMetric::new(AgnosticMetric::default()),
-            StabilityMap::<AgnosticMetric, AgnosticMetric>::new(|_| ()).into_any()
-        )))
-    }
     let DI = try_!(Type::try_from(DI));
     let DO = try_!(Type::try_from(DO));
 
-    dispatch!(monomorphize, [
-        (DI, [AllDomain<f64>, VectorDomain<AllDomain<f64>>]),
-        (DO, [AllDomain<f64>, VectorDomain<AllDomain<f64>>])
-    ], (function))
+    FfiResult::Ok(util::into_raw(Transformation::new(
+        try_!(default_domain(DI)),
+        try_!(default_domain(DO)),
+        Function::new_fallible(wrap_func(function)),
+        AnyMetric::new(AgnosticMetric::default()),
+        AnyMetric::new(AgnosticMetric::default()),
+        StabilityMap::<AgnosticMetric, AgnosticMetric>::new(|_| ()).into_any(),
+    )))
 }

--- a/rust/src/combinators/user_defined/ffi.rs
+++ b/rust/src/combinators/user_defined/ffi.rs
@@ -111,7 +111,7 @@ pub(crate) fn default_measure(M: Type) -> Fallible<AnyMeasure> {
 }
 
 #[bootstrap(
-    name = "make_custom_transformation_with_defaults",
+    name = "make_default_transformation",
     features("contrib", "honest-but-curious"),
     arguments(
         function(rust_type = "$domain_carrier_type(DO)"),
@@ -149,7 +149,7 @@ pub(crate) fn default_measure(M: Type) -> Fallible<AnyMeasure> {
 /// * `MI` - Input Metric. See Supported Metrics
 /// * `MO` - Output Metric. See Supported Metrics
 #[no_mangle]
-pub extern "C" fn opendp_combinators__make_custom_transformation_with_defaults(
+pub extern "C" fn opendp_combinators__make_default_transformation(
     function: CallbackFn,
     stability_map: CallbackFn,
     DI: *const c_char,
@@ -173,7 +173,7 @@ pub extern "C" fn opendp_combinators__make_custom_transformation_with_defaults(
 }
 
 #[bootstrap(
-    name = "make_custom_measurement_with_defaults",
+    name = "make_default_measurement",
     features("contrib", "honest-but-curious"),
     arguments(
         function(rust_type = "$domain_carrier_type(DO)"),
@@ -217,7 +217,7 @@ pub extern "C" fn opendp_combinators__make_custom_transformation_with_defaults(
 /// * `MI` - Input Metric. See Supported Metrics
 /// * `MO` - Output Measure. See Supported Measures
 #[no_mangle]
-pub extern "C" fn opendp_combinators__make_custom_measurement_with_defaults(
+pub extern "C" fn opendp_combinators__make_default_measurement(
     function: CallbackFn,
     privacy_map: CallbackFn,
     DI: *const c_char,
@@ -241,7 +241,7 @@ pub extern "C" fn opendp_combinators__make_custom_measurement_with_defaults(
 }
 
 #[bootstrap(
-    name = "make_custom_postprocessor_with_defaults",
+    name = "make_default_postprocessor",
     features("contrib"),
     arguments(
         function(rust_type = "$domain_carrier_type(DO)"),
@@ -262,7 +262,7 @@ pub extern "C" fn opendp_combinators__make_custom_measurement_with_defaults(
 /// * `DI` - Input Domain. See Supported Domains
 /// * `DO` - Output Domain. See Supported Domains
 #[no_mangle]
-pub extern "C" fn opendp_combinators__make_custom_postprocessor_with_defaults(
+pub extern "C" fn opendp_combinators__make_default_postprocessor(
     function: CallbackFn,
     DI: *const c_char,
     DO: *const c_char,

--- a/rust/src/combinators/user_defined/mod.rs
+++ b/rust/src/combinators/user_defined/mod.rs
@@ -1,1 +1,1 @@
-mod ffi;
+pub(crate) mod ffi;

--- a/rust/src/combinators/user_defined/mod.rs
+++ b/rust/src/combinators/user_defined/mod.rs
@@ -1,0 +1,19 @@
+mod ffi;
+// use crate::core::{Domain, Metric, Transformation};
+
+
+// fn make_custom_transformation_with_defaults<DI, DO, MI, MO>(
+//     function: 
+// )
+// where
+//     DI: 'static + Domain + Default,
+//     DO: 'static + Domain + Default,
+//     MI: 'static + Metric + Default,
+//     MO: 'static + Metric + Default,
+// {
+//     Transformation::new(
+//         DI::default(),
+//         DO::default(),
+//         Function::new_fallible(function)
+//     )
+// }

--- a/rust/src/combinators/user_defined/mod.rs
+++ b/rust/src/combinators/user_defined/mod.rs
@@ -1,19 +1,1 @@
 mod ffi;
-// use crate::core::{Domain, Metric, Transformation};
-
-
-// fn make_custom_transformation_with_defaults<DI, DO, MI, MO>(
-//     function: 
-// )
-// where
-//     DI: 'static + Domain + Default,
-//     DO: 'static + Domain + Default,
-//     MI: 'static + Metric + Default,
-//     MO: 'static + Metric + Default,
-// {
-//     Transformation::new(
-//         DI::default(),
-//         DO::default(),
-//         Function::new_fallible(function)
-//     )
-// }

--- a/rust/src/data/ffi.rs
+++ b/rust/src/data/ffi.rs
@@ -403,12 +403,13 @@ pub extern "C" fn opendp_data__to_string(this: *const AnyObject) -> FfiResult<*m
         FfiResult::Ok)
 }
 
-/// Internal function. Convert the AnyObject to a string representation.
+/// wrap an AnyObject in an FfiResult::Ok(this)
 #[no_mangle]
 pub extern "C" fn ffiresult_ok(this: *const AnyObject) -> *const FfiResult<*const AnyObject> {
     util::into_raw(FfiResult::Ok(this))
 }
 
+/// construct an FfiResult::Err(e)
 #[no_mangle]
 pub extern "C" fn ffiresult_err(
     message: *mut c_char, 

--- a/rust/src/data/ffi.rs
+++ b/rust/src/data/ffi.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::ffi::c_void;
+use std::ffi::{c_void, CString};
 use std::fmt::Formatter;
 use std::hash::Hash;
 use std::os::raw::c_char;
@@ -15,7 +15,7 @@ use crate::core::{FfiError, FfiResult, FfiSlice};
 use crate::data::Column;
 use crate::error::Fallible;
 use crate::ffi::any::{AnyObject, Downcast};
-use crate::ffi::util;
+use crate::ffi::util::{self, into_c_char_p};
 use crate::ffi::util::{c_bool, AnyMeasurementPtr, AnyTransformationPtr, Type, TypeContents};
 
 #[bootstrap(
@@ -401,6 +401,34 @@ pub extern "C" fn opendp_data__to_string(this: *const AnyObject) -> FfiResult<*m
     util::into_c_char_p(format!("{:?}", try_as_ref!(this))).map_or_else(
         |e| FfiResult::Err(util::into_raw(FfiError::from(e))),
         FfiResult::Ok)
+}
+
+/// Internal function. Convert the AnyObject to a string representation.
+#[no_mangle]
+pub extern "C" fn ffiresult_ok(this: *const AnyObject) -> *const FfiResult<*const AnyObject> {
+    util::into_raw(FfiResult::Ok(this))
+}
+
+#[no_mangle]
+pub extern "C" fn ffiresult_err(
+    message: *mut c_char, 
+    backtrace: *mut c_char
+) -> *const FfiResult<*const AnyObject> {
+    fn make_message(message: *mut c_char, backtrace: *mut c_char) -> Fallible<*mut c_char> {
+        let message = util::to_str(message)?;
+        let backtrace = util::to_str(backtrace)?;
+        let message = format!("{message}:\n{backtrace}");
+        into_c_char_p(message)
+    }
+    let message = match make_message(message, backtrace) {
+        Ok(v) => v,
+        Err(e) => return util::into_raw(FfiResult::from(e))
+    };
+    util::into_raw(FfiResult::Err(util::into_raw(FfiError {
+        variant: CString::new("FFI").unwrap().into_raw(),
+        message, 
+        backtrace: CString::new("").unwrap().into_raw(),
+    })))
 }
 
 #[cfg(test)]

--- a/rust/src/measures/mod.rs
+++ b/rust/src/measures/mod.rs
@@ -30,10 +30,15 @@ use crate::{error::Fallible, core::Measure, domains::type_name};
 /// ```math
 /// D_{\infty}(M(u) \| M(v)) = \max_{S \subseteq \textrm{Supp}(Y)} \Big[\ln \dfrac{\Pr[M(u) \in S]}{\Pr[M(v) \in S]} \Big] \leq d.
 /// ```
-#[derive(Clone)]
 pub struct MaxDivergence<Q>(PhantomData<Q>);
 impl<Q> Default for MaxDivergence<Q> {
     fn default() -> Self {
+        MaxDivergence(PhantomData)
+    }
+}
+
+impl<Q> Clone for MaxDivergence<Q> {
+    fn clone(&self) -> Self {
         MaxDivergence(PhantomData)
     }
 }
@@ -50,7 +55,7 @@ impl<Q> Debug for MaxDivergence<Q> {
     }
 }
 
-impl<Q: Clone> Measure for MaxDivergence<Q> {
+impl<Q> Measure for MaxDivergence<Q> {
     type Distance = Q;
 }
 
@@ -72,11 +77,15 @@ impl<Q: Clone> Measure for MaxDivergence<Q> {
 /// ```math
 /// D_{S\infty}(M(u) \| M(v)) = \max_{S \subseteq \textrm{Supp}(Y)} \Big[\ln \dfrac{\Pr[M(u) \in S] + \delta}{\Pr[M(v) \in S]} \Big] \leq \epsilon.
 /// ```
-#[derive(Clone)]
 pub struct SmoothedMaxDivergence<Q>(PhantomData<Q>);
 
 impl<Q> Default for SmoothedMaxDivergence<Q> {
     fn default() -> Self {
+        SmoothedMaxDivergence(PhantomData)
+    }
+}
+impl<Q> Clone for SmoothedMaxDivergence<Q> {
+    fn clone(&self) -> Self {
         SmoothedMaxDivergence(PhantomData)
     }
 }
@@ -92,7 +101,7 @@ impl<Q> Debug for SmoothedMaxDivergence<Q> {
     }
 }
 
-impl<Q: Clone> Measure for SmoothedMaxDivergence<Q> {
+impl<Q> Measure for SmoothedMaxDivergence<Q> {
     type Distance = SMDCurve<Q>;
 }
 
@@ -134,11 +143,15 @@ impl<Q> SMDCurve<Q> {
 /// ```math
 /// D_{S\infty}(M(u) \| M(v)) = \max_{S \subseteq \textrm{Supp}(Y)} \Big[\ln \dfrac{\Pr[M(u) \in S] + \delta}{\Pr[M(v) \in S]} \Big] \leq \epsilon.
 /// ```
-#[derive(Clone)]
 pub struct FixedSmoothedMaxDivergence<Q>(PhantomData<Q>);
 
 impl<Q> Default for FixedSmoothedMaxDivergence<Q> {
     fn default() -> Self {
+        FixedSmoothedMaxDivergence(PhantomData)
+    }
+}
+impl<Q> Clone for FixedSmoothedMaxDivergence<Q> {
+    fn clone(&self) -> Self {
         FixedSmoothedMaxDivergence(PhantomData)
     }
 }
@@ -155,7 +168,7 @@ impl<Q> Debug for FixedSmoothedMaxDivergence<Q> {
     }
 }
 
-impl<Q: Clone> Measure for FixedSmoothedMaxDivergence<Q> {
+impl<Q> Measure for FixedSmoothedMaxDivergence<Q> {
     type Distance = (Q, Q);
 }
 
@@ -175,10 +188,14 @@ impl<Q: Clone> Measure for FixedSmoothedMaxDivergence<Q> {
 /// D_{\alpha}(P \| Q) = \frac{1}{1 - \alpha} \mathbb{E}_{x \sim Q} \Big[\ln \left( \dfrac{P(x)}{Q(x)} \right)^\alpha \Big] \leq d \alpha.
 /// ```
 /// for all possible choices of $\alpha \in (1, \infty)$.
-#[derive(Clone)]
 pub struct ZeroConcentratedDivergence<Q>(PhantomData<Q>);
 impl<Q> Default for ZeroConcentratedDivergence<Q> {
     fn default() -> Self {
+        ZeroConcentratedDivergence(PhantomData)
+    }
+}
+impl<Q> Clone for ZeroConcentratedDivergence<Q> {
+    fn clone(&self) -> Self {
         ZeroConcentratedDivergence(PhantomData)
     }
 }
@@ -195,6 +212,6 @@ impl<Q> Debug for ZeroConcentratedDivergence<Q> {
     }
 }
 
-impl<Q: Clone> Measure for ZeroConcentratedDivergence<Q> {
+impl<Q> Measure for ZeroConcentratedDivergence<Q> {
     type Distance = Q;
 }


### PR DESCRIPTION
Closes #44 
Closes #603 

Allows users to write custom transformations, measurements and postprocessors from Python code:

```python
enable_features("contrib", "honest-but-curious")

def make_duplicate(multiplicity):
    """An example user-defined transformation from Python"""
    def function(arg):
        return [elem + 1 for elem in arg] * multiplicity

    def stability_map(d_in):
        return d_in * multiplicity

    return make_default_transformation(
        function,
        stability_map,
        DI=VectorDomain[AllDomain[i32]],
        DO=VectorDomain[AllDomain[i32]],
        MI=SymmetricDistance,
        MO=SymmetricDistance,
    )

trans = (
    make_cast_default(TIA=str, TOA=int)
    >> make_duplicate(2)
    >> make_clamp((1, 2))
    >> make_bounded_sum((1, 2))
    >> make_base_discrete_laplace(1.0)
)

print(trans(["0", "1", "2", "3"]))
print(trans.map(1))
```