### PR TITLE
`make_lipschitz_float_mul` clamp fix

### DIFF
--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -130,7 +130,7 @@ class Measurement(ctypes.POINTER(AnyMeasurement)):
         try:
             from opendp.core import _measurement_free
             _measurement_free(self)
-        except ImportError:
+        except Exception:
             # ImportError: sys.meta_path is None, Python is likely shutting down
             pass
 
@@ -264,7 +264,7 @@ class Transformation(ctypes.POINTER(AnyTransformation)):
         try:
             from opendp.core import _transformation_free
             _transformation_free(self)
-        except ImportError:
+        except Exception:
             # ImportError: sys.meta_path is None, Python is likely shutting down
             pass
 

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -130,7 +130,7 @@ class Measurement(ctypes.POINTER(AnyMeasurement)):
         try:
             from opendp.core import _measurement_free
             _measurement_free(self)
-        except Exception:
+        except (ImportError, TypeError):
             # ImportError: sys.meta_path is None, Python is likely shutting down
             pass
 
@@ -264,7 +264,7 @@ class Transformation(ctypes.POINTER(AnyTransformation)):
         try:
             from opendp.core import _transformation_free
             _transformation_free(self)
-        except Exception:
+        except (ImportError, TypeError):
             # ImportError: sys.meta_path is None, Python is likely shutting down
             pass
 

--- a/rust/src/transformations/lipschitz_mul/mod.rs
+++ b/rust/src/transformations/lipschitz_mul/mod.rs
@@ -102,7 +102,7 @@ where
 {
     type Atom = T;
     fn transform(constant: &T, &(lower, upper): &(T, T), v: &T) -> Fallible<T> {
-        Ok(constant.total_clamp(lower, upper)?.saturating_mul(v))
+        Ok(v.total_clamp(lower, upper)?.saturating_mul(constant))
     }
 }
 


### PR DESCRIPTION
Closes #581 

Also broadens the error exclusion on `__del__`, as more error types as the interpreter is closing down were not being caught.