### PR TITLE
clamp negative epsilon in `make_zcdp_to_approxdp`

### DIFF
--- a/rust/src/combinators/measure_cast/zCDP_to_approxDP/cks20.rs
+++ b/rust/src/combinators/measure_cast/zCDP_to_approxDP/cks20.rs
@@ -5,8 +5,8 @@ pub(crate) fn cdp_epsilon<Q: Float>(rho: Q, delta: Q) -> Fallible<Q> {
         return fallible!(FailedRelation, "rho must be non-negative");
     }
 
-    if delta.is_sign_negative() {
-        return fallible!(FailedRelation, "delta must be non-negative");
+    if !delta.is_sign_positive() {
+        return fallible!(FailedRelation, "delta must be positive");
     }
 
     if rho.is_zero() {
@@ -84,5 +84,5 @@ pub(crate) fn cdp_epsilon<Q: Float>(rho: Q, delta: Q) -> Fallible<Q> {
     //          = δρ                          + numer        / denom
     let epsilon = a_max.inf_mul(&rho)?.inf_add(&numer.inf_div(&denom)?)?;
 
-    Ok(epsilon)
+    Ok(epsilon.max(Q::zero()))
 }

--- a/rust/src/combinators/measure_cast/zCDP_to_approxDP/mod.rs
+++ b/rust/src/combinators/measure_cast/zCDP_to_approxDP/mod.rs
@@ -49,9 +49,7 @@ where
         SmoothedMaxDivergence::default(),
         PrivacyMap::new_fallible(move |d_in: &MI::Distance| {
             let rho = privacy_map.eval(d_in)?;
-            if rho.is_sign_negative() {
-                return fallible!(FailedRelation, "rho must be non-negative");
-            }
+            
             Ok(SMDCurve::new(move |&delta: &QO| cdp_epsilon(rho, delta)))
         }),
     ))


### PR DESCRIPTION
Closes #621 

This PR also rejects zero delta, and removes an unnecessary check.