### PR TITLE
Do crate version munging in release_tool, so changes can be committed.

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,7 +32,7 @@ rust-version.workspace = true
 exclude = ["windows/*"]
 
 [dependencies]
-opendp_derive = { path = "opendp_derive" }
+opendp_derive = { path = "opendp_derive", version = "0.0.0+development" }
 rand = "0.7.3"
 num = "0.3.1"
 thiserror = "1.0.24"
@@ -47,7 +47,7 @@ lazy_static = { version = "1.4.0", optional = true }
 vega_lite_4 = { version = "0.6.0", optional = true }
 
 [build-dependencies]
-opendp_tooling = { path = "opendp_tooling", optional = true }
+opendp_tooling = { path = "opendp_tooling", version = "0.0.0+development", optional = true }
 syn = { workspace = true, optional = true }
 proc-macro2 = { workspace = true, optional = true }
 

--- a/rust/opendp_derive/Cargo.toml
+++ b/rust/opendp_derive/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 [dependencies]
 syn = { workspace = true, optional = true }
 quote = { workspace = true, optional = true }
-opendp_tooling = { path = "../opendp_tooling", optional = true  }
+opendp_tooling = { path = "../opendp_tooling", version = "0.0.0+development", optional = true }
 
 [features]
 full = ["syn", "quote", "opendp_tooling"]

--- a/tools/publish_tool.py
+++ b/tools/publish_tool.py
@@ -27,19 +27,6 @@ def rust(args):
     if args.dry_run:
         raise NotImplementedError("dry runs aren't supported on workspaces")
 
-    import toml
-    # write the version into the opendp crate dependencies
-    opendp_toml = toml.load('rust/Cargo.toml')
-    version = opendp_toml['workspace']['package']['version']
-    opendp_toml['dependencies']['opendp_derive']['version'] = version
-    opendp_toml['build-dependencies']['opendp_tooling']['version'] = version
-    toml.dump(opendp_toml, open('rust/Cargo.toml', 'w'))
-
-    # write the version into the derive crate dependencies
-    opendp_derive_toml = toml.load('rust/opendp_derive/Cargo.toml')
-    opendp_derive_toml['dependencies']['opendp_tooling']['version'] = version
-    toml.dump(opendp_derive_toml, open('rust/opendp_derive/Cargo.toml', 'w'))
-
     run_command("Publishing opendp_tooling crate", f"cargo publish --verbose --manifest-path=rust/opendp_tooling/Cargo.toml")
     run_command("Letting crates.io index settle", f"sleep {args.settle_time}")
     run_command("Publishing opendp_derive crate", f"cargo publish --verbose --manifest-path=rust/opendp_derive/Cargo.toml")

--- a/tools/release_tool.py
+++ b/tools/release_tool.py
@@ -186,12 +186,17 @@ def version(args):
     versioned_files = [
         "VERSION",
         "rust/Cargo.toml",
+        "rust/opendp_derive/Cargo.toml",
         "python/setup.cfg",
     ]
     log(f"Updating versioned files")
     inplace_arg = "-i ''" if platform.system() == "Darwin" else "-i"
     run_command(None, f"echo {resolved_target_version} >VERSION")
     run_command(None, f"sed {inplace_arg} 's/^version = \"{cached_version}\"$/version = \"{resolved_target_version}\"/' rust/Cargo.toml")
+    # Update the dependency versions, so that crate publishing will work.
+    # It's a little janky to do this with sed, rather than with toml, but this way we retain our formatting.
+    run_command(None, f"sed {inplace_arg} 's/, version = \"{cached_version}\"/, version = \"{resolved_target_version}\"/' rust/Cargo.toml")
+    run_command(None, f"sed {inplace_arg} 's/, version = \"{cached_version}\"/, version = \"{resolved_target_version}\"/' rust/opendp_derive/Cargo.toml")
     run_command(None, f"sed {inplace_arg} 's/^version = {cached_version}$/version = {resolved_target_version}/' python/setup.cfg")
     commit("versioned files", versioned_files, f"RELEASE_TOOL: Set version to {resolved_target_version}.")
 


### PR DESCRIPTION
Because we need to munge the version to publish the dependency crates, we ran into an issue with cargo complaining about a dirty repo: https://github.com/opendp/opendp/actions/runs/3325358361/jobs/5497961034

We could use the --allow-dirty flag, but that feels a little dicey.

Instead, this change moves the munging from `publish_tool.py` to `release_tool.py`, which is already dealing with git changes on the release branch.


Side note: We could've tested this locally outside GitHub, and avoided a lot of hassle, if not for the fact that you can't use --dry-run with workspaces. Possible solution here: https://github.com/rust-lang/cargo/issues/1169#issuecomment-1254260875