### PR TITLE
Clean up default builds

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,7 +32,7 @@ rust-version.workspace = true
 exclude = ["windows/*"]
 
 [dependencies]
-opendp_derive = { path = "opendp_derive", version = "0.0.0+development" }
+opendp_derive = { path = "opendp_derive" }
 rand = "0.7.3"
 num = "0.3.1"
 thiserror = "1.0.24"
@@ -47,7 +47,7 @@ lazy_static = { version = "1.4.0", optional = true }
 vega_lite_4 = { version = "0.6.0", optional = true }
 
 [build-dependencies]
-opendp_tooling = { path = "opendp_tooling", version = "0.0.0+development", optional = true }
+opendp_tooling = { path = "opendp_tooling", optional = true }
 syn = { workspace = true, optional = true }
 proc-macro2 = { workspace = true, optional = true }
 

--- a/rust/opendp_derive/Cargo.toml
+++ b/rust/opendp_derive/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 [dependencies]
 syn = { workspace = true, optional = true }
 quote = { workspace = true, optional = true }
-opendp_tooling = { path = "../opendp_tooling", version = "0.0.0+development", optional = true }
+opendp_tooling = { path = "../opendp_tooling", optional = true }
 
 [features]
 full = ["syn", "quote", "opendp_tooling"]

--- a/rust/src/combinators/mod.rs
+++ b/rust/src/combinators/mod.rs
@@ -34,13 +34,11 @@ pub use crate::combinators::fix_delta::*;
 
 #[cfg(test)]
 pub mod tests {
-    use crate::core::{Function, Measurement, PrivacyMap, Transformation};
+    use crate::core::{Function, Measurement, PrivacyMap, StabilityMap, Transformation};
     use crate::measures::MaxDivergence;
     use crate::metrics::SymmetricDistance;
     use crate::domains::AllDomain;
-    use crate::error::*;
     use crate::traits::CheckNull;
-    use crate::transformations;
 
     pub fn make_test_measurement<T: Clone + CheckNull>() -> Measurement<AllDomain<T>, AllDomain<T>, SymmetricDistance, MaxDivergence<f64>> {
         Measurement::new(
@@ -54,6 +52,13 @@ pub mod tests {
     }
 
     pub fn make_test_transformation<T: Clone + CheckNull>() -> Transformation<AllDomain<T>, AllDomain<T>, SymmetricDistance, SymmetricDistance> {
-        transformations::make_identity(AllDomain::<T>::new(), SymmetricDistance::default()).unwrap_test()
+        Transformation::new(
+            AllDomain::default(),
+            AllDomain::default(),
+            Function::new(|arg: &T| arg.clone()),
+            SymmetricDistance::default(),
+            SymmetricDistance::default(),
+            StabilityMap::new_from_constant(1)
+        )
     }
 }

--- a/rust/src/domains/mod.rs
+++ b/rust/src/domains/mod.rs
@@ -8,7 +8,8 @@
 //! Each metric (see [`crate::metrics`]) is associated with certain data domains. 
 //! The [`Domain`] trait is implemented for all domains used in OpenDP.
 
-#[cfg(feature="ffi")]
+// Once we have things using `Any` that are outside of `contrib`, this should specify `feature="ffi"`.
+#[cfg(feature="contrib")]
 use std::any::Any;
 use std::collections::HashMap;
 use std::hash::Hash;

--- a/rust/src/domains/mod.rs
+++ b/rust/src/domains/mod.rs
@@ -8,6 +8,7 @@
 //! Each metric (see [`crate::metrics`]) is associated with certain data domains. 
 //! The [`Domain`] trait is implemented for all domains used in OpenDP.
 
+#[cfg(feature="ffi")]
 use std::any::Any;
 use std::collections::HashMap;
 use std::hash::Hash;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -145,7 +145,8 @@
 #![recursion_limit="512"]
 
 // create clones of variables that are free to be consumed by a closure
-#[cfg(feature="ffi")]
+// Once we have things using `enclose!` that are outside of `contrib`, this should specify `feature="ffi"`.
+#[cfg(feature="contrib")]
 macro_rules! enclose {
     ( $x:ident, $y:expr ) => (enclose!(($x), $y));
     ( ($( $x:ident ),*), $y:expr ) => {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -145,6 +145,7 @@
 #![recursion_limit="512"]
 
 // create clones of variables that are free to be consumed by a closure
+#[cfg(feature="ffi")]
 macro_rules! enclose {
     ( $x:ident, $y:expr ) => (enclose!(($x), $y));
     ( ($( $x:ident ),*), $y:expr ) => {

--- a/tools/release_tool.py
+++ b/tools/release_tool.py
@@ -195,8 +195,8 @@ def version(args):
     run_command(None, f"sed {inplace_arg} 's/^version = \"{cached_version}\"$/version = \"{resolved_target_version}\"/' rust/Cargo.toml")
     # Update the dependency versions, so that crate publishing will work.
     # It's a little janky to do this with sed, rather than with toml, but this way we retain our formatting.
-    run_command(None, f"sed {inplace_arg} 's/, version = \"{cached_version}\"/, version = \"{resolved_target_version}\"/' rust/Cargo.toml")
-    run_command(None, f"sed {inplace_arg} 's/, version = \"{cached_version}\"/, version = \"{resolved_target_version}\"/' rust/opendp_derive/Cargo.toml")
+    run_command(None, f"sed {inplace_arg} 's/^\\(opendp_.* = {{.*\\) }}/\\1, version = \"{resolved_target_version}\" }}/' rust/Cargo.toml")
+    run_command(None, f"sed {inplace_arg} 's/^\\(opendp_.* = {{.*\\) }}/\\1, version = \"{resolved_target_version}\" }}/' rust/opendp_derive/Cargo.toml")
     run_command(None, f"sed {inplace_arg} 's/^version = {cached_version}$/version = {resolved_target_version}/' python/setup.cfg")
     commit("versioned files", versioned_files, f"RELEASE_TOOL: Set version to {resolved_target_version}.")
 


### PR DESCRIPTION
Fixes #615

This tweaks a few things so you can run `cargo build` and `cargo test` with the default features, and things will work OK.

* Adds a few '#[cfg(feature="ffi")]'
* Changes a few imports
* Removes versions from local crate dependencies
* Adjusts `release_tool.py` to add local versions, so crate builds continue to work
