### PR TITLE
PSRN Gumbel Exponential Mechanism

### DIFF
--- a/python/src/opendp/measurements.py
+++ b/python/src/opendp/measurements.py
@@ -5,6 +5,7 @@ from opendp.mod import *
 from opendp.typing import *
 
 __all__ = [
+    "make_base_discrete_exponential",
     "make_base_discrete_gaussian",
     "make_base_discrete_laplace",
     "make_base_discrete_laplace_cks20",
@@ -16,6 +17,62 @@ __all__ = [
     "make_randomized_response",
     "make_randomized_response_bool"
 ]
+
+
+def make_base_discrete_exponential(
+    temperature: Any,
+    optimize: str,
+    TIA: RuntimeTypeDescriptor,
+    QO: RuntimeTypeDescriptor = None
+) -> Measurement:
+    """Make a Measurement that takes a vector of scores and privately selects the index of the highest score.
+    
+    [make_base_discrete_exponential in Rust documentation.](https://docs.rs/opendp/latest/opendp/measurements/fn.make_base_discrete_exponential.html)
+    
+    **Supporting Elements:**
+    
+    * Input Domain:   `VectorDomain<AllDomain<TIA>>`
+    * Output Type:    `usize`
+    * Input Metric:   `InfDifferenceDistance<TIA>`
+    * Output Measure: `MaxDivergence<QO>`
+    
+    **Proof Definition:**
+    
+    [(Proof Document)](https://docs.opendp.org/en/latest/proofs/rust/src/measurements/discrete_exponential/make_base_discrete_exponential.pdf)
+    
+    :param temperature: Higher temperatures are more private.
+    :type temperature: Any
+    :param optimize: Indicate whether to privately return the "Max" or "Min"
+    :type optimize: str
+    :param TIA: Atom Input Type. Type of each element in the score vector.
+    :type TIA: :py:ref:`RuntimeTypeDescriptor`
+    :param QO: Output Distance Type.
+    :type QO: :py:ref:`RuntimeTypeDescriptor`
+    :rtype: Measurement
+    :raises TypeError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    assert_features("contrib", "floating-point")
+    
+    # Standardize type arguments.
+    TIA = RuntimeType.parse(type_name=TIA)
+    QO = RuntimeType.parse_or_infer(type_name=QO, public_example=temperature)
+    
+    # Convert arguments to c types.
+    c_temperature = py_to_c(temperature, c_type=AnyObjectPtr, type_name=QO)
+    c_optimize = py_to_c(optimize, c_type=ctypes.c_char_p, type_name=String)
+    c_TIA = py_to_c(TIA, c_type=ctypes.c_char_p)
+    c_QO = py_to_c(QO, c_type=ctypes.c_char_p)
+    
+    # Call library function.
+    lib_function = lib.opendp_measurements__make_base_discrete_exponential
+    lib_function.argtypes = [AnyObjectPtr, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+    lib_function.restype = FfiResult
+    
+    output = c_to_py(unwrap(lib_function(c_temperature, c_optimize, c_TIA, c_QO), Measurement))
+    
+    return output
 
 
 def make_base_discrete_gaussian(

--- a/python/test/integration/test_quantile.py
+++ b/python/test/integration/test_quantile.py
@@ -1,0 +1,21 @@
+from opendp.mod import enable_features
+
+enable_features("floating-point", "contrib")
+
+
+def test_quantile_score_candidates():
+    from opendp.transformations import make_quantile_score_candidates
+    from opendp.measurements import make_base_discrete_exponential
+
+    candidates = [20, 33, 40, 50, 72, 100]
+    quant_trans = make_quantile_score_candidates(candidates, alpha=0.5)
+
+    print(quant_trans(list(range(100))))
+
+    expo_meas = make_base_discrete_exponential(1000., "min", "usize")
+
+    quantile_meas = quant_trans >> expo_meas
+    idx = quantile_meas(list(range(100)))
+    print(candidates[idx])
+
+    assert quantile_meas.map(1) >= 0.1

--- a/python/test/test_meas.py
+++ b/python/test/test_meas.py
@@ -172,3 +172,11 @@ def test_randomized_response_bool():
     import math
     assert meas.check(1, math.log(3.))
     assert not meas.check(1, math.log(2.999))
+
+
+def test_discrete_exponential():
+    from opendp.measurements import make_base_discrete_exponential
+
+    meas = make_base_discrete_exponential(1., "maximize", TIA=int)
+    print(meas(list(range(10))))
+    print(meas.map(2))

--- a/rust/src/lib.sty
+++ b/rust/src/lib.sty
@@ -172,7 +172,6 @@
   \end{enumerate}
 }
 
-
 \newcommand{\validMeasurement}[2]{%
   For every setting of the input parameters #1 to #2 such that the given preconditions
   hold, #2 raises an exception (at compile time or run time) or returns a valid measurement. A valid measurement has the following properties:

--- a/rust/src/measurements/discrete_exponential/ffi.rs
+++ b/rust/src/measurements/discrete_exponential/ffi.rs
@@ -1,0 +1,45 @@
+use std::ffi::c_char;
+
+use crate::{
+    core::{FfiResult, IntoAnyMeasurementFfiResultExt},
+    ffi::{
+        any::{AnyMeasurement, AnyObject, Downcast},
+        util::{to_str, Type},
+    },
+    measurements::{make_base_discrete_exponential, Optimize},
+    traits::{
+        samplers::{CastInternalRational, SampleUniform},
+        CheckNull, Float, InfCast, Number, RoundCast,
+    },
+};
+
+#[no_mangle]
+pub extern "C" fn opendp_measurements__make_base_discrete_exponential(
+    temperature: *const AnyObject,
+    optimize: *const c_char,
+    TIA: *const c_char,
+    QO: *const c_char,
+) -> FfiResult<*mut AnyMeasurement> {
+    fn monomorphize<TIA, QO>(
+        temperature: *const AnyObject,
+        optimize: Optimize,
+    ) -> FfiResult<*mut AnyMeasurement>
+    where
+        TIA: Clone + CheckNull + Number + CastInternalRational,
+        QO: 'static + InfCast<TIA> + RoundCast<TIA> + Float + SampleUniform + CastInternalRational,
+    {
+        let temperature = *try_!(try_as_ref!(temperature).downcast_ref::<QO>());
+        make_base_discrete_exponential::<TIA, QO>(temperature, optimize).into_any()
+    }
+    let optimize = match try_!(to_str(optimize)) {
+        i if i.to_lowercase().starts_with("min") => Optimize::Min,
+        i if i.to_lowercase().starts_with("max") => Optimize::Max,
+        _ => return err!(FFI, "optimize must start with \"min\" or \"max\"").into(),
+    };
+    let TIA = try_!(Type::try_from(TIA));
+    let QO = try_!(Type::try_from(QO));
+    dispatch!(monomorphize, [
+        (TIA, [u32, u64, i32, i64, usize, f32, f64]),
+        (QO, @floats)
+    ], (temperature, optimize))
+}

--- a/rust/src/measurements/discrete_exponential/make_base_discrete_exponential.tex
+++ b/rust/src/measurements/discrete_exponential/make_base_discrete_exponential.tex
@@ -153,13 +153,11 @@ It is shown in \ref{privacy-guarantee} that a tighter analysis of the exponentia
 \section{Hoare Triple}
 \subsection*{Precondition}
 \begin{itemize}
-    \item \texttt{TIA} (input atom type) is a type with trait \rustdoc{traits/trait}{Number}.
+    \item \texttt{TIA} (input atom type) is a type with traits \rustdoc{traits/trait}{Number} and \rustdoc{traits/samplers/trait}{CastInternalRational}
 
     \item \texttt{QO} (output distance type) is a type with traits \rustdoc{traits/trait}{Float}, 
-    \rustdoc{traits/trait}{InfCast} from type \texttt{TIA}, 
-    \rustdoc{traits/trait}{RoundCast} from type \texttt{TIA}, 
-    and \rustdoc{traits/samplers/trait}{SampleUniform}
-        
+    \rustdoc{traits/samplers/trait}{CastInternalRational} and
+    \rustdoc{traits/trait}{DistanceConstant} from type \texttt{TIA}
 \end{itemize}
 
 \subsection*{Function}

--- a/rust/src/measurements/discrete_exponential/make_base_discrete_exponential.tex
+++ b/rust/src/measurements/discrete_exponential/make_base_discrete_exponential.tex
@@ -1,0 +1,245 @@
+\documentclass{article}
+\input{../../lib.sty}
+
+\title{\texttt{fn make\_base\_discrete\_exponential}}
+\author{Michael Shoemate}
+\begin{document} 
+\maketitle
+
+\contrib
+
+Proves soundness of \rustdoc{measurements/fn}{make\_base\_discrete\_exponential} 
+in \asOfCommit{mod.rs}{f5bb719}.
+\texttt{make\_base\_discrete\_exponential} returns a Measurement that 
+noisily selects the index of the greatest score, from a vector of input scores.
+
+This released index can be later be used to index into a public candidate set (postprocessing).
+
+\subsection*{Vetting History}
+\begin{itemize}
+    \item \vettingPR{456}
+\end{itemize}
+
+The naive implementation samples some index $k$ from a categorical distribution, 
+with probabilities assigned to each candidate relative to their score.
+We may use inverse transform sampling to select the smallest index $k$ for which the cumulative probability is greater than some $U \sim Uniform(0, 1)$.
+\begin{equation} 
+    \label{m-naive} 
+    M(s) = argmin_k \sum_i^k p_i >= U
+\end{equation} 
+
+The probability of index $k$ being selected is the normalization of its likelihood $e^{s_k / \tau}$.
+As a candidate's score $s_k$ increases, the candidate becomes exponentially more likely to be selected.
+\begin{equation}
+    \label{prob-of-k}
+    p_k = \frac{e^{s_k / \tau}}{\sum_i e^{s_i / \tau}}
+\end{equation}
+
+This equation introduces a new temperature parameter, $\tau$, which calibrates how distinguishable scores are from each other.
+As temperature increases, the categorical output distribution tends towards entropy/uniformity and becomes more privacy preserving.
+As temperature decreases, the categorical distribution tends towards a one-hot vector, becoming less private.
+Temperature is related to $\epsilon$ and the sensitivity ($\Delta$) of the scoring function as follows:
+
+\begin{equation}
+    \tau = \Delta / \epsilon
+\end{equation}
+When $\epsilon$ increases, temperature decreases, and candidates become more distinguishable from each other.
+We also divide scores by their global sensitivity to normalize the sensitivity to one.
+In the differential privacy literature for the exponential mechanism, the sensitivity is often multiplied by two.
+In OpenDP this factor is bundled into the $\Delta$ term, which is expressed in terms of a metric that captures monotonicity.
+
+\section{Gumbel Reparameterization}
+\label{gumbel-reparam}
+
+In practice, computing $e^{s_i / \tau}$ is prone to zero underflow and overflow. 
+Specifically, a scaled score of just $-709$ underflows to zero and $+710$ overflows to infinity when stored in a 64-bit float. 
+A simple improvement is to shift the scores by subtracting the greatest score from all scores.
+In idealized arithmetic, the resulting probabilities are not affected by shifts in the underlying scores.
+On finite data types, this shift prevents a catastrophic overflow, but makes underflow more likely, 
+causing tail values of the distribution to round to zero. 
+
+The inverse transform sampling is also subject to accumulated rounding errors from the arithmetic and sum, 
+which influence the likelihood of being chosen.
+
+The Gumbel-max trick may instead be used to privately select an index.
+Let $K = argmax_k G_k$, a random variable representing the selected index. 
+Denote the $k^{th}$ noisy score as $G_k \sim Gumbel(\mu = s_k / \tau)$.
+$K$ can be sampled via an inverse transform, where $u_k$ is sampled iid uniformly from $(0, 1)$:
+\begin{equation}
+    M(s) = argmax_k (s_k / \tau - log(-log(u_k)))
+\end{equation}
+
+\begin{theorem}
+    \label{gumbel-equiv}
+Sampling from K is equivalent to sampling from the softmax, because $P(K=k) = p_k$. \cite{Medina2020DuffAD}
+\end{theorem}
+\begin{align*}
+    P(K = k) &= P(G_k = max_i G_i) &&\text{by definition of K} \\
+    &= P(-log(Z_k / N) = max_i -log(Z_k / N)) &&\text{by \ref{g-z-equiv}}\\
+    &= P(log(Z_k / N) = min_i log(Z_k / N)) &&\text{since } max -a_i = -min_i a_i \\
+    &= P(Z_k = min_i Z_i) &&\text{simplify monotonic terms} \\
+    &= P(Z_k \leq min_{i \neq k} Z_i) \\
+    &= P(Z_k \leq Q) &&\text{by \ref{exp-min} where } Q \sim Exp(\sum_{i \neq k} p_i)\\
+    &= \frac{p_k}{p_k + \sum_{i \neq k} p_i}  &&\text{by \ref{exp-comp}} \\
+    &= p_k &&\text{since } p_k + \sum_{i \neq k} p_i = 1
+\end{align*}
+
+
+\begin{lemma}
+\label{g-z-equiv}
+$G_k = -log(Z_k / N)$ where $Z_k \sim Exp(p_k)$ and normalization term $N = \sum_i e^{s_i / \tau}$.
+\end{lemma}
+\begin{align*}
+    G_k &= s_k / \tau - log(-log(U_k)) &&\text{Gumbel PDF centered at } s_k / \tau \\
+    &= log(e^{s_k / \tau}) - log(-log(U_k)) \\
+    &= log(p_k N) - log(-log(U_k)) &&\text{since } p_k = e^{s_k / \tau} / N \\
+    &= log(p_k N / (-log(U_k))) \\
+    &= -log(-log(U_k) / (p_k N)) \\
+    &= -log(Z_k / N) &&\text{substitute $Z_k = -log(U_k) / p_k$}
+\end{align*}
+
+\begin{lemma}
+\label{exp-min}
+If $X_1 \sim Exp(\lambda_1)$, $X_2 \sim Exp(\lambda_2)$ and $Z \sim Exp(\lambda_1 + \lambda_2)$, then $min(X_1, X_2) \sim Z$.
+\end{lemma}
+\begin{align*}
+    P(min(X_1, X_2) \geq x) &= P(X_1 \geq x)P(X_2 \geq x) &&\text{by independence} \\
+    &= e^{-\lambda_1x}e^{-\lambda_2x} &&\text{substitute exponential density} \\
+    &= e^{-(\lambda_1 + \lambda_2)x} \\
+    &= P(Z \geq x) &&\text{substitute exponential density}
+\end{align*}
+
+
+\begin{lemma}
+\label{exp-comp}
+If $X_1 \sim Exp(\lambda_1)$, $X_2 \sim Exp(\lambda_2)$, then $P(X_1 \leq X_2) = \frac{\lambda_1}{\lambda_1 + \lambda_2}$.
+
+\begin{align*}
+    P(X_1 \leq X_2) &= \int_0^\infty \int_{x_1}^\infty \lambda_1 \lambda_2 e^{-\lambda_1 x_1} e^{-\lambda_2 x_2} \,dx_1 dx_2 \\
+    &= \int_0^\infty -\lambda e^{-(\lambda_1 + \lambda_2) x_1} \,dx_1 \\
+    &= \frac{\lambda_1}{\lambda_1 + \lambda_2}
+\end{align*}
+
+% Since $P(Z_k > z) = e^{p_k z}$, $P(Z_k \geq max_j Z_j) = e^{p_k max_j Z_j}$ 
+\end{lemma}
+
+
+\subsection{Metric}
+We need a metric that captures the distance between score vectors $u$ and $v$ respectively on neighboring datasets. 
+The $i^{th}$ element of each score vector is the score for the $i^{th}$ candidate.
+Traditionally, the sensitivity of the scoring function is measured in terms of some metric \texttt{InfDistance}, 
+the greatest that any one score may change (or more formally, the $L_\infty$ norm on distances).
+The sensitivity is defined as follows:
+\begin{equation}
+    \Delta_{\infty} = \max\limits_{u \sim v} \max\limits_{i} \abs{s_i - s'_i}
+\end{equation}
+Unfortunately, this choice of metric always results in a loosening by a factor of 2 when evaluating the privacy guarantee of the exponential mechanism.
+This is because both the $i^{th}$ likelihood and normalization term may vary in opposite directions, resulting in a more distinguishing event.
+However, this loosening is not necessary if we can prove that the scoring function is monotonic, because the $i^{th}$ likelihood and normalization term will always vary in the same direction.
+
+We instead use a slight adjustment to this metric, \texttt{InfDifferenceDistance}, with sensitivity as follows:
+\begin{equation}
+    \Delta_{IDD} = \max\limits_{u \sim v} \max\limits_{ij} \abs{(u_i - v_i) - (u_j - v_j)}
+\end{equation}
+Consider when the scoring function is not monotonic.
+The sensitivity is maximized when $u_i - v_i$ and $u_j - v_j$ vary maximally in opposite directions, resulting in the same loosening factor of 2.
+On the other hand, when the scoring function is monotonic, the sign of the $u_i - v_i$ term matches the sign of the $u_j - v_j$ term,
+and their magnitudes cancel.
+Therefore, when the scorer is monotonic, the sensitivity is maximized when one term is zero. 
+It is shown in \ref{privacy-guarantee} that a tighter analysis of the exponential mechanism is compatible with a score vector whose sensitivity is expressed in terms of this metric.
+
+
+
+\section{Hoare Triple}
+\subsection*{Precondition}
+\begin{itemize}
+    \item \texttt{TIA} (input atom type) is a type with trait \rustdoc{traits/trait}{Number}.
+
+    \item \texttt{QO} (output distance type) is a type with traits \rustdoc{traits/trait}{Float}, 
+    \rustdoc{traits/trait}{InfCast} from type \texttt{TIA}, 
+    \rustdoc{traits/trait}{RoundCast} from type \texttt{TIA}, 
+    and \rustdoc{traits/samplers/trait}{SampleUniform}
+        
+\end{itemize}
+
+\subsection*{Function}
+\label{sec:python-pseudocode}
+\lstinputlisting[language=Python,firstline=2]{./pseudocode/make_base_discrete_exponential.py}
+
+\subsection*{Postcondition}
+
+\validMeasurement{\texttt{temperature}}{\texttt{make\_base\_discrete\_exponential}} 
+
+\section{Proof}
+\subsection{Domain-metric compatibility} 
+\texttt{InfDifferenceDistance} is well-defined on \texttt{VectorDomain<AtomDomain<TIA>>} 
+when \texttt{TIA} implements the trait bounds specified in the preconditions.
+
+\subsection{Privacy Guarantee}
+
+
+\begin{lemma}
+    \label{priv-inequality}
+    Assume $u$, $v$ in \texttt{input\_domain}. Then
+    $\ln\left(\frac{\sum_{i} \exp(\frac{\epsilon v_i}{\Delta})}{\sum_{i} \exp(\frac{\epsilon u_i}{\Delta})}\right) \le \frac{\epsilon \max_j (v_j - u_j)}{\Delta}$.
+\end{lemma}
+
+\begin{proof}
+\begin{align*}
+    \ln\left(\frac{\sum_{i} \exp(\frac{\epsilon v_i}{\Delta})}{\sum_{i} \exp(\frac{\epsilon u_i}{\Delta})}\right)
+    &= \ln\left(\frac{\sum_{i} \exp(\frac{\epsilon (v_i - u_i + u_i)}{\Delta})}{\sum_{i} \exp(\frac{\epsilon u_i}{\Delta})}\right) \\
+    &= \ln\left(\frac{\sum_{i} \exp(\frac{\epsilon (v_i - u_i)}{\Delta})\exp(\frac{\epsilon (u_i)}{\Delta})}{\sum_{i} \exp(\frac{\epsilon u_i}{\Delta})}\right) \\
+    &\le \ln\left(\frac{\exp(\frac{\epsilon \max_j(v_j - u_j)}{\Delta}) \sum_{i} \exp(\frac{\epsilon (u_i)}{\Delta})}{\sum_{i} \exp(\frac{\epsilon u_i}{\Delta})}\right) \\
+    &= \frac{\epsilon \max_j(v_j - u_j)}{\Delta}
+\end{align*}
+\end{proof}
+
+\label{privacy-guarantee}
+Assume $u$, $v$ in \texttt{input\_domain} are \din-close under \rustdoc{metrics/struct}{InfDifferenceDistance} and $\texttt{privacy\_map}(\din) \le \dout$.
+
+\begin{align*}
+    &\quad \max\limits_{u \sim v} D_\infty(\function(u), \function(v)) \\
+    &= \max\limits_{u \sim v} \max\limits_{i} \ln\left(\frac{\Pr[\function(u) = i]}{\Pr[\function(v) = i]}\right) 
+    &&\text{by } \rustdoc{measures/struct}{MaxDivergence}\\
+    &= \max\limits_{u \sim v} \max\limits_{i} \ln\left(\frac
+            {\Pr[\mathrm{argmax}_k (u_k / \tau - \ln(-\ln(U_k))) = i]}
+            {\Pr[\mathrm{argmax}_k (v_k / \tau - \ln(-\ln(U_k))) = i]}
+        \right) &&\text{substitute \function}\\
+    \intertext{Assuming $\texttt{privacy\_map}(\din) \le \dout = \epsilon$, then $ \tau \geq \Delta / \epsilon$.}
+    &\le \max\limits_{u \sim v} \max\limits_{i} \ln\left(\frac
+            {\Pr[\mathrm{argmax}_k (u_k \epsilon / \Delta - \ln(-\ln(U_k))) = i]}
+            {\Pr[\mathrm{argmax}_k (v_k \epsilon / \Delta - \ln(-\ln(U_k))) = i]}
+        \right)\\
+    &= \max\limits_{u \sim v} \max\limits_{i} \ln \left(
+        \frac
+            {\exp(\frac{\epsilon u_i}{\Delta})}
+            {\sum_{k} \exp(\frac{\epsilon u_k}{\Delta})
+        }
+        \bigg/ \frac
+            {\exp(\frac{\epsilon v_i}{\Delta})}
+            {\sum_{k} \exp(\frac{\epsilon v_k}{\Delta})} \right)
+        &&\text{by \ref{gumbel-reparam}} \\
+    &= \max\limits_{u \sim v} \max\limits_{i} \ln \left(\frac
+        {\exp(\frac{\epsilon u_i}{\Delta})}{\exp(\frac{\epsilon v_i}{\Delta})}
+        \frac{\sum_{k} \exp(\frac{\epsilon v_k}{\Delta})}{\sum_{k} \exp(\frac{\epsilon u_k}{\Delta})}\right) \\
+    &= \max\limits_{u \sim v} \max\limits_{i} \ln \left(\frac
+        {\exp(\frac{\epsilon u_i}{\Delta})}{\exp(\frac{\epsilon v_i}{\Delta})}\right) + \ln \left(
+        \frac{\sum_{k} \exp(\frac{\epsilon v_k}{\Delta})}{\sum_{k} \exp(\frac{\epsilon u_k}{\Delta})}\right) \\
+    &= \max\limits_{u \sim v} \max\limits_{i} \frac{\epsilon (u_i - v_i)}{\Delta} 
+        + \ln\left(\frac{\sum_{k} \exp(\frac{\epsilon v_k}{\Delta})}{\sum_{k} \exp(\frac{\epsilon u_k}{\Delta})}\right) \\
+    &\leq \max\limits_{u \sim v} \max\limits_{i} \frac{\epsilon (u_i - v_i)}{\Delta} + \frac{\epsilon \max_j (v_j - u_j)}{\Delta} &&\text{by \ref{priv-inequality}} \\
+    &\leq \epsilon \max\limits_{u \sim v} \frac{\max\limits_{ij} \abs{(u_i - v_i) - (u_j - v_j)}}{\Delta} \\
+    &\leq \epsilon &&\text{by }\rustdoc{metrics/struct}{InfDifferenceDistance} \\
+    &= \dout
+\end{align*}    
+
+It has been shown that $\function(u)$ and $\function(v)$ are \dout-close under \texttt{output\_measure} 
+under the definitions of $\function$ and \texttt{privacy\_map}, 
+and the conditions on the input distance and privacy map.
+
+
+
+\bibliographystyle{plain}
+\bibliography{references.bib}
+
+\end{document}

--- a/rust/src/measurements/discrete_exponential/mod.rs
+++ b/rust/src/measurements/discrete_exponential/mod.rs
@@ -1,0 +1,184 @@
+#[cfg(feature = "ffi")]
+mod ffi;
+
+use opendp_derive::bootstrap;
+
+use crate::{
+    core::{Function, Measurement, PrivacyMap},
+    domains::{AtomDomain, VectorDomain},
+    error::Fallible,
+    measures::MaxDivergence,
+    metrics::InfDifferenceDistance,
+    traits::{Float, Number},
+};
+
+#[cfg(feature = "use-mpfr")]
+use crate::traits::{
+    samplers::{CastInternalRational, GumbelPSRN},
+    DistanceConstant,
+};
+#[cfg(feature = "use-mpfr")]
+use rug::ops::NegAssign;
+
+#[cfg(not(feature = "use-mpfr"))]
+use crate::traits::{samplers::SampleUniform, CheckNull, InfCast, RoundCast};
+
+#[derive(PartialEq)]
+pub enum Optimize {
+    Max,
+    Min,
+}
+
+#[cfg(feature = "use-mpfr")]
+#[bootstrap(
+    features("contrib", "floating-point"),
+    arguments(optimize(c_type = "char *", rust_type = "String"))
+)]
+/// Make a Measurement that takes a vector of scores and privately selects the index of the highest score.
+///
+/// # Arguments
+/// * `temperature` - Higher temperatures are more private.
+/// * `optimize` - Indicate whether to privately return the "Max" or "Min"
+///
+/// # Generics
+/// * `TIA` - Atom Input Type. Type of each element in the score vector.
+/// * `QO` - Output Distance Type.
+pub fn make_base_discrete_exponential<TIA, QO>(
+    temperature: QO,
+    optimize: Optimize,
+) -> Fallible<
+    Measurement<
+        VectorDomain<AtomDomain<TIA>>,
+        usize,
+        InfDifferenceDistance<TIA>,
+        MaxDivergence<QO>,
+    >,
+>
+where
+    TIA: Number + CastInternalRational,
+    QO: CastInternalRational + DistanceConstant<TIA> + Float,
+{
+    let temp_frac = temperature.clone().into_rational()?;
+
+    Ok(Measurement::new(
+        VectorDomain::new_all(),
+        Function::new_fallible(move |arg: &Vec<TIA>| {
+            arg.iter()
+                .cloned()
+                .enumerate()
+                .map(|(i, v)| {
+                    let mut shift = v.into_rational()? / &temp_frac;
+                    if optimize == Optimize::Min {
+                        shift.neg_assign();
+                    }
+                    Ok((i, GumbelPSRN::new(shift)))
+                })
+                .reduce(|l, r| {
+                    let (mut l, mut r) = (l?, r?);
+                    Ok(if l.1.greater_than(&mut r.1)? { l } else { r })
+                })
+                .ok_or_else(|| err!(FailedFunction, "there must be at least one candidate"))?
+                .map(|v| v.0)
+        }),
+        InfDifferenceDistance::default(),
+        MaxDivergence::default(),
+        PrivacyMap::new_fallible(move |d_in: &TIA| {
+            let d_in = QO::inf_cast(d_in.clone())?;
+            if d_in.is_sign_negative() {
+                return fallible!(InvalidDistance, "sensitivity must be non-negative");
+            }
+            if temperature.is_zero() {
+                return Ok(QO::infinity());
+            }
+            // d_out >= d_in / temperature
+            d_in.inf_div(&temperature)
+        }),
+    ))
+}
+
+#[cfg(not(feature = "use-mpfr"))]
+/// Make a Measurement that takes a vector of scores and privately selects the index of the highest score.
+///
+/// # Arguments
+/// * `temperature` - Higher temperatures are more private.
+/// * `optimize` - Indicate whether to privately return the "Max" or "Min"
+///
+/// # Generics
+/// * `TIA` - Atom Input Type. Type of each element in the score vector.
+/// * `QO` - Output Distance Type.
+pub fn make_base_discrete_exponential<TIA, QO>(
+    temperature: QO,
+    optimize: Optimize,
+) -> Fallible<
+    Measurement<
+        VectorDomain<AtomDomain<TIA>>,
+        usize,
+        InfDifferenceDistance<TIA>,
+        MaxDivergence<QO>,
+    >,
+>
+where
+    TIA: Clone + CheckNull + Number,
+    QO: 'static + InfCast<TIA> + RoundCast<TIA> + Float + SampleUniform,
+{
+    if temperature.is_sign_negative() || temperature.is_zero() {
+        return fallible!(MakeMeasurement, "temperature must be positive");
+    }
+
+    let sign = match optimize {
+        Optimize::Max => QO::one(),
+        Optimize::Min => QO::one().neg(),
+    };
+
+    Ok(Measurement::new(
+        VectorDomain::new_all(),
+        Function::new_fallible(move |arg: &Vec<TIA>| {
+            arg.iter()
+                .cloned()
+                .map(|v| QO::round_cast(v).map(|v| sign * v / temperature))
+                // enumerate before sampling so that indexes are inside the result
+                .enumerate()
+                // gumbel samples are porous
+                .map(|(i, llik)| {
+                    let llik = llik?;
+                    QO::sample_standard_uniform(false).map(|u| (i, llik - u.ln().neg().ln()))
+                })
+                // retrieve the highest noisy likelihood pair
+                .try_fold((arg.len(), QO::neg_infinity()), |acc: (usize, QO), res| {
+                    res.map(|v| if acc.1 > v.1 { acc } else { v })
+                })
+                // only return the index
+                .map(|v| v.0)
+        }),
+        InfDifferenceDistance::default(),
+        MaxDivergence::default(),
+        PrivacyMap::new_fallible(move |d_in: &TIA| {
+            let d_in = QO::inf_cast(d_in.clone())?;
+            if d_in.is_sign_negative() {
+                return fallible!(InvalidDistance, "sensitivity must be non-negative");
+            }
+            if d_in.is_zero() {
+                return Ok(QO::zero());
+            }
+            // d_out >= d_in / temperature
+            d_in.inf_div(&temperature)
+        }),
+    ))
+}
+
+#[cfg(feature = "floating-point")]
+#[cfg(test)]
+pub mod test_exponential {
+    use crate::error::Fallible;
+
+    use super::*;
+
+    #[test]
+    fn test_exponential() -> Fallible<()> {
+        let de = make_base_discrete_exponential(1., Optimize::Max)?;
+        let release = de.invoke(&vec![1., 2., 3., 2., 1.])?;
+        println!("{:?}", release);
+
+        Ok(())
+    }
+}

--- a/rust/src/measurements/discrete_exponential/pseudocode/make_base_discrete_exponential.py
+++ b/rust/src/measurements/discrete_exponential/pseudocode/make_base_discrete_exponential.py
@@ -1,0 +1,40 @@
+# type: ignore
+def make_base_discrete_exponential(temperature: TIA, optimize: Optimize):
+    if temperature <= 0:
+        raise ValueError("temperature must be positive")
+
+    if optimize == "max":
+        sign = +1
+    elif optimize == "min":
+        sign = -1
+    else:
+        raise ValueError("must specify optimization")
+
+    temp_frac = Fraction(temperature)
+
+    def function(scores: List[TIA]):
+        def map_gumbel(score):
+            return GumbelPSRN(shift=sign * Fraction(score) / temp_frac)
+        gumbel_scores = map(map_gumbel, scores)
+
+        def reduce_best(a, b):
+            return a if a[1].greater_than(b[1]) else b
+        return reduce(reduce_best, enumerate(gumbel_scores))[0]
+
+    def privacy_map(d_in: TIA):
+        d_in = QO.inf_cast(d_in)
+        if d_in < 0:
+            raise ValueError("input distance must be non-negative")
+
+        if d_in == 0:
+            return 0
+
+        return d_in.inf_div(temperature)
+
+    return Measurement(
+        input_domain=VectorDomain(AtomDomain(TIA)),
+        function=function,
+        input_metric=InfDifferenceDistance(TIA),
+        output_metric=MaxDivergence(QO),
+        privacy_map=privacy_map,
+    )

--- a/rust/src/measurements/discrete_exponential/references.bib
+++ b/rust/src/measurements/discrete_exponential/references.bib
@@ -1,0 +1,36 @@
+@article{TCS-042,
+    url = {http://dx.doi.org/10.1561/0400000042},
+    year = {2014},
+    volume = {9},
+    journal = {Foundations and Trends® in Theoretical Computer Science},
+    title = {The Algorithmic Foundations of Differential Privacy},
+    doi = {10.1561/0400000042},
+    issn = {1551-305X},
+    number = {3–4},
+    pages = {211-407},
+    author = {Cynthia Dwork and Aaron Roth}
+}
+
+@InProceedings{10.1007/11681878_14,
+    author="Dwork, Cynthia
+    and McSherry, Frank
+    and Nissim, Kobbi
+    and Smith, Adam",
+    editor="Halevi, Shai
+    and Rabin, Tal",
+    title="Calibrating Noise to Sensitivity in Private Data Analysis",
+    booktitle="Theory of Cryptography",
+    year="2006",
+    publisher="Springer Berlin Heidelberg",
+    address="Berlin, Heidelberg",
+    pages="265--284",
+    isbn="978-3-540-32732-5"
+}
+
+@article{Medina2020DuffAD,
+    title={Duff: A Dataset-Distance-Based Utility Function Family for the Exponential Mechanism},
+    author={Andr{\'e}s Mu{\~n}oz Medina and Jennifer Gillenwater},
+    journal={ArXiv},
+    year={2020},
+    volume={abs/2010.04235}
+}

--- a/rust/src/measurements/mod.rs
+++ b/rust/src/measurements/mod.rs
@@ -2,6 +2,12 @@
 //!
 //! The different [`crate::core::Measurement`] implementations in this module are accessed by calling the appropriate constructor function.
 //! Constructors are named in the form `make_xxx()`, where `xxx` indicates what the resulting `Measurement` does.
+
+#[cfg(feature = "contrib")]
+mod discrete_exponential;
+#[cfg(feature = "contrib")]
+pub use crate::measurements::discrete_exponential::*;
+
 #[cfg(all(feature = "use-mpfr", feature = "contrib"))]
 mod discrete_gaussian;
 #[cfg(all(feature = "use-mpfr", feature = "contrib"))]

--- a/rust/src/traits/arithmetic/mod.rs
+++ b/rust/src/traits/arithmetic/mod.rs
@@ -1,11 +1,10 @@
-use crate::traits::ExactIntCast;
+use crate::{error::Fallible, traits::ExactIntCast};
 #[cfg(feature = "use-mpfr")]
 use rug::{
     ops::{AddAssignRound, DivAssignRound, MulAssignRound, PowAssignRound, SubAssignRound},
     Float,
 };
 
-use crate::error::Fallible;
 #[cfg(feature = "use-mpfr")]
 use crate::traits::InfCast;
 
@@ -184,6 +183,22 @@ pub trait InfSqrt: Sized {
     /// `self.neg_inf_log2()` either returns `Ok(out)`,
     /// where $out \le \sqrt{self}$, or `Err(e)`.
     fn neg_inf_sqrt(self) -> Fallible<Self>;
+}
+
+/// Fallible recip with specified rounding.
+///
+/// Throws an error if the ideal output is not finite or representable.
+pub trait InfRecip: Sized {
+    /// # Proof Definition
+    /// For any `self` of type `Self`,
+    /// `self.inf_recip()` either returns `Ok(out)`,
+    /// where $out \ge 1 / self$, or `Err(e)`.
+    fn inf_recip(self) -> Fallible<Self>;
+    /// # Proof Definition
+    /// For any `self` of type `Self`,
+    /// `self.neg_inf_recip()` either returns `Ok(out)`,
+    /// where $out \le 1 / self$, or `Err(e)`.
+    fn neg_inf_recip(self) -> Fallible<Self>;
 }
 
 /// Fallibly raise self to the power with specified rounding.
@@ -504,6 +519,7 @@ impl_float_inf_uni!(f64, f32; InfExp, inf_exp, neg_inf_exp, exp_round, exp);
 impl_float_inf_uni!(f64, f32; InfLn1P, inf_ln_1p, neg_inf_ln_1p, ln_1p_round, ln_1p);
 impl_float_inf_uni!(f64, f32; InfExpM1, inf_exp_m1, neg_inf_exp_m1, exp_m1_round, exp_m1);
 impl_float_inf_uni!(f64, f32; InfSqrt, inf_sqrt, neg_inf_sqrt, sqrt_round, sqrt);
+impl_float_inf_uni!(f64, f32; InfRecip, inf_recip, neg_inf_recip, recip_round, recip);
 
 // TRAIT InfAdd, InfSub, InfMul, InfDiv (bivariate)
 macro_rules! impl_int_inf {

--- a/rust/src/traits/samplers/mod.rs
+++ b/rust/src/traits/samplers/mod.rs
@@ -16,6 +16,11 @@ pub use discretize::*;
 mod geometric;
 pub use geometric::*;
 
+#[cfg(feature = "use-mpfr")]
+mod psrn;
+#[cfg(feature = "use-mpfr")]
+pub use psrn::*;
+
 mod uniform;
 pub use uniform::*;
 

--- a/rust/src/traits/samplers/psrn/mod.rs
+++ b/rust/src/traits/samplers/psrn/mod.rs
@@ -69,10 +69,22 @@ impl GumbelPSRN {
     /// Computes the inverse cdf of the standard Gumbel with controlled rounding:
     /// $-ln(-ln(u))$ where $u \sim \mathrm{Uniform}(0, 1)$
     fn inverse_cdf(mut sample: Float, round: Round) -> Float {
+        fn complement(value: Round) -> Round {
+            match value {
+                Round::Up => Round::Down,
+                Round::Down => Round::Up,
+                _ => panic!("complement is only supported for Up/Down"),
+            }
+        }
+
+        // This round is behind two negations, so the rounding direction is preserved
         sample.ln_round(round);
         sample.neg_assign();
-        sample.ln_round(round);
+        
+        // This round is behind a negation, so the rounding direction is reversed
+        sample.ln_round(complement(round));
         sample.neg_assign();
+
         sample
     }
 

--- a/rust/src/traits/samplers/psrn/mod.rs
+++ b/rust/src/traits/samplers/psrn/mod.rs
@@ -1,0 +1,103 @@
+use std::ops::AddAssign;
+
+use rug::{float::Round, ops::NegAssign, Float, Integer, Rational};
+
+use crate::{error::Fallible, traits::samplers::SampleStandardBernoulli};
+
+/// A partially sampled uniform random number.
+/// Initializes to the interval [0, 1].
+#[derive(Default)]
+pub struct UniformPSRN {
+    pub numer: Integer,
+    pub denom: u32,
+}
+
+impl UniformPSRN {
+    // Retrieve either the lower or upper edge of the uniform interval.
+    fn value(&self, round: Round) -> Rational {
+        let round = match round {
+            Round::Up => 1,
+            Round::Down => 0,
+            _ => panic!("value must be rounded Up or Down"),
+        };
+        Rational::from((self.numer.clone() + round, Integer::from(1) << self.denom))
+    }
+    // Randomly discard the lower or upper half of the remaining interval.
+    fn refine(&mut self) -> Fallible<()> {
+        self.numer <<= 1;
+        self.denom += 1;
+        if bool::sample_standard_bernoulli()? {
+            self.numer += 1;
+        }
+        Ok(())
+    }
+}
+
+/// A partially sampled Gumbel random number.
+/// Initializes to span all reals.
+pub struct GumbelPSRN {
+    shift: Rational,
+    uniform: UniformPSRN,
+    precision: u32,
+}
+
+impl GumbelPSRN {
+    pub fn new(shift: Rational) -> Self {
+        GumbelPSRN {
+            shift,
+            uniform: UniformPSRN::default(),
+            precision: 5,
+        }
+    }
+
+    /// Retrieve either the lower or upper edge of the Gumbel interval.
+    /// The PSRN is refined until a valid value can be retrieved.
+    pub fn value(&mut self, round: Round) -> Fallible<Rational> {
+        // The first few rounds are susceptible to NaN due to the uniform PSRN initializing at zero.
+        loop {
+            let sample = Float::with_val(self.precision, self.uniform.value(round));
+
+            if let Some(mut sample) = Self::inverse_cdf(sample, round).to_rational() {
+                sample.add_assign(&self.shift);
+                return Ok(sample);
+            } else {
+                self.refine()?;
+            }
+        }
+    }
+
+    /// Computes the inverse cdf of the standard Gumbel with controlled rounding:
+    /// $-ln(-ln(u))$ where $u \sim \mathrm{Uniform}(0, 1)$
+    fn inverse_cdf(mut sample: Float, round: Round) -> Float {
+        sample.ln_round(round);
+        sample.neg_assign();
+        sample.ln_round(round);
+        sample.neg_assign();
+        sample
+    }
+
+    /// Improves the precision of the inverse transform,
+    /// and halves the interval spanned by the uniform PSRN.
+    pub fn refine(&mut self) -> Fallible<()> {
+        self.precision += 5;
+        self.uniform.refine()
+    }
+
+    /// Checks if `self` is greater than `other`,
+    /// by refining the estimates for `self` and `other` until their intervals are disjoint.
+    pub fn greater_than(&mut self, other: &mut Self) -> Fallible<bool> {
+        Ok(loop {
+            if self.value(Round::Down)? > other.value(Round::Up)? {
+                break true;
+            }
+            if self.value(Round::Up)? < other.value(Round::Down)? {
+                break false;
+            }
+            if self.precision < other.precision {
+                self.refine()?
+            } else {
+                other.refine()?
+            }
+        })
+    }
+}

--- a/rust/src/traits/samplers/psrn/mod.rs
+++ b/rust/src/traits/samplers/psrn/mod.rs
@@ -114,7 +114,6 @@ impl GumbelPSRN {
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -123,7 +122,12 @@ mod test {
     fn test_sample_gumbel_interval_progression() -> Fallible<()> {
         let mut gumbel = GumbelPSRN::new(Rational::from(0));
         for _ in 0..10 {
-            println!("{:?}, {:?}, {}", gumbel.value(Round::Down)?.to_f64(), gumbel.value(Round::Up)?.to_f64(), gumbel.precision);
+            println!(
+                "{:?}, {:?}, {}",
+                gumbel.value(Round::Down)?.to_f64(),
+                gumbel.value(Round::Up)?.to_f64(),
+                gumbel.precision
+            );
             gumbel.refine()?;
         }
         Ok(())
@@ -131,7 +135,6 @@ mod test {
 
     #[test]
     fn test_gumbel_psrn() -> Fallible<()> {
-
         fn sample_gumbel() -> Fallible<f64> {
             let mut gumbel = GumbelPSRN::new(Rational::from(0));
             for _ in 0..10 {
@@ -139,7 +142,9 @@ mod test {
             }
             Ok(gumbel.value(Round::Down)?.to_f64())
         }
-        let samples = (0..1000).map(|_| sample_gumbel()).collect::<Fallible<Vec<_>>>()?;
+        let samples = (0..1000)
+            .map(|_| sample_gumbel())
+            .collect::<Fallible<Vec<_>>>()?;
         println!("{:?}", samples);
         Ok(())
     }

--- a/rust/src/traits/samplers/vulnerable_fallbacks/mod.rs
+++ b/rust/src/traits/samplers/vulnerable_fallbacks/mod.rs
@@ -44,6 +44,4 @@ impl SampleDiscreteGaussianZ2k for f32 {
 }
 
 pub trait CastInternalRational {}
-
-impl CastInternalRational for f32 {}
-impl CastInternalRational for f64 {}
+impl<T> CastInternalRational for T {}

--- a/rust/src/transformations/sum/float/checked/mod.rs
+++ b/rust/src/transformations/sum/float/checked/mod.rs
@@ -348,6 +348,8 @@ mod test_checks {
         Ok(())
     }
 
+    // feature-gated because non-mpfr InfCast errors on numbers greater than 2^52
+    #[cfg(feature = "use-mpfr")]
     #[test]
     fn test_float_sum_overflows_sequential() -> Fallible<()> {
         let almost_max = f64::from_bits(f64::MAX.to_bits() - 1);
@@ -368,6 +370,8 @@ mod test_checks {
         Ok(())
     }
 
+    // feature-gated because non-mpfr InfCast errors on numbers greater than 2^52
+    #[cfg(feature = "use-mpfr")]
     #[test]
     fn test_float_sum_overflows_pairwise() -> Fallible<()> {
         let almost_max = f64::from_bits(f64::MAX.to_bits() - 1);


### PR DESCRIPTION
This PR implements a floating-point-safe exponential mechanism via partially sampled random numbers (PSRN). 

This implementation exploits the nice property of the Gumbel noisy-max algorithm wherein each Gumbel variate only needs to be known with sufficient precision to guarantee that no other Gumbel variate can be greater than the best-scoring Gumbel variate (or top k).

The sampling starts with a uniform PSRN, initialized to the interval [0, 1]. The next bit of the uniform random number is acquired by randomly halving the interval. The lower and upper edge of the interval can be retrieved at any given time.

There is similarly a Gumbel(μ, 1) PSRN supported on the reals with rational μ. It contains a uniform PSRN, an inverse transform precision u32, and a shift Rational. In each refinement of the Gumbel, the uniform sampler is refined and the precision is increased. To retrieve the lower or upper edge of the Gumbel, first retrieve the lower or upper edge of the uniform PSRN and then apply the inverse transform with controlled rounding. 

The Gumbel exponential mechanism maps over each score, exactly-scaling it by the temperature parameter and wrapping it in an exactly-shifted Gumbel PSRN. The mechanism then reduces over all pairs of Gumbel PSRNs, refining each PSRN until their intervals are disjoint and in each case discarding the smaller Gumbel PSRN. The differentially private release is the index of the last-surviving Gumbel PSRN.

This work was inspired by the [interval refining paper from Tumult,](https://tpdp.journalprivacyconfidentiality.org/2022/papers/HaneyDHSH22.pdf) and [Peter Occil's website](https://peteroupc.github.io/randomfunc.html#Inverse_Transform_Sampling).

