### PR TITLE
run cargo fmt

### DIFF
--- a/python/src/opendp/_data.py
+++ b/python/src/opendp/_data.py
@@ -21,7 +21,7 @@ __all__ = [
 def bool_free(
     this
 ):
-    """Internal function. Free the memory associated with `this`, a bool. 
+    """Internal function. Free the memory associated with `this`, a bool.
     Used to clean up after the relation check.
     
     [bool_free in Rust documentation.](https://docs.rs/opendp/latest/opendp/data/fn.bool_free.html)
@@ -169,7 +169,7 @@ def slice_as_object(
     :type raw: FfiSlicePtr
     :param T: 
     :type T: str
-    :return: An AnyObject that contains the data in `slice`. 
+    :return: An AnyObject that contains the data in `slice`.
     The AnyObject also captures rust type information.
     :rtype: Any
     :raises TypeError: if an argument's type differs from the expected type
@@ -196,7 +196,7 @@ def slice_as_object(
 def slice_free(
     this: Any
 ):
-    """Internal function. Free the memory associated with `this`, an FfiSlicePtr. 
+    """Internal function. Free the memory associated with `this`, an FfiSlicePtr.
     Used to clean up after object_as_slice.
     Frees the slice, but not what the slice references!
     
@@ -258,7 +258,7 @@ def smd_curve_epsilon(
 def str_free(
     this: str
 ):
-    """Internal function. Free the memory associated with `this`, a string. 
+    """Internal function. Free the memory associated with `this`, a string.
     Used to clean up after the type getter functions.
     
     [str_free in Rust documentation.](https://docs.rs/opendp/latest/opendp/data/fn.str_free.html)

--- a/python/src/opendp/accuracy.py
+++ b/python/src/opendp/accuracy.py
@@ -220,7 +220,7 @@ def discrete_laplacian_scale_to_accuracy(
     $\alpha = P[Y \ge accuracy]$, where $Y = |X - z|$, and $X \sim \mathcal{L}_{Z}(0, scale)$.
     That is, $X$ is a discrete Laplace random variable and $Y$ is the distribution of the errors.
     
-    This function returns a float accuracy. 
+    This function returns a float accuracy.
     You can take the floor without affecting the coverage probability.
     
     [discrete_laplacian_scale_to_accuracy in Rust documentation.](https://docs.rs/opendp/latest/opendp/accuracy/fn.discrete_laplacian_scale_to_accuracy.html)

--- a/python/src/opendp/combinators.py
+++ b/python/src/opendp/combinators.py
@@ -26,7 +26,7 @@ __all__ = [
 def make_basic_composition(
     measurements: Any
 ) -> Measurement:
-    """Construct the DP composition [`measurement0`, `measurement1`, ...]. 
+    """Construct the DP composition [`measurement0`, `measurement1`, ...].
     Returns a Measurement that when invoked, computes `[measurement0(x), measurement1(x), ...]`
     
     All metrics and domains must be equivalent, except for the output domain.
@@ -201,12 +201,12 @@ def make_population_amplification(
     population_size: int
 ) -> Measurement:
     """Construct an amplified measurement from a `measurement` with privacy amplification by subsampling.
-    This measurement does not perform any sampling. 
+    This measurement does not perform any sampling.
     It is useful when you have a dataset on-hand that is a simple random sample from a larger population.
     
     The DIA, DO, MI and MO between the input measurement and amplified output measurement all match.
     
-    Protected by the "honest-but-curious" feature flag 
+    Protected by the "honest-but-curious" feature flag
     because a dishonest adversary could set the population size to be arbitrarily large.
     
     [make_population_amplification in Rust documentation.](https://docs.rs/opendp/latest/opendp/combinators/fn.make_population_amplification.html)

--- a/python/src/opendp/measurements.py
+++ b/python/src/opendp/measurements.py
@@ -145,10 +145,11 @@ def make_base_discrete_laplace_cks20(
     D: RuntimeTypeDescriptor = "AllDomain<int>",
     QO: RuntimeTypeDescriptor = None
 ) -> Measurement:
-    """Make a Measurement that adds noise from the discrete_laplace(`scale`) distribution to the input, 
+    """Make a Measurement that adds noise from the discrete_laplace(`scale`) distribution to the input,
     using an efficient algorithm on rational bignums.
     
     Set `D` to change the input data type and input metric:
+    
     
     | `D`                          | input type   | `D::InputMetric`       |
     | ---------------------------- | ------------ | ---------------------- |
@@ -205,11 +206,12 @@ def make_base_discrete_laplace_linear(
     D: RuntimeTypeDescriptor = "AllDomain<int>",
     QO: RuntimeTypeDescriptor = None
 ) -> Measurement:
-    """Make a Measurement that adds noise from the discrete_laplace(`scale`) distribution to the input, 
+    """Make a Measurement that adds noise from the discrete_laplace(`scale`) distribution to the input,
     using a linear-time algorithm on finite data types.
     
     This algorithm can be executed in constant time if bounds are passed.
     Set `D` to change the input data type and input metric:
+    
     
     | `D`                          | input type   | `D::InputMetric`       |
     | ---------------------------- | ------------ | ---------------------- |
@@ -275,13 +277,14 @@ def make_base_gaussian(
     
     Set `D` to change the input data type and input metric:
     
+    
     | `D`                          | input type   | `D::InputMetric`       |
     | ---------------------------- | ------------ | ---------------------- |
     | `AllDomain<T>` (default)     | `T`          | `AbsoluteDistance<T>`  |
     | `VectorDomain<AllDomain<T>>` | `Vec<T>`     | `L2Distance<T>`        |
     
-    This function takes a noise granularity in terms of 2^k. 
-    Larger granularities are more computationally efficient, but have a looser privacy map. 
+    This function takes a noise granularity in terms of 2^k.
+    Larger granularities are more computationally efficient, but have a looser privacy map.
     If k is not set, k defaults to the smallest granularity.
     
     [make_base_gaussian in Rust documentation.](https://docs.rs/opendp/latest/opendp/measurements/fn.make_base_gaussian.html)
@@ -336,8 +339,8 @@ def make_base_geometric(
     D: RuntimeTypeDescriptor = "AllDomain<int>",
     QO: RuntimeTypeDescriptor = None
 ) -> Measurement:
-    """Deprecated. 
-    Use `make_base_discrete_laplace` instead (more efficient). 
+    """Deprecated.
+    Use `make_base_discrete_laplace` instead (more efficient).
     `make_base_discrete_laplace_linear` has a similar interface with the optional constant-time bounds.
     
     [make_base_geometric in Rust documentation.](https://docs.rs/opendp/latest/opendp/measurements/fn.make_base_geometric.html)
@@ -400,8 +403,8 @@ def make_base_laplace(
     | `VectorDomain<AllDomain<T>>` | `Vec<T>`     | `L1Distance<T>`        |
     
     
-    This function takes a noise granularity in terms of 2^k. 
-    Larger granularities are more computationally efficient, but have a looser privacy map. 
+    This function takes a noise granularity in terms of 2^k.
+    Larger granularities are more computationally efficient, but have a looser privacy map.
     If k is not set, k defaults to the smallest granularity.
     
     [make_base_laplace in Rust documentation.](https://docs.rs/opendp/latest/opendp/measurements/fn.make_base_laplace.html)
@@ -453,8 +456,9 @@ def make_base_ptr(
     TV: RuntimeTypeDescriptor = None
 ) -> Measurement:
     """Make a Measurement that uses propose-test-release to privatize a hashmap of counts.
-    This function takes a noise granularity in terms of 2^k. 
-    Larger granularities are more computationally efficient, but have a looser privacy map. 
+    
+    This function takes a noise granularity in terms of 2^k.
+    Larger granularities are more computationally efficient, but have a looser privacy map.
     If k is not set, k defaults to the smallest granularity.
     
     [make_base_ptr in Rust documentation.](https://docs.rs/opendp/latest/opendp/measurements/fn.make_base_ptr.html)

--- a/python/src/opendp/transformations.py
+++ b/python/src/opendp/transformations.py
@@ -64,7 +64,7 @@ __all__ = [
 def choose_branching_factor(
     size_guess: int
 ) -> int:
-    """Returns an approximation to the ideal `branching_factor` for a dataset of a given size, 
+    """Returns an approximation to the ideal `branching_factor` for a dataset of a given size,
     that minimizes error in cdf and quantile estimates based on b-ary trees.
     
     [choose_branching_factor in Rust documentation.](https://docs.rs/opendp/latest/opendp/transformations/fn.choose_branching_factor.html)
@@ -101,7 +101,7 @@ def make_b_ary_tree(
     M: RuntimeTypeDescriptor,
     TA: RuntimeTypeDescriptor = "int"
 ) -> Transformation:
-    """Expand a vector of counts into a b-ary tree of counts, 
+    """Expand a vector of counts into a b-ary tree of counts,
     where each branch is the sum of its `b` immediate children.
     
     [make_b_ary_tree in Rust documentation.](https://docs.rs/opendp/latest/opendp/transformations/fn.make_b_ary_tree.html)
@@ -153,9 +153,9 @@ def make_bounded_float_checked_sum(
     bounds: Tuple[Any, Any],
     S: RuntimeTypeDescriptor = "Pairwise<T>"
 ) -> Transformation:
-    """Make a Transformation that computes the sum of bounded data with known dataset size. 
+    """Make a Transformation that computes the sum of bounded data with known dataset size.
     
-    This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility. 
+    This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility.
     Use `make_clamp` to bound data and `make_resize` to establish dataset size.
     
     | S (summation algorithm) | input type     |
@@ -163,7 +163,7 @@ def make_bounded_float_checked_sum(
     | `Sequential<S::Item>`   | `Vec<S::Item>` |
     | `Pairwise<S::Item>`     | `Vec<S::Item>` |
     
-    `S::Item` is the type of all of the following: 
+    `S::Item` is the type of all of the following:
     each bound, each element in the input data, the output data, and the output sensitivity.
     
     For example, to construct a transformation that pairwise-sums `f32` half-precision floats,
@@ -221,7 +221,7 @@ def make_bounded_float_ordered_sum(
     bounds: Tuple[Any, Any],
     S: RuntimeTypeDescriptor = "Pairwise<T>"
 ) -> Transformation:
-    """Make a Transformation that computes the sum of bounded floats with known ordering. 
+    """Make a Transformation that computes the sum of bounded floats with known ordering.
     
     Only useful when `make_bounded_float_checked_sum` returns an error due to potential for overflow.
     You may need to use `make_ordered_random` to impose an ordering on the data.
@@ -232,7 +232,7 @@ def make_bounded_float_ordered_sum(
     | `Sequential<S::Item>`   | `Vec<S::Item>` |
     | `Pairwise<S::Item>`     | `Vec<S::Item>` |
     
-    `S::Item` is the type of all of the following: 
+    `S::Item` is the type of all of the following:
     each bound, each element in the input data, the output data, and the output sensitivity.
     
     For example, to construct a transformation that pairwise-sums `f32` half-precision floats,
@@ -289,7 +289,7 @@ def make_bounded_int_monotonic_sum(
     bounds: Tuple[Any, Any],
     T: RuntimeTypeDescriptor = None
 ) -> Transformation:
-    """Make a Transformation that computes the sum of bounded ints, 
+    """Make a Transformation that computes the sum of bounded ints,
     where all values share the same sign.
     
     [make_bounded_int_monotonic_sum in Rust documentation.](https://docs.rs/opendp/latest/opendp/transformations/fn.make_bounded_int_monotonic_sum.html)
@@ -387,7 +387,7 @@ def make_bounded_int_split_sum(
     bounds: Tuple[Any, Any],
     T: RuntimeTypeDescriptor = None
 ) -> Transformation:
-    """Make a Transformation that computes the sum of bounded ints. 
+    """Make a Transformation that computes the sum of bounded ints.
     Adds the saturating sum of the positives to the saturating sum of the negatives.
     
     [make_bounded_int_split_sum in Rust documentation.](https://docs.rs/opendp/latest/opendp/transformations/fn.make_bounded_int_split_sum.html)
@@ -437,7 +437,7 @@ def make_bounded_sum(
     MI: RuntimeTypeDescriptor = "SymmetricDistance",
     T: RuntimeTypeDescriptor = None
 ) -> Transformation:
-    """Make a Transformation that computes the sum of bounded data. 
+    """Make a Transformation that computes the sum of bounded data.
     Use `make_clamp` to bound data.
     
     [make_bounded_sum in Rust documentation.](https://docs.rs/opendp/latest/opendp/transformations/fn.make_bounded_sum.html)
@@ -530,7 +530,7 @@ def make_cast_default(
     TIA: RuntimeTypeDescriptor,
     TOA: RuntimeTypeDescriptor
 ) -> Transformation:
-    """Make a Transformation that casts a vector of data from type `TIA` to type `TOA`. 
+    """Make a Transformation that casts a vector of data from type `TIA` to type `TOA`.
     Any element that fails to cast is filled with default.
     
     
@@ -583,7 +583,7 @@ def make_cast_inherent(
     TIA: RuntimeTypeDescriptor,
     TOA: RuntimeTypeDescriptor
 ) -> Transformation:
-    """Make a Transformation that casts a vector of data from type `TIA` to a type that can represent nullity `TOA`. 
+    """Make a Transformation that casts a vector of data from type `TIA` to a type that can represent nullity `TOA`.
     If cast fails, fill with `TOA`'s null value.
     
     | `TIA`  | `TIA::default()` |
@@ -671,7 +671,7 @@ def make_clamp(
 ) -> Transformation:
     """Make a Transformation that clamps numeric data in `Vec<TA>` to `bounds`.
     
-    If datum is less than lower, let datum be lower. 
+    If datum is less than lower, let datum be lower.
     If datum is greater than upper, let datum be upper.
     
     [make_clamp in Rust documentation.](https://docs.rs/opendp/latest/opendp/transformations/fn.make_clamp.html)
@@ -825,7 +825,7 @@ def make_count_by(
     TK: RuntimeTypeDescriptor,
     TV: RuntimeTypeDescriptor = "int"
 ) -> Transformation:
-    """Make a Transformation that computes the count of each unique value in data. 
+    """Make a Transformation that computes the count of each unique value in data.
     This assumes that the category set is unknown.
     
     [make_count_by in Rust documentation.](https://docs.rs/opendp/latest/opendp/transformations/fn.make_count_by.html)
@@ -882,7 +882,7 @@ def make_count_by_categories(
     TIA: RuntimeTypeDescriptor = None,
     TOA: RuntimeTypeDescriptor = "int"
 ) -> Transformation:
-    """Make a Transformation that computes the number of times each category appears in the data. 
+    """Make a Transformation that computes the number of times each category appears in the data.
     This assumes that the category set is known.
     
     [make_count_by_categories in Rust documentation.](https://docs.rs/opendp/latest/opendp/transformations/fn.make_count_by_categories.html)
@@ -1036,7 +1036,7 @@ def make_df_cast_default(
     TOA: RuntimeTypeDescriptor,
     TK: RuntimeTypeDescriptor = None
 ) -> Transformation:
-    """Make a Transformation that casts the elements in a column in a dataframe from type `TIA` to type `TOA`. 
+    """Make a Transformation that casts the elements in a column in a dataframe from type `TIA` to type `TOA`.
     If cast fails, fill with default.
     
     
@@ -1243,7 +1243,7 @@ def make_find_bin(
     """Make a transformation that finds the bin index in a monotonically increasing vector of edges.
     
     For each value in the input vector, finds the index of the bin the value falls into.
-    `edges` splits the entire range of `TIA` into bins. 
+    `edges` splits the entire range of `TIA` into bins.
     The first bin at index zero ranges from negative infinity to the first edge, non-inclusive.
     The last bin at index `edges.len()` ranges from the last bin, inclusive, to positive infinity.
     
@@ -1338,7 +1338,7 @@ def make_impute_constant(
     """Make a Transformation that replaces null/None data with `constant`.
     
     By default, the input type is `Vec<Option<TA>>`, as emitted by make_cast.
-    Set `DA` to `InherentNullDomain<AllDomain<TA>>` for imputing on types 
+    Set `DA` to `InherentNullDomain<AllDomain<TA>>` for imputing on types
     that have an inherent representation of nullity, like floats.
     
     | Atom Input Domain `DIA`             |  Input Type       | `DIA::Imputed` |
@@ -1618,10 +1618,10 @@ def make_metric_bounded(
     D: RuntimeTypeDescriptor = None,
     MI: RuntimeTypeDescriptor = "SymmetricDistance"
 ) -> Transformation:
-    """Make a Transformation that converts the unbounded dataset metric `MI` 
-    to the respective bounded dataset metric with a no-op. 
+    """Make a Transformation that converts the unbounded dataset metric `MI`
+    to the respective bounded dataset metric with a no-op.
     
-    The constructor enforces that the input domain has known size, 
+    The constructor enforces that the input domain has known size,
     because it must have known size to be valid under a bounded dataset metric.
     
     | `MI`                 | `MI::BoundedMetric` |
@@ -1674,8 +1674,8 @@ def make_metric_unbounded(
     D: RuntimeTypeDescriptor = None,
     MI: RuntimeTypeDescriptor = "ChangeOneDistance"
 ) -> Transformation:
-    """Make a Transformation that converts the bounded dataset metric `MI` 
-    to the respective unbounded dataset metric with a no-op. 
+    """Make a Transformation that converts the bounded dataset metric `MI`
+    to the respective unbounded dataset metric with a no-op.
     
     | `MI`              | `MI::UnboundedMetric` |
     | ----------------- | --------------------- |
@@ -1729,6 +1729,7 @@ def make_ordered_random(
 ) -> Transformation:
     """Make a Transformation that converts the unordered dataset metric `SymmetricDistance`
     to the respective ordered dataset metric `InsertDeleteDistance` by assigning a random permutation.
+    
     | `MI`              | `MI::OrderedMetric`  |
     | ----------------- | -------------------- |
     | SymmetricDistance | InsertDeleteDistance |
@@ -1836,7 +1837,7 @@ def make_resize(
     MI: RuntimeTypeDescriptor = "SymmetricDistance",
     MO: RuntimeTypeDescriptor = "SymmetricDistance"
 ) -> Transformation:
-    """Make a Transformation that either truncates or imputes records 
+    """Make a Transformation that either truncates or imputes records
     with `constant` to match a provided `size`.
     
     [make_resize in Rust documentation.](https://docs.rs/opendp/latest/opendp/transformations/fn.make_resize.html)
@@ -1944,7 +1945,7 @@ def make_sized_bounded_float_checked_sum(
     bounds: Tuple[Any, Any],
     S: RuntimeTypeDescriptor = "Pairwise<T>"
 ) -> Transformation:
-    """Make a Transformation that computes the sum of bounded floats with known dataset size. 
+    """Make a Transformation that computes the sum of bounded floats with known dataset size.
     
     This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility.
     
@@ -1953,7 +1954,7 @@ def make_sized_bounded_float_checked_sum(
     | `Sequential<S::Item>`   | `Vec<S::Item>` |
     | `Pairwise<S::Item>`     | `Vec<S::Item>` |
     
-    `S::Item` is the type of all of the following: 
+    `S::Item` is the type of all of the following:
     each bound, each element in the input data, the output data, and the output sensitivity.
     
     For example, to construct a transformation that pairwise-sums `f32` half-precision floats,
@@ -1963,7 +1964,7 @@ def make_sized_bounded_float_checked_sum(
     
     **Citations:**
     
-    * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf) 
+    * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
     * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
     
     **Supporting Elements:**
@@ -2011,10 +2012,10 @@ def make_sized_bounded_float_ordered_sum(
     bounds: Tuple[Any, Any],
     S: RuntimeTypeDescriptor = "Pairwise<T>"
 ) -> Transformation:
-    """Make a Transformation that computes the sum of bounded floats with known ordering and dataset size. 
+    """Make a Transformation that computes the sum of bounded floats with known ordering and dataset size.
     
     Only useful when `make_bounded_float_checked_sum` returns an error due to potential for overflow.
-    This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility. 
+    This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility.
     You may need to use `make_ordered_random` to impose an ordering on the data.
     
     | S (summation algorithm) | input type     |
@@ -2022,7 +2023,7 @@ def make_sized_bounded_float_ordered_sum(
     | `Sequential<S::Item>`   | `Vec<S::Item>` |
     | `Pairwise<S::Item>`     | `Vec<S::Item>` |
     
-    `S::Item` is the type of all of the following: 
+    `S::Item` is the type of all of the following:
     each bound, each element in the input data, the output data, and the output sensitivity.
     
     For example, to construct a transformation that pairwise-sums `f32` half-precision floats,
@@ -2080,7 +2081,7 @@ def make_sized_bounded_int_checked_sum(
     bounds: Tuple[Any, Any],
     T: RuntimeTypeDescriptor = None
 ) -> Transformation:
-    """Make a Transformation that computes the sum of bounded ints. 
+    """Make a Transformation that computes the sum of bounded ints.
     The effective range is reduced, as (bounds * size) must not overflow.
     
     [make_sized_bounded_int_checked_sum in Rust documentation.](https://docs.rs/opendp/latest/opendp/transformations/fn.make_sized_bounded_int_checked_sum.html)
@@ -2133,7 +2134,7 @@ def make_sized_bounded_int_monotonic_sum(
     bounds: Tuple[Any, Any],
     T: RuntimeTypeDescriptor = None
 ) -> Transformation:
-    """Make a Transformation that computes the sum of bounded ints, 
+    """Make a Transformation that computes the sum of bounded ints,
     where all values share the same sign.
     
     [make_sized_bounded_int_monotonic_sum in Rust documentation.](https://docs.rs/opendp/latest/opendp/transformations/fn.make_sized_bounded_int_monotonic_sum.html)
@@ -2186,9 +2187,9 @@ def make_sized_bounded_int_ordered_sum(
     bounds: Tuple[Any, Any],
     T: RuntimeTypeDescriptor = None
 ) -> Transformation:
-    """Make a Transformation that computes the sum of bounded ints with known dataset size. 
+    """Make a Transformation that computes the sum of bounded ints with known dataset size.
     
-    This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility. 
+    This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility.
     You may need to use `make_ordered_random` to impose an ordering on the data.
     
     [make_sized_bounded_int_ordered_sum in Rust documentation.](https://docs.rs/opendp/latest/opendp/transformations/fn.make_sized_bounded_int_ordered_sum.html)
@@ -2241,9 +2242,9 @@ def make_sized_bounded_int_split_sum(
     bounds: Tuple[Any, Any],
     T: RuntimeTypeDescriptor = None
 ) -> Transformation:
-    """Make a Transformation that computes the sum of bounded ints with known dataset size. 
+    """Make a Transformation that computes the sum of bounded ints with known dataset size.
     
-    This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility. 
+    This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility.
     Adds the saturating sum of the positives to the saturating sum of the negatives.
     
     [make_sized_bounded_int_split_sum in Rust documentation.](https://docs.rs/opendp/latest/opendp/transformations/fn.make_sized_bounded_int_split_sum.html)
@@ -2352,9 +2353,9 @@ def make_sized_bounded_sum(
     MI: RuntimeTypeDescriptor = "SymmetricDistance",
     T: RuntimeTypeDescriptor = None
 ) -> Transformation:
-    """Make a Transformation that computes the sum of bounded data with known dataset size. 
+    """Make a Transformation that computes the sum of bounded data with known dataset size.
     
-    This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility. 
+    This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility.
     Use `make_clamp` to bound data and `make_resize` to establish dataset size.
     
     [make_sized_bounded_sum in Rust documentation.](https://docs.rs/opendp/latest/opendp/transformations/fn.make_sized_bounded_sum.html)
@@ -2404,16 +2405,17 @@ def make_sized_bounded_sum_of_squared_deviations(
     bounds: Tuple[Any, Any],
     S: RuntimeTypeDescriptor = "Pairwise<T>"
 ) -> Transformation:
-    """Make a Transformation that computes the sum of squared deviations of bounded data. 
+    """Make a Transformation that computes the sum of squared deviations of bounded data.
     
-    This uses a restricted-sensitivity proof that takes advantage of known dataset size. 
+    This uses a restricted-sensitivity proof that takes advantage of known dataset size.
     Use `make_clamp` to bound data and `make_resize` to establish dataset size.
+    
     | S (summation algorithm) | input type     |
     | ----------------------- | -------------- |
     | `Sequential<S::Item>`   | `Vec<S::Item>` |
     | `Pairwise<S::Item>`     | `Vec<S::Item>` |
     
-    `S::Item` is the type of all of the following: 
+    `S::Item` is the type of all of the following:
     each bound, each element in the input data, the output data, and the output sensitivity.
     
     For example, to construct a transformation that computes the SSD of `f32` half-precision floats,
@@ -2472,9 +2474,9 @@ def make_sized_bounded_variance(
     ddof: int = 1,
     S: RuntimeTypeDescriptor = "Pairwise<T>"
 ) -> Transformation:
-    """Make a Transformation that computes the variance of bounded data. 
+    """Make a Transformation that computes the variance of bounded data.
     
-    This uses a restricted-sensitivity proof that takes advantage of known dataset size. 
+    This uses a restricted-sensitivity proof that takes advantage of known dataset size.
     Use `make_clamp` to bound data and `make_resize` to establish dataset size.
     
     [make_sized_bounded_variance in Rust documentation.](https://docs.rs/opendp/latest/opendp/transformations/fn.make_sized_bounded_variance.html)

--- a/rust/benches/discrete_laplace/main.rs
+++ b/rust/benches/discrete_laplace/main.rs
@@ -5,14 +5,14 @@ use opendp::{
 };
 
 pub fn collect(c: &mut Criterion) {
-
     (1..20).for_each(|v| {
         let scale = v as f64;
         c.bench_function(format!("{} linear", scale).as_str(), |b| {
             b.iter(|| {
-                let meas =
-                    make_base_discrete_laplace_linear::<VectorDomain<AllDomain<i32>>, _>(scale, None)
-                        .unwrap();
+                let meas = make_base_discrete_laplace_linear::<VectorDomain<AllDomain<i32>>, _>(
+                    scale, None,
+                )
+                .unwrap();
                 meas.invoke(&vec![0; 1000]).unwrap();
             })
         });
@@ -20,7 +20,8 @@ pub fn collect(c: &mut Criterion) {
         c.bench_function(format!("{} cks20", scale).as_str(), |b| {
             b.iter(|| {
                 let meas =
-                    make_base_discrete_laplace_cks20::<VectorDomain<AllDomain<i32>>, _>(scale).unwrap();
+                    make_base_discrete_laplace_cks20::<VectorDomain<AllDomain<i32>>, _>(scale)
+                        .unwrap();
                 meas.invoke(&vec![0; 1000]).unwrap();
             })
         });

--- a/rust/build/derive.rs
+++ b/rust/build/derive.rs
@@ -13,7 +13,7 @@ pub fn main() {
     // rebuild if link paths change
     println!("cargo:rerun-if-env-changed=OPENDP_SPHINX_PORT");
     println!("cargo:rerun-if-env-changed=OPENDP_RUSTDOC_PORT");
-    
+
     println!("cargo:rerun-if-env-changed=OPENDP_REMOTE_SPHINX_URI");
     println!("cargo:rerun-if-env-changed=OPENDP_REMOTE_RUSTDOC_URI");
 
@@ -72,7 +72,7 @@ fn parse_crate(
 fn parse_file_tree(
     dir: &Path,
     proof_paths: &HashMap<String, Option<String>>,
-    module_name: &str
+    module_name: &str,
 ) -> std::io::Result<Option<Vec<Function>>> {
     // use here to shadow syn::File
     use std::{fs::File, io::Read};

--- a/rust/opendp_derive/src/full.rs
+++ b/rust/opendp_derive/src/full.rs
@@ -79,7 +79,10 @@ pub(crate) fn proven(attr_args: TokenStream, input: TokenStream) -> TokenStream 
         _ => unreachable!(),
     };
     // mutate the docstring to add a proof path
-    try_!(insert_proof_attribute(attr_docs, proof_path), original_input);
+    try_!(
+        insert_proof_attribute(attr_docs, proof_path),
+        original_input
+    );
 
     let mut output = TokenStream::new();
 

--- a/rust/opendp_derive/src/lib.rs
+++ b/rust/opendp_derive/src/lib.rs
@@ -5,24 +5,24 @@ mod full;
 
 /// When the opendp crate is compiled with the "derive" feature,
 /// the bootstrap procedural macro is executed on the function it decorates, before the library is compiled.
-/// 
+///
 /// We use this to insert a link to the proof in the documentation of the function, if an adjacent proof exists.
-/// 
+///
 /// We also use this to extract the rust documentation, so that we can reuse it in external language bindings.
 /// The bootstrap macro also looks at the names and types of arguments, the generics used, and the return type
 /// to automatically generate additional documentation and technical information needed for language bindings.
-/// 
-/// External language bindings (like python) oftentimes need some additional metadata-- 
+///
+/// External language bindings (like python) oftentimes need some additional metadata--
 /// like the default value of arguments or types, or how to infer type information from arguments.
 /// This additional metadata is passed directly to the proc-macro itself.
-/// 
+///
 /// # Linking Proofs
-/// 
+///
 /// The proc-macro will look for a proof file for your function. If you are proving `fn my_function`,
-/// and a file named `my_function.tex` is found on the filesystem, 
+/// and a file named `my_function.tex` is found on the filesystem,
 /// the bootstrap macro will insert a link to that file into the documentation.
 /// Depending on the environment, this link will go directly to a versioned docs site, or to a local file.
-/// 
+///
 /// you can also specify the location of the proof file directly:
 /// ```no_run
 /// #[bootstrap(
@@ -35,9 +35,9 @@ mod full;
 /// /// [(Proof Link)](link/to/proof.pdf)
 /// fn my_func() {}
 /// ```
-/// 
+///
 /// Note that when you specify the location of the proof file, it should be relative to the src/ directory.
-/// 
+///
 /// # Features
 /// You can indicate a list of features that must be enabled by the user for the function to exist.
 /// ```no_run
@@ -47,11 +47,11 @@ mod full;
 /// ```
 /// It is recommended to specify features through the `bootstrap` function, not via `cfg` attributes,
 /// because features listed via `bootstrap` are present in external language bindings.
-/// 
+///
 /// # Name
-/// In some situations, you want the name of the function in external languages to be different 
+/// In some situations, you want the name of the function in external languages to be different
 /// from the name of the function in the rust code.
-/// This is useful in situations where the bootstrap macro is invoked directly on extern "C" functions, 
+/// This is useful in situations where the bootstrap macro is invoked directly on extern "C" functions,
 /// like in the core and data modules. You can ignore this in most contexts.
 /// ```no_run
 /// #[bootstrap(
@@ -64,10 +64,10 @@ mod full;
 /// def my_func_renamed():
 ///     pass
 /// ```
-/// 
+///
 /// # Arguments, Generics and Return
 /// You can pass additional metadata that is specific to each argument or generic.
-/// 
+///
 /// ```no_run
 /// #[bootstrap(
 ///     // can specify multiple. Everything is optional
@@ -78,10 +78,10 @@ mod full;
 ///     returns(c_type = "FfiResult<AnyTransformation *>")
 /// )]
 /// ```
-/// 
-/// The rest of this doc comment documents how to specify metadata for 
+///
+/// The rest of this doc comment documents how to specify metadata for
 /// specific arguments, specific generics and the return value.
-/// 
+///
 /// ## Default Value
 /// You can set the default value for arguments and generics in bindings languages:
 /// ```no_run
@@ -94,11 +94,11 @@ mod full;
 /// }
 /// ```
 /// This can make the library more accessible by making some arguments optional with sensible defaults.
-/// 
+///
 /// When specifying the default value for types, you can also specify "int" or "float" instead of concrete types like "i8" or "f32".
 /// "int" refers to the default concrete type for ints, and respectively for floats.
 /// The default concrete types for ints and floats can be configured by users.
-/// 
+///
 /// ## Generics in Default Values
 /// This metadata is specific to default values for generic arguments.
 /// It is used when you want to specify a default type,
@@ -115,14 +115,14 @@ mod full;
 /// }
 /// ```
 /// In the above example, when you pass a constant to the function, the type T is first derived via the "$" macro.
-/// It is then substituted in-place of T in the generics `D` and `M`. 
+/// It is then substituted in-place of T in the generics `D` and `M`.
 /// You can separate multiple generics with commas.
-/// 
+///
 /// ## Type Example
 /// It is often unnecessary for a user to specify the type T, because it can be inferred from other arguments.
 /// In the previous example, the generated bindings for `my_func` will treat the argument `T` as optional,
 /// because it can be inferred from `value`.
-/// 
+///
 /// This breaks down when the public example is embedded in another data structure, like a tuple.
 /// You can provide instructions on how to retrieve an example that can be used to infer a type:
 /// ```no_run
@@ -136,17 +136,17 @@ mod full;
 /// In the generated code, the type argument T becomes optional.
 /// If T is not set, T is inferred from the output of the "$" macro-- inferred from the first bound.
 /// The generated code will run a function, `get_first`, that has been defined locally in the bindings language.
-/// 
+///
 /// You can specify a null default value with the byte-string literal `b"null"`.
-/// 
+///
 /// ## C Type
 /// When used by other languages, data is passed to and from the OpenDP library via C interfaces.
-/// 
+///
 /// The bootstrap macro will infer the correct C type in most situations by inspecting the types in the Rust signature.
 /// There are some cases that are ambiguous, though.
 /// For example, the inferred C type is always "AnyObject *" if the rust type is generic.
 /// However, it is not always necessary to construct an AnyObject; a raw pointer will do.
-/// 
+///
 /// In the following example, the generated bindings would expect `value` to be passed as an "AnyObject *" because it is generic.
 /// ```no_run
 /// #[bootstrap()]
@@ -165,16 +165,16 @@ mod full;
 /// ```
 /// With this annotation, the extern function associated with `my_func` should accept a "value: c_void".
 /// The extern function will downcast the pointer to a concrete rust type based on the argument "T".
-/// 
+///
 /// Note that it is not meaningful to set the C type on generics, as generics are always passed as a "char *".
-/// 
+///
 /// ## Rust Type
-/// For generic arguments, when unpacking data behind "void *" or "AnyObject *", 
+/// For generic arguments, when unpacking data behind "void *" or "AnyObject *",
 /// it is necessary to know the concrete type to downcast to.
 /// This is the purpose of the "rust_type" metadata.
 /// Generally speaking, the bootstrap macro infers the rust type by reading the function arguments in the Rust signature.
 /// In the previous example, the rust type for `value` is automatically inferred to be "T".
-/// 
+///
 /// The rust type for `bounds` in the following function is `(T, T)`.
 /// ```no_run
 /// #[bootstrap()]
@@ -183,7 +183,7 @@ mod full;
 /// }
 /// ```
 /// It is again unnecessary to pass additional metadata about the bounds' rust_type because it is inferred from the Rust signature.
-/// 
+///
 /// Now consider if each bound is wrapped in an enum that indicates if the value is inclusive or exclusive.
 /// It is unclear what the memory layout of the bound enum is in C.
 /// For simplicity, the extern C function slightly changes the interface to be less general by assuming that the bounds are inclusive.
@@ -197,17 +197,17 @@ mod full;
 ///     unimplemented!()
 /// }
 /// ```
-/// In this case, the extern C function is written to expect `bounds: AnyObject *`, 
+/// In this case, the extern C function is written to expect `bounds: AnyObject *`,
 /// the default C type for any nontrivial or generic data structure.
 /// The extern function downcasts said AnyObject to the rust type `(T, T)` and wraps each bound in Bound::Inclusive.
-/// This constructor manually specified the rust_type to smooth over a small difference between the api of the rust function, 
+/// This constructor manually specified the rust_type to smooth over a small difference between the api of the rust function,
 /// and the api of the extern function.
-/// 
-/// 
+///
+///
 /// In a slightly more complicated example, consider the case where the function is generic over some type `S`.
 /// `S` has an associated type `S::Atom`, and the function expects bounds of type `S::Atom`.
 /// The bootstrap macro doesn't know how to handle these associated types.
-/// 
+///
 /// We can instead derive a type, by saying there exists some type T that is inferred from the first bound.
 /// As a developer we have knowledge that our naive tooling doesn't-- that T is the same as S::Atom.
 /// We can then use this inferred type to specify the rust type.
@@ -220,11 +220,11 @@ mod full;
 ///     unimplemented!()
 /// }
 /// ```
-/// In the bindings, the type T is inferred from the first bound, 
-/// and it packs the tuple data structure into an AnyObject of type `(T, T)`. 
+/// In the bindings, the type T is inferred from the first bound,
+/// and it packs the tuple data structure into an AnyObject of type `(T, T)`.
 /// The implementation of the rust extern "C" function downcasts the AnyObject to an `(S::Item, S::Item)`.
 /// This pattern is used often in the sum constructors.
-/// 
+///
 /// It is also possible to specify the rust type via a macro.
 /// Here is an example for the invoke function:
 /// ```no_run
@@ -237,7 +237,7 @@ mod full;
 /// )]
 /// #[no_mangle]
 /// pub extern "C" fn opendp_core__measurement_invoke(
-///     this: *const AnyMeasurement, 
+///     this: *const AnyMeasurement,
 ///     arg: *const AnyObject
 /// ) -> FfiResult<*mut AnyObject> {
 ///     unimplemented!()
@@ -247,10 +247,10 @@ mod full;
 /// Secondly, the rust type of the argument should always be the input carrier type on the measurement.
 /// We use another function `measurement_input_carrier_type`, defined in the bindings, to retrieve this value.
 /// Thus `arg` is always an instance of the Rust type that the measurement expects.
-/// 
-/// Note that it is not meaningful to set the rust type on generics, 
+///
+/// Note that it is not meaningful to set the rust type on generics,
 /// as generics are just type information, passed as a string.
-/// 
+///
 /// ## Hints
 /// This metadata contains a fair amount of Python-only syntax.
 /// It is added as a type hint to the argument in Python.
@@ -261,8 +261,8 @@ mod full;
 /// fn my_func<MO: SensitivityMetric>() {}
 /// ```
 /// The above type MO has a trait bound `SensitivityMetric` that restricts the set of possible types MO can be.
-/// 
-/// The generated code downgrades this to just a type hint. 
+///
+/// The generated code downgrades this to just a type hint.
 /// ```no_run
 /// def my_func(
 ///     MO: SensitivityMetric
@@ -270,13 +270,13 @@ mod full;
 ///     pass
 /// ```
 /// The extern "C" rust function would throw an error if any type that is not a sensitivity metric were passed.
-/// 
+///
 /// ## Do Not Convert
 /// By default, generated bindings code always calls a function to convert between rust types and C types.
 /// This can be disabled on individual arguments by specifying `do_not_convert = true`.
-/// This is typically only useful on the innermost structural utilities, 
+/// This is typically only useful on the innermost structural utilities,
 /// like when converting from an FfiSlice to an AnyObject or vice versa.
-/// 
+///
 #[cfg(feature = "full")]
 #[proc_macro_attribute]
 pub fn bootstrap(attr_args: TokenStream, input: TokenStream) -> TokenStream {
@@ -284,7 +284,7 @@ pub fn bootstrap(attr_args: TokenStream, input: TokenStream) -> TokenStream {
 }
 
 /// When the "derive" crate feature is not enabled, no work is done, and dependencies are simplified.
-/// 
+///
 #[cfg(not(feature = "full"))]
 #[proc_macro_attribute]
 pub fn bootstrap(_attr_args: TokenStream, input: TokenStream) -> TokenStream {
@@ -293,15 +293,15 @@ pub fn bootstrap(_attr_args: TokenStream, input: TokenStream) -> TokenStream {
 
 /// This shares the same interface as the bootstrap macro, but only accepts the first two arguments:
 /// proof_link, and features.
-/// 
-/// This macro differs from bootstrap in that it is much simpler, 
+///
+/// This macro differs from bootstrap in that it is much simpler,
 /// and is meant to be used on internal functions that don't get foreign language bindings.
 /// This macro throws a compile error if the proof file cannot be found.
-/// 
-/// This macro can also be affixed on trait and struct impls. 
-/// When used on a trait impl, it looks for `TraitName.tex`, 
+///
+/// This macro can also be affixed on trait and struct impls.
+/// When used on a trait impl, it looks for `TraitName.tex`,
 /// and when used on a struct impl, it looks for `StructName.tex`.
-/// 
+///
 #[cfg(feature = "full")]
 #[proc_macro_attribute]
 pub fn proven(attr_args: TokenStream, input: TokenStream) -> TokenStream {

--- a/rust/opendp_tooling/src/bootstrap/docstring.rs
+++ b/rust/opendp_tooling/src/bootstrap/docstring.rs
@@ -132,12 +132,13 @@ fn parse_docstring_sections(attrs: Vec<Attribute>) -> Result<HashMap<String, Str
         .map(parse_doc_attribute)
         .collect::<Result<Vec<_>>>()?
         .into_iter()
-        .filter_map(|v|
+        .filter_map(|v| {
             if v.is_empty() {
                 Some(String::new())
             } else {
                 v.starts_with(" ").then(|| v[1..].to_string())
-            })
+            }
+        })
         .collect::<Vec<String>>();
 
     // wrap in headers to prepare for parsing

--- a/rust/opendp_tooling/src/bootstrap/docstring.rs
+++ b/rust/opendp_tooling/src/bootstrap/docstring.rs
@@ -21,7 +21,11 @@ pub struct BootstrapDocstring {
 }
 
 impl BootstrapDocstring {
-    pub fn from_attrs(attrs: Vec<Attribute>, output: &ReturnType, path: Option<(&str, &str)>) -> Result<BootstrapDocstring> {
+    pub fn from_attrs(
+        attrs: Vec<Attribute>,
+        output: &ReturnType,
+        path: Option<(&str, &str)>,
+    ) -> Result<BootstrapDocstring> {
         let mut doc_sections = parse_docstring_sections(attrs)?;
 
         if let Some(sup_elements) = parse_sig_output(output)? {
@@ -35,7 +39,7 @@ impl BootstrapDocstring {
             description.push(String::new());
             description.push(make_rustdoc_link(module, name)?)
         }
-        
+
         let mut add_section_to_description = |section_name: &str| {
             doc_sections.remove(section_name).map(|section| {
                 description.push(format!("\n**{section_name}:**\n"));
@@ -67,11 +71,11 @@ impl BootstrapDocstring {
 }
 
 /// Parses a section that is delimited by bullets into a hashmap.
-/// 
+///
 /// The keys are the arg names and values are the descriptions.
-/// 
+///
 /// # Example
-/// 
+///
 /// ```text
 /// # Arguments
 /// * `a` - a description for argument a
@@ -79,14 +83,14 @@ impl BootstrapDocstring {
 ///         ...multiple lines of description
 /// * `c` - a description for argument c
 /// ```
-/// 
+///
 fn parse_docstring_args(args: String) -> HashMap<String, String> {
     // split by newlines
     let mut args = args
         .split("\n")
         .map(ToString::to_string)
         .collect::<Vec<_>>();
-    
+
     // add a trailing delimiter so that we can use .windows
     args.push("* `".to_string());
 
@@ -120,7 +124,7 @@ fn parse_docstring_args(args: String) -> HashMap<String, String> {
 }
 
 /// Break a vector of syn Attributes into a hashmap.
-/// 
+///
 /// Keys represent section names, and values are the text under the section
 fn parse_docstring_sections(attrs: Vec<Attribute>) -> Result<HashMap<String, String>> {
     let mut docstrings = (attrs.into_iter())
@@ -128,7 +132,12 @@ fn parse_docstring_sections(attrs: Vec<Attribute>) -> Result<HashMap<String, Str
         .map(parse_doc_attribute)
         .collect::<Result<Vec<_>>>()?
         .into_iter()
-        .filter_map(|v| v.starts_with(" ").then(|| v[1..].to_string()))
+        .filter_map(|v|
+            if v.is_empty() {
+                Some(String::new())
+            } else {
+                v.starts_with(" ").then(|| v[1..].to_string())
+            })
         .collect::<Vec<String>>();
 
     // wrap in headers to prepare for parsing
@@ -240,7 +249,6 @@ fn parse_supporting_elements(ty: &Type) -> Result<Option<String>> {
                     ];
 
                     if i != "Function" {
-
                         let output_distance = match i {
                             i if i == "Transformation" => "Metric: ",
                             i if i == "Measurement" => "Measure:",
@@ -349,17 +357,15 @@ fn new_comment_attribute(comment: &str) -> Attribute {
     }
 }
 
-
 pub fn make_rustdoc_link(module: &str, name: &str) -> Result<String> {
-    
     // link from foreign library docs to rust docs
     let proof_uri = if let Ok(rustdoc_port) = std::env::var("OPENDP_RUSTDOC_PORT") {
         format!("http://localhost:{rustdoc_port}")
     } else {
         // find the docs uri
-        let docs_uri = env::var("OPENDP_REMOTE_RUSTDOC_URI")
-            .unwrap_or_else(|_| "https://docs.rs".to_string());
-    
+        let docs_uri =
+            env::var("OPENDP_REMOTE_RUSTDOC_URI").unwrap_or_else(|_| "https://docs.rs".to_string());
+
         // find the version
         let mut version = env!("CARGO_PKG_VERSION");
         if version == "0.0.0+development" {
@@ -369,5 +375,7 @@ pub fn make_rustdoc_link(module: &str, name: &str) -> Result<String> {
         format!("{docs_uri}/opendp/{version}")
     };
 
-    Ok(format!("[{name} in Rust documentation.]({proof_uri}/opendp/{module}/fn.{name}.html)"))
+    Ok(format!(
+        "[{name} in Rust documentation.]({proof_uri}/opendp/{module}/fn.{name}.html)"
+    ))
 }

--- a/rust/opendp_tooling/src/bootstrap/mod.rs
+++ b/rust/opendp_tooling/src/bootstrap/mod.rs
@@ -7,7 +7,7 @@ pub mod arguments;
 pub mod docstring;
 pub mod signature;
 
-use darling::{Result, Error};
+use darling::{Error, Result};
 
 use crate::bootstrap::{arguments::BootstrapArguments, docstring::BootstrapDocstring};
 
@@ -20,7 +20,7 @@ impl Function {
     pub fn from_ast(
         attr_args: AttributeArgs,
         item_fn: ItemFn,
-        module: Option<&str>
+        module: Option<&str>,
     ) -> Result<Function> {
         // Parse the proc bootstrap macro args
         let arguments = BootstrapArguments::from_attribute_args(&attr_args)?;
@@ -29,7 +29,12 @@ impl Function {
         let signature = BootstrapSignature::from_syn(item_fn.sig.clone())?;
 
         // Parse the docstring
-        let path = module.map(|m| (m, arguments.name.as_ref().unwrap_or(&signature.name).as_str()));
+        let path = module.map(|m| {
+            (
+                m,
+                arguments.name.as_ref().unwrap_or(&signature.name).as_str(),
+            )
+        });
         let docstring = BootstrapDocstring::from_attrs(item_fn.attrs, &item_fn.sig.output, path)?;
 
         // aggregate info from all sources
@@ -112,7 +117,7 @@ fn reconcile_generics(
         .map(|name| {
             let boot_type = bootstrap_args.remove(&name).unwrap_or_default();
             if boot_type.c_type.is_some() {
-                return Err(Error::custom("c_type should not be specified on generics"))
+                return Err(Error::custom("c_type should not be specified on generics"));
             }
             Ok(Argument {
                 name: Some(name.clone()),

--- a/rust/opendp_tooling/src/bootstrap/signature.rs
+++ b/rust/opendp_tooling/src/bootstrap/signature.rs
@@ -2,8 +2,8 @@ use std::collections::HashSet;
 
 use darling::{Error, Result};
 use syn::{
-    FnArg, GenericArgument, GenericParam, Pat, Path, PathArguments, Signature, Type, TypeParam,
-    TypePath, TypePtr, TypeReference, ReturnType,
+    FnArg, GenericArgument, GenericParam, Pat, Path, PathArguments, ReturnType, Signature, Type,
+    TypeParam, TypePath, TypePtr, TypeReference,
 };
 
 use crate::TypeRecipe;
@@ -25,19 +25,29 @@ pub struct BootSigArgType {
 
 impl BootstrapSignature {
     pub fn from_syn(sig: Signature) -> Result<Self> {
-        let generics = sig.generics.params.into_iter().map(|generic| {
-            syn_generic_to_syn_type_param(&generic).map(|v| v.ident.to_string())
-        }).collect::<Result<Vec<_>>>()?;
+        let generics = sig
+            .generics
+            .params
+            .into_iter()
+            .map(|generic| syn_generic_to_syn_type_param(&generic).map(|v| v.ident.to_string()))
+            .collect::<Result<Vec<_>>>()?;
         Ok(BootstrapSignature {
             name: sig.ident.to_string(),
-            arguments: sig.inputs.into_iter().map(|fn_arg| {
-                let (pat, ty) = syn_fnarg_to_syn_pattype(fn_arg)?;
-                
-                Ok((syn_pat_to_string(&pat)?, BootSigArgType {
-                    rust_type: syn_type_to_type_recipe(&ty),
-                    c_type: syn_type_to_c_type(ty, &HashSet::from_iter(generics.clone())),
-                }))
-            }).collect::<Result<Vec<_>>>()?,
+            arguments: sig
+                .inputs
+                .into_iter()
+                .map(|fn_arg| {
+                    let (pat, ty) = syn_fnarg_to_syn_pattype(fn_arg)?;
+
+                    Ok((
+                        syn_pat_to_string(&pat)?,
+                        BootSigArgType {
+                            rust_type: syn_type_to_type_recipe(&ty),
+                            c_type: syn_type_to_c_type(ty, &HashSet::from_iter(generics.clone())),
+                        },
+                    ))
+                })
+                .collect::<Result<Vec<_>>>()?,
             generics: generics.clone(),
             output_c_type: syn_type_to_c_type(
                 match sig.output {

--- a/rust/opendp_tooling/src/codegen/python.rs
+++ b/rust/opendp_tooling/src/codegen/python.rs
@@ -155,14 +155,11 @@ fn generate_input_argument(
 
 /// generate a docstring for the current function, with the function description, args, and return
 /// in Sphinx format: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
-fn generate_docstring(
-    func: &Function,
-    hierarchy: &HashMap<String, Vec<String>>,
-) -> String {
+fn generate_docstring(func: &Function, hierarchy: &HashMap<String, Vec<String>>) -> String {
     let description = (func.description.as_ref())
         .map(|v| format!("{}\n", v))
         .unwrap_or_else(String::new);
-    
+
     let doc_args = func
         .args
         .iter()
@@ -369,7 +366,7 @@ fn generate_data_converter(func: &Function, typemap: &HashMap<String, String>) -
         .map(|arg| {
             let name = arg.name();
             if arg.do_not_convert {
-                return format!("c_{name} = {name}")
+                return format!("c_{name} = {name}");
             };
             format!(
                 r#"c_{name} = py_to_c({name}, c_type={c_type}{rust_type_arg})"#,
@@ -447,14 +444,15 @@ output = {call}"#,
     )
 }
 
-
-fn set_dependencies(
-    dependencies: &Vec<TypeRecipe>
-) -> String {
+fn set_dependencies(dependencies: &Vec<TypeRecipe>) -> String {
     if dependencies.is_empty() {
         String::new()
     } else {
-        let dependencies = dependencies.iter().map(|dep| dep.to_python()).collect::<Vec<String>>().join(", ");
+        let dependencies = dependencies
+            .iter()
+            .map(|dep| dep.to_python())
+            .collect::<Vec<String>>()
+            .join(", ");
         format!("output._depends_on({dependencies})")
     }
 }

--- a/rust/opendp_tooling/src/lib.rs
+++ b/rust/opendp_tooling/src/lib.rs
@@ -22,7 +22,7 @@ pub struct Function {
     // metadata for return type
     pub ret: Argument,
     // references to values that should share the same lifetime
-    pub dependencies: Vec<TypeRecipe>
+    pub dependencies: Vec<TypeRecipe>,
 }
 
 // Metadata for function arguments, derived types and returns.
@@ -49,9 +49,8 @@ pub struct Argument {
     //  to prevent the returned AnyObject from getting converted back to python
     pub do_not_convert: bool,
     // when is_type, use this as an example to infer the type
-    pub example: Option<TypeRecipe>
+    pub example: Option<TypeRecipe>,
 }
-
 
 // TypeRecipe contains the metadata to generate code that evaluates to a rust type name
 #[derive(Debug, PartialEq, Clone)]
@@ -59,11 +58,17 @@ pub enum TypeRecipe {
     // reference an existing type
     Name(String),
     // build up a rust type from other rust types
-    Nest { origin: String, args: Vec<TypeRecipe> },
+    Nest {
+        origin: String,
+        args: Vec<TypeRecipe>,
+    },
     // explicitly absent
     None,
     // construct the rust type via function call
-    Function { function: String, params: Vec<TypeRecipe> },
+    Function {
+        function: String,
+        params: Vec<TypeRecipe>,
+    },
 }
 
 // holds literal values, like for default

--- a/rust/opendp_tooling/src/proven/filesystem.rs
+++ b/rust/opendp_tooling/src/proven/filesystem.rs
@@ -105,7 +105,7 @@ pub fn make_proof_link(relative_path: &str) -> Result<String> {
 
         format!("{docs_uri}/en/{version}")
     };
-    
+
     Ok(format!(
         "[(Proof Document)]({proof_uri}/proofs/rust/src/{relative_path}) ",
         relative_path = relative_path.display()

--- a/rust/opendp_tooling/src/proven/mod.rs
+++ b/rust/opendp_tooling/src/proven/mod.rs
@@ -11,21 +11,18 @@ pub mod filesystem;
 pub struct Proven {
     pub proof_path: Option<String>,
     #[darling(default)]
-    pub features: Features
+    pub features: Features,
 }
 
 impl Proven {
     // assumes that proof paths have already been written in the lib's build script
-    pub fn from_ast(
-        attr_args: AttributeArgs,
-        item: Item,
-    ) -> Result<Self> {
+    pub fn from_ast(attr_args: AttributeArgs, item: Item) -> Result<Self> {
         let mut proven = Proven::from_list(&attr_args)?;
 
         if proven.proof_path.is_some() {
             return Ok(proven);
         }
-    
+
         // parse function
         let name = match item {
             Item::Fn(func) => func.sig.ident.to_string(),
@@ -44,23 +41,27 @@ impl Proven {
                     .ident
                     .to_string()
             }
-    
+
             input => {
                 return Err(Error::custom("only functions or impls can be proven").with_span(&input))
             }
         };
-    
+
         let help = "You can specify a path instead: `#[proven(proof_path = \"{{module}}/path/to/proof.tex\")]`";
 
         // we have a hashmap of options. So retrieving a the value at a key gives you an Option<Option<String>>:
         //    None              no path was found
         //    Some(None) means  more than one path was found
         //    Some(Some(path))  one unique path was found
-        
-        proven.proof_path = Some(load_proof_paths()?
-            .remove(&name)
-            .ok_or_else(|| Error::custom(format!("failed to find {name}.tex. {help}")))?
-            .ok_or_else(|| Error::custom(format!("more than one file named {name}.tex. {help}")))?);
+
+        proven.proof_path = Some(
+            load_proof_paths()?
+                .remove(&name)
+                .ok_or_else(|| Error::custom(format!("failed to find {name}.tex. {help}")))?
+                .ok_or_else(|| {
+                    Error::custom(format!("more than one file named {name}.tex. {help}"))
+                })?,
+        );
 
         Ok(proven)
     }

--- a/rust/src/accuracy/ffi.rs
+++ b/rust/src/accuracy/ffi.rs
@@ -40,11 +40,43 @@ macro_rules! build_extern_accuracy {
     }
 }
 
-build_extern_accuracy!(scale, opendp_accuracy__laplacian_scale_to_accuracy, laplacian_scale_to_accuracy);
-build_extern_accuracy!(scale, opendp_accuracy__discrete_laplacian_scale_to_accuracy, discrete_laplacian_scale_to_accuracy);
-build_extern_accuracy!(accuracy, opendp_accuracy__accuracy_to_laplacian_scale, accuracy_to_laplacian_scale);
-build_extern_accuracy!(accuracy, opendp_accuracy__accuracy_to_discrete_laplacian_scale, accuracy_to_discrete_laplacian_scale);
-build_extern_accuracy!(scale, opendp_accuracy__gaussian_scale_to_accuracy, gaussian_scale_to_accuracy);
-build_extern_accuracy!(scale, opendp_accuracy__discrete_gaussian_scale_to_accuracy, discrete_gaussian_scale_to_accuracy);
-build_extern_accuracy!(accuracy, opendp_accuracy__accuracy_to_gaussian_scale, accuracy_to_gaussian_scale);
-build_extern_accuracy!(accuracy, opendp_accuracy__accuracy_to_discrete_gaussian_scale, accuracy_to_discrete_gaussian_scale);
+build_extern_accuracy!(
+    scale,
+    opendp_accuracy__laplacian_scale_to_accuracy,
+    laplacian_scale_to_accuracy
+);
+build_extern_accuracy!(
+    scale,
+    opendp_accuracy__discrete_laplacian_scale_to_accuracy,
+    discrete_laplacian_scale_to_accuracy
+);
+build_extern_accuracy!(
+    accuracy,
+    opendp_accuracy__accuracy_to_laplacian_scale,
+    accuracy_to_laplacian_scale
+);
+build_extern_accuracy!(
+    accuracy,
+    opendp_accuracy__accuracy_to_discrete_laplacian_scale,
+    accuracy_to_discrete_laplacian_scale
+);
+build_extern_accuracy!(
+    scale,
+    opendp_accuracy__gaussian_scale_to_accuracy,
+    gaussian_scale_to_accuracy
+);
+build_extern_accuracy!(
+    scale,
+    opendp_accuracy__discrete_gaussian_scale_to_accuracy,
+    discrete_gaussian_scale_to_accuracy
+);
+build_extern_accuracy!(
+    accuracy,
+    opendp_accuracy__accuracy_to_gaussian_scale,
+    accuracy_to_gaussian_scale
+);
+build_extern_accuracy!(
+    accuracy,
+    opendp_accuracy__accuracy_to_discrete_gaussian_scale,
+    accuracy_to_discrete_gaussian_scale
+);

--- a/rust/src/accuracy/mod.rs
+++ b/rust/src/accuracy/mod.rs
@@ -1,6 +1,6 @@
 //! Convert between noise scales and accuracies.
 
-#[cfg(feature="ffi")]
+#[cfg(feature = "ffi")]
 mod ffi;
 
 use std::f64::consts::SQRT_2;
@@ -15,44 +15,50 @@ use std::fmt::Debug;
 
 #[bootstrap(arguments(scale(c_type = "void *"), alpha(c_type = "void *")))]
 /// Convert a Laplacian scale into an accuracy estimate (tolerance) at a statistical significance level `alpha`.
-/// 
+///
 /// # Arguments
 /// * `scale` - Laplacian noise scale.
 /// * `alpha` - Statistical significance, level-`alpha`, or (1. - `alpha`)100% confidence. Must be within (0, 1].
-/// 
+///
 /// # Generics
 /// * `T` - Data type of `scale` and `alpha`
-pub fn laplacian_scale_to_accuracy<T: Float + Zero + One + Debug>(scale: T, alpha: T) -> Fallible<T> {
+pub fn laplacian_scale_to_accuracy<T: Float + Zero + One + Debug>(
+    scale: T,
+    alpha: T,
+) -> Fallible<T> {
     if scale.is_sign_negative() {
-        return fallible!(InvalidDistance, "scale may not be negative")
+        return fallible!(InvalidDistance, "scale may not be negative");
     }
     if alpha <= T::zero() || T::one() < alpha {
-        return fallible!(InvalidDistance, "alpha ({:?}) must be in (0, 1]")
+        return fallible!(InvalidDistance, "alpha ({:?}) must be in (0, 1]");
     }
     Ok(-scale * alpha.ln())
 }
 
 #[bootstrap(arguments(scale(c_type = "void *"), alpha(c_type = "void *")))]
 /// Convert a discrete Laplacian scale into an accuracy estimate (tolerance) at a statistical significance level `alpha`.
-/// 
+///
 /// $\alpha = P[Y \ge accuracy]$, where $Y = |X - z|$, and $X \sim \mathcal{L}_{Z}(0, scale)$.
 /// That is, $X$ is a discrete Laplace random variable and $Y$ is the distribution of the errors.
-/// 
-/// This function returns a float accuracy. 
+///
+/// This function returns a float accuracy.
 /// You can take the floor without affecting the coverage probability.
-/// 
+///
 /// # Arguments
 /// * `scale` - Discrete Laplacian noise scale.
 /// * `alpha` - Statistical significance, level-`alpha`, or (1. - `alpha`)100% confidence. Must be within (0, 1].
-/// 
+///
 /// # Generics
 /// * `T` - Data type of `scale` and `alpha`
-pub fn discrete_laplacian_scale_to_accuracy<T: Float + Zero + One + Debug>(scale: T, alpha: T) -> Fallible<T> {
+pub fn discrete_laplacian_scale_to_accuracy<T: Float + Zero + One + Debug>(
+    scale: T,
+    alpha: T,
+) -> Fallible<T> {
     if scale.is_sign_negative() {
-        return fallible!(InvalidDistance, "scale may not be negative")
+        return fallible!(InvalidDistance, "scale may not be negative");
     }
     if alpha <= T::zero() || T::one() < alpha {
-        return fallible!(InvalidDistance, "alpha ({:?}) must be in (0, 1]")
+        return fallible!(InvalidDistance, "alpha ({:?}) must be in (0, 1]");
     }
 
     let _1 = T::one();
@@ -68,39 +74,45 @@ pub fn discrete_laplacian_scale_to_accuracy<T: Float + Zero + One + Debug>(scale
 
 #[bootstrap(arguments(accuracy(c_type = "void *"), alpha(c_type = "void *")))]
 /// Convert a desired `accuracy` (tolerance) into a Laplacian noise scale at a statistical significance level `alpha`.
-/// 
+///
 /// # Arguments
 /// * `accuracy` - Desired accuracy. A tolerance for how far values may diverge from the input to the mechanism.
 /// * `alpha` - Statistical significance, level-`alpha`, or (1. - `alpha`)100% confidence. Must be within (0, 1].
-/// 
+///
 /// # Generics
 /// * `T` - Data type of `accuracy` and `alpha`
-/// 
+///
 /// # Returns
 /// Laplacian noise scale that meets the `accuracy` requirement at a given level-`alpha`.
-pub fn accuracy_to_laplacian_scale<T: Float + Zero + One + Debug>(accuracy: T, alpha: T) -> Fallible<T> {
+pub fn accuracy_to_laplacian_scale<T: Float + Zero + One + Debug>(
+    accuracy: T,
+    alpha: T,
+) -> Fallible<T> {
     if accuracy.is_sign_negative() {
-        return fallible!(InvalidDistance, "accuracy may not be negative")
+        return fallible!(InvalidDistance, "accuracy may not be negative");
     }
     if alpha <= T::zero() || T::one() <= alpha {
-        return fallible!(InvalidDistance, "alpha ({:?}) must be in (0, 1)")
+        return fallible!(InvalidDistance, "alpha ({:?}) must be in (0, 1)");
     }
     Ok(-accuracy / alpha.ln())
 }
 
 #[bootstrap(arguments(accuracy(c_type = "void *"), alpha(c_type = "void *")))]
 /// Convert a desired `accuracy` (tolerance) into a discrete Laplacian noise scale at a statistical significance level `alpha`.
-/// 
+///
 /// # Arguments
 /// * `accuracy` - Desired accuracy. A tolerance for how far values may diverge from the input to the mechanism.
 /// * `alpha` - Statistical significance, level-`alpha`, or (1. - `alpha`)100% confidence. Must be within (0, 1].
-/// 
+///
 /// # Generics
 /// * `T` - Data type of `accuracy` and `alpha`
-/// 
+///
 /// # Returns
 /// Discrete laplacian noise scale that meets the `accuracy` requirement at a given level-`alpha`.
-pub fn accuracy_to_discrete_laplacian_scale<T: Float + Zero + One + Debug>(accuracy: T, alpha: T) -> Fallible<T> {
+pub fn accuracy_to_discrete_laplacian_scale<T: Float + Zero + One + Debug>(
+    accuracy: T,
+    alpha: T,
+) -> Fallible<T> {
     // the continuous laplacian scale is an upper bound
     let mut s_max = accuracy_to_laplacian_scale(accuracy, alpha)?;
     let mut s_min = T::zero();
@@ -113,7 +125,7 @@ pub fn accuracy_to_discrete_laplacian_scale<T: Float + Zero + One + Debug>(accur
         let s_mid = s_min + diff / _2;
 
         if s_mid == s_max || s_mid == s_min {
-            return Ok(s_max)
+            return Ok(s_max);
         }
 
         if discrete_laplacian_scale_to_accuracy(s_mid, alpha)? >= accuracy {
@@ -126,41 +138,46 @@ pub fn accuracy_to_discrete_laplacian_scale<T: Float + Zero + One + Debug>(accur
 
 #[bootstrap(arguments(scale(c_type = "void *"), alpha(c_type = "void *")))]
 /// Convert a gaussian scale into an accuracy estimate (tolerance) at a statistical significance level `alpha`.
-/// 
+///
 /// # Arguments
 /// * `scale` - Gaussian noise scale.
 /// * `alpha` - Statistical significance, level-`alpha`, or (1. - `alpha`)100% confidence. Must be within (0, 1].
-/// 
+///
 /// # Generics
 /// * `T` - Data type of `scale` and `alpha`
 pub fn gaussian_scale_to_accuracy<T>(scale: T, alpha: T) -> Fallible<T>
-    where f64: InfCast<T>, T: InfCast<f64> {
+where
+    f64: InfCast<T>,
+    T: InfCast<f64>,
+{
     let scale = f64::inf_cast(scale)?;
     let alpha = f64::inf_cast(alpha)?;
     if scale.is_sign_negative() {
-        return fallible!(InvalidDistance, "scale may not be negative")
+        return fallible!(InvalidDistance, "scale may not be negative");
     }
     if alpha <= 0. || 1. < alpha {
-        return fallible!(InvalidDistance, "alpha ({:?}) must be in (0, 1]")
+        return fallible!(InvalidDistance, "alpha ({:?}) must be in (0, 1]");
     }
     T::inf_cast(scale * SQRT_2 * erf_inv(1. - alpha))
 }
 
-
 #[bootstrap(arguments(scale(c_type = "void *"), alpha(c_type = "void *")))]
 /// Convert a discrete gaussian scale into an accuracy estimate (tolerance) at a statistical significance level `alpha`.
-/// 
+///
 /// # Arguments
 /// * `scale` - Gaussian noise scale.
 /// * `alpha` - Statistical significance, level-`alpha`, or (1. - `alpha`)100% confidence. Must be within (0, 1].
-/// 
+///
 /// # Generics
 /// * `T` - Data type of `scale` and `alpha`
 pub fn discrete_gaussian_scale_to_accuracy<T>(scale: T, alpha: T) -> Fallible<T>
-    where f64: InfCast<T>, T: InfCast<f64> {
+where
+    f64: InfCast<T>,
+    T: InfCast<f64>,
+{
     let scale = f64::inf_cast(scale)?;
     let alpha = f64::inf_cast(alpha)?;
-    
+
     let mut total = (1. - alpha) * dg_normalization_term(scale);
     let mut i = 0;
     total -= dg_pdf(i, scale);
@@ -175,41 +192,45 @@ pub fn discrete_gaussian_scale_to_accuracy<T>(scale: T, alpha: T) -> Fallible<T>
     T::inf_cast((i + 1) as f64)
 }
 
-
 #[bootstrap(arguments(accuracy(c_type = "void *"), alpha(c_type = "void *")))]
 /// Convert a desired `accuracy` (tolerance) into a gaussian noise scale at a statistical significance level `alpha`.
-/// 
+///
 /// # Arguments
 /// * `accuracy` - Desired accuracy. A tolerance for how far values may diverge from the input to the mechanism.
 /// * `alpha` - Statistical significance, level-`alpha`, or (1. - `alpha`)100% confidence. Must be within (0, 1].
-/// 
+///
 /// # Generics
 /// * `T` - Data type of `accuracy` and `alpha`
 pub fn accuracy_to_gaussian_scale<T>(accuracy: T, alpha: T) -> Fallible<T>
-    where f64: InfCast<T>, T: InfCast<f64> {
+where
+    f64: InfCast<T>,
+    T: InfCast<f64>,
+{
     let accuracy = f64::inf_cast(accuracy)?;
     let alpha = f64::inf_cast(alpha)?;
     if accuracy.is_sign_negative() {
-        return fallible!(InvalidDistance, "accuracy may not be negative")
+        return fallible!(InvalidDistance, "accuracy may not be negative");
     }
     if alpha <= 0. || 1. <= alpha {
-        return fallible!(InvalidDistance, "alpha ({:?}) must be in (0, 1)")
+        return fallible!(InvalidDistance, "alpha ({:?}) must be in (0, 1)");
     }
     T::inf_cast(accuracy / SQRT_2 / erf_inv(1. - alpha))
 }
 
-
 #[bootstrap(arguments(accuracy(c_type = "void *"), alpha(c_type = "void *")))]
 /// Convert a desired `accuracy` (tolerance) into a discrete gaussian noise scale at a statistical significance level `alpha`.
-/// 
+///
 /// # Arguments
 /// * `accuracy` - Desired accuracy. A tolerance for how far values may diverge from the input to the mechanism.
 /// * `alpha` - Statistical significance, level-`alpha`, or (1. - `alpha`)100% confidence. Must be within (0, 1].
-/// 
+///
 /// # Generics
 /// * `T` - Data type of `accuracy` and `alpha`
 pub fn accuracy_to_discrete_gaussian_scale<T>(accuracy: T, alpha: T) -> Fallible<T>
-    where f64: InfCast<T>, T: InfCast<f64> {
+where
+    f64: InfCast<T>,
+    T: InfCast<f64>,
+{
     let accuracy = f64::inf_cast(accuracy)?;
     let alpha = f64::inf_cast(alpha)?;
 
@@ -226,7 +247,7 @@ pub fn accuracy_to_discrete_gaussian_scale<T>(accuracy: T, alpha: T) -> Fallible
         let s_mid = s_min + diff / 2.;
 
         if s_mid == s_max || s_mid == s_min {
-            return T::inf_cast(s_max)
+            return T::inf_cast(s_max);
         }
 
         let success_prob = exponential_sum(accuracy as i32, s_mid) / dg_normalization_term(s_mid);
@@ -237,7 +258,6 @@ pub fn accuracy_to_discrete_gaussian_scale<T>(accuracy: T, alpha: T) -> Fallible
         }
     }
 }
-
 
 fn dg_pdf(x: i32, scale: f64) -> f64 {
     (-(x as f64 / scale).powi(2) / 2.).exp()
@@ -250,22 +270,24 @@ fn dg_normalization_term(scale: f64) -> f64 {
         i += 1;
         let density_i = 2. * dg_pdf(i, scale);
         if density_i.is_zero() {
-            return total
+            return total;
         }
         total += density_i;
     }
 }
 
-
-#[cfg(all(test, feature="untrusted"))]
+#[cfg(all(test, feature = "untrusted"))]
 pub mod test {
     use std::fmt::Debug;
     use std::ops::{Mul, Sub};
 
     use super::*;
-    use crate::measurements::{make_base_laplace, make_base_gaussian, make_base_discrete_laplace, make_base_discrete_gaussian};
-    use crate::error::ExplainUnwrap;
     use crate::domains::AllDomain;
+    use crate::error::ExplainUnwrap;
+    use crate::measurements::{
+        make_base_discrete_gaussian, make_base_discrete_laplace, make_base_gaussian,
+        make_base_laplace,
+    };
     use crate::measures::ZeroConcentratedDivergence;
 
     #[test]
@@ -300,74 +322,115 @@ pub mod test {
         Ok(())
     }
 
-    fn print_statement<T: Copy + Debug + One + From<i8> + Sub<Output=T> + Mul<Output=T>>(dist: &str, scale: T, accuracy: T, alpha: T) {
+    fn print_statement<T: Copy + Debug + One + From<i8> + Sub<Output = T> + Mul<Output = T>>(
+        dist: &str,
+        scale: T,
+        accuracy: T,
+        alpha: T,
+    ) {
         let _100 = T::from(100);
-        println!("When the {dist} scale is {scale:?}, the DP estimate differs from the true value \
+        println!(
+            "When the {dist} scale is {scale:?}, the DP estimate differs from the true value \
                     by no more than {accuracy:?} at a level-alpha of {alpha:?}, \
                     or with (1 - {alpha:?})100% = {perc:.2?}% confidence.",
-                 dist = dist, scale = scale,
-                 accuracy = accuracy, alpha = alpha, perc = (T::one() - alpha) * _100);
+            dist = dist,
+            scale = scale,
+            accuracy = accuracy,
+            alpha = alpha,
+            perc = (T::one() - alpha) * _100
+        );
     }
 
     #[test]
     fn test_laplacian_scale_to_accuracy() -> Fallible<()> {
-        macro_rules! check_laplacian_scale_to_accuracy {(scale=$scale:literal, alpha=$alpha:literal) =>
-            (print_statement("laplacian", $scale, laplacian_scale_to_accuracy($scale, $alpha)?, $alpha))
+        macro_rules! check_laplacian_scale_to_accuracy {
+            (scale=$scale:literal, alpha=$alpha:literal) => {
+                print_statement(
+                    "laplacian",
+                    $scale,
+                    laplacian_scale_to_accuracy($scale, $alpha)?,
+                    $alpha,
+                )
+            };
         }
-        check_laplacian_scale_to_accuracy!(scale=1., alpha=0.05);
-        check_laplacian_scale_to_accuracy!(scale=2., alpha=0.05);
-        check_laplacian_scale_to_accuracy!(scale=0., alpha=0.55);
+        check_laplacian_scale_to_accuracy!(scale = 1., alpha = 0.05);
+        check_laplacian_scale_to_accuracy!(scale = 2., alpha = 0.05);
+        check_laplacian_scale_to_accuracy!(scale = 0., alpha = 0.55);
         Ok(())
     }
 
     #[test]
     pub fn test_accuracy_to_laplacian_scale() -> Fallible<()> {
-        macro_rules! check_accuracy_to_laplacian_scale {(accuracy=$accuracy:literal, alpha=$alpha:literal) =>
-            (print_statement("laplacian", accuracy_to_laplacian_scale($accuracy, $alpha)?, $accuracy, $alpha))
+        macro_rules! check_accuracy_to_laplacian_scale {
+            (accuracy=$accuracy:literal, alpha=$alpha:literal) => {
+                print_statement(
+                    "laplacian",
+                    accuracy_to_laplacian_scale($accuracy, $alpha)?,
+                    $accuracy,
+                    $alpha,
+                )
+            };
         }
-        check_accuracy_to_laplacian_scale!(accuracy=1., alpha=0.05);
-        check_accuracy_to_laplacian_scale!(accuracy=2., alpha=0.05);
-        check_accuracy_to_laplacian_scale!(accuracy=0.01, alpha=0.1);
+        check_accuracy_to_laplacian_scale!(accuracy = 1., alpha = 0.05);
+        check_accuracy_to_laplacian_scale!(accuracy = 2., alpha = 0.05);
+        check_accuracy_to_laplacian_scale!(accuracy = 0.01, alpha = 0.1);
         Ok(())
     }
 
     #[test]
     pub fn test_gaussian_scale_to_accuracy() -> Fallible<()> {
-        macro_rules! check_gaussian_scale_to_accuracy {(scale=$scale:literal, alpha=$alpha:literal) =>
-            (print_statement("gaussian", $scale, gaussian_scale_to_accuracy($scale, $alpha)?, $alpha))
+        macro_rules! check_gaussian_scale_to_accuracy {
+            (scale=$scale:literal, alpha=$alpha:literal) => {
+                print_statement(
+                    "gaussian",
+                    $scale,
+                    gaussian_scale_to_accuracy($scale, $alpha)?,
+                    $alpha,
+                )
+            };
         }
 
-        check_gaussian_scale_to_accuracy!(scale=1., alpha=0.05);
-        check_gaussian_scale_to_accuracy!(scale=2., alpha=0.10);
-        check_gaussian_scale_to_accuracy!(scale=3., alpha=0.55);
+        check_gaussian_scale_to_accuracy!(scale = 1., alpha = 0.05);
+        check_gaussian_scale_to_accuracy!(scale = 2., alpha = 0.10);
+        check_gaussian_scale_to_accuracy!(scale = 3., alpha = 0.55);
         Ok(())
     }
 
     #[test]
     pub fn test_accuracy_to_gaussian_scale() -> Fallible<()> {
-        macro_rules! check_accuracy_to_gaussian_scale {(accuracy=$accuracy:literal, alpha=$alpha:literal) =>
-            (print_statement("gaussian", accuracy_to_gaussian_scale($accuracy, $alpha)?, $accuracy, $alpha))
+        macro_rules! check_accuracy_to_gaussian_scale {
+            (accuracy=$accuracy:literal, alpha=$alpha:literal) => {
+                print_statement(
+                    "gaussian",
+                    accuracy_to_gaussian_scale($accuracy, $alpha)?,
+                    $accuracy,
+                    $alpha,
+                )
+            };
         }
-        check_accuracy_to_gaussian_scale!(accuracy=1., alpha=0.05);
-        check_accuracy_to_gaussian_scale!(accuracy=2., alpha=0.05);
-        check_accuracy_to_gaussian_scale!(accuracy=1.2, alpha=0.1);
+        check_accuracy_to_gaussian_scale!(accuracy = 1., alpha = 0.05);
+        check_accuracy_to_gaussian_scale!(accuracy = 2., alpha = 0.05);
+        check_accuracy_to_gaussian_scale!(accuracy = 1.2, alpha = 0.1);
         Ok(())
     }
-
 
     #[test]
     fn test_relative_laplacian_scale_to_accuracy() -> Fallible<()> {
         // fix the scale.
         // you get a tighter accuracy interval when you require greater statistical significance
         // a higher confidence accuracy interval is wider than a lower confidence accuracy interval
-        assert!(laplacian_scale_to_accuracy(1., 0.05)? // 95% confidence
-            > laplacian_scale_to_accuracy(1., 0.06)?); // 94% confidence
+        assert!(
+            laplacian_scale_to_accuracy(1., 0.05)? // 95% confidence
+            > laplacian_scale_to_accuracy(1., 0.06)?
+        ); // 94% confidence
 
         // fix the alpha/statistical significance.
         // you get a tighter accuracy interval when there is less noise
         // a less noisy sample produces a tighter/smaller accuracy interval
-        assert!(laplacian_scale_to_accuracy(2., 0.05)? // 95% confidence
-            > laplacian_scale_to_accuracy(1., 0.05)?); // 95% confidence
+        assert!(
+            laplacian_scale_to_accuracy(2., 0.05)? // 95% confidence
+            > laplacian_scale_to_accuracy(1., 0.05)?
+        ); // 95% confidence
 
         Ok(())
     }
@@ -378,13 +441,17 @@ pub mod test {
         // if I want more confidence in the result, then I should have less noise
         // you get a larger noise scale when you require greater statistical significance
         // a higher confidence laplace scale is smaller than a lower confidence laplace scale
-        assert!(accuracy_to_laplacian_scale(1., 0.05)? // 95% confidence
-            < accuracy_to_laplacian_scale(1., 0.06)?); // 94% confidence
+        assert!(
+            accuracy_to_laplacian_scale(1., 0.05)? // 95% confidence
+            < accuracy_to_laplacian_scale(1., 0.06)?
+        ); // 94% confidence
 
         // fix alpha/statistical significance.
         // you get a larger noise scale when there is a wider accuracy interval
-        assert!(accuracy_to_laplacian_scale(2., 0.05)? // 95% confidence
-            > accuracy_to_laplacian_scale(1., 0.05)?); // 95% confidence
+        assert!(
+            accuracy_to_laplacian_scale(2., 0.05)? // 95% confidence
+            > accuracy_to_laplacian_scale(1., 0.05)?
+        ); // 95% confidence
 
         Ok(())
     }
@@ -394,14 +461,18 @@ pub mod test {
         // fix the scale.
         // you get a tighter accuracy interval when you require greater statistical significance
         // a higher confidence accuracy interval is wider than a lower confidence accuracy interval
-        assert!(gaussian_scale_to_accuracy(1., 0.05)? // 95% confidence
-            > gaussian_scale_to_accuracy(1., 0.06)?); // 94% confidence
+        assert!(
+            gaussian_scale_to_accuracy(1., 0.05)? // 95% confidence
+            > gaussian_scale_to_accuracy(1., 0.06)?
+        ); // 94% confidence
 
         // fix the alpha/statistical significance.
         // you get a tighter accuracy interval when there is less noise
         // a less noisy sample produces a tighter/smaller accuracy interval
-        assert!(gaussian_scale_to_accuracy(2., 0.05)? // 95% confidence
-            > gaussian_scale_to_accuracy(1., 0.05)?); // 95% confidence
+        assert!(
+            gaussian_scale_to_accuracy(2., 0.05)? // 95% confidence
+            > gaussian_scale_to_accuracy(1., 0.05)?
+        ); // 95% confidence
 
         Ok(())
     }
@@ -412,13 +483,17 @@ pub mod test {
         // if I want more confidence in the result, then I should have less noise
         // you get a larger noise scale when you require greater statistical significance
         // a higher confidence noise scale is smaller than a lower confidence noise scale
-        assert!(accuracy_to_gaussian_scale(1., 0.05)? // 95% confidence
-            < accuracy_to_gaussian_scale(1., 0.06)?); // 94% confidence
+        assert!(
+            accuracy_to_gaussian_scale(1., 0.05)? // 95% confidence
+            < accuracy_to_gaussian_scale(1., 0.06)?
+        ); // 94% confidence
 
         // fix alpha/statistical significance.
         // you get a larger noise scale when there is a wider accuracy interval
-        assert!(accuracy_to_gaussian_scale(2., 0.05)? // 95% confidence
-            > accuracy_to_gaussian_scale(1., 0.05)?); // 95% confidence
+        assert!(
+            accuracy_to_gaussian_scale(2., 0.05)? // 95% confidence
+            > accuracy_to_gaussian_scale(1., 0.05)?
+        ); // 95% confidence
         Ok(())
     }
 
@@ -431,7 +506,8 @@ pub mod test {
         let n = 50_000;
         let empirical_alpha = (0..n)
             .filter(|_| base_laplace.invoke(&0.0).unwrap_test().abs() > accuracy)
-            .count() as f64 / n as f64;
+            .count() as f64
+            / n as f64;
 
         println!("Laplacian significance levels/alpha");
         println!("Theoretical: {:?}", theoretical_alpha);
@@ -445,11 +521,13 @@ pub mod test {
         let accuracy = 1.0;
         let theoretical_alpha = 0.05;
         let scale = accuracy_to_gaussian_scale(accuracy, theoretical_alpha)?;
-        let base_gaussian = make_base_gaussian::<AllDomain<f64>, ZeroConcentratedDivergence<_>>(scale, Some(-100))?;
+        let base_gaussian =
+            make_base_gaussian::<AllDomain<f64>, ZeroConcentratedDivergence<_>>(scale, Some(-100))?;
         let n = 50_000;
         let empirical_alpha = (0..n)
             .filter(|_| base_gaussian.invoke(&0.0).unwrap_test().abs() > accuracy)
-            .count() as f64 / n as f64;
+            .count() as f64
+            / n as f64;
 
         println!("Gaussian significance levels/alpha");
         println!("Theoretical: {:?}", theoretical_alpha);
@@ -468,7 +546,8 @@ pub mod test {
         let n = 50_000;
         let empirical_alpha = (0..n)
             .filter(|_| base_dl.invoke(&0).unwrap_test().clamp(-127, 127).abs() >= accuracy)
-            .count() as f64 / n as f64;
+            .count() as f64
+            / n as f64;
 
         println!("Discrete laplace significance levels/alpha");
         println!("Theoretical: {:?}", theoretical_alpha);
@@ -485,11 +564,15 @@ pub mod test {
         // let scale = 12.503562372734077;
 
         println!("scale: {}", scale);
-        let base_dg = make_base_discrete_gaussian::<AllDomain<i8>, ZeroConcentratedDivergence<f64>, i32>(scale)?;
+        let base_dg =
+            make_base_discrete_gaussian::<AllDomain<i8>, ZeroConcentratedDivergence<f64>, i32>(
+                scale,
+            )?;
         let n = 50_000;
         let empirical_alpha = (0..n)
             .filter(|_| base_dg.invoke(&0).unwrap_test().clamp(-127, 127).abs() >= accuracy)
-            .count() as f64 / n as f64;
+            .count() as f64
+            / n as f64;
 
         println!("Discrete gaussian significance levels/alpha");
         println!("Theoretical: {:?}", theoretical_alpha);
@@ -502,10 +585,12 @@ pub mod test {
     pub fn test_roundtrip() -> Fallible<()> {
         let accuracy = 1.;
         let alpha = 0.05;
-        let accuracy_2 = gaussian_scale_to_accuracy(accuracy_to_gaussian_scale(accuracy, alpha)?, alpha)?;
+        let accuracy_2 =
+            gaussian_scale_to_accuracy(accuracy_to_gaussian_scale(accuracy, alpha)?, alpha)?;
         assert!((accuracy - accuracy_2).abs() < 1e-8);
 
-        let accuracy_2 = laplacian_scale_to_accuracy(accuracy_to_laplacian_scale(accuracy, alpha)?, alpha)?;
+        let accuracy_2 =
+            laplacian_scale_to_accuracy(accuracy_to_laplacian_scale(accuracy, alpha)?, alpha)?;
         assert!((accuracy - accuracy_2).abs() < 1e-8);
         Ok(())
     }

--- a/rust/src/combinators/amplify/ffi.rs
+++ b/rust/src/combinators/amplify/ffi.rs
@@ -4,26 +4,39 @@ use opendp_derive::bootstrap;
 
 use crate::combinators::{AmplifiableMeasure, IsSizedDomain};
 use crate::core::FfiResult;
-use crate::measures::{MaxDivergence, FixedSmoothedMaxDivergence};
 use crate::domains::{AllDomain, BoundedDomain, SizedDomain, VectorDomain};
 use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMeasure, AnyMeasurement, AnyObject, Downcast};
 use crate::ffi::util::Type;
-use crate::traits::{ExactIntCast, InfMul, InfExpM1, InfLn1P, InfDiv, TotalOrd, CheckNull};
+use crate::measures::{FixedSmoothedMaxDivergence, MaxDivergence};
+use crate::traits::{CheckNull, ExactIntCast, InfDiv, InfExpM1, InfLn1P, InfMul, TotalOrd};
 
 impl AmplifiableMeasure for AnyMeasure {
     fn amplify(
-        &self, budget: &AnyObject, population_size: usize, sample_size: usize,
+        &self,
+        budget: &AnyObject,
+        population_size: usize,
+        sample_size: usize,
     ) -> Fallible<AnyObject> {
-        fn monomorphize1<QO: 'static + ExactIntCast<usize> + InfMul + InfExpM1 + InfLn1P + InfDiv + Clone>(
-            measure: &AnyMeasure, budget: &AnyObject, population_size: usize, sample_size: usize,
+        fn monomorphize1<
+            QO: 'static + ExactIntCast<usize> + InfMul + InfExpM1 + InfLn1P + InfDiv + Clone,
+        >(
+            measure: &AnyMeasure,
+            budget: &AnyObject,
+            population_size: usize,
+            sample_size: usize,
         ) -> Fallible<AnyObject> {
             fn monomorphize2<M: 'static + AmplifiableMeasure>(
-                measure: &AnyMeasure, budget: &AnyObject, population_size: usize, sample_size: usize,
+                measure: &AnyMeasure,
+                budget: &AnyObject,
+                population_size: usize,
+                sample_size: usize,
             ) -> Fallible<AnyObject> {
                 let measure = measure.downcast_ref::<M>()?;
                 let budget = budget.downcast_ref::<M::Distance>()?;
-                measure.amplify(budget, population_size, sample_size).map(AnyObject::new)
+                measure
+                    .amplify(budget, population_size, sample_size)
+                    .map(AnyObject::new)
             }
             let measure_type = Type::of_id(&measure.measure.value.type_id())?;
             dispatch!(monomorphize2, [
@@ -38,12 +51,23 @@ impl AmplifiableMeasure for AnyMeasure {
 impl IsSizedDomain for AnyDomain {
     fn get_size(&self) -> Fallible<usize> {
         fn monomorphize1<TIA>(domain: &AnyDomain, DIA: Type) -> Fallible<usize>
-            where TIA: 'static + Clone + TotalOrd + CheckNull {
+        where
+            TIA: 'static + Clone + TotalOrd + CheckNull,
+        {
             fn monomorphize2<DIA: IsSizedDomain>(domain: &AnyDomain) -> Fallible<usize>
-                where DIA: 'static,
-                      DIA::Carrier: 'static + Clone {
-                domain.downcast_ref::<DIA>()
-                    .map_err(|_| err!(FFI, "failed to downcast AnyDomain to {}", Type::of::<DIA>().to_string()))?
+            where
+                DIA: 'static,
+                DIA::Carrier: 'static + Clone,
+            {
+                domain
+                    .downcast_ref::<DIA>()
+                    .map_err(|_| {
+                        err!(
+                            FFI,
+                            "failed to downcast AnyDomain to {}",
+                            Type::of::<DIA>().to_string()
+                        )
+                    })?
                     .get_size()
             }
 
@@ -65,30 +89,28 @@ impl IsSizedDomain for AnyDomain {
     dependencies("$get_dependencies(measurement)")
 )]
 /// Construct an amplified measurement from a `measurement` with privacy amplification by subsampling.
-/// This measurement does not perform any sampling. 
+/// This measurement does not perform any sampling.
 /// It is useful when you have a dataset on-hand that is a simple random sample from a larger population.
-/// 
+///
 /// The DIA, DO, MI and MO between the input measurement and amplified output measurement all match.
-/// 
-/// Protected by the "honest-but-curious" feature flag 
+///
+/// Protected by the "honest-but-curious" feature flag
 /// because a dishonest adversary could set the population size to be arbitrarily large.
-/// 
+///
 /// # Arguments
 /// * `measurement` - the computation to amplify
 /// * `population_size` - the size of the population from which the input dataset is a simple sample
 fn make_population_amplification(
     measurement: &AnyMeasurement,
-    population_size: usize
+    population_size: usize,
 ) -> Fallible<AnyMeasurement> {
     super::make_population_amplification(measurement, population_size)
 }
 
 #[no_mangle]
 pub extern "C" fn opendp_combinators__make_population_amplification(
-    measurement: *const AnyMeasurement, population_size: c_uint,
+    measurement: *const AnyMeasurement,
+    population_size: c_uint,
 ) -> FfiResult<*mut AnyMeasurement> {
-    make_population_amplification(
-        try_as_ref!(measurement),
-        population_size as usize).into()
+    make_population_amplification(try_as_ref!(measurement), population_size as usize).into()
 }
-

--- a/rust/src/combinators/amplify/mod.rs
+++ b/rust/src/combinators/amplify/mod.rs
@@ -1,84 +1,125 @@
-#[cfg(feature="ffi")]
+#[cfg(feature = "ffi")]
 mod ffi;
 
-use crate::core::{Domain, Measurement, Metric, PrivacyMap, Measure};
-use crate::measures::{MaxDivergence, FixedSmoothedMaxDivergence};
-use crate::domains::{SizedDomain};
+use crate::core::{Domain, Measure, Measurement, Metric, PrivacyMap};
+use crate::domains::SizedDomain;
 use crate::error::Fallible;
-use crate::traits::{ExactIntCast, InfMul, InfExpM1, InfLn1P, InfDiv, CollectionSize};
+use crate::measures::{FixedSmoothedMaxDivergence, MaxDivergence};
+use crate::traits::{CollectionSize, ExactIntCast, InfDiv, InfExpM1, InfLn1P, InfMul};
 
-pub trait IsSizedDomain: Domain { fn get_size(&self) -> Fallible<usize>; }
-impl<D: Domain> IsSizedDomain for SizedDomain<D> where D::Carrier: CollectionSize {
-    fn get_size(&self) -> Fallible<usize> { Ok(self.size) }
+pub trait IsSizedDomain: Domain {
+    fn get_size(&self) -> Fallible<usize>;
+}
+impl<D: Domain> IsSizedDomain for SizedDomain<D>
+where
+    D::Carrier: CollectionSize,
+{
+    fn get_size(&self) -> Fallible<usize> {
+        Ok(self.size)
+    }
 }
 
 pub trait AmplifiableMeasure: Measure {
-    fn amplify(&self, budget: &Self::Distance, population_size: usize, sample_size: usize) -> Fallible<Self::Distance>;
+    fn amplify(
+        &self,
+        budget: &Self::Distance,
+        population_size: usize,
+        sample_size: usize,
+    ) -> Fallible<Self::Distance>;
 }
 
 impl<Q> AmplifiableMeasure for MaxDivergence<Q>
-    where Q: ExactIntCast<usize> + InfMul + InfExpM1 + InfLn1P + InfDiv + Clone {
+where
+    Q: ExactIntCast<usize> + InfMul + InfExpM1 + InfLn1P + InfDiv + Clone,
+{
     fn amplify(&self, epsilon: &Q, population_size: usize, sample_size: usize) -> Fallible<Q> {
-        let sampling_rate = Q::exact_int_cast(sample_size)?.inf_div(&Q::exact_int_cast(population_size)?)?;
-        epsilon.clone().inf_exp_m1()?.inf_mul(&sampling_rate)?.inf_ln_1p()
+        let sampling_rate =
+            Q::exact_int_cast(sample_size)?.inf_div(&Q::exact_int_cast(population_size)?)?;
+        epsilon
+            .clone()
+            .inf_exp_m1()?
+            .inf_mul(&sampling_rate)?
+            .inf_ln_1p()
     }
 }
 impl<Q> AmplifiableMeasure for FixedSmoothedMaxDivergence<Q>
-    where Q: ExactIntCast<usize> + InfMul + InfExpM1 + InfLn1P + InfDiv + Clone {
-    fn amplify(&self, (epsilon, delta): &(Q, Q), population_size: usize, sample_size: usize) -> Fallible<(Q, Q)> {
-        let sampling_rate = Q::exact_int_cast(sample_size)?.inf_div(&Q::exact_int_cast(population_size)?)?;
-        Ok((epsilon.clone().inf_exp_m1()?.inf_mul(&sampling_rate)?.inf_ln_1p()?, delta.inf_mul(&sampling_rate)?))
+where
+    Q: ExactIntCast<usize> + InfMul + InfExpM1 + InfLn1P + InfDiv + Clone,
+{
+    fn amplify(
+        &self,
+        (epsilon, delta): &(Q, Q),
+        population_size: usize,
+        sample_size: usize,
+    ) -> Fallible<(Q, Q)> {
+        let sampling_rate =
+            Q::exact_int_cast(sample_size)?.inf_div(&Q::exact_int_cast(population_size)?)?;
+        Ok((
+            epsilon
+                .clone()
+                .inf_exp_m1()?
+                .inf_mul(&sampling_rate)?
+                .inf_ln_1p()?,
+            delta.inf_mul(&sampling_rate)?,
+        ))
     }
 }
 
 /// Construct an amplified measurement from a `measurement` with privacy amplification by subsampling.
-/// This measurement does not perform any sampling. 
+/// This measurement does not perform any sampling.
 /// It is useful when you have a dataset on-hand that is a simple random sample from a larger population.
-/// 
+///
 /// The `DIA`, `DO`, `MI` and `MO` between the input measurement and amplified output measurement all match.
-/// 
+///
 /// # Arguments
 /// * `measurement` - the computation to apply privacy amplification to
 /// * `population_size` - the size of the population from which the input dataset is a simple sample
-/// 
+///
 /// # Generics
 /// * `DIA` - Atomic Input Domain. The domain of individual records in the input dataset.
-/// * `DO` - Output Domain. 
+/// * `DO` - Output Domain.
 /// * `MI` - Input Metric.
 /// * `MO` - Output Metric.
 pub fn make_population_amplification<DIA, TO, MI, MO>(
     measurement: &Measurement<DIA, TO, MI, MO>,
     population_size: usize,
 ) -> Fallible<Measurement<DIA, TO, MI, MO>>
-    where DIA: IsSizedDomain,
-          MI: 'static + Metric,
-          MO: 'static + AmplifiableMeasure {
+where
+    DIA: IsSizedDomain,
+    MI: 'static + Metric,
+    MO: 'static + AmplifiableMeasure,
+{
     let mut measurement = measurement.clone();
     let sample_size = measurement.input_domain.get_size()?;
-    if population_size < sample_size { 
-        return fallible!(MakeMeasurement, "population size cannot be less than sample size") 
+    if population_size < sample_size {
+        return fallible!(
+            MakeMeasurement,
+            "population size cannot be less than sample size"
+        );
     }
 
     let privacy_map = measurement.privacy_map;
     let output_measure: MO = measurement.output_measure.clone();
 
-    measurement.privacy_map = PrivacyMap::new_fallible(
-        move |d_in| output_measure.amplify(&privacy_map.eval(d_in)?, population_size, sample_size));
+    measurement.privacy_map = PrivacyMap::new_fallible(move |d_in| {
+        output_measure.amplify(&privacy_map.eval(d_in)?, population_size, sample_size)
+    });
 
     Ok(measurement)
 }
 
 #[cfg(test)]
 mod test {
-    use crate::metrics::SymmetricDistance;
-    use crate::error::Fallible;
-    use crate::transformations::make_sized_bounded_mean;
-    use crate::measurements::make_base_laplace;
     use crate::combinators::make_population_amplification;
+    use crate::error::Fallible;
+    use crate::measurements::make_base_laplace;
+    use crate::metrics::SymmetricDistance;
+    use crate::transformations::make_sized_bounded_mean;
 
     #[test]
     fn test_amplifier() -> Fallible<()> {
-        let meas = (make_sized_bounded_mean::<SymmetricDistance, _>(10, (0., 10.))? >> make_base_laplace(0.5, None)?)?;
+        let meas = (make_sized_bounded_mean::<SymmetricDistance, _>(10, (0., 10.))?
+            >> make_base_laplace(0.5, None)?)?;
         let amp = make_population_amplification(&meas, 100)?;
         amp.function.eval(&vec![1.; 10])?;
         assert!(meas.check(&2, &(2. + 1e-6))?);

--- a/rust/src/combinators/chain/ffi.rs
+++ b/rust/src/combinators/chain/ffi.rs
@@ -3,12 +3,18 @@ use opendp_derive::bootstrap;
 use crate::core::FfiResult;
 
 use crate::error::Fallible;
-use crate::ffi::any::{AnyMeasurement, AnyTransformation, AnyFunction};
+use crate::ffi::any::{AnyFunction, AnyMeasurement, AnyTransformation};
 
 #[bootstrap(
     features("contrib"),
-    arguments(measurement1(rust_type = b"null"), transformation0(rust_type = b"null")),
-    dependencies("$get_dependencies(measurement1)", "$get_dependencies(transformation0)")
+    arguments(
+        measurement1(rust_type = b"null"),
+        transformation0(rust_type = b"null")
+    ),
+    dependencies(
+        "$get_dependencies(measurement1)",
+        "$get_dependencies(transformation0)"
+    )
 )]
 /// Construct the functional composition (`measurement1` ○ `transformation0`).
 /// Returns a Measurement that when invoked, computes `measurement1(transformation0(x))`.
@@ -35,8 +41,14 @@ pub extern "C" fn opendp_combinators__make_chain_mt(
 
 #[bootstrap(
     features("contrib"),
-    arguments(transformation1(rust_type = b"null"), transformation0(rust_type = b"null")),
-    dependencies("$get_dependencies(transformation1)", "$get_dependencies(transformation0)")
+    arguments(
+        transformation1(rust_type = b"null"),
+        transformation0(rust_type = b"null")
+    ),
+    dependencies(
+        "$get_dependencies(transformation1)",
+        "$get_dependencies(transformation0)"
+    )
 )]
 /// Construct the functional composition (`transformation1` ○ `transformation0`).
 /// Returns a Transformation that when invoked, computes `transformation1(transformation0(x))`.

--- a/rust/src/combinators/chain/mod.rs
+++ b/rust/src/combinators/chain/mod.rs
@@ -1,9 +1,11 @@
-#[cfg(feature="ffi")]
+#[cfg(feature = "ffi")]
 mod ffi;
 
 use std::ops::Shr;
 
-use crate::core::{Domain, Function, Measure, Measurement, Metric, PrivacyMap, StabilityMap, Transformation};
+use crate::core::{
+    Domain, Function, Measure, Measurement, Metric, PrivacyMap, StabilityMap, Transformation,
+};
 use crate::error::Fallible;
 use std::fmt::Debug;
 
@@ -15,18 +17,26 @@ fn mismatch_message<T1: Debug, T2: Debug>(mode: &str, struct1: &T1, struct2: &T2
     let explanation = if str1 == str2 {
         format!("\n    The structure of the intermediate {mode}s are the same, but the parameters differ.\n    shared_{mode}: {str1}\n", mode=mode, str1=str1)
     } else {
-        format!("\n    output_{mode}: {struct1}\n    input_{mode}:  {struct2}\n", mode=mode, struct1=str1, struct2=str2)
+        format!(
+            "\n    output_{mode}: {struct1}\n    input_{mode}:  {struct2}\n",
+            mode = mode,
+            struct1 = str1,
+            struct2 = str2
+        )
     };
-    return format!("Intermediate {}s don't match. See {}{}", mode, ERROR_URL, explanation)
+    return format!(
+        "Intermediate {}s don't match. See {}{}",
+        mode, ERROR_URL, explanation
+    );
 }
 
 /// Construct the functional composition (`measurement1` ○ `transformation0`).
 /// Returns a Measurement that when invoked, computes `measurement1(transformation0(x))`.
-/// 
+///
 /// # Arguments
 /// * `measurement1` - outer measurement/mechanism
 /// * `transformation0` - inner transformation
-/// 
+///
 /// # Generics
 /// * `DI` - Input Domain.
 /// * `DX` - Intermediate Domain.
@@ -36,19 +46,35 @@ fn mismatch_message<T1: Debug, T2: Debug>(mode: &str, struct1: &T1, struct2: &T2
 /// * `MO` - Output Measure.
 pub fn make_chain_mt<DI, DX, TO, MI, MX, MO>(
     measurement1: &Measurement<DX, TO, MX, MO>,
-    transformation0: &Transformation<DI, DX, MI, MX>
+    transformation0: &Transformation<DI, DX, MI, MX>,
 ) -> Fallible<Measurement<DI, TO, MI, MO>>
-    where DI: 'static + Domain,
-          DX: 'static + Domain,
-          TO: 'static,
-          MI: 'static + Metric,
-          MX: 'static + Metric,
-          MO: 'static + Measure {
+where
+    DI: 'static + Domain,
+    DX: 'static + Domain,
+    TO: 'static,
+    MI: 'static + Metric,
+    MX: 'static + Metric,
+    MO: 'static + Measure,
+{
     if transformation0.output_domain != measurement1.input_domain {
-        return fallible!(DomainMismatch, mismatch_message("domain", &transformation0.output_domain, &measurement1.input_domain))
+        return fallible!(
+            DomainMismatch,
+            mismatch_message(
+                "domain",
+                &transformation0.output_domain,
+                &measurement1.input_domain
+            )
+        );
     }
     if transformation0.output_metric != measurement1.input_metric {
-        return fallible!(MetricMismatch, mismatch_message("metric", &transformation0.output_metric, &measurement1.input_metric))
+        return fallible!(
+            MetricMismatch,
+            mismatch_message(
+                "metric",
+                &transformation0.output_metric,
+                &measurement1.input_metric
+            )
+        );
     }
 
     Ok(Measurement::new(
@@ -56,17 +82,17 @@ pub fn make_chain_mt<DI, DX, TO, MI, MX, MO>(
         Function::make_chain(&measurement1.function, &transformation0.function),
         transformation0.input_metric.clone(),
         measurement1.output_measure.clone(),
-        PrivacyMap::make_chain(&measurement1.privacy_map, &transformation0.stability_map)
+        PrivacyMap::make_chain(&measurement1.privacy_map, &transformation0.stability_map),
     ))
 }
 
 /// Construct the functional composition (`transformation1` ○ `transformation0`).
 /// Returns a Measurement that when invoked, computes `transformation1(transformation0(x))`.
-/// 
+///
 /// # Arguments
 /// * `transformation1` - outer transformation
 /// * `transformation0` - inner transformation
-/// 
+///
 /// # Generics
 /// * `DI` - Input Domain.
 /// * `DX` - Intermediate Domain.
@@ -78,17 +104,33 @@ pub fn make_chain_tt<DI, DX, DO, MI, MX, MO>(
     transformation1: &Transformation<DX, DO, MX, MO>,
     transformation0: &Transformation<DI, DX, MI, MX>,
 ) -> Fallible<Transformation<DI, DO, MI, MO>>
-    where DI: 'static + Domain,
-          DX: 'static + Domain,
-          DO: 'static + Domain,
-          MI: 'static + Metric,
-          MX: 'static + Metric,
-          MO: 'static + Metric {
+where
+    DI: 'static + Domain,
+    DX: 'static + Domain,
+    DO: 'static + Domain,
+    MI: 'static + Metric,
+    MX: 'static + Metric,
+    MO: 'static + Metric,
+{
     if transformation0.output_domain != transformation1.input_domain {
-        return fallible!(DomainMismatch, mismatch_message("domain", &transformation0.output_domain, &transformation1.input_domain))
+        return fallible!(
+            DomainMismatch,
+            mismatch_message(
+                "domain",
+                &transformation0.output_domain,
+                &transformation1.input_domain
+            )
+        );
     }
     if transformation0.output_metric != transformation1.input_metric {
-        return fallible!(MetricMismatch, mismatch_message("metric", &transformation0.output_metric, &transformation1.input_metric))
+        return fallible!(
+            MetricMismatch,
+            mismatch_message(
+                "metric",
+                &transformation0.output_metric,
+                &transformation1.input_metric
+            )
+        );
     }
 
     Ok(Transformation::new(
@@ -97,18 +139,21 @@ pub fn make_chain_tt<DI, DX, DO, MI, MX, MO>(
         Function::make_chain(&transformation1.function, &transformation0.function),
         transformation0.input_metric.clone(),
         transformation1.output_metric.clone(),
-        StabilityMap::make_chain(&transformation1.stability_map, &transformation0.stability_map)
+        StabilityMap::make_chain(
+            &transformation1.stability_map,
+            &transformation0.stability_map,
+        ),
     ))
 }
 
 /// Construct the functional composition (`transformation1` ○ `measurement0`).
 /// Returns a Measurement that when invoked, computes `transformation1(measurement0(x))`.
 /// Used to represent non-interactive postprocessing.
-/// 
+///
 /// # Arguments
 /// * `transformation1` - outer postprocessing transformation
 /// * `measurement0` - inner measurement/mechanism
-/// 
+///
 /// # Generics
 /// * `DI` - Input Domain.
 /// * `DX` - Intermediate Domain.
@@ -137,15 +182,14 @@ where
     ))
 }
 
-
 // UNIT TESTS
 #[cfg(test)]
 mod tests {
     use crate::core::*;
-    use crate::metrics::L1Distance;
-    use crate::measures::MaxDivergence;
     use crate::domains::AllDomain;
     use crate::error::ExplainUnwrap;
+    use crate::measures::MaxDivergence;
+    use crate::metrics::L1Distance;
 
     use super::*;
 
@@ -157,13 +201,26 @@ mod tests {
         let input_metric0 = L1Distance::<i32>::default();
         let output_metric0 = L1Distance::<i32>::default();
         let stability_map0 = StabilityMap::new_from_constant(1);
-        let transformation0 = Transformation::new(input_domain0, output_domain0, function0, input_metric0, output_metric0, stability_map0);
+        let transformation0 = Transformation::new(
+            input_domain0,
+            output_domain0,
+            function0,
+            input_metric0,
+            output_metric0,
+            stability_map0,
+        );
         let input_domain1 = AllDomain::<i32>::new();
         let function1 = Function::new(|a: &i32| (a + 1) as f64);
         let input_metric1 = L1Distance::<i32>::default();
         let output_measure1 = MaxDivergence::default();
         let privacy_map1 = PrivacyMap::new(|d_in: &i32| *d_in as f64 + 1.);
-        let measurement1 = Measurement::new(input_domain1, function1, input_metric1, output_measure1, privacy_map1);
+        let measurement1 = Measurement::new(
+            input_domain1,
+            function1,
+            input_metric1,
+            output_measure1,
+            privacy_map1,
+        );
         let chain = make_chain_mt(&measurement1, &transformation0).unwrap_test();
 
         let arg = 99_u8;
@@ -183,14 +240,28 @@ mod tests {
         let input_metric0 = L1Distance::<i32>::default();
         let output_metric0 = L1Distance::<i32>::default();
         let stability_map0 = StabilityMap::new_from_constant(1);
-        let transformation0 = Transformation::new(input_domain0, output_domain0, function0, input_metric0, output_metric0, stability_map0);
+        let transformation0 = Transformation::new(
+            input_domain0,
+            output_domain0,
+            function0,
+            input_metric0,
+            output_metric0,
+            stability_map0,
+        );
         let input_domain1 = AllDomain::<i32>::new();
         let output_domain1 = AllDomain::<f64>::new();
         let function1 = Function::new(|a: &i32| (a + 1) as f64);
         let input_metric1 = L1Distance::<i32>::default();
         let output_metric1 = L1Distance::<i32>::default();
         let stability_map1 = StabilityMap::new_from_constant(1);
-        let transformation1 = Transformation::new(input_domain1, output_domain1, function1, input_metric1, output_metric1, stability_map1);
+        let transformation1 = Transformation::new(
+            input_domain1,
+            output_domain1,
+            function1,
+            input_metric1,
+            output_metric1,
+            stability_map1,
+        );
         let chain = make_chain_tt(&transformation1, &transformation0).unwrap_test();
 
         let arg = 99_u8;
@@ -200,8 +271,8 @@ mod tests {
         let d_in = 99_i32;
         let d_out = chain.map(&d_in).unwrap_test();
         assert_eq!(d_out, 99);
-    } 
-    
+    }
+
     #[test]
     fn test_make_chain_tm() {
         let input_domain0 = AllDomain::<u8>::new();
@@ -209,7 +280,13 @@ mod tests {
         let input_metric0 = L1Distance::<i32>::default();
         let output_measure0 = MaxDivergence::<i32>::default();
         let privacy_map0 = PrivacyMap::new_from_constant(1);
-        let measurement0 = Measurement::new(input_domain0, function0, input_metric0, output_measure0, privacy_map0);
+        let measurement0 = Measurement::new(
+            input_domain0,
+            function0,
+            input_metric0,
+            output_measure0,
+            privacy_map0,
+        );
         let function1 = Function::new(|a: &i32| (a + 1) as f64);
         let chain = make_chain_pm(&function1, &measurement0).unwrap_test();
 
@@ -223,14 +300,15 @@ mod tests {
     }
 }
 
-
 impl<DI, DX, TO, MI, MX, MO> Shr<Measurement<DX, TO, MX, MO>> for Transformation<DI, DX, MI, MX>
-    where DI: 'static + Domain,
-          DX: 'static + Domain,
-          TO: 'static,
-          MI: 'static + Metric,
-          MX: 'static + Metric,
-          MO: 'static + Measure {
+where
+    DI: 'static + Domain,
+    DX: 'static + Domain,
+    TO: 'static,
+    MI: 'static + Metric,
+    MX: 'static + Metric,
+    MO: 'static + Measure,
+{
     type Output = Fallible<Measurement<DI, TO, MI, MO>>;
 
     fn shr(self, rhs: Measurement<DX, TO, MX, MO>) -> Self::Output {
@@ -238,13 +316,16 @@ impl<DI, DX, TO, MI, MX, MO> Shr<Measurement<DX, TO, MX, MO>> for Transformation
     }
 }
 
-impl<DI, DX, TO, MI, MX, MO> Shr<Measurement<DX, TO, MX, MO>> for Fallible<Transformation<DI, DX, MI, MX>>
-    where DI: 'static + Domain,
-          DX: 'static + Domain,
-          TO: 'static,
-          MI: 'static + Metric,
-          MX: 'static + Metric,
-          MO: 'static + Measure {
+impl<DI, DX, TO, MI, MX, MO> Shr<Measurement<DX, TO, MX, MO>>
+    for Fallible<Transformation<DI, DX, MI, MX>>
+where
+    DI: 'static + Domain,
+    DX: 'static + Domain,
+    TO: 'static,
+    MI: 'static + Metric,
+    MX: 'static + Metric,
+    MO: 'static + Measure,
+{
     type Output = Fallible<Measurement<DI, TO, MI, MO>>;
 
     fn shr(self, rhs: Measurement<DX, TO, MX, MO>) -> Self::Output {
@@ -253,12 +334,14 @@ impl<DI, DX, TO, MI, MX, MO> Shr<Measurement<DX, TO, MX, MO>> for Fallible<Trans
 }
 
 impl<DI, DX, DO, MI, MX, MO> Shr<Transformation<DX, DO, MX, MO>> for Transformation<DI, DX, MI, MX>
-    where DI: 'static + Domain,
-          DX: 'static + Domain,
-          DO: 'static + Domain,
-          MI: 'static + Metric,
-          MX: 'static + Metric,
-          MO: 'static + Metric {
+where
+    DI: 'static + Domain,
+    DX: 'static + Domain,
+    DO: 'static + Domain,
+    MI: 'static + Metric,
+    MX: 'static + Metric,
+    MO: 'static + Metric,
+{
     type Output = Fallible<Transformation<DI, DO, MI, MO>>;
 
     fn shr(self, rhs: Transformation<DX, DO, MX, MO>) -> Self::Output {
@@ -266,13 +349,16 @@ impl<DI, DX, DO, MI, MX, MO> Shr<Transformation<DX, DO, MX, MO>> for Transformat
     }
 }
 
-impl<DI, DX, DO, MI, MX, MO> Shr<Transformation<DX, DO, MX, MO>> for Fallible<Transformation<DI, DX, MI, MX>>
-    where DI: 'static + Domain,
-          DX: 'static + Domain,
-          DO: 'static + Domain,
-          MI: 'static + Metric,
-          MX: 'static + Metric,
-          MO: 'static + Metric {
+impl<DI, DX, DO, MI, MX, MO> Shr<Transformation<DX, DO, MX, MO>>
+    for Fallible<Transformation<DI, DX, MI, MX>>
+where
+    DI: 'static + Domain,
+    DX: 'static + Domain,
+    DO: 'static + Domain,
+    MI: 'static + Metric,
+    MX: 'static + Metric,
+    MO: 'static + Metric,
+{
     type Output = Fallible<Transformation<DI, DO, MI, MO>>;
 
     fn shr(self, rhs: Transformation<DX, DO, MX, MO>) -> Self::Output {
@@ -280,8 +366,7 @@ impl<DI, DX, DO, MI, MX, MO> Shr<Transformation<DX, DO, MX, MO>> for Fallible<Tr
     }
 }
 
-impl<DI, TX, TO, MI, MO> Shr<Function<TX, TO>>
-    for Measurement<DI, TX, MI, MO>
+impl<DI, TX, TO, MI, MO> Shr<Function<TX, TO>> for Measurement<DI, TX, MI, MO>
 where
     DI: 'static + Domain,
     TX: 'static,
@@ -296,8 +381,7 @@ where
     }
 }
 
-impl<DI, TX, TO, MI, MO> Shr<Function<TX, TO>>
-    for Fallible<Measurement<DI, TX, MI, MO>>
+impl<DI, TX, TO, MI, MO> Shr<Function<TX, TO>> for Fallible<Measurement<DI, TX, MI, MO>>
 where
     DI: 'static + Domain,
     TX: 'static,
@@ -311,7 +395,6 @@ where
         make_chain_pm(&rhs, &self?)
     }
 }
-
 
 impl<DI, DX, DO, MI, MO, MTI, MTO> Shr<Transformation<DX, DO, MTI, MTO>>
     for Measurement<DI, DX::Carrier, MI, MO>
@@ -349,23 +432,22 @@ where
     }
 }
 
-
-
 #[cfg(test)]
 mod tests_shr {
     use crate::measurements::make_base_discrete_laplace;
-    use crate::transformations::{make_bounded_sum, make_cast_default, make_clamp, make_split_lines};
+    use crate::transformations::{
+        make_bounded_sum, make_cast_default, make_clamp, make_split_lines,
+    };
 
     use super::*;
 
     #[test]
     fn test_shr() -> Fallible<()> {
-        (
-            make_split_lines()? >>
-            make_cast_default()? >>
-            make_clamp((0, 1))? >>
-            make_bounded_sum((0, 1))? >>
-            make_base_discrete_laplace(1.)?
-        ).map(|_| ())
+        (make_split_lines()?
+            >> make_cast_default()?
+            >> make_clamp((0, 1))?
+            >> make_bounded_sum((0, 1))?
+            >> make_base_discrete_laplace(1.)?)
+        .map(|_| ())
     }
 }

--- a/rust/src/combinators/compose/ffi.rs
+++ b/rust/src/combinators/compose/ffi.rs
@@ -3,10 +3,13 @@ use opendp_derive::bootstrap;
 
 use crate::{
     core::FfiResult,
+    error::Fallible,
     ffi::{
-        any::{AnyMeasurement, AnyObject, IntoAnyMeasurementOutExt, Downcast, AnyMeasure},
+        any::{AnyMeasure, AnyMeasurement, AnyObject, Downcast, IntoAnyMeasurementOutExt},
         util::AnyMeasurementPtr,
-    }, error::Fallible, traits::InfAdd, measures::{MaxDivergence, FixedSmoothedMaxDivergence, ZeroConcentratedDivergence},
+    },
+    measures::{FixedSmoothedMaxDivergence, MaxDivergence, ZeroConcentratedDivergence},
+    traits::InfAdd,
 };
 
 use super::BasicCompositionMeasure;
@@ -16,11 +19,11 @@ use super::BasicCompositionMeasure;
     arguments(measurements(rust_type = "Vec<AnyMeasurementPtr>")),
     dependencies("$get_dependencies_iterable(measurements)")
 )]
-/// Construct the DP composition [`measurement0`, `measurement1`, ...]. 
+/// Construct the DP composition [`measurement0`, `measurement1`, ...].
 /// Returns a Measurement that when invoked, computes `[measurement0(x), measurement1(x), ...]`
-/// 
+///
 /// All metrics and domains must be equivalent, except for the output domain.
-/// 
+///
 /// # Arguments
 /// * `measurements` - A vector of Measurements to compose.
 fn make_basic_composition(measurements: Vec<&AnyMeasurement>) -> Fallible<AnyMeasurement> {
@@ -36,23 +39,30 @@ pub extern "C" fn opendp_combinators__make_basic_composition(
     let measurements: Vec<&AnyMeasurement> =
         try_!(meas_ptrs.iter().map(|ptr| Ok(try_as_ref!(*ptr))).collect());
 
-    make_basic_composition(measurements)
-        .into()
+    make_basic_composition(measurements).into()
 }
-
 
 impl BasicCompositionMeasure for AnyMeasure {
     fn compose(&self, d_i: Vec<Self::Distance>) -> Fallible<Self::Distance> {
         fn monomorphize1<Q: 'static + Clone + InfAdd + Zero>(
-            self_: &AnyMeasure, d_i: Vec<AnyObject>
+            self_: &AnyMeasure,
+            d_i: Vec<AnyObject>,
         ) -> Fallible<AnyObject> {
             fn monomorphize2<M: 'static + BasicCompositionMeasure>(
-                self_: &AnyMeasure, d_i: Vec<AnyObject>
+                self_: &AnyMeasure,
+                d_i: Vec<AnyObject>,
             ) -> Fallible<AnyObject>
-                where M::Distance: Clone {
-                self_.downcast_ref::<M>()?.compose(d_i.iter()
-                    .map(|d_i| d_i.downcast_ref::<M::Distance>().map(Clone::clone))
-                    .collect::<Fallible<Vec<M::Distance>>>()?).map(AnyObject::new)
+            where
+                M::Distance: Clone,
+            {
+                self_
+                    .downcast_ref::<M>()?
+                    .compose(
+                        d_i.iter()
+                            .map(|d_i| d_i.downcast_ref::<M::Distance>().map(Clone::clone))
+                            .collect::<Fallible<Vec<M::Distance>>>()?,
+                    )
+                    .map(AnyObject::new)
             }
             dispatch!(monomorphize2, [
                 (self_.type_, [MaxDivergence<Q>, FixedSmoothedMaxDivergence<Q>, ZeroConcentratedDivergence<Q>])
@@ -76,17 +86,21 @@ mod tests {
 
     #[test]
     fn test_make_basic_composition_ffi() -> Fallible<()> {
-        let measurement0 = util::into_raw(make_test_measurement::<i32>().into_any()) as AnyMeasurementPtr;
-        let measurement1 = util::into_raw(make_test_measurement::<i32>().into_any()) as AnyMeasurementPtr;
+        let measurement0 =
+            util::into_raw(make_test_measurement::<i32>().into_any()) as AnyMeasurementPtr;
+        let measurement1 =
+            util::into_raw(make_test_measurement::<i32>().into_any()) as AnyMeasurementPtr;
         let measurements = vec![measurement0, measurement1];
-        let basic_composition =
-            Result::from(opendp_combinators__make_basic_composition(
-                AnyObject::new_raw(measurements),
-            ))?;
+        let basic_composition = Result::from(opendp_combinators__make_basic_composition(
+            AnyObject::new_raw(measurements),
+        ))?;
         let arg = AnyObject::new_raw(999);
         let res = core::opendp_core__measurement_invoke(&basic_composition, arg);
         let res: Vec<AnyObject> = Fallible::from(res)?.downcast()?;
-        let res = (*res[0].downcast_ref::<i32>()?, *res[1].downcast_ref::<i32>()?);
+        let res = (
+            *res[0].downcast_ref::<i32>()?,
+            *res[1].downcast_ref::<i32>()?,
+        );
         println!("{:?}", res);
         assert_eq!(res, (999, 999));
         Ok(())

--- a/rust/src/combinators/compose/mod.rs
+++ b/rust/src/combinators/compose/mod.rs
@@ -6,10 +6,7 @@ use num::Zero;
 use crate::{
     core::{Domain, Function, Measure, Measurement, Metric, PrivacyMap},
     error::Fallible,
-    measures::{
-        FixedSmoothedMaxDivergence, MaxDivergence,
-        ZeroConcentratedDivergence,
-    },
+    measures::{FixedSmoothedMaxDivergence, MaxDivergence, ZeroConcentratedDivergence},
     traits::InfAdd,
 };
 

--- a/rust/src/combinators/fix_delta/ffi.rs
+++ b/rust/src/combinators/fix_delta/ffi.rs
@@ -16,7 +16,8 @@ use super::FixDeltaMeasure;
     features("contrib"),
     arguments(
         measurement(rust_type = b"null"),
-        delta(rust_type = "$get_atom(measurement_output_distance_type(measurement))")),
+        delta(rust_type = "$get_atom(measurement_output_distance_type(measurement))")
+    ),
     dependencies("$get_dependencies(measurement)")
 )]
 /// Fix the delta parameter in the privacy map of a `measurement` with a SmoothedMaxDivergence output measure.

--- a/rust/src/combinators/fix_delta/mod.rs
+++ b/rust/src/combinators/fix_delta/mod.rs
@@ -1,22 +1,22 @@
 use crate::{
     core::{Domain, Measure, Measurement, Metric, PrivacyMap},
-    measures::{FixedSmoothedMaxDivergence, SmoothedMaxDivergence},
     error::Fallible,
+    measures::{FixedSmoothedMaxDivergence, SmoothedMaxDivergence},
 };
 
 #[cfg(feature = "ffi")]
 mod ffi;
 
 /// Fix the delta parameter in the privacy map of a `measurement` with a `SmoothedMaxDivergence` output measure.
-/// 
+///
 /// # Arguments
 /// * `measurement` - a measurement with a privacy curve to be fixed
 /// * `delta` - parameter to fix the privacy curve with
-/// 
+///
 /// # Generics
 /// * `DI` - Input Domain
 /// * `TO` - Output Type
-/// * `MI` - Input Metric. 
+/// * `MI` - Input Metric.
 /// * `MO` - Output Measure of the input argument. Must be SmoothedMaxDivergence<Q>
 pub fn make_fix_delta<DI, TO, MI, MO>(
     measurement: &Measurement<DI, TO, MI, MO>,
@@ -54,7 +54,7 @@ pub trait FixDeltaMeasure: Measure {
 
     // This fn is used for FFI support
     fn new_fixed_measure(&self) -> Fallible<Self::FixedMeasure>;
-    
+
     fn fix_delta(
         &self,
         curve: &Self::Distance,

--- a/rust/src/combinators/measure_cast/mod.rs
+++ b/rust/src/combinators/measure_cast/mod.rs
@@ -1,4 +1,3 @@
-
 #[allow(non_snake_case)]
 mod zCDP_to_approxDP;
 pub use zCDP_to_approxDP::*;

--- a/rust/src/combinators/measure_cast/pureDP_to_fixed_approxDP/ffi.rs
+++ b/rust/src/combinators/measure_cast/pureDP_to_fixed_approxDP/ffi.rs
@@ -15,7 +15,6 @@ use crate::{
 /// # Arguments
 /// * `measurement` - a measurement with a privacy measure to be casted
 fn make_pureDP_to_fixed_approxDP(measurement: &AnyMeasurement) -> Fallible<AnyMeasurement> {
-    
     fn monomorphize<QO: Float>(measurement: &AnyMeasurement) -> Fallible<AnyMeasurement> {
         let AnyMeasurement {
             input_domain,
@@ -24,7 +23,7 @@ fn make_pureDP_to_fixed_approxDP(measurement: &AnyMeasurement) -> Fallible<AnyMe
             output_measure,
             privacy_map,
         } = measurement.clone();
-    
+
         let measurement = Measurement {
             input_domain,
             function,
@@ -34,9 +33,9 @@ fn make_pureDP_to_fixed_approxDP(measurement: &AnyMeasurement) -> Fallible<AnyMe
                 privacy_map.eval(d_in)?.downcast::<QO>()
             }),
         };
-    
+
         let measurement = super::make_pureDP_to_fixed_approxDP(measurement)?;
-    
+
         let Measurement {
             input_domain,
             function,
@@ -44,7 +43,7 @@ fn make_pureDP_to_fixed_approxDP(measurement: &AnyMeasurement) -> Fallible<AnyMe
             output_measure,
             privacy_map,
         } = measurement;
-    
+
         Ok(AnyMeasurement {
             input_domain,
             function,

--- a/rust/src/combinators/measure_cast/pureDP_to_fixed_approxDP/mod.rs
+++ b/rust/src/combinators/measure_cast/pureDP_to_fixed_approxDP/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     core::{Domain, Measurement, Metric, PrivacyMap},
     error::Fallible,
-    measures::{MaxDivergence, FixedSmoothedMaxDivergence},
+    measures::{FixedSmoothedMaxDivergence, MaxDivergence},
     traits::Float,
 };
 

--- a/rust/src/combinators/measure_cast/pureDP_to_zCDP/ffi.rs
+++ b/rust/src/combinators/measure_cast/pureDP_to_zCDP/ffi.rs
@@ -14,11 +14,10 @@ use crate::{
 ///
 /// # Citations
 /// - [BS16 Concentrated Differential Privacy: Simplifications, Extensions, and Lower Bounds](https://arxiv.org/pdf/1605.02065.pdf#subsection.3.1)
-/// 
+///
 /// # Arguments
 /// * `measurement` - a measurement with a privacy measure to be casted
 fn make_pureDP_to_zCDP(measurement: &AnyMeasurement) -> Fallible<AnyMeasurement> {
-    
     fn monomorphize<QO: Float>(measurement: &AnyMeasurement) -> Fallible<AnyMeasurement> {
         let AnyMeasurement {
             input_domain,
@@ -27,7 +26,7 @@ fn make_pureDP_to_zCDP(measurement: &AnyMeasurement) -> Fallible<AnyMeasurement>
             output_measure,
             privacy_map,
         } = measurement.clone();
-    
+
         let measurement = Measurement {
             input_domain,
             function,
@@ -37,9 +36,9 @@ fn make_pureDP_to_zCDP(measurement: &AnyMeasurement) -> Fallible<AnyMeasurement>
                 privacy_map.eval(d_in)?.downcast::<QO>()
             }),
         };
-    
+
         let measurement = super::make_pureDP_to_zCDP(measurement)?;
-    
+
         let Measurement {
             input_domain,
             function,
@@ -47,7 +46,7 @@ fn make_pureDP_to_zCDP(measurement: &AnyMeasurement) -> Fallible<AnyMeasurement>
             output_measure,
             privacy_map,
         } = measurement;
-    
+
         Ok(AnyMeasurement {
             input_domain,
             function,

--- a/rust/src/combinators/measure_cast/pureDP_to_zCDP/mod.rs
+++ b/rust/src/combinators/measure_cast/pureDP_to_zCDP/mod.rs
@@ -13,7 +13,7 @@ mod ffi;
 ///
 /// # Citations
 /// - [BS16 Concentrated Differential Privacy: Simplifications, Extensions, and Lower Bounds](https://arxiv.org/pdf/1605.02065.pdf#subsection.3.1)
-/// 
+///
 /// # Arguments
 /// * `meas` - a measurement with a privacy curve to be casted
 ///
@@ -46,7 +46,9 @@ where
         input_metric,
         ZeroConcentratedDivergence::default(),
         PrivacyMap::new_fallible(move |d_in: &MI::Distance| {
-            privacy_map.eval(d_in).and_then(|eps| eps.inf_pow(&_2)?.inf_div(&_2))
+            privacy_map
+                .eval(d_in)
+                .and_then(|eps| eps.inf_pow(&_2)?.inf_div(&_2))
         }),
     ))
 }

--- a/rust/src/combinators/measure_cast/zCDP_to_approxDP/cdp_epsilon.rs
+++ b/rust/src/combinators/measure_cast/zCDP_to_approxDP/cdp_epsilon.rs
@@ -19,7 +19,7 @@ pub(crate) fn cdp_epsilon<Q: Float>(rho: Q, delta: Q) -> Fallible<Q> {
     // It has been proven that...
     //     delta = exp((α-1) (αρ - ε) + α ln1p(-1/α)) / (α-1)
     // ...for any choice of alpha in (1, infty)
-    
+
     // The following expression is equivalent for ε:
     //   epsilon = δρ + (ln(1/δ) + (α - 1)ln(1 - 1/α) - ln(α)) / (α - 1)
 

--- a/rust/src/combinators/measure_cast/zCDP_to_approxDP/ffi.rs
+++ b/rust/src/combinators/measure_cast/zCDP_to_approxDP/ffi.rs
@@ -8,17 +8,13 @@ use crate::{
     traits::Float,
 };
 
-#[bootstrap(
-    features("contrib"),
-    dependencies("$get_dependencies(measurement)")
-)]
+#[bootstrap(features("contrib"), dependencies("$get_dependencies(measurement)"))]
 /// Constructs a new output measurement where the output measure
 /// is casted from `ZeroConcentratedDivergence<QO>` to `SmoothedMaxDivergence<QO>`.
 ///
 /// # Arguments
 /// * `measurement` - a measurement with a privacy measure to be casted
 fn make_zCDP_to_approxDP(measurement: &AnyMeasurement) -> Fallible<AnyMeasurement> {
-    
     fn monomorphize<QO: Float>(measurement: &AnyMeasurement) -> Fallible<AnyMeasurement> {
         let AnyMeasurement {
             input_domain,
@@ -27,7 +23,7 @@ fn make_zCDP_to_approxDP(measurement: &AnyMeasurement) -> Fallible<AnyMeasuremen
             output_measure,
             privacy_map,
         } = measurement.clone();
-    
+
         let measurement = Measurement {
             input_domain,
             function,
@@ -37,9 +33,9 @@ fn make_zCDP_to_approxDP(measurement: &AnyMeasurement) -> Fallible<AnyMeasuremen
                 privacy_map.eval(d_in)?.downcast::<QO>()
             }),
         };
-    
+
         let measurement = super::make_zCDP_to_approxDP(measurement)?;
-    
+
         let Measurement {
             input_domain,
             function,
@@ -47,7 +43,7 @@ fn make_zCDP_to_approxDP(measurement: &AnyMeasurement) -> Fallible<AnyMeasuremen
             output_measure,
             privacy_map,
         } = measurement;
-    
+
         Ok(AnyMeasurement {
             input_domain,
             function,

--- a/rust/src/combinators/measure_cast/zCDP_to_approxDP/mod.rs
+++ b/rust/src/combinators/measure_cast/zCDP_to_approxDP/mod.rs
@@ -12,12 +12,12 @@ mod ffi;
 
 mod cdp_epsilon;
 
-/// Constructs a new output measurement where the output measure 
+/// Constructs a new output measurement where the output measure
 /// is casted from `ZeroConcentratedDivergence<QO>` to `SmoothedMaxDivergence<QO>`.
-/// 
+///
 /// # Arguments
 /// * `meas` - a measurement with a privacy measure to be casted
-/// 
+///
 /// # Generics
 /// * `DI` - Input Domain
 /// * `TO` - Output Type
@@ -46,7 +46,7 @@ where
         SmoothedMaxDivergence::default(),
         PrivacyMap::new_fallible(move |d_in: &MI::Distance| {
             let rho = privacy_map.eval(d_in)?;
-            
+
             Ok(SMDCurve::new(move |&delta: &QO| cdp_epsilon(rho, delta)))
         }),
     ))

--- a/rust/src/combinators/mod.rs
+++ b/rust/src/combinators/mod.rs
@@ -1,44 +1,43 @@
 //! Various combinator constructors.
 
-#[cfg(all(feature="contrib", feature="honest-but-curious"))]
+#[cfg(all(feature = "contrib", feature = "honest-but-curious"))]
 mod amplify;
-#[cfg(all(feature="contrib", feature="honest-but-curious"))]
+#[cfg(all(feature = "contrib", feature = "honest-but-curious"))]
 pub use crate::combinators::amplify::*;
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod chain;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::combinators::chain::*;
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod compose;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::combinators::compose::*;
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod measure_cast;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::combinators::measure_cast::*;
 
-#[cfg(all(feature="contrib", feature="ffi"))]
+#[cfg(all(feature = "contrib", feature = "ffi"))]
 mod user_defined;
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod fix_delta;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::combinators::fix_delta::*;
-
-
 
 #[cfg(test)]
 pub mod tests {
     use crate::core::{Function, Measurement, PrivacyMap, StabilityMap, Transformation};
+    use crate::domains::AllDomain;
     use crate::measures::MaxDivergence;
     use crate::metrics::SymmetricDistance;
-    use crate::domains::AllDomain;
     use crate::traits::CheckNull;
 
-    pub fn make_test_measurement<T: Clone + CheckNull>() -> Measurement<AllDomain<T>, T, SymmetricDistance, MaxDivergence<f64>> {
+    pub fn make_test_measurement<T: Clone + CheckNull>(
+    ) -> Measurement<AllDomain<T>, T, SymmetricDistance, MaxDivergence<f64>> {
         Measurement::new(
             AllDomain::new(),
             Function::new(|arg: &T| arg.clone()),
@@ -48,14 +47,15 @@ pub mod tests {
         )
     }
 
-    pub fn make_test_transformation<T: Clone + CheckNull>() -> Transformation<AllDomain<T>, AllDomain<T>, SymmetricDistance, SymmetricDistance> {
+    pub fn make_test_transformation<T: Clone + CheckNull>(
+    ) -> Transformation<AllDomain<T>, AllDomain<T>, SymmetricDistance, SymmetricDistance> {
         Transformation::new(
             AllDomain::default(),
             AllDomain::default(),
             Function::new(|arg: &T| arg.clone()),
             SymmetricDistance::default(),
             SymmetricDistance::default(),
-            StabilityMap::new_from_constant(1)
+            StabilityMap::new_from_constant(1),
         )
     }
 }

--- a/rust/src/combinators/user_defined/ffi.rs
+++ b/rust/src/combinators/user_defined/ffi.rs
@@ -7,7 +7,8 @@ use crate::{
     error::Fallible,
     ffi::{
         any::{
-            AnyDomain, AnyMeasure, AnyMeasurement, AnyMetric, AnyObject, AnyTransformation, AnyFunction,
+            AnyDomain, AnyFunction, AnyMeasure, AnyMeasurement, AnyMetric, AnyObject,
+            AnyTransformation,
         },
         util,
     },
@@ -21,8 +22,6 @@ fn wrap_func(func: CallbackFn) -> impl Fn(&AnyObject) -> Fallible<AnyObject> {
         util::into_owned(func(arg as *const AnyObject))?.into()
     }
 }
-
-
 
 #[bootstrap(
     name = "make_user_transformation",
@@ -85,7 +84,7 @@ pub extern "C" fn opendp_combinators__make_user_transformation(
 /// * `input_metric` - The metric from which distances between adjacent inputs are measured.
 /// * `output_measure` - The measure from which distances between adjacent output distributions are measured.
 /// * `privacy_map` - A function mapping distances from `input_metric` to `output_measure`.
-/// 
+///
 /// # Generics
 /// * `TO` - The data type of outputs from the function.
 #[allow(dead_code)]
@@ -135,13 +134,11 @@ pub extern "C" fn opendp_combinators__make_user_measurement(
 ///
 /// # Arguments
 /// * `function` - A function mapping data to a value of type `TO`
-/// 
+///
 /// # Generics
 /// * `TO` - Output Type
 #[allow(dead_code)]
-fn make_user_postprocessor<TO>(
-    function: CallbackFn,
-) -> Fallible<AnyFunction> {
+fn make_user_postprocessor<TO>(function: CallbackFn) -> Fallible<AnyFunction> {
     let _ = function;
     panic!("this signature only exists for code generation")
 }

--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -20,9 +20,9 @@
 // Ordering of generic arguments
 // DI, DO, MI, MO, TI, TO, QI, QO
 
-#[cfg(feature="ffi")]
+#[cfg(feature = "ffi")]
 mod ffi;
-#[cfg(feature="ffi")]
+#[cfg(feature = "ffi")]
 pub use ffi::*;
 
 use std::rc::Rc;
@@ -31,35 +31,34 @@ use crate::error::*;
 use crate::traits::{DistanceConstant, InfCast, InfMul, TotalOrd};
 use std::fmt::Debug;
 
-
 /// A set which constrains the input or output of a [`Function`].
 ///
 /// Domains capture the notion of what values are allowed to be the input or output of a `Function`.
-/// 
+///
 /// # Proof Definition
 /// A type `Self` implements `Domain` iff it can represent a set of values that make up a domain.
 pub trait Domain: Clone + PartialEq + Debug {
     /// The underlying type that the Domain specializes.
     /// This is the type of a member of a domain, where a domain is any data type that implements this trait.
-    /// 
-    /// On any type `D` for which the `Domain` trait is implemented, 
+    ///
+    /// On any type `D` for which the `Domain` trait is implemented,
     /// the syntax `D::Carrier` refers to this associated type.
     /// For example, consider `D` to be `AllDomain<T>`, the domain of all non-null values of type `T`.
-    /// The implementation of this trait for `AllDomain<T>` designates that `type Carrier = T`. 
+    /// The implementation of this trait for `AllDomain<T>` designates that `type Carrier = T`.
     /// Thus `AllDomain<T>::Carrier` is `T`.
-    /// 
+    ///
     /// # Proof Definition
     /// `Self::Carrier` can represent all values in the set described by `Self`.
     type Carrier;
 
     /// Predicate to test an element for membership in the domain.
     /// Not all possible values of `::Carrier` are a member of the domain.
-    /// 
+    ///
     /// # Proof Definition
-    /// For all settings of the input parameters, 
+    /// For all settings of the input parameters,
     /// returns `Err(e)` if the member check failed,
     /// or `Ok(out)`, where `out` is true if `val` is a member of `self`, otherwise false.
-    /// 
+    ///
     /// # Notes
     /// It generally suffices to treat `Err(e)` as if `val` is not a member of the domain.
     /// It can be useful, however, to see richer debug information via `e` in the event of a failure.
@@ -72,7 +71,9 @@ pub struct Function<TI, TO> {
 }
 impl<TI, TO> Clone for Function<TI, TO> {
     fn clone(&self) -> Self {
-        Function { function: self.function.clone() }
+        Function {
+            function: self.function.clone(),
+        }
     }
 }
 
@@ -82,7 +83,9 @@ impl<TI, TO> Function<TI, TO> {
     }
 
     pub fn new_fallible(function: impl Fn(&TI) -> Fallible<TO> + 'static) -> Self {
-        Self { function: Rc::new(function) }
+        Self {
+            function: Rc::new(function),
+        }
     }
 
     pub fn eval(&self, arg: &TI) -> Fallible<TO> {
@@ -91,7 +94,10 @@ impl<TI, TO> Function<TI, TO> {
 }
 
 impl<TI: 'static, TO: 'static> Function<TI, TO> {
-    pub fn make_chain<TX: 'static>(function1: &Function<TX, TO>, function0: &Function<TI, TX>) -> Function<TI, TO> {
+    pub fn make_chain<TX: 'static>(
+        function1: &Function<TX, TO>,
+        function0: &Function<TI, TX>,
+    ) -> Function<TI, TO> {
         let function0 = function0.function.clone();
         let function1 = function1.function.clone();
         Self::new_fallible(move |arg| function1(&function0(arg)?))
@@ -99,9 +105,9 @@ impl<TI: 'static, TO: 'static> Function<TI, TO> {
 }
 
 /// A representation of the distance between two elements in a set.
-/// 
+///
 /// # Proof Definition
-/// A type `Self` has an implementation for `Metric` iff it can represent a metric for quantifying distances between values in a set. 
+/// A type `Self` has an implementation for `Metric` iff it can represent a metric for quantifying distances between values in a set.
 pub trait Metric: Default + Clone + PartialEq + Debug {
     /// # Proof Definition
     /// `Self::Distance` is a type that represents distances in terms of a metric `Self`.
@@ -109,9 +115,9 @@ pub trait Metric: Default + Clone + PartialEq + Debug {
 }
 
 /// A representation of the distance between two distributions.
-/// 
+///
 /// # Proof Definition
-/// A type `Self` has an implementation for `Measure` iff it can represent a measure for quantifying distances between distributions. 
+/// A type `Self` has an implementation for `Measure` iff it can represent a measure for quantifying distances between distributions.
 
 pub trait Measure: Default + Clone + PartialEq + Debug {
     /// # Proof Definition
@@ -123,7 +129,9 @@ pub trait Measure: Default + Clone + PartialEq + Debug {
 ///
 /// A `PrivacyMap` is implemented as a function that takes an input [`Metric::Distance`]
 /// and returns the smallest upper bound on distances between output distributions on neighboring input datasets.
-pub struct PrivacyMap<MI: Metric, MO: Measure>(pub Rc<dyn Fn(&MI::Distance) -> Fallible<MO::Distance>>);
+pub struct PrivacyMap<MI: Metric, MO: Measure>(
+    pub Rc<dyn Fn(&MI::Distance) -> Fallible<MO::Distance>>,
+);
 
 impl<MI: Metric, MO: Measure> Clone for PrivacyMap<MI, MO> {
     fn clone(&self) -> Self {
@@ -138,11 +146,14 @@ impl<MI: Metric, MO: Measure> PrivacyMap<MI, MO> {
     pub fn new_fallible(map: impl Fn(&MI::Distance) -> Fallible<MO::Distance> + 'static) -> Self {
         PrivacyMap(Rc::new(map))
     }
-    pub fn new_from_constant(c: MO::Distance) -> Self where
+    pub fn new_from_constant(c: MO::Distance) -> Self
+    where
         MI::Distance: Clone,
-        MO::Distance: DistanceConstant<MI::Distance> {
-        PrivacyMap::new_fallible(move |d_in: &MI::Distance|
-            MO::Distance::inf_cast(d_in.clone())?.inf_mul(&c))
+        MO::Distance: DistanceConstant<MI::Distance>,
+    {
+        PrivacyMap::new_fallible(move |d_in: &MI::Distance| {
+            MO::Distance::inf_cast(d_in.clone())?.inf_mul(&c)
+        })
     }
     pub fn eval(&self, input_distance: &MI::Distance) -> Fallible<MO::Distance> {
         (self.0)(input_distance)
@@ -164,7 +175,9 @@ impl<MI: 'static + Metric, MO: 'static + Measure> PrivacyMap<MI, MO> {
 ///
 /// A `StabilityMap` is implemented as a function that takes an input [`Metric::Distance`],
 /// and returns the smallest upper bound on distances between output datasets on neighboring input datasets.
-pub struct StabilityMap<MI: Metric, MO: Metric>(pub Rc<dyn Fn(&MI::Distance) -> Fallible<MO::Distance>>);
+pub struct StabilityMap<MI: Metric, MO: Metric>(
+    pub Rc<dyn Fn(&MI::Distance) -> Fallible<MO::Distance>>,
+);
 
 impl<MI: Metric, MO: Metric> Clone for StabilityMap<MI, MO> {
     fn clone(&self) -> Self {
@@ -179,11 +192,14 @@ impl<MI: Metric, MO: Metric> StabilityMap<MI, MO> {
     pub fn new_fallible(map: impl Fn(&MI::Distance) -> Fallible<MO::Distance> + 'static) -> Self {
         StabilityMap(Rc::new(map))
     }
-    pub fn new_from_constant(c: MO::Distance) -> Self where
+    pub fn new_from_constant(c: MO::Distance) -> Self
+    where
         MI::Distance: Clone,
-        MO::Distance: DistanceConstant<MI::Distance> {
-        StabilityMap::new_fallible(move |d_in: &MI::Distance|
-            MO::Distance::inf_cast(d_in.clone())?.inf_mul(&c))
+        MO::Distance: DistanceConstant<MI::Distance>,
+    {
+        StabilityMap::new_fallible(move |d_in: &MI::Distance| {
+            MO::Distance::inf_cast(d_in.clone())?.inf_mul(&c)
+        })
     }
     pub fn eval(&self, input_distance: &MI::Distance) -> Fallible<MO::Distance> {
         (self.0)(input_distance)
@@ -191,21 +207,23 @@ impl<MI: Metric, MO: Metric> StabilityMap<MI, MO> {
 }
 
 impl<MI: 'static + Metric, MO: 'static + Metric> StabilityMap<MI, MO> {
-    pub fn make_chain<MX: 'static + Metric>(map1: &StabilityMap<MX, MO>, map0: &StabilityMap<MI, MX>) -> Self {
+    pub fn make_chain<MX: 'static + Metric>(
+        map1: &StabilityMap<MX, MO>,
+        map0: &StabilityMap<MI, MX>,
+    ) -> Self {
         let map1 = map1.0.clone();
         let map0 = map0.0.clone();
         StabilityMap(Rc::new(move |d_in: &MI::Distance| map1(&map0(d_in)?)))
     }
 }
 
-
 /// A randomized mechanism with certain privacy characteristics.
-/// 
+///
 /// The trait bounds provided by the Rust type system guarantee that:
 /// * `input_domain` and `output_domain` are valid domains
 /// * `input_metric` is a valid metric
 /// * `output_measure` is a valid measure
-/// 
+///
 /// It is, however, left to constructor functions to prove that:
 /// * `input_metric` is compatible with `input_domain`
 /// * `privacy_map` is a mapping from the input metric to the output measure
@@ -219,12 +237,12 @@ pub struct Measurement<DI: Domain, TO, MI: Metric, MO: Measure> {
 
 impl<DI: Domain, TO, MI: Metric, MO: Measure> Clone for Measurement<DI, TO, MI, MO> {
     fn clone(&self) -> Self {
-        Self { 
-            input_domain: self.input_domain.clone(), 
-            function: self.function.clone(), 
-            input_metric: self.input_metric.clone(), 
-            output_measure: self.output_measure.clone(), 
-            privacy_map: self.privacy_map.clone() 
+        Self {
+            input_domain: self.input_domain.clone(),
+            function: self.function.clone(),
+            input_metric: self.input_metric.clone(),
+            output_measure: self.output_measure.clone(),
+            privacy_map: self.privacy_map.clone(),
         }
     }
 }
@@ -255,17 +273,19 @@ impl<DI: Domain, TO, MI: Metric, MO: Measure> Measurement<DI, TO, MI, MO> {
     }
 
     pub fn check(&self, d_in: &MI::Distance, d_out: &MO::Distance) -> Fallible<bool>
-        where MO::Distance: TotalOrd {
+    where
+        MO::Distance: TotalOrd,
+    {
         d_out.total_ge(&self.map(d_in)?)
     }
 }
 
 /// A data transformation with certain stability characteristics.
-/// 
+///
 /// The trait bounds provided by the Rust type system guarantee that:
 /// * `input_domain` and `output_domain` are valid domains
 /// * `input_metric` and `output_metric` are valid metrics
-/// 
+///
 /// It is, however, left to constructor functions to prove that:
 /// * metrics are compatible with domains
 /// * `function` is a mapping from the input domain to the output domain
@@ -308,17 +328,18 @@ impl<DI: Domain, DO: Domain, MI: Metric, MO: Metric> Transformation<DI, DO, MI, 
     }
 
     pub fn check(&self, d_in: &MI::Distance, d_out: &MO::Distance) -> Fallible<bool>
-        where MO::Distance: TotalOrd {
+    where
+        MO::Distance: TotalOrd,
+    {
         d_out.total_ge(&self.map(d_in)?)
     }
 }
 
-
 #[cfg(test)]
 mod tests {
-    use crate::metrics::L1Distance;
     use crate::domains::AllDomain;
     use crate::error::ExplainUnwrap;
+    use crate::metrics::L1Distance;
 
     use super::*;
 
@@ -330,7 +351,14 @@ mod tests {
         let input_metric = L1Distance::<i32>::default();
         let output_metric = L1Distance::<i32>::default();
         let stability_map = StabilityMap::new_from_constant(1);
-        let identity = Transformation::new(input_domain, output_domain, function, input_metric, output_metric, stability_map);
+        let identity = Transformation::new(
+            input_domain,
+            output_domain,
+            function,
+            input_metric,
+            output_metric,
+            stability_map,
+        );
         let arg = 99;
         let ret = identity.invoke(&arg).unwrap_test();
         assert_eq!(ret, 99);

--- a/rust/src/data/ffi.rs
+++ b/rust/src/data/ffi.rs
@@ -8,38 +8,53 @@ use std::slice;
 
 use opendp_derive::bootstrap;
 
-use crate::measures::SMDCurve;
-use crate::traits::TotalOrd;
-use crate::traits::samplers::Shuffle;
-use crate::{err, fallible, try_, try_as_ref};
 use crate::core::{FfiError, FfiResult, FfiSlice};
 use crate::data::Column;
 use crate::error::Fallible;
 use crate::ffi::any::{AnyObject, Downcast};
 use crate::ffi::util::{self, into_c_char_p};
 use crate::ffi::util::{c_bool, AnyMeasurementPtr, AnyTransformationPtr, Type, TypeContents};
+use crate::measures::SMDCurve;
+use crate::traits::samplers::Shuffle;
+use crate::traits::TotalOrd;
+use crate::{err, fallible, try_, try_as_ref};
 
 #[bootstrap(
     name = "slice_as_object",
-    arguments(raw(rust_type = "T", hint="FfiSlicePtr"), T(c_type = "char *", rust_type = b"null")),
+    arguments(
+        raw(rust_type = "T", hint = "FfiSlicePtr"),
+        T(c_type = "char *", rust_type = b"null")
+    ),
     returns(do_not_convert = true, c_type = "FfiResult<const AnyObject *>"),
     derived_types(T = "$parse_or_infer(T, raw)")
 )]
 /// Internal function. Load data from a `slice` into an AnyObject
-/// 
+///
 /// # Returns
-/// An AnyObject that contains the data in `slice`. 
+/// An AnyObject that contains the data in `slice`.
 /// The AnyObject also captures rust type information.
 #[no_mangle]
-pub extern "C" fn opendp_data__slice_as_object(raw: *const FfiSlice, T: *const c_char) -> FfiResult<*mut AnyObject> {
+pub extern "C" fn opendp_data__slice_as_object(
+    raw: *const FfiSlice,
+    T: *const c_char,
+) -> FfiResult<*mut AnyObject> {
     let raw = try_as_ref!(raw);
     let T = try_!(Type::try_from(T));
     fn raw_to_plain<T: 'static + Clone>(raw: &FfiSlice) -> Fallible<AnyObject> {
         if raw.len != 1 {
-            return fallible!(FFI, "The slice length must be one when creating a scalar from FfiSlice");
+            return fallible!(
+                FFI,
+                "The slice length must be one when creating a scalar from FfiSlice"
+            );
         }
         let plain = util::as_ref(raw.ptr as *const T)
-            .ok_or_else(|| err!(FFI, "Attempted to follow a null pointer to create an object"))?.clone();
+            .ok_or_else(|| {
+                err!(
+                    FFI,
+                    "Attempted to follow a null pointer to create an object"
+                )
+            })?
+            .clone();
         Ok(AnyObject::new(plain))
     }
     fn raw_to_string(raw: &FfiSlice) -> Fallible<AnyObject> {
@@ -48,7 +63,8 @@ pub extern "C" fn opendp_data__slice_as_object(raw: *const FfiSlice, T: *const c
     }
     fn raw_to_vec_string(raw: &FfiSlice) -> Fallible<AnyObject> {
         let slice = unsafe { slice::from_raw_parts(raw.ptr as *const *const c_char, raw.len) };
-        let vec = slice.iter()
+        let vec = slice
+            .iter()
             .map(|str_ptr| Ok(util::to_str(*str_ptr)?.to_owned()))
             .collect::<Fallible<Vec<String>>>()?;
         Ok(AnyObject::new(vec))
@@ -63,36 +79,51 @@ pub extern "C" fn opendp_data__slice_as_object(raw: *const FfiSlice, T: *const c
         let vec = slice.to_vec();
         Ok(AnyObject::new(vec))
     }
-    fn raw_to_tuple<T0: 'static + Clone, T1: 'static + Clone>(raw: &FfiSlice) -> Fallible<AnyObject> {
+    fn raw_to_tuple<T0: 'static + Clone, T1: 'static + Clone>(
+        raw: &FfiSlice,
+    ) -> Fallible<AnyObject> {
         if raw.len != 2 {
-            return fallible!(FFI, "The slice length must be two when creating a tuple from FfiSlice");
+            return fallible!(
+                FFI,
+                "The slice length must be two when creating a tuple from FfiSlice"
+            );
         }
         let slice = unsafe { slice::from_raw_parts(raw.ptr as *const *const c_void, 2) };
 
-        let tuple = util::as_ref(slice[0] as *const T0).cloned()
+        let tuple = util::as_ref(slice[0] as *const T0)
+            .cloned()
             .zip(util::as_ref(slice[1] as *const T1).cloned())
             .ok_or_else(|| err!(FFI, "Attempted to follow a null pointer to create a tuple"))?;
         Ok(AnyObject::new(tuple))
     }
-    fn raw_to_hashmap<K: 'static + Clone + Hash + Eq, V: 'static + Clone>(raw: &FfiSlice) -> Fallible<AnyObject> {
+    fn raw_to_hashmap<K: 'static + Clone + Hash + Eq, V: 'static + Clone>(
+        raw: &FfiSlice,
+    ) -> Fallible<AnyObject> {
         let slice = unsafe { slice::from_raw_parts(raw.ptr as *const *const AnyObject, raw.len) };
 
         // unpack keys and values into slices
-        if slice.len() != 2 { return fallible!(FFI, "HashMap FfiSlice must have length 2"); }
+        if slice.len() != 2 {
+            return fallible!(FFI, "HashMap FfiSlice must have length 2");
+        }
         let keys = try_as_ref!(slice[0]).downcast_ref::<Vec<K>>()?;
         let vals = try_as_ref!(slice[1]).downcast_ref::<Vec<V>>()?;
 
         // construct the hashmap
-        if keys.len() != vals.len() { return fallible!(FFI, "HashMap FfiSlice must have an equivalent number of keys and values"); };
-        let map = keys.iter().cloned()
+        if keys.len() != vals.len() {
+            return fallible!(
+                FFI,
+                "HashMap FfiSlice must have an equivalent number of keys and values"
+            );
+        };
+        let map = keys
+            .iter()
+            .cloned()
             .zip(vals.iter().cloned())
             .collect::<HashMap<K, V>>();
         Ok(AnyObject::new(map))
     }
     match T.contents {
-        TypeContents::PLAIN("String") => {
-            raw_to_string(raw)
-        }
+        TypeContents::PLAIN("String") => raw_to_string(raw),
         TypeContents::SLICE(element_id) => {
             let element = try_!(Type::of_id(&element_id));
             dispatch!(raw_to_slice, [(element, @primitives)], (raw))
@@ -110,22 +141,37 @@ pub extern "C" fn opendp_data__slice_as_object(raw: *const FfiSlice, T: *const c
             if element_ids.len() != 2 {
                 return fallible!(FFI, "Only tuples of length 2 are supported").into();
             }
-            let types = try_!(element_ids.iter().map(Type::of_id).collect::<Fallible<Vec<_>>>());
+            let types = try_!(element_ids
+                .iter()
+                .map(Type::of_id)
+                .collect::<Fallible<Vec<_>>>());
             // In the inbound direction, we can handle tuples of primitives only. This is probably OK,
             // because the only likely way to get a tuple of AnyObjects is as the output of composition.
             dispatch!(raw_to_tuple, [(types[0], @primitives), (types[1], @primitives)], (raw))
         }
         TypeContents::GENERIC { name, args } => {
             if name == "HashMap" {
-                if args.len() != 2 { return err!(FFI, "HashMaps should have 2 type arguments").into(); }
+                if args.len() != 2 {
+                    return err!(FFI, "HashMaps should have 2 type arguments").into();
+                }
                 let K = try_!(Type::of_id(&args[0]));
                 let V = try_!(Type::of_id(&args[1]));
                 dispatch!(raw_to_hashmap, [(K, @hashable), (V, @primitives)], (raw))
-            } else { fallible!(FFI, "unrecognized generic {:?}", name) }
+            } else {
+                fallible!(FFI, "unrecognized generic {:?}", name)
+            }
         }
         // This list is explicit because it allows us to avoid including u32 in the @primitives
-        _ => dispatch!(raw_to_plain, [(T, [u8, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, bool])], (raw))
-    }.into()
+        _ => dispatch!(
+            raw_to_plain,
+            [(
+                T,
+                [u8, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, bool]
+            )],
+            (raw)
+        ),
+    }
+    .into()
 }
 
 #[bootstrap(
@@ -140,7 +186,7 @@ pub extern "C" fn opendp_data__object_type(this: *mut AnyObject) -> FfiResult<*m
 
     match util::into_c_char_p(obj.type_.descriptor.to_string()) {
         Ok(v) => FfiResult::Ok(v),
-        Err(e) => e.into()
+        Err(e) => e.into(),
     }
 }
 
@@ -150,7 +196,7 @@ pub extern "C" fn opendp_data__object_type(this: *mut AnyObject) -> FfiResult<*m
     returns(do_not_convert = true, c_type = "FfiResult<const FfiSlice *>")
 )]
 /// Internal function. Unload data from an AnyObject into an FfiSlicePtr.
-/// 
+///
 /// # Returns
 /// An FfiSlice that contains the data in FfiObject, but in a format readable in bindings languages.
 #[no_mangle]
@@ -163,12 +209,17 @@ pub extern "C" fn opendp_data__object_as_slice(obj: *const AnyObject) -> FfiResu
     fn string_to_raw(obj: &AnyObject) -> Fallible<FfiSlice> {
         let string: &String = obj.downcast_ref()?;
         // FIXME: There's no way to get a CString without copying, so this leaks.
-        Ok(FfiSlice::new(util::into_c_char_p(string.clone())? as *mut c_void, string.len() + 1))
+        Ok(FfiSlice::new(
+            util::into_c_char_p(string.clone())? as *mut c_void,
+            string.len() + 1,
+        ))
     }
     fn vec_string_to_raw(obj: &AnyObject) -> Fallible<FfiSlice> {
         let vec_str: &Vec<String> = obj.downcast_ref()?;
-        let vec = vec_str.iter()
-            .cloned().map(util::into_c_char_p)
+        let vec = vec_str
+            .iter()
+            .cloned()
+            .map(util::into_c_char_p)
             .collect::<Fallible<Vec<*mut c_char>>>()?;
 
         let res = Ok(FfiSlice::new(vec.as_ptr() as *mut c_void, vec.len()));
@@ -185,12 +236,17 @@ pub extern "C" fn opendp_data__object_as_slice(obj: *const AnyObject) -> FfiResu
     }
     fn tuple_to_raw<T0: 'static, T1: 'static>(obj: &AnyObject) -> Fallible<FfiSlice> {
         let tuple: &(T0, T1) = obj.downcast_ref()?;
-        Ok(FfiSlice::new(util::into_raw([
-            &tuple.0 as *const T0 as *const c_void,
-            &tuple.1 as *const T1 as *const c_void
-        ]) as *mut c_void, 2))
+        Ok(FfiSlice::new(
+            util::into_raw([
+                &tuple.0 as *const T0 as *const c_void,
+                &tuple.1 as *const T1 as *const c_void,
+            ]) as *mut c_void,
+            2,
+        ))
     }
-    fn hashmap_to_raw<K: 'static + Clone + Hash + Eq, V: 'static + Clone>(obj: &AnyObject) -> Fallible<FfiSlice> {
+    fn hashmap_to_raw<K: 'static + Clone + Hash + Eq, V: 'static + Clone>(
+        obj: &AnyObject,
+    ) -> Fallible<FfiSlice> {
         let data: &HashMap<K, V> = obj.downcast_ref()?;
 
         // wrap keys and values up in an AnyObject
@@ -243,7 +299,8 @@ pub extern "C" fn opendp_data__object_as_slice(obj: *const AnyObject) -> FfiResu
 #[bootstrap(
     name = "ffislice_of_anyobjectptrs",
     arguments(raw(rust_type = b"null")),
-    returns(do_not_convert = true))]
+    returns(do_not_convert = true)
+)]
 /// Internal function. Converts an FfiSlice of AnyObjects to an FfiSlice of AnyObjectPtrs.
 #[no_mangle]
 pub extern "C" fn opendp_data__ffislice_of_anyobjectptrs(
@@ -259,7 +316,11 @@ pub extern "C" fn opendp_data__ffislice_of_anyobjectptrs(
         .collect::<Vec<_>>();
 
     // build a new ffislice out of the pointers
-    Ok(FfiSlice::new(vec_any_ptrs.leak() as *mut _ as *mut c_void, raw.len)).into()
+    Ok(FfiSlice::new(
+        vec_any_ptrs.leak() as *mut _ as *mut c_void,
+        raw.len,
+    ))
+    .into()
 }
 
 #[bootstrap(
@@ -278,7 +339,7 @@ pub extern "C" fn opendp_data__object_free(this: *mut AnyObject) -> FfiResult<*m
     arguments(this(do_not_convert = true)),
     returns(c_type = "FfiResult<void *>")
 )]
-/// Internal function. Free the memory associated with `this`, an FfiSlicePtr. 
+/// Internal function. Free the memory associated with `this`, an FfiSlicePtr.
 /// Used to clean up after object_as_slice.
 /// Frees the slice, but not what the slice references!
 #[no_mangle]
@@ -291,7 +352,7 @@ pub extern "C" fn opendp_data__slice_free(this: *mut FfiSlice) -> FfiResult<*mut
     arguments(this(do_not_convert = true, c_type = "char *")),
     returns(c_type = "FfiResult<void *>")
 )]
-/// Internal function. Free the memory associated with `this`, a string. 
+/// Internal function. Free the memory associated with `this`, a string.
 /// Used to clean up after the type getter functions.
 #[no_mangle]
 pub extern "C" fn opendp_data__str_free(this: *mut c_char) -> FfiResult<*mut ()> {
@@ -303,20 +364,19 @@ pub extern "C" fn opendp_data__str_free(this: *mut c_char) -> FfiResult<*mut ()>
     arguments(this(do_not_convert = true, c_type = "bool *")),
     returns(c_type = "FfiResult<void *>")
 )]
-/// Internal function. Free the memory associated with `this`, a bool. 
+/// Internal function. Free the memory associated with `this`, a bool.
 /// Used to clean up after the relation check.
 #[no_mangle]
 pub extern "C" fn opendp_data__bool_free(this: *mut c_bool) -> FfiResult<*mut ()> {
     util::into_owned(this).map(|_| ()).into()
 }
 
-
 impl std::fmt::Debug for AnyObject {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         fn monomorphize<T: 'static + std::fmt::Debug>(this: &AnyObject) -> Fallible<String> {
             Ok(match this.downcast_ref::<T>() {
                 Ok(v) => format!("{:?}", v),
-                Err(e) => e.to_string()
+                Err(e) => e.to_string(),
             })
         }
         let type_arg = &self.type_;
@@ -336,7 +396,10 @@ impl std::fmt::Debug for AnyObject {
 
 impl PartialEq for AnyObject {
     fn eq(&self, other: &Self) -> bool {
-        fn monomorphize<T: 'static + PartialEq>(this: &AnyObject, other: &AnyObject) -> Fallible<bool> {
+        fn monomorphize<T: 'static + PartialEq>(
+            this: &AnyObject,
+            other: &AnyObject,
+        ) -> Fallible<bool> {
             Ok(this.downcast_ref::<T>()? == other.downcast_ref::<T>()?)
         }
 
@@ -347,8 +410,13 @@ impl PartialEq for AnyObject {
 
 impl PartialOrd for AnyObject {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        fn monomorphize<T: 'static + PartialOrd>(this: &AnyObject, other: &AnyObject) -> Fallible<Option<std::cmp::Ordering>> {
-            Ok(this.downcast_ref::<T>()?.partial_cmp(other.downcast_ref::<T>()?))
+        fn monomorphize<T: 'static + PartialOrd>(
+            this: &AnyObject,
+            other: &AnyObject,
+        ) -> Fallible<Option<std::cmp::Ordering>> {
+            Ok(this
+                .downcast_ref::<T>()?
+                .partial_cmp(other.downcast_ref::<T>()?))
         }
 
         let type_arg = &self.type_;
@@ -358,18 +426,42 @@ impl PartialOrd for AnyObject {
 
 impl TotalOrd for AnyObject {
     fn total_cmp(&self, other: &Self) -> Fallible<std::cmp::Ordering> {
-        fn monomorphize<T: 'static + TotalOrd>(this: &AnyObject, other: &AnyObject) -> Fallible<std::cmp::Ordering> {
-            this.downcast_ref::<T>()?.total_cmp(other.downcast_ref::<T>()?)
+        fn monomorphize<T: 'static + TotalOrd>(
+            this: &AnyObject,
+            other: &AnyObject,
+        ) -> Fallible<std::cmp::Ordering> {
+            this.downcast_ref::<T>()?
+                .total_cmp(other.downcast_ref::<T>()?)
         }
 
         let type_arg = &self.type_;
         // type list is explicit because (f32, f32), (f64, f64) are not in @numbers
-        dispatch!(monomorphize, [(type_arg, [
-            u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, (f32, f32), (f64, f64)
-        ])], (self, other))
+        dispatch!(
+            monomorphize,
+            [(
+                type_arg,
+                [
+                    u8,
+                    u16,
+                    u32,
+                    u64,
+                    u128,
+                    i8,
+                    i16,
+                    i32,
+                    i64,
+                    i128,
+                    usize,
+                    f32,
+                    f64,
+                    (f32, f32),
+                    (f64, f64)
+                ]
+            )],
+            (self, other)
+        )
     }
 }
-
 
 impl Clone for AnyObject {
     fn clone(&self) -> Self {
@@ -384,7 +476,9 @@ impl Clone for AnyObject {
         fn clone_hashmap<T0: 'static + Clone, T1: 'static + Clone>(
             obj: &AnyObject,
         ) -> Fallible<AnyObject> {
-            Ok(AnyObject::new(obj.downcast_ref::<HashMap<T0, T1>>()?.clone()))
+            Ok(AnyObject::new(
+                obj.downcast_ref::<HashMap<T0, T1>>()?.clone(),
+            ))
         }
         fn clone_vec<T: 'static + Clone>(obj: &AnyObject) -> Fallible<AnyObject> {
             Ok(AnyObject::new(obj.downcast_ref::<Vec<T>>()?.clone()))
@@ -398,11 +492,13 @@ impl Clone for AnyObject {
                 }
 
                 dispatch!(clone_tuple2, [
-                    (Type::of_id(&type_ids[0]).unwrap(), @primitives), 
+                    (Type::of_id(&type_ids[0]).unwrap(), @primitives),
                     (Type::of_id(&type_ids[1]).unwrap(), @primitives)
                 ], (self))
             }
-            TypeContents::ARRAY { .. } => unimplemented!("AnyObject Clone: attempted to clone array"),
+            TypeContents::ARRAY { .. } => {
+                unimplemented!("AnyObject Clone: attempted to clone array")
+            }
             TypeContents::SLICE(_) => unimplemented!("AnyObject Clone: attempted to clone slice"),
             TypeContents::GENERIC { name, args } => {
                 if *name == "HashMap" {
@@ -415,13 +511,14 @@ impl Clone for AnyObject {
                 } else {
                     unimplemented!("unrecognized generic {:?}", name)
                 }
-            },
-            TypeContents::VEC(type_id) => dispatch!(clone_vec, [(Type::of_id(type_id).unwrap(), @primitives)], (self)),
-        }.expect(&format!("Clone is not implemented for {:?}", self.type_))
+            }
+            TypeContents::VEC(type_id) => {
+                dispatch!(clone_vec, [(Type::of_id(type_id).unwrap(), @primitives)], (self))
+            }
+        }
+        .expect(&format!("Clone is not implemented for {:?}", self.type_))
     }
 }
-
-
 
 #[cfg(feature = "ffi")]
 impl Shuffle for AnyObject {
@@ -432,10 +529,14 @@ impl Shuffle for AnyObject {
                 fn monomorphize<T: 'static>(object: &mut AnyObject) -> Fallible<()> {
                     object.downcast_mut::<Vec<T>>()?.shuffle()
                 }
-                dispatch!(monomorphize, [(atom_type, @primitives)], (self))
-                    .map_err(|_| err!(FFI, "Shuffle for Vec is only implemented for primitive types"))
-            },
-            _ => fallible!(FFI, "Shuffle is only implemented for Vec<T>")
+                dispatch!(monomorphize, [(atom_type, @primitives)], (self)).map_err(|_| {
+                    err!(
+                        FFI,
+                        "Shuffle for Vec is only implemented for primitive types"
+                    )
+                })
+            }
+            _ => fallible!(FFI, "Shuffle is only implemented for Vec<T>"),
         }
     }
 }
@@ -444,17 +545,24 @@ impl Shuffle for AnyObject {
     name = "smd_curve_epsilon",
     arguments(
         curve(rust_type = b"null"),
-        delta(rust_type = "$get_atom(object_type(curve))"))
+        delta(rust_type = "$get_atom(object_type(curve))")
+    )
 )]
 /// Internal function. Use an SMDCurve to find epsilon at a given `delta`.
-/// 
+///
 /// # Returns
 /// Epsilon at a given `delta`.
 #[no_mangle]
-pub extern "C" fn opendp_data__smd_curve_epsilon(curve: *const AnyObject, delta: *const AnyObject) -> FfiResult<*mut AnyObject> {
+pub extern "C" fn opendp_data__smd_curve_epsilon(
+    curve: *const AnyObject,
+    delta: *const AnyObject,
+) -> FfiResult<*mut AnyObject> {
     fn monomorphize<T: 'static>(curve: &AnyObject, delta: &AnyObject) -> Fallible<AnyObject> {
         let delta = delta.downcast_ref::<T>()?;
-        curve.downcast_ref::<SMDCurve<T>>()?.epsilon(delta).map(AnyObject::new)
+        curve
+            .downcast_ref::<SMDCurve<T>>()?
+            .epsilon(delta)
+            .map(AnyObject::new)
     }
     let curve = try_as_ref!(curve);
     let delta = try_as_ref!(delta);
@@ -471,7 +579,8 @@ pub extern "C" fn opendp_data__smd_curve_epsilon(curve: *const AnyObject, delta:
 pub extern "C" fn opendp_data__to_string(this: *const AnyObject) -> FfiResult<*mut c_char> {
     util::into_c_char_p(format!("{:?}", try_as_ref!(this))).map_or_else(
         |e| FfiResult::Err(util::into_raw(FfiError::from(e))),
-        FfiResult::Ok)
+        FfiResult::Ok,
+    )
 }
 
 /// wrap an AnyObject in an FfiResult::Ok(this)
@@ -483,8 +592,8 @@ pub extern "C" fn ffiresult_ok(this: *const AnyObject) -> *const FfiResult<*cons
 /// construct an FfiResult::Err(e)
 #[no_mangle]
 pub extern "C" fn ffiresult_err(
-    message: *mut c_char, 
-    backtrace: *mut c_char
+    message: *mut c_char,
+    backtrace: *mut c_char,
 ) -> *const FfiResult<*const AnyObject> {
     fn make_message(message: *mut c_char, backtrace: *mut c_char) -> Fallible<*mut c_char> {
         let message = util::to_str(message)?;
@@ -494,19 +603,19 @@ pub extern "C" fn ffiresult_err(
     }
     let message = match make_message(message, backtrace) {
         Ok(v) => v,
-        Err(e) => return util::into_raw(FfiResult::from(e))
+        Err(e) => return util::into_raw(FfiResult::from(e)),
     };
     util::into_raw(FfiResult::Err(util::into_raw(FfiError {
         variant: CString::new("FFI").unwrap().into_raw(),
-        message, 
+        message,
         backtrace: CString::new("").unwrap().into_raw(),
     })))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::error::*;
     use crate::error::ExplainUnwrap;
+    use crate::error::*;
     use crate::ffi::util;
     use crate::ffi::util::ToCharP;
 
@@ -574,7 +683,10 @@ mod tests {
         let res = opendp_data__object_as_slice(obj);
         let res = Fallible::from(res)?;
         assert_eq!(res.len, 6);
-        assert_eq!(util::into_string(res.ptr as *mut c_char).unwrap_test(), "Hello");
+        assert_eq!(
+            util::into_string(res.ptr as *mut c_char).unwrap_test(),
+            "Hello"
+        );
         Ok(())
     }
 
@@ -584,7 +696,10 @@ mod tests {
         let res = opendp_data__object_as_slice(obj);
         let res = Fallible::from(res)?;
         assert_eq!(res.len, 3);
-        assert_eq!(util::as_ref(res.ptr as *const [i32; 3]).unwrap_test(), &[1, 2, 3]);
+        assert_eq!(
+            util::as_ref(res.ptr as *const [i32; 3]).unwrap_test(),
+            &[1, 2, 3]
+        );
         Ok(())
     }
 
@@ -595,7 +710,13 @@ mod tests {
         let res = Fallible::from(res)?;
         assert_eq!(res.len, 2);
         let res_ptr = util::as_ref(res.ptr as *const [*mut i32; 2]).unwrap_test();
-        assert_eq!((util::as_ref(res_ptr[0]).unwrap_test(), util::as_ref(res_ptr[1]).unwrap_test()), (&999, &-999));
+        assert_eq!(
+            (
+                util::as_ref(res_ptr[0]).unwrap_test(),
+                util::as_ref(res_ptr[1]).unwrap_test()
+            ),
+            (&999, &-999)
+        );
         Ok(())
     }
 
@@ -607,7 +728,10 @@ mod tests {
         assert_eq!(res.len, 2);
         let res_ptr = util::as_ref(res.ptr as *const [*mut AnyObject; 2]).unwrap_test();
         assert_eq!(
-            (util::as_ref(res_ptr[0]).unwrap_test().downcast_ref()?, util::as_ref(res_ptr[1]).unwrap_test().downcast_ref()?),
+            (
+                util::as_ref(res_ptr[0]).unwrap_test().downcast_ref()?,
+                util::as_ref(res_ptr[1]).unwrap_test().downcast_ref()?
+            ),
             (&999, &999.0)
         );
         Ok(())

--- a/rust/src/data/ffi.rs
+++ b/rust/src/data/ffi.rs
@@ -425,6 +425,7 @@ impl PartialOrd for AnyObject {
 }
 
 impl TotalOrd for AnyObject {
+    #[rustfmt::skip]
     fn total_cmp(&self, other: &Self) -> Fallible<std::cmp::Ordering> {
         fn monomorphize<T: 'static + TotalOrd>(
             this: &AnyObject,
@@ -436,7 +437,6 @@ impl TotalOrd for AnyObject {
 
         let type_arg = &self.type_;
         // type list is explicit because (f32, f32), (f64, f64) are not in @numbers
-        #[rustfmt::skip]
         dispatch!(monomorphize, [(type_arg, [
             u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, (f32, f32), (f64, f64)
         ])], (self, other))

--- a/rust/src/data/ffi.rs
+++ b/rust/src/data/ffi.rs
@@ -436,30 +436,10 @@ impl TotalOrd for AnyObject {
 
         let type_arg = &self.type_;
         // type list is explicit because (f32, f32), (f64, f64) are not in @numbers
-        dispatch!(
-            monomorphize,
-            [(
-                type_arg,
-                [
-                    u8,
-                    u16,
-                    u32,
-                    u64,
-                    u128,
-                    i8,
-                    i16,
-                    i32,
-                    i64,
-                    i128,
-                    usize,
-                    f32,
-                    f64,
-                    (f32, f32),
-                    (f64, f64)
-                ]
-            )],
-            (self, other)
-        )
+        #[rustfmt::skip]
+        dispatch!(monomorphize, [(type_arg, [
+            u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, (f32, f32), (f64, f64)
+        ])], (self, other))
     }
 }
 

--- a/rust/src/data/mod.rs
+++ b/rust/src/data/mod.rs
@@ -1,13 +1,13 @@
 //! Framework for flexible abstract data type model for DataFrames.
 
-#[cfg(feature="ffi")]
+#[cfg(feature = "ffi")]
 mod ffi;
 
-use std::any::Any;
-use std::fmt::Debug;
 use crate::domains::type_name;
 use crate::error::*;
 use crate::traits::CheckNull;
+use std::any::Any;
+use std::fmt::Debug;
 
 pub trait IsVec: Debug {
     // Not sure if we need into_any() (which consumes the Form), keeping it for now.
@@ -18,45 +18,67 @@ pub trait IsVec: Debug {
     fn subset(&self, indicator: &Vec<bool>) -> Box<dyn IsVec>;
 }
 
-impl<T> IsVec for Vec<T> where
-    T: 'static + Debug + Clone + PartialEq {
-    fn into_any(self: Box<Self>) -> Box<dyn Any> { self }
-    fn as_any(&self) -> &dyn Any { self }
-    fn box_clone(&self) -> Box<dyn IsVec> { Box::new(self.clone()) }
-    fn eq(&self, other: &dyn Any) -> bool { other.downcast_ref::<Self>().map_or(false, |o| o == self) }
+impl<T> IsVec for Vec<T>
+where
+    T: 'static + Debug + Clone + PartialEq,
+{
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn box_clone(&self) -> Box<dyn IsVec> {
+        Box::new(self.clone())
+    }
+    fn eq(&self, other: &dyn Any) -> bool {
+        other.downcast_ref::<Self>().map_or(false, |o| o == self)
+    }
     fn subset(&self, indicator: &Vec<bool>) -> Box<dyn IsVec> {
-        Box::new((self.iter())
-            .zip(indicator)
-            .filter_map(|(v, b)| b.then_some(v))
-            .cloned()
-            .collect::<Vec<_>>()) as Box<dyn IsVec>
+        Box::new(
+            (self.iter())
+                .zip(indicator)
+                .filter_map(|(v, b)| b.then_some(v))
+                .cloned()
+                .collect::<Vec<_>>(),
+        ) as Box<dyn IsVec>
     }
 }
 
 impl<T> From<Vec<T>> for Column
-    where T: 'static + Debug + Clone + PartialEq {
+where
+    T: 'static + Debug + Clone + PartialEq,
+{
     fn from(src: Vec<T>) -> Self {
         Column::new(src)
     }
 }
 
-
 #[derive(Debug)]
 pub struct Column(Box<dyn IsVec>);
 impl CheckNull for Column {
-    fn is_null(&self) -> bool { false }
+    fn is_null(&self) -> bool {
+        false
+    }
 }
 
 impl Column {
-    pub fn new<T: 'static + Debug>(form: Vec<T>) -> Self where Vec<T>: IsVec {
+    pub fn new<T: 'static + Debug>(form: Vec<T>) -> Self
+    where
+        Vec<T>: IsVec,
+    {
         Column(Box::new(form))
     }
     pub fn as_form<T: 'static + IsVec>(&self) -> Fallible<&T> {
-        self.0.as_any().downcast_ref::<T>()
+        self.0
+            .as_any()
+            .downcast_ref::<T>()
             .ok_or_else(|| err!(FailedCast, "tried to downcast to {:?}", type_name!(T)))
     }
     pub fn into_form<T: 'static + IsVec>(self) -> Fallible<T> {
-        self.0.into_any().downcast::<T>()
+        self.0
+            .into_any()
+            .downcast::<T>()
             .map_err(|_e| err!(FailedCast))
             .map(|v| *v)
     }
@@ -76,7 +98,6 @@ impl PartialEq for Column {
         self.0.eq(other.0.as_any())
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/rust/src/domains/mod.rs
+++ b/rust/src/domains/mod.rs
@@ -3,16 +3,16 @@
 //! These different versions of [`Domain`] provide a general set of models used throughout OpenDP.
 //! Most of the implementations are generic, with the type parameter setting the underlying [`Domain::Carrier`]
 //! type.
-//! 
+//!
 //! A data domain is a representation of the set of values on which the function associated with a transformation or measurement can operate.
-//! Each metric (see [`crate::metrics`]) is associated with certain data domains. 
+//! Each metric (see [`crate::metrics`]) is associated with certain data domains.
 //! The [`Domain`] trait is implemented for all domains used in OpenDP.
 
-#[cfg(feature="ffi")]
+#[cfg(feature = "ffi")]
 mod ffi;
 
 // Once we have things using `Any` that are outside of `contrib`, this should specify `feature="ffi"`.
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 use std::any::Any;
 use std::collections::HashMap;
 use std::hash::Hash;
@@ -21,30 +21,30 @@ use std::ops::Bound;
 
 use crate::core::Domain;
 use crate::error::Fallible;
-use crate::traits::{CheckNull, TotalOrd, InherentNull, CollectionSize};
+use crate::traits::{CheckNull, CollectionSize, InherentNull, TotalOrd};
 use std::fmt::{Debug, Formatter};
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod poly;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use poly::*;
 
 /// # Proof Definition
 /// `AllDomain(T)` is the domain of all **non-null** values of type `T`.
-/// 
+///
 /// # Example
 /// ```
 /// // Create a domain that includes all values `{0, 1, ..., 2^32 - 1}`.
 /// use opendp::domains::AllDomain;
 /// let i32_domain = AllDomain::<i32>::new();
-/// 
+///
 /// // 1 is a member of the i32_domain
 /// use opendp::core::Domain;
 /// assert!(i32_domain.member(&1)?);
-/// 
+///
 /// // Create a domain that includes all non-null 32-bit floats.
 /// let f32_domain = AllDomain::<f32>::new();
-/// 
+///
 /// // 1. is a member of the f32_domain
 /// assert!(f32_domain.member(&1.)?);
 /// // NAN is not a member of the f32_domain
@@ -60,47 +60,57 @@ impl<T> Debug for AllDomain<T> {
     }
 }
 impl<T> Default for AllDomain<T> {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 impl<T> AllDomain<T> {
     pub fn new() -> Self {
-        AllDomain { _marker: PhantomData }
+        AllDomain {
+            _marker: PhantomData,
+        }
     }
 }
 // Auto-deriving Clone would put the same trait bound on T, so we implement it manually.
 impl<T> Clone for AllDomain<T> {
-    fn clone(&self) -> Self { Self::new() }
+    fn clone(&self) -> Self {
+        Self::new()
+    }
 }
 // Auto-deriving PartialEq would put the same trait bound on T, so we implement it manually.
 impl<T> PartialEq for AllDomain<T> {
-    fn eq(&self, _other: &Self) -> bool { true }
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
 }
 impl<T: CheckNull> Domain for AllDomain<T> {
     type Carrier = T;
-    fn member(&self, val: &Self::Carrier) -> Fallible<bool> { Ok(!val.is_null()) }
+    fn member(&self, val: &Self::Carrier) -> Fallible<bool> {
+        Ok(!val.is_null())
+    }
 }
 
 /// # Proof Definition
 /// `BoundedDomain(lower, upper, T)` is the domain of all **non-null** values of type `T`
 /// between some `lower` bound and `upper` bound.
-/// 
+///
 /// # Notes
 /// The bounds may be inclusive, exclusive, or unbounded (for half-open intervals).
 /// For a type `T` to be valid, it must be totally ordered ([`crate::traits::TotalOrd`]).
-/// 
+///
 /// It is impossible to construct an instance of `BoundedDomain` with inconsistent bounds.
 /// The constructors for this struct return an error if `lower > upper`, or if the bounds both exclude and include a value.
-/// 
+///
 /// # Example
 /// ```
 /// // Create a domain that includes the values `{1, 2, 3}`.
 /// use opendp::domains::BoundedDomain;
 /// let i32_bounded_domain = BoundedDomain::<i32>::new_closed((1, 3))?;
-/// 
+///
 /// // 1 is a member of the i32_domain
 /// use opendp::core::Domain;
 /// assert!(i32_bounded_domain.member(&1)?);
-/// 
+///
 /// // 4 is not a member of the i32_domain
 /// assert!(!i32_bounded_domain.member(&4)?);
 /// # opendp::error::Fallible::Ok(())
@@ -121,20 +131,25 @@ impl<T: TotalOrd> BoundedDomain<T> {
             match value {
                 Bound::Included(value) => Some(value),
                 Bound::Excluded(value) => Some(value),
-                Bound::Unbounded => None
+                Bound::Unbounded => None,
             }
         }
         if let Some((v_lower, v_upper)) = get(&lower).zip(get(&upper)) {
             if v_lower > v_upper {
-                return fallible!(MakeDomain, "lower bound may not be greater than upper bound")
+                return fallible!(
+                    MakeDomain,
+                    "lower bound may not be greater than upper bound"
+                );
             }
             if v_lower == v_upper {
                 match (&lower, &upper) {
-                    (Bound::Included(_l), Bound::Excluded(_u)) =>
-                        return fallible!(MakeDomain, "upper bound excludes inclusive lower bound"),
-                    (Bound::Excluded(_l), Bound::Included(_u)) =>
-                        return fallible!(MakeDomain, "lower bound excludes inclusive upper bound"),
-                    _ => ()
+                    (Bound::Included(_l), Bound::Excluded(_u)) => {
+                        return fallible!(MakeDomain, "upper bound excludes inclusive lower bound")
+                    }
+                    (Bound::Excluded(_l), Bound::Included(_u)) => {
+                        return fallible!(MakeDomain, "lower bound excludes inclusive upper bound")
+                    }
+                    _ => (),
                 }
             }
         }
@@ -150,100 +165,113 @@ impl<T: Clone + TotalOrd> Domain for BoundedDomain<T> {
     type Carrier = T;
     fn member(&self, val: &Self::Carrier) -> Fallible<bool> {
         Ok(match &self.lower {
-            Bound::Included(bound) => { val >= bound }
-            Bound::Excluded(bound) => { val > bound }
-            Bound::Unbounded => { true }
+            Bound::Included(bound) => val >= bound,
+            Bound::Excluded(bound) => val > bound,
+            Bound::Unbounded => true,
         } && match &self.upper {
-            Bound::Included(bound) => { val <= bound }
-            Bound::Excluded(bound) => { val < bound }
-            Bound::Unbounded => { true }
+            Bound::Included(bound) => val <= bound,
+            Bound::Excluded(bound) => val < bound,
+            Bound::Unbounded => true,
         })
     }
 }
 
-
 /// A Domain that contains maps of (homogeneous) values.
-/// 
+///
 /// # Proof Definition
-/// `MapDomain(key_domain, value_domain, DK, DV)` consists of all hashmaps where 
+/// `MapDomain(key_domain, value_domain, DK, DV)` consists of all hashmaps where
 /// keys are elements of key_domain (of type DK) and
 /// values are elements of value_domain (of type DV).
-/// 
+///
 /// The elements in the DK domain are hashable and have a strict equality operation.
-/// 
+///
 /// # Example
 /// ```
 /// use opendp::domains::{MapDomain, AllDomain};
 /// // Rust infers the type from the context, at compile-time.
 /// // Members of this domain are of type `HashMap<&str, i32>`.
 /// let domain = MapDomain::new(AllDomain::new(), AllDomain::new());
-/// 
+///
 /// use opendp::core::Domain;
 /// use std::collections::HashMap;
-/// 
+///
 /// // create a hashmap we can test with
 /// let hashmap = HashMap::from_iter([("a", 23), ("b", 12)]);
 /// assert!(domain.member(&hashmap)?);
-/// 
+///
 /// // Can build up more complicated domains as needed:
 /// use opendp::domains::{InherentNullDomain, BoundedDomain};
 /// let value_domain = InherentNullDomain::new(BoundedDomain::new_closed((0., 1.))?);
 /// let domain = MapDomain::new(AllDomain::new(), value_domain);
-/// 
+///
 /// // The following is not a member of the hashmap domain, because a value is out-of-range:
 /// let hashmap = HashMap::from_iter([("a", 0.), ("b", 2.)]);
 /// assert!(!domain.member(&hashmap)?);
 /// # opendp::error::Fallible::Ok(())
 /// ```
 #[derive(Clone, PartialEq, Debug)]
-pub struct MapDomain<DK: Domain, DV: Domain> where DK::Carrier: Eq + Hash {
+pub struct MapDomain<DK: Domain, DV: Domain>
+where
+    DK::Carrier: Eq + Hash,
+{
     pub key_domain: DK,
-    pub value_domain: DV
+    pub value_domain: DV,
 }
-impl<DK: Domain, DV: Domain> MapDomain<DK, DV> where DK::Carrier: Eq + Hash {
+impl<DK: Domain, DV: Domain> MapDomain<DK, DV>
+where
+    DK::Carrier: Eq + Hash,
+{
     pub fn new(key_domain: DK, element_domain: DV) -> Self {
-        MapDomain { key_domain, value_domain: element_domain }
+        MapDomain {
+            key_domain,
+            value_domain: element_domain,
+        }
     }
 }
-impl<K: CheckNull, V: CheckNull> MapDomain<AllDomain<K>, AllDomain<V>> where K: Eq + Hash {
+impl<K: CheckNull, V: CheckNull> MapDomain<AllDomain<K>, AllDomain<V>>
+where
+    K: Eq + Hash,
+{
     pub fn new_all() -> Self {
         Self::new(AllDomain::<K>::new(), AllDomain::<V>::new())
     }
 }
-impl<DK: Domain, DV: Domain> Domain for MapDomain<DK, DV> where DK::Carrier: Eq + Hash {
+impl<DK: Domain, DV: Domain> Domain for MapDomain<DK, DV>
+where
+    DK::Carrier: Eq + Hash,
+{
     type Carrier = HashMap<DK::Carrier, DV::Carrier>;
     fn member(&self, val: &Self::Carrier) -> Fallible<bool> {
         for (k, v) in val {
             if !self.key_domain.member(k)? || !self.value_domain.member(v)? {
-                return Ok(false)
+                return Ok(false);
             }
         }
         Ok(true)
     }
 }
 
-
 /// A Domain that contains vectors of (homogeneous) values.
-/// 
+///
 /// # Proof Definition
-/// `VectorDomain(inner_domain, D)` is the domain of all vectors of elements drawn from domain `inner_domain`. 
-/// 
+/// `VectorDomain(inner_domain, D)` is the domain of all vectors of elements drawn from domain `inner_domain`.
+///
 /// # Example
 /// ```
 /// use opendp::domains::{VectorDomain, AllDomain, BoundedDomain};
 /// use opendp::core::Domain;
-/// 
+///
 /// // Represents the domain of all vectors.
 /// let all_domain = VectorDomain::new(AllDomain::new());
 /// assert!(all_domain.member(&vec![1, 2, 3])?);
-/// 
+///
 /// // Represents the domain of all bounded vectors.
 /// let bounded_domain = VectorDomain::new(BoundedDomain::new_closed((-10, 10))?);
-/// 
+///
 /// // vec![0] is a member, but vec![12] is not, because 12 is out of bounds of the inner domain
 /// assert!(bounded_domain.member(&vec![0])?);
 /// assert!(!bounded_domain.member(&vec![12])?);
-/// 
+///
 /// # opendp::error::Fallible::Ok(())
 /// ```
 #[derive(Clone, PartialEq)]
@@ -256,7 +284,9 @@ impl<D: Domain> Debug for VectorDomain<D> {
     }
 }
 impl<D: Domain + Default> Default for VectorDomain<D> {
-    fn default() -> Self { Self::new(D::default()) }
+    fn default() -> Self {
+        Self::new(D::default())
+    }
 }
 impl<D: Domain> VectorDomain<D> {
     pub fn new(element_domain: D) -> Self {
@@ -272,21 +302,23 @@ impl<D: Domain> Domain for VectorDomain<D> {
     type Carrier = Vec<D::Carrier>;
     fn member(&self, val: &Self::Carrier) -> Fallible<bool> {
         for e in val {
-            if !self.element_domain.member(e)? {return Ok(false)}
+            if !self.element_domain.member(e)? {
+                return Ok(false);
+            }
         }
         Ok(true)
     }
 }
 
 /// A Domain that specifies the length of the enclosed domain.
-/// 
+///
 /// # Proof Definition
 /// `SizedDomain(inner_domain, size, D)` is the domain of `inner_domain` restricted to only elements with size `size`.
-/// 
+///
 /// # Example
-/// First let `inner_domain` be `VectorDomain::new(AllDomain::<i32>::new())`. 
+/// First let `inner_domain` be `VectorDomain::new(AllDomain::<i32>::new())`.
 /// `inner_domain` indicates the set of all i32 vectors.
-/// 
+///
 /// Then `SizedDomain::new(inner_domain, 3)` indicates the set of all i32 vectors of length 3.
 ///
 /// # Example
@@ -296,11 +328,11 @@ impl<D: Domain> Domain for VectorDomain<D> {
 /// let vec_domain = VectorDomain::new_all();
 /// // Create a domain that includes all i32 vectors of length 3.
 /// let sized_domain = SizedDomain::new(vec_domain, 3);
-/// 
+///
 /// // vec![1, 2, 3] is a member of the sized_domain
 /// use opendp::core::Domain;
 /// assert!(sized_domain.member(&vec![1i32, 2, 3])?);
-/// 
+///
 /// // vec![1, 2] is not a member of the sized_domain
 /// assert!(!sized_domain.member(&vec![1, 2])?);
 /// # opendp::error::Fallible::Ok(())
@@ -308,102 +340,131 @@ impl<D: Domain> Domain for VectorDomain<D> {
 #[derive(Clone, PartialEq)]
 pub struct SizedDomain<D: Domain> {
     pub inner_domain: D,
-    pub size: usize
+    pub size: usize,
 }
 impl<D: Domain> SizedDomain<D> {
     pub fn new(member_domain: D, size: usize) -> Self {
-        SizedDomain { inner_domain: member_domain, size }
+        SizedDomain {
+            inner_domain: member_domain,
+            size,
+        }
     }
 }
 impl<D: Domain> Debug for SizedDomain<D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "SizedDomain({:?}, size={})", self.inner_domain, self.size)
+        write!(
+            f,
+            "SizedDomain({:?}, size={})",
+            self.inner_domain, self.size
+        )
     }
 }
-impl<D: Domain> Domain for SizedDomain<D> where D::Carrier: CollectionSize {
+impl<D: Domain> Domain for SizedDomain<D>
+where
+    D::Carrier: CollectionSize,
+{
     type Carrier = D::Carrier;
     fn member(&self, val: &Self::Carrier) -> Fallible<bool> {
         if val.size() != self.size {
-            return Ok(false)
+            return Ok(false);
         }
         self.inner_domain.member(val)
     }
 }
 
 /// # Proof Definition
-/// `InherentNullDomain(element_domain, D)` is the domain of all values of `element_domain` (of type `D`, a domain) 
-/// unioned with all null members in `D`. 
-/// 
+/// `InherentNullDomain(element_domain, D)` is the domain of all values of `element_domain` (of type `D`, a domain)
+/// unioned with all null members in `D`.
+///
 /// The nullity of members in `D` is indicated via the trait [`crate::traits::InherentNull`].
-/// 
+///
 /// # Notes
-/// A domain may have multiple possible null values, 
+/// A domain may have multiple possible null values,
 /// like in the case of floating-point numbers, which have ~`2^MANTISSA_BITS` null values.
-/// 
-/// Because this domain is defined in terms of a union, 
+///
+/// Because this domain is defined in terms of a union,
 /// null values need a conceptual definition of equality to uniquely identify them in a set.
-/// In order to construct a well-defined set of members in the domain, 
+/// In order to construct a well-defined set of members in the domain,
 /// we consider null values to have the same identity if their bit representation is equal.
-/// 
+///
 /// # Example
 /// ```
 /// use opendp::domains::{InherentNullDomain, AllDomain};
 /// let all_domain = AllDomain::new();
 /// let null_domain = InherentNullDomain::new(all_domain.clone());
-/// 
+///
 /// use opendp::core::Domain;
 /// // f64 NAN is not a member of all_domain, but is a member of null_domain
 /// assert!(!all_domain.member(&f64::NAN)?);
 /// assert!(null_domain.member(&f64::NAN)?);
-/// 
+///
 /// # opendp::error::Fallible::Ok(())
 /// ```
 #[derive(Clone, PartialEq)]
 pub struct InherentNullDomain<D: Domain>
-    where D::Carrier: InherentNull {
+where
+    D::Carrier: InherentNull,
+{
     pub element_domain: D,
 }
 impl<D: Domain + Default> Default for InherentNullDomain<D>
-    where D::Carrier: InherentNull {
-    fn default() -> Self { Self::new(D::default()) }
-}
-impl<D: Domain> InherentNullDomain<D> where D::Carrier: InherentNull {
-    pub fn new(member_domain: D) -> Self {
-        InherentNullDomain { element_domain: member_domain }
+where
+    D::Carrier: InherentNull,
+{
+    fn default() -> Self {
+        Self::new(D::default())
     }
 }
-impl<D: Domain> Debug for InherentNullDomain<D> where D::Carrier: InherentNull {
+impl<D: Domain> InherentNullDomain<D>
+where
+    D::Carrier: InherentNull,
+{
+    pub fn new(member_domain: D) -> Self {
+        InherentNullDomain {
+            element_domain: member_domain,
+        }
+    }
+}
+impl<D: Domain> Debug for InherentNullDomain<D>
+where
+    D::Carrier: InherentNull,
+{
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(f, "InherentNullDomain({:?})", self.element_domain)
     }
 }
-impl<D: Domain> Domain for InherentNullDomain<D> where D::Carrier: InherentNull {
+impl<D: Domain> Domain for InherentNullDomain<D>
+where
+    D::Carrier: InherentNull,
+{
     type Carrier = D::Carrier;
     fn member(&self, val: &Self::Carrier) -> Fallible<bool> {
-        if val.is_null() {return Ok(true)}
+        if val.is_null() {
+            return Ok(true);
+        }
         self.element_domain.member(val)
     }
 }
 
 /// A domain that represents nullity via the Option type.
-/// 
+///
 /// # Proof Definition
-/// `OptionNullDomain(element_domain, D)` is the domain of all values of `element_domain` (of type `D`, a domain) 
+/// `OptionNullDomain(element_domain, D)` is the domain of all values of `element_domain` (of type `D`, a domain)
 /// wrapped in `Some`, as well as `None`.
-/// 
+///
 /// # Notes
-/// This is used to represent nullity for data types like integers or strings, 
+/// This is used to represent nullity for data types like integers or strings,
 /// for which all values they take on are non-null.
-/// 
+///
 /// # Example
 /// ```
 /// use opendp::domains::{OptionNullDomain, AllDomain};
 /// let null_domain = OptionNullDomain::new(AllDomain::new());
-/// 
+///
 /// use opendp::core::Domain;
 /// assert!(null_domain.member(&Some(1))?);
 /// assert!(null_domain.member(&None)?);
-/// 
+///
 /// # opendp::error::Fallible::Ok(())
 /// ```
 #[derive(Clone, PartialEq)]
@@ -411,11 +472,15 @@ pub struct OptionNullDomain<D: Domain> {
     pub element_domain: D,
 }
 impl<D: Domain + Default> Default for OptionNullDomain<D> {
-    fn default() -> Self { Self::new(D::default()) }
+    fn default() -> Self {
+        Self::new(D::default())
+    }
 }
 impl<D: Domain> OptionNullDomain<D> {
     pub fn new(member_domain: D) -> Self {
-        OptionNullDomain { element_domain: member_domain }
+        OptionNullDomain {
+            element_domain: member_domain,
+        }
     }
 }
 impl<D: Domain> Debug for OptionNullDomain<D> {
@@ -426,7 +491,8 @@ impl<D: Domain> Debug for OptionNullDomain<D> {
 impl<D: Domain> Domain for OptionNullDomain<D> {
     type Carrier = Option<D::Carrier>;
     fn member(&self, value: &Self::Carrier) -> Fallible<bool> {
-        value.as_ref()
+        value
+            .as_ref()
             .map(|v| self.element_domain.member(v))
             .unwrap_or(Ok(true))
     }
@@ -434,7 +500,12 @@ impl<D: Domain> Domain for OptionNullDomain<D> {
 
 /// retrieves the type_name for a given type
 macro_rules! type_name {
-    ($ty:ty) => (std::any::type_name::<$ty>().split("::").last().unwrap_or(""))
+    ($ty:ty) => {
+        std::any::type_name::<$ty>()
+            .split("::")
+            .last()
+            .unwrap_or("")
+    };
 }
 pub(crate) use type_name;
 
@@ -459,12 +530,11 @@ mod contrib {
             Ok(self.0.member(&val.0)? && self.1.member(&val.1)?)
         }
     }
-    
-    
+
     /// A Domain that carries an underlying Domain in a Box.
     #[derive(Clone, PartialEq, Debug)]
     pub struct BoxDomain<D: Domain> {
-        element_domain: Box<D>
+        element_domain: Box<D>,
     }
     impl<D: Domain> BoxDomain<D> {
         pub fn new(element_domain: Box<D>) -> Self {
@@ -477,8 +547,7 @@ mod contrib {
             self.element_domain.member(val)
         }
     }
-    
-    
+
     /// A Domain that unwraps a Data wrapper.
     #[derive(Clone, PartialEq, Debug)]
     pub struct DataDomain<D: Domain> {
@@ -489,13 +558,16 @@ mod contrib {
             DataDomain { form_domain }
         }
     }
-    impl<D: Domain> Domain for DataDomain<D> where
-        D::Carrier: 'static + Any {
+    impl<D: Domain> Domain for DataDomain<D>
+    where
+        D::Carrier: 'static + Any,
+    {
         type Carrier = Box<dyn Any>;
         fn member(&self, val: &Self::Carrier) -> Fallible<bool> {
-            let val = val.downcast_ref::<D::Carrier>()
+            let val = val
+                .downcast_ref::<D::Carrier>()
                 .ok_or_else(|| err!(FailedCast, "failed to downcast to carrier type"))?;
             self.form_domain.member(val)
         }
-    }    
+    }
 }

--- a/rust/src/domains/poly.rs
+++ b/rust/src/domains/poly.rs
@@ -17,16 +17,27 @@ impl<TI: 'static, TO: 'static> Function<TI, TO> {
 
 impl<TI> Function<TI, Box<dyn Any>> {
     pub fn eval_poly<TO: 'static>(&self, arg: &TI) -> Fallible<TO> {
-        self.eval(arg)?.downcast().map_err(|_| err!(FailedCast, "Failed downcast of eval_poly result to {}", any::type_name::<TO>())).map(|res| *res)
+        self.eval(arg)?
+            .downcast()
+            .map_err(|_| {
+                err!(
+                    FailedCast,
+                    "Failed downcast of eval_poly result to {}",
+                    any::type_name::<TO>()
+                )
+            })
+            .map(|res| *res)
     }
 }
 
 impl<DI, TO, MI, MO> Measurement<DI, TO, MI, MO>
-    where DI: 'static + Domain,
-          DI::Carrier: 'static,
-          TO: 'static,
-          MI: 'static + Metric,
-          MO: 'static + Measure {
+where
+    DI: 'static + Domain,
+    DI::Carrier: 'static,
+    TO: 'static,
+    MI: 'static + Metric,
+    MO: 'static + Measure,
+{
     /// Converts this Measurement into one with polymorphic output. This is useful for composition
     /// of heterogeneous Measurements.
     pub fn into_poly(self) -> Measurement<DI, Box<dyn Any>, MI, MO> {
@@ -40,13 +51,12 @@ impl<DI, TO, MI, MO> Measurement<DI, TO, MI, MO>
     }
 }
 
-
-#[cfg(all(test, feature="untrusted"))]
+#[cfg(all(test, feature = "untrusted"))]
 mod tests {
     use crate::domains::AllDomain;
     use crate::error::*;
     use crate::measurements;
-    
+
     #[test]
     fn test_poly_measurement() -> Fallible<()> {
         let op_plain = measurements::make_base_laplace::<AllDomain<_>>(0.0, None)?;
@@ -57,8 +67,10 @@ mod tests {
         let res_poly = op_poly.function.eval_poly::<f64>(&arg)?;
         assert_eq!(res_poly, arg);
         let res_bogus = op_poly.function.eval_poly::<i32>(&arg);
-        assert_eq!(res_bogus.err().unwrap_test().variant, ErrorVariant::FailedCast);
+        assert_eq!(
+            res_bogus.err().unwrap_test().variant,
+            ErrorVariant::FailedCast
+        );
         Ok(())
     }
-
 }

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -30,21 +30,20 @@ macro_rules! err {
     // args to format into message
     ($variant:ident, $template:expr, $($args:expr),+) =>
         (err!($variant, format!($template, $($args,)+)));
-    
+
     // always resolve backtraces in debug mode
-    (@backtrace) => (if cfg!(debug_assertions) { 
+    (@backtrace) => (if cfg!(debug_assertions) {
         backtrace::Backtrace::new()
     } else {
-        backtrace::Backtrace::new_unresolved() 
+        backtrace::Backtrace::new_unresolved()
     });
 }
-
 
 #[derive(thiserror::Error, Debug)]
 pub struct Error {
     pub variant: ErrorVariant,
     pub message: Option<String>,
-    pub backtrace: _Backtrace
+    pub backtrace: _Backtrace,
 }
 
 impl PartialEq for Error {
@@ -106,7 +105,7 @@ impl fmt::Display for Error {
 }
 
 // simplify error creation from vega_lite_4
-#[cfg(all(test, feature="test-plot"))]
+#[cfg(all(test, feature = "test-plot"))]
 impl From<String> for Error {
     fn from(v: String) -> Self {
         err!(FailedFunction, v)
@@ -115,7 +114,11 @@ impl From<String> for Error {
 
 impl From<ErrorVariant> for Error {
     fn from(variant: ErrorVariant) -> Self {
-        Self { variant, message: None, backtrace: _Backtrace::new() }
+        Self {
+            variant,
+            message: None,
+            backtrace: _Backtrace::new(),
+        }
     }
 }
 

--- a/rust/src/ffi/glue.rs
+++ b/rust/src/ffi/glue.rs
@@ -39,7 +39,9 @@ impl<T: ?Sized> Clone for Glue<T> {
 }
 
 impl<T: ?Sized> PartialEq for Glue<T> {
-    fn eq(&self, _other: &Self) -> bool { true }
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
 }
 
 impl<T: ?Sized> Deref for Glue<T> {
@@ -48,7 +50,6 @@ impl<T: ?Sized> Deref for Glue<T> {
         self.0.deref()
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -62,7 +63,10 @@ mod tests {
         }
         impl Foo {
             pub fn new(val: i32) -> Self {
-                Self { val, add_glue: Glue::new(|self_: &Foo, other: &Foo| self_.val + other.val) }
+                Self {
+                    val,
+                    add_glue: Glue::new(|self_: &Foo, other: &Foo| self_.val + other.val),
+                }
             }
             pub fn add(&self, other: &Self) -> i32 {
                 (self.add_glue)(self, other)
@@ -83,7 +87,12 @@ mod tests {
         }
         impl Foo {
             pub fn new(val: i32) -> Self {
-                Self { val, add_glue: Glue::new_rc(Rc::new(|self_: &Foo, other: &Foo| self_.val + other.val)) }
+                Self {
+                    val,
+                    add_glue: Glue::new_rc(Rc::new(|self_: &Foo, other: &Foo| {
+                        self_.val + other.val
+                    })),
+                }
             }
             pub fn add(&self, other: &Self) -> i32 {
                 (self.add_glue)(self, other)

--- a/rust/src/ffi/mod.rs
+++ b/rust/src/ffi/mod.rs
@@ -76,7 +76,6 @@
 //! # Memory Management
 //!
 
-
 #[macro_use]
 pub mod dispatch;
 pub mod any;
@@ -91,7 +90,7 @@ macro_rules! try_ {
             Ok(x) => x,
             Err(e) => return e.into(),
         }
-    }
+    };
 }
 // attempt to convert a raw pointer to a reference
 //      as_ref      ok_or_else       try_!
@@ -99,6 +98,7 @@ macro_rules! try_ {
 #[macro_export]
 macro_rules! try_as_ref {
     ($value:expr) => {
-        try_!($crate::ffi::util::as_ref($value).ok_or_else(|| err!(FFI, concat!("null pointer: ", stringify!($value)))))
-    }
+        try_!($crate::ffi::util::as_ref($value)
+            .ok_or_else(|| err!(FFI, concat!("null pointer: ", stringify!($value)))))
+    };
 }

--- a/rust/src/interactive.rs
+++ b/rust/src/interactive.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use crate::core::Measurement;
 use crate::domains::AllDomain;
 use crate::error::*;
-use crate::traits::{CheckNull};
+use crate::traits::CheckNull;
 
 /// A structure tracking the state of an interactive measurement queryable.
 /// It's generic over state (S), query (Q), answer (A), so it can be used for any
@@ -30,7 +30,10 @@ impl<S, Q, A> Queryable<S, Q, A> {
     /// Evaluates a query.
     pub fn eval(&mut self, query: &Q) -> Fallible<A> {
         // Take temporary ownership of the state from this struct.
-        let state = self.state.take().unwrap_assert("Queryable state is only accessed in this method, always replaced.");
+        let state = self
+            .state
+            .take()
+            .unwrap_assert("Queryable state is only accessed in this method, always replaced.");
         // Obtain then new state and answer.
         let new_state_answer = (self.transition)(state, query)?;
         // Restore ownership of the state into this struct.
@@ -42,10 +45,18 @@ impl<S, Q, A> Queryable<S, Q, A> {
 impl<S, Q> Queryable<S, Q, Box<dyn Any>> {
     /// Evaluates a polymorphic query and downcasts to the given type.
     pub fn eval_poly<A: 'static>(&mut self, query: &Q) -> Fallible<A> {
-        self.eval(query)?.downcast().map_err(|_| err!(FailedCast)).map(|b| *b)
+        self.eval(query)?
+            .downcast()
+            .map_err(|_| err!(FailedCast))
+            .map(|b| *b)
     }
 }
 
-impl<S, Q, A> CheckNull for Queryable<S, Q, A> { fn is_null(&self) -> bool { false } }
+impl<S, Q, A> CheckNull for Queryable<S, Q, A> {
+    fn is_null(&self) -> bool {
+        false
+    }
+}
 
-pub type InteractiveMeasurement<DI, TO, MI, MO, S, Q> = Measurement<DI, AllDomain<Queryable<S, Q, TO>>, MI, MO>;
+pub type InteractiveMeasurement<DI, TO, MI, MO, S, Q> =
+    Measurement<DI, AllDomain<Queryable<S, Q, TO>>, MI, MO>;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -42,7 +42,7 @@
 //!     use opendp::transformations::{make_split_lines, make_cast_default, make_clamp, make_bounded_sum};
 //!     use opendp::combinators::{make_chain_tt, make_chain_mt};
 //!     use opendp::measurements::make_base_laplace;
-//! 
+//!
 //!     let data = "56\n15\n97\n56\n6\n17\n2\n19\n16\n50".to_owned();
 //!     let bounds = (0.0, 100.0);
 //!     let epsilon = 1.0;
@@ -88,7 +88,7 @@
 //! # Contributor Guide
 //!
 //! A more thorough Contributor Guide [can be found on the docs website](https://docs.opendp.org/en/stable/contributor/index.html).
-//! 
+//!
 //! ## Adding Constructors
 //!
 //! Measurement constructors go in the module [`crate::measurements`],
@@ -138,15 +138,13 @@
 
 #![allow(clippy::just_underscores_and_digits)]
 #![allow(clippy::type_complexity)]
-
-#![cfg_attr(feature="ffi", allow(clippy::upper_case_acronyms))]
-#![cfg_attr(feature="ffi", allow(non_snake_case))]
-
-#![recursion_limit="512"]
+#![cfg_attr(feature = "ffi", allow(clippy::upper_case_acronyms))]
+#![cfg_attr(feature = "ffi", allow(non_snake_case))]
+#![recursion_limit = "512"]
 
 // create clones of variables that are free to be consumed by a closure
 // Once we have things using `enclose!` that are outside of `contrib`, this should specify `feature="ffi"`.
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 macro_rules! enclose {
     ( $x:ident, $y:expr ) => (enclose!(($x), $y));
     ( ($( $x:ident ),*), $y:expr ) => {
@@ -160,25 +158,25 @@ macro_rules! enclose {
 // #![feature(trace_macros)]
 // trace_macros!(true);
 
-#[cfg(feature="ffi")]
+#[cfg(feature = "ffi")]
 #[macro_use]
 mod ffi;
-#[cfg(feature="ffi")]
+#[cfg(feature = "ffi")]
 #[macro_use]
 extern crate lazy_static;
 
 #[macro_use]
 pub mod error;
 
+pub mod accuracy;
+pub mod combinators;
 pub mod core;
 pub mod data;
-#[cfg(feature="contrib")]
+pub mod domains;
+#[cfg(feature = "contrib")]
 pub mod interactive;
 pub mod measurements;
+pub mod measures;
+pub mod metrics;
 pub mod traits;
 pub mod transformations;
-pub mod combinators;
-pub mod accuracy;
-pub mod domains;
-pub mod metrics;
-pub mod measures;

--- a/rust/src/measurements/alp/mod.rs
+++ b/rust/src/measurements/alp/mod.rs
@@ -3,26 +3,26 @@ use std::hash::{Hash, Hasher};
 use std::rc::Rc;
 
 use num::{Integer, ToPrimitive};
-use rug::{Float, float::Round, ops::AddAssignRound, ops::DivAssignRound};
+use rug::{float::Round, ops::AddAssignRound, ops::DivAssignRound, Float};
 
-use crate::core::{Measurement, Function, PrivacyMap};
-use crate::metrics::L1Distance;
-use crate::measures::MaxDivergence;
+use crate::core::{Function, Measurement, PrivacyMap};
 use crate::domains::{AllDomain, MapDomain};
 use crate::error::Fallible;
 use crate::interactive::Queryable;
-use crate::traits::{DistanceConstant, CheckNull, InfCast};
+use crate::measures::MaxDivergence;
+use crate::metrics::L1Distance;
 use crate::traits::samplers::{fill_bytes, SampleBernoulli};
+use crate::traits::{CheckNull, DistanceConstant, InfCast};
 use std::collections::hash_map::DefaultHasher;
 
-const ALPHA_DEFAULT : u32 = 4;
-const SIZE_FACTOR_DEFAULT : u32 = 50;
+const ALPHA_DEFAULT: u32 = 4;
+const SIZE_FACTOR_DEFAULT: u32 = 50;
 
 /// Implementation of a mechanism for representing sparse integer queries e.g. a sparse histogram.
 /// The mechanism was introduced in the paper:
-/// 
+///
 /// "Differentially Private Sparse Vectors with Low Error, Optimal Space, and Fast Access"
-/// 
+///
 /// Available here: arxiv.org/abs/2106.10068
 
 /// Input domain. The mechanism is designed for settings where the domain of K is huge.
@@ -32,16 +32,17 @@ type SparseDomain<K, C> = MapDomain<AllDomain<K>, AllDomain<C>>;
 type BitVector = Vec<bool>;
 type HashFunctions<K> = Vec<Rc<dyn Fn(&K) -> usize>>;
 #[derive(Clone)]
-
 #[doc(hidden)]
-pub struct AlpState<K, T>{
+pub struct AlpState<K, T> {
     alpha: T,
     scale: T,
     h: HashFunctions<K>,
-    z: BitVector 
+    z: BitVector,
 }
-impl <K,T> CheckNull for AlpState<K,T> {
-    fn is_null(&self) -> bool { false }
+impl<K, T> CheckNull for AlpState<K, T> {
+    fn is_null(&self) -> bool {
+        false
+    }
 }
 
 // hash function with type: [2^64] -> [2^l]
@@ -51,7 +52,7 @@ impl <K,T> CheckNull for AlpState<K,T> {
 // The hash function is 2-approximate universal and uniform
 // See http://hjemmesider.diku.dk/~jyrki/Paper/CP-11.4.1997.pdf
 // "A Reliable Randomized Algorithm for the Closest-Pair Problem"
-fn hash(x: u64, a: u64, b:u64, l: u32) -> usize {
+fn hash(x: u64, a: u64, b: u64, l: u32) -> usize {
     (a.wrapping_mul(x).wrapping_add(b) >> (64 - l)) as usize
 }
 fn pre_hash<K: Hash>(x: K) -> u64 {
@@ -60,8 +61,10 @@ fn pre_hash<K: Hash>(x: K) -> u64 {
     hasher.finish()
 }
 
-fn sample_hash_function<K>(l: u32) -> Fallible<Rc<dyn Fn(&K) -> usize>> 
-    where K: Clone + Hash {
+fn sample_hash_function<K>(l: u32) -> Fallible<Rc<dyn Fn(&K) -> usize>>
+where
+    K: Clone + Hash,
+{
     let mut buf = [0u8; 8];
     fill_bytes(&mut buf)?;
     let a = u64::from_ne_bytes(buf) | 1u64;
@@ -73,30 +76,45 @@ fn sample_hash_function<K>(l: u32) -> Fallible<Rc<dyn Fn(&K) -> usize>>
 // Returns ceil(log_2(x))
 fn exponent_next_power_of_two(x: u64) -> u32 {
     let exp = 63 - x.leading_zeros();
-    if x > (1 << exp) { exp + 1 } else { exp }
+    if x > (1 << exp) {
+        exp + 1
+    } else {
+        exp
+    }
 }
 
 // Multiplies x with scale/alpha and applies randomized rounding to return an integer
-fn scale_and_round<C, T>(x : C, alpha: T, scale: T) -> Fallible<usize> 
-    where C: Integer + ToPrimitive,
-          T: InfCast<Float>,
-          Float: InfCast<T> {
+fn scale_and_round<C, T>(x: C, alpha: T, scale: T) -> Fallible<usize>
+where
+    C: Integer + ToPrimitive,
+    T: InfCast<Float>,
+    Float: InfCast<T>,
+{
     let mut scalar = Float::neg_inf_cast(scale)?;
     scalar.div_assign_round(Float::inf_cast(alpha)?, Round::Down);
     // Truncate bits that represents values below 2^-53
-    scalar.set_prec_round((f64::MANTISSA_DIGITS as i32 - scalar.get_exp().unwrap()).max(1) as u32, Round::Down);
+    scalar.set_prec_round(
+        (f64::MANTISSA_DIGITS as i32 - scalar.get_exp().unwrap()).max(1) as u32,
+        Round::Down,
+    );
 
-    let r = Float::with_val(f64::MANTISSA_DIGITS * 2, x.max(C::zero()).to_u64().unwrap_or_default()) * scalar;
+    let r = Float::with_val(
+        f64::MANTISSA_DIGITS * 2,
+        x.max(C::zero()).to_u64().unwrap_or_default(),
+    ) * scalar;
     let floored = f64::inf_cast(r.clone().floor())? as usize;
-    
+
     match bool::sample_bernoulli(f64::inf_cast(r.fract())?, false)? {
         true => Ok(floored + 1),
-        false => Ok(floored)
+        false => Ok(floored),
     }
 }
 
 // Probability of flipping bits = 1 / (alpha + 2)
-fn compute_prob<T: InfCast<Float>>(alpha: T) -> f64 where Float: InfCast<T> {
+fn compute_prob<T: InfCast<Float>>(alpha: T) -> f64
+where
+    Float: InfCast<T>,
+{
     let mut a = Float::neg_inf_cast(alpha).expect("impl is infallible");
     a.add_assign_round(2, Round::Down);
     a.recip_round(Round::Up);
@@ -106,17 +124,28 @@ fn compute_prob<T: InfCast<Float>>(alpha: T) -> f64 where Float: InfCast<T> {
 
 // Due to privacy concerns the current implementation discards bits with significance less than 2^-52 from scale/alpha
 // Concern (Mike): validate that this constant remains correct when T is parameterized by f32
-fn check_parameters<T: InfCast<Float>>(alpha: T, scale: T) -> bool where Float: InfCast<T> {
+fn check_parameters<T: InfCast<Float>>(alpha: T, scale: T) -> bool
+where
+    Float: InfCast<T>,
+{
     let scale = Float::inf_cast(scale).expect("impl is infallible");
     let alpha = Float::neg_inf_cast(alpha).expect("impl is infallible");
     scale * Float::with_val(53, 52).exp2() < alpha
 }
 
 // Computes the DP projection. This corresponds to Algorithm 4 in the paper
-fn compute_projection<K, C, T>(x: &HashMap<K, C>, h: &HashFunctions<K>, alpha: T, scale: T, s: usize) -> Fallible<BitVector> 
-    where C: Clone + Integer + ToPrimitive,
-          T: Clone + InfCast<Float>,
-          Float: InfCast<T> {
+fn compute_projection<K, C, T>(
+    x: &HashMap<K, C>,
+    h: &HashFunctions<K>,
+    alpha: T,
+    scale: T,
+    s: usize,
+) -> Fallible<BitVector>
+where
+    C: Clone + Integer + ToPrimitive,
+    T: Clone + InfCast<Float>,
+    Float: InfCast<T>,
+{
     let mut z = vec![false; s];
 
     for (k, v) in x.iter() {
@@ -126,42 +155,57 @@ fn compute_projection<K, C, T>(x: &HashMap<K, C>, h: &HashFunctions<K>, alpha: T
 
     let p = compute_prob(alpha);
 
-    z.iter().map(|b| bool::sample_bernoulli(p , false).map(|flip| b ^ flip)).collect()
+    z.iter()
+        .map(|b| bool::sample_bernoulli(p, false).map(|flip| b ^ flip))
+        .collect()
 }
 
 // Estimate the value of an entry based on its noisy bitrepresentation. This is Algorithm 3 in the paper
 fn estimate_unary<T>(v: &Vec<bool>) -> T
-    where T : num::Float {
+where
+    T: num::Float,
+{
     let mut prefix_sum = Vec::with_capacity(v.len() + 1usize);
     prefix_sum.push(0);
 
-    v.iter().map(|b| if *b {1} else {-1}).for_each(|x| prefix_sum.push(prefix_sum.last().unwrap() + x));
-    
+    v.iter()
+        .map(|b| if *b { 1 } else { -1 })
+        .for_each(|x| prefix_sum.push(prefix_sum.last().unwrap() + x));
+
     let high = prefix_sum.iter().max().unwrap();
-    let peaks = prefix_sum.iter().enumerate()
-            .filter_map(|(idx, height)| if high == height {Some(idx)} else {None}).collect::<Vec<_>>();
-    
+    let peaks = prefix_sum
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, height)| if high == height { Some(idx) } else { None })
+        .collect::<Vec<_>>();
+
     // Return the average position
     T::from(peaks.iter().sum::<usize>()).unwrap() / T::from(peaks.len()).unwrap()
 }
 
 // This is Algorithm 5 in the paper
 fn compute_estimate<K, T>(state: &AlpState<K, T>, key: &K) -> T
-    where T: num::Float {
-    let v = state.h.iter().map(|f| state.z[f(key) % state.z.len()]).collect::<Vec<_>>();
+where
+    T: num::Float,
+{
+    let v = state
+        .h
+        .iter()
+        .map(|f| state.z[f(key) % state.z.len()])
+        .collect::<Vec<_>>();
 
     estimate_unary::<T>(&v) * T::from(state.alpha).unwrap() / state.scale
 }
 
-/// Measurement to compute a DP projection of bounded sparse data. 
-/// 
-/// This function allows the user to create custom hash functions. The mechanism provides no utility guarantees 
+/// Measurement to compute a DP projection of bounded sparse data.
+///
+/// This function allows the user to create custom hash functions. The mechanism provides no utility guarantees
 /// if hash functions are chosen poorly. It is recommended to use make_base_alp.
-/// 
+///
 /// # Citations
 /// * [ALP21 Differentially Private Sparse Vectors with Low Error, Optimal Space, and Fast Access](https://arxiv.org/abs/2106.10068)
 ///   Algorithm 4
-/// 
+///
 /// # Arguments
 /// * `alpha` - Parameter used for scaling and determining p in randomized response step. The default value is 4.
 /// * `scale` - Privacy loss parameter. This is equal to epsilon/sensitivity.
@@ -169,113 +213,145 @@ fn compute_estimate<K, T>(state: &AlpState<K, T>, key: &K) -> T
 /// * `h` - Hash functions used to project and estimate entries. The hash functions are not allowed to panic on any input.
 /// The hash functions in `h` should have type K -> \[s\]. To limit collisions the functions should be universal and uniform.
 /// The evaluation time of post-processing is O(h.len()).
-pub fn make_base_alp_with_hashers<K, C, T>(alpha: T, scale: T, s: usize, h: HashFunctions<K>)
-        -> Fallible<Measurement<SparseDomain<K, C>,
-                                AlpState<K, T>,
-                                L1Distance<C>, MaxDivergence<T>>>
-    where K: 'static + Eq + Hash + CheckNull,
-          C: 'static + Clone + Integer + CheckNull + DistanceConstant<C> + ToPrimitive,
-          T: 'static + num::Float + DistanceConstant<T> + InfCast<Float> + InfCast<C>,
-          AlpState<K,T> : CheckNull,
-          Float: InfCast<T> {
-    
+pub fn make_base_alp_with_hashers<K, C, T>(
+    alpha: T,
+    scale: T,
+    s: usize,
+    h: HashFunctions<K>,
+) -> Fallible<Measurement<SparseDomain<K, C>, AlpState<K, T>, L1Distance<C>, MaxDivergence<T>>>
+where
+    K: 'static + Eq + Hash + CheckNull,
+    C: 'static + Clone + Integer + CheckNull + DistanceConstant<C> + ToPrimitive,
+    T: 'static + num::Float + DistanceConstant<T> + InfCast<Float> + InfCast<C>,
+    AlpState<K, T>: CheckNull,
+    Float: InfCast<T>,
+{
     if alpha.is_sign_negative() || alpha.is_zero() {
-        return fallible!(MakeMeasurement, "alpha must be positive")
+        return fallible!(MakeMeasurement, "alpha must be positive");
     }
     if scale.is_sign_negative() || scale.is_zero() {
-        return fallible!(MakeMeasurement, "scale must be positive")
+        return fallible!(MakeMeasurement, "scale must be positive");
     }
     if s == 0 {
-        return fallible!(MakeMeasurement, "s can not be zero")
+        return fallible!(MakeMeasurement, "s can not be zero");
     }
     if check_parameters(alpha, scale) {
-        return fallible!(MakeMeasurement, "scale divided by alpha must be above 2^-52")
+        return fallible!(
+            MakeMeasurement,
+            "scale divided by alpha must be above 2^-52"
+        );
     }
-    
+
     Ok(Measurement::new(
-        MapDomain { key_domain: AllDomain::new(), value_domain: AllDomain::new()},
+        MapDomain {
+            key_domain: AllDomain::new(),
+            value_domain: AllDomain::new(),
+        },
         Function::new_fallible(move |x: &HashMap<K, C>| {
             let z = compute_projection(x, &h, alpha, scale, s)?;
-            Ok(AlpState { alpha, scale, h:h.clone(), z })
+            Ok(AlpState {
+                alpha,
+                scale,
+                h: h.clone(),
+                z,
+            })
         }),
         L1Distance::default(),
         MaxDivergence::default(),
-        PrivacyMap::new_from_constant(scale)
+        PrivacyMap::new_from_constant(scale),
     ))
 }
 
-/// Measurement to compute a DP projection of bounded sparse data. 
-/// 
+/// Measurement to compute a DP projection of bounded sparse data.
+///
 /// The size of the projection is O(total * size_factor * scale / alpha).
-/// The evaluation time of post-processing is O(beta * scale / alpha). 
+/// The evaluation time of post-processing is O(beta * scale / alpha).
 ///
 /// # Citations
 /// * [ALP21 Differentially Private Sparse Vectors with Low Error, Optimal Space, and Fast Access](https://arxiv.org/abs/2106.10068)
 ///   Algorithm 4
-/// 
+///
 /// # Arguments
-/// * `total` - Estimate or true value of the sum of all values in the input. 
+/// * `total` - Estimate or true value of the sum of all values in the input.
 /// This should be an upper bound if the true total is private.
 /// * `size_factor` - Optional multiplier for setting the size of the projection. There is a memory/utility trade-off.
 /// The value should be sufficient large to limit hash collisions. The default value is 50.
 /// * `alpha` - Optional parameter used for scaling and determining p in randomized response step. The default value is 4.
 /// * `scale` - Privacy loss parameter. This is equal to epsilon/sensitivity.
 /// * `beta` - Upper bound on values. Entries above beta are clamped.
-pub fn make_base_alp<K, C, T>(total: usize, size_factor: Option<u32>, alpha: Option<T>, scale: T, beta: C) 
-        -> Fallible<Measurement<SparseDomain<K, C>, 
-                                AlpState<K, T>, 
-                                L1Distance<C>, MaxDivergence<T>>>
-    where K: 'static + Eq + Hash + Clone + CheckNull,
-          C: 'static + Clone + Integer + CheckNull + DistanceConstant<C> + InfCast<T> + ToPrimitive,
-          T: 'static + num::Float + DistanceConstant<T> + InfCast<Float> + InfCast<C>,
-          AlpState<K,T> : CheckNull,
-          Float: InfCast<T> {
-
+pub fn make_base_alp<K, C, T>(
+    total: usize,
+    size_factor: Option<u32>,
+    alpha: Option<T>,
+    scale: T,
+    beta: C,
+) -> Fallible<Measurement<SparseDomain<K, C>, AlpState<K, T>, L1Distance<C>, MaxDivergence<T>>>
+where
+    K: 'static + Eq + Hash + Clone + CheckNull,
+    C: 'static + Clone + Integer + CheckNull + DistanceConstant<C> + InfCast<T> + ToPrimitive,
+    T: 'static + num::Float + DistanceConstant<T> + InfCast<Float> + InfCast<C>,
+    AlpState<K, T>: CheckNull,
+    Float: InfCast<T>,
+{
     let factor = size_factor.unwrap_or(SIZE_FACTOR_DEFAULT) as f64;
     let alpha = alpha.unwrap_or_else(|| T::from(ALPHA_DEFAULT).unwrap());
 
-    let beta: f64 = T::inf_cast(beta)?.to_f64()
+    let beta: f64 = T::inf_cast(beta)?
+        .to_f64()
         .ok_or_else(|| err!(MakeTransformation, "failed to parse beta"))?;
-    let quotient = (scale / alpha).to_f64()
+    let quotient = (scale / alpha)
+        .to_f64()
         .ok_or_else(|| err!(MakeTransformation, "failed to parse scale/alpha"))?;
     let m = (beta * quotient).ceil() as usize;
-    
+
     let exp = exponent_next_power_of_two((factor * total as f64 * quotient) as u64);
-    let h = (0..m).map(|_| sample_hash_function(exp)).collect::<Fallible<HashFunctions<K>>>()?;
+    let h = (0..m)
+        .map(|_| sample_hash_function(exp))
+        .collect::<Fallible<HashFunctions<K>>>()?;
 
     make_base_alp_with_hashers(alpha, scale, 1 << exp, h)
 }
 
 /// Wrap the AlpState in a Queryable object.
-/// 
+///
 /// The Queryable object works similar to a dictionary.
 /// Note that the access time is O(state.h.len()).
 pub fn post_process<K, T>(state: AlpState<K, T>) -> Queryable<AlpState<K, T>, K, T>
-    where T: num::Float {
-    Queryable::new(
-        state,
-        move |state: AlpState<K, T>, key: &K| {
-            let estimate = compute_estimate(&state, key);
-            Ok((state, estimate))
+where
+    T: num::Float,
+{
+    Queryable::new(state, move |state: AlpState<K, T>, key: &K| {
+        let estimate = compute_estimate(&state, key);
+        Ok((state, estimate))
     })
 }
 
 /// Wrapper Measurement. See [`post_process`].
 pub fn make_alp_histogram_post_process<K, C, T>(
-    m: &Measurement<SparseDomain<K, C>, AlpState<K, T>, L1Distance<C>, MaxDivergence<T>>
-) -> Fallible<Measurement<SparseDomain<K, C>, Queryable<AlpState<K, T>, K, T>, L1Distance<C>, MaxDivergence<T>>>
-    where K: 'static + Eq + Hash + CheckNull,
-          C: 'static + Clone + CheckNull,
-          T: 'static + num::Float,
-          HashMap<K,C>: Clone,
-          AlpState<K,T>: Clone {
+    m: &Measurement<SparseDomain<K, C>, AlpState<K, T>, L1Distance<C>, MaxDivergence<T>>,
+) -> Fallible<
+    Measurement<
+        SparseDomain<K, C>,
+        Queryable<AlpState<K, T>, K, T>,
+        L1Distance<C>,
+        MaxDivergence<T>,
+    >,
+>
+where
+    K: 'static + Eq + Hash + CheckNull,
+    C: 'static + Clone + CheckNull,
+    T: 'static + num::Float,
+    HashMap<K, C>: Clone,
+    AlpState<K, T>: Clone,
+{
     let function = m.function.clone();
     Ok(Measurement::new(
         m.input_domain.clone(),
         Function::new_fallible(move |x| function.eval(x).map(post_process)),
         m.input_metric.clone(),
         m.output_measure.clone(),
-        m.privacy_map.clone()))
+        m.privacy_map.clone(),
+    ))
 }
 
 #[cfg(test)]
@@ -287,10 +363,8 @@ mod tests {
     }
 
     // Functions that always return its index
-    fn index_identify_functions<T> (n: usize) -> HashFunctions<T> {
-        (0..n).map(|i| {
-            idx(i)
-        }).collect::<HashFunctions<T>>()
+    fn index_identify_functions<T>(n: usize) -> HashFunctions<T> {
+        (0..n).map(|i| idx(i)).collect::<HashFunctions<T>>()
     }
 
     #[test]
@@ -305,7 +379,6 @@ mod tests {
 
         Ok(())
     }
-
 
     #[test]
     fn test_hash() -> Fallible<()> {
@@ -334,7 +407,12 @@ mod tests {
     #[test]
     fn test_alp_construction() -> Fallible<()> {
         let beta = 10;
-        let alp = make_base_alp_with_hashers::<u32, u32, f64>(1., 1.0, beta, index_identify_functions(beta))?;
+        let alp = make_base_alp_with_hashers::<u32, u32, f64>(
+            1.,
+            1.0,
+            beta,
+            index_identify_functions(beta),
+        )?;
 
         assert_eq!(alp.map(&1)?, 1.);
 
@@ -357,7 +435,7 @@ mod tests {
         // Handle silently using modulo
         // Returning an error would violate privacy
         let h = index_identify_functions(20);
-        let alp = make_base_alp_with_hashers::<u32, u32, f64>( 1., 1.0, s, h)?;
+        let alp = make_base_alp_with_hashers::<u32, u32, f64>(1., 1.0, s, h)?;
 
         let mut x = HashMap::new();
         x.insert(42, 3);
@@ -384,13 +462,43 @@ mod tests {
     #[test]
     fn test_compute_estimate() -> Fallible<()> {
         let z1 = vec![true, true, true, false, true, false, false, true];
-        assert!(compute_estimate(&AlpState {alpha:3., scale:1.0, h:index_identify_functions(8), z:z1}, &0) == 12.0);
+        assert!(
+            compute_estimate(
+                &AlpState {
+                    alpha: 3.,
+                    scale: 1.0,
+                    h: index_identify_functions(8),
+                    z: z1
+                },
+                &0
+            ) == 12.0
+        );
 
         let z2 = vec![true, false, false, false, true, false, false, true];
-        assert!(compute_estimate(&AlpState {alpha:1., scale:2.0, h:index_identify_functions(8), z:z2}, &0) == 0.5);
+        assert!(
+            compute_estimate(
+                &AlpState {
+                    alpha: 1.,
+                    scale: 2.0,
+                    h: index_identify_functions(8),
+                    z: z2
+                },
+                &0
+            ) == 0.5
+        );
 
         let z3 = vec![false, true, true, false, false, true, false, true];
-        assert!(compute_estimate(&AlpState {alpha:1., scale:0.5, h:index_identify_functions(8), z:z3}, &0) == 6.0);
+        assert!(
+            compute_estimate(
+                &AlpState {
+                    alpha: 1.,
+                    scale: 0.5,
+                    h: index_identify_functions(8),
+                    z: z3
+                },
+                &0
+            ) == 6.0
+        );
 
         Ok(())
     }
@@ -402,7 +510,7 @@ mod tests {
         x.insert(42, 12);
         x.insert(100, 5);
 
-        let alp = make_base_alp::<i32,i32,f64>(24, None, None, 2., 24)?;
+        let alp = make_base_alp::<i32, i32, f64>(24, None, None, 2., 24)?;
 
         let state = alp.function.eval(&x)?;
 
@@ -423,10 +531,10 @@ mod tests {
         x.insert(42, 12);
         x.insert(100, 5);
 
-        let alp = make_base_alp::<i32,i32,f64>(24, None, None, 2., 24)?;
+        let alp = make_base_alp::<i32, i32, f64>(24, None, None, 2., 24)?;
 
         let wrapped = make_alp_histogram_post_process(&alp)?;
-        
+
         assert_eq!(wrapped.map(&1)?, 2.);
 
         let mut query = wrapped.function.eval(&x)?;

--- a/rust/src/measurements/discrete_gaussian/ffi.rs
+++ b/rust/src/measurements/discrete_gaussian/ffi.rs
@@ -8,9 +8,11 @@ use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::domains::{AllDomain, VectorDomain};
 use crate::ffi::any::AnyMeasurement;
 use crate::ffi::util::Type;
-use crate::measurements::{make_base_discrete_gaussian, DiscreteGaussianDomain, DiscreteGaussianMeasure};
+use crate::measurements::{
+    make_base_discrete_gaussian, DiscreteGaussianDomain, DiscreteGaussianMeasure,
+};
 use crate::measures::ZeroConcentratedDivergence;
-use crate::traits::{Float, CheckNull, InfCast, Number};
+use crate::traits::{CheckNull, Float, InfCast, Number};
 
 #[no_mangle]
 pub extern "C" fn opendp_measurements__make_base_discrete_gaussian(
@@ -19,7 +21,12 @@ pub extern "C" fn opendp_measurements__make_base_discrete_gaussian(
     MO: *const c_char,
     QI: *const c_char,
 ) -> FfiResult<*mut AnyMeasurement> {
-    fn monomorphize<T, QI, QO>(scale: *const c_void, D: Type, MO: Type, QI: Type) -> FfiResult<*mut AnyMeasurement>
+    fn monomorphize<T, QI, QO>(
+        scale: *const c_void,
+        D: Type,
+        MO: Type,
+        QI: Type,
+    ) -> FfiResult<*mut AnyMeasurement>
     where
         T: 'static + Clone + CheckNull,
         Integer: From<T> + SaturatingCast<T>,
@@ -36,7 +43,7 @@ pub extern "C" fn opendp_measurements__make_base_discrete_gaussian(
             MO: 'static + DiscreteGaussianMeasure<D, QI>,
             Rational: TryFrom<MO::Atom>,
 
-            QI: Number
+            QI: Number,
         {
             make_base_discrete_gaussian::<D, MO, QI>(scale).into_any()
         }

--- a/rust/src/measurements/discrete_gaussian/mod.rs
+++ b/rust/src/measurements/discrete_gaussian/mod.rs
@@ -6,7 +6,7 @@ use opendp_derive::bootstrap;
 use rug::{Integer, Rational};
 
 use crate::{
-    core::{Measure, Measurement, PrivacyMap, Metric},
+    core::{Measure, Measurement, Metric, PrivacyMap},
     domains::{AllDomain, VectorDomain},
     error::Fallible,
     measures::ZeroConcentratedDivergence,
@@ -72,27 +72,27 @@ where
 
 #[bootstrap(
     features("contrib"),
-    arguments(
-        scale(rust_type = "QO", c_type = "void *")),
+    arguments(scale(rust_type = "QO", c_type = "void *")),
     generics(
         D(default = "AllDomain<int>"),
         MO(default = "ZeroConcentratedDivergence<QO>", generics = "QO"),
-        QI(default = "int")),
+        QI(default = "int")
+    ),
     derived_types(QO = "$get_atom_or_infer(MO, scale)")
 )]
 /// Make a Measurement that adds noise from the discrete_gaussian(`scale`) distribution to the input.
-/// 
+///
 /// Set `D` to change the input data type and input metric:
-/// 
+///
 /// | `D`                          | input type   | `D::InputMetric`        |
 /// | ---------------------------- | ------------ | ----------------------- |
 /// | `AllDomain<T>` (default)     | `T`          | `AbsoluteDistance<QI>`  |
 /// | `VectorDomain<AllDomain<T>>` | `Vec<T>`     | `L2Distance<QI>`        |
-/// 
+///
 /// # Arguments
 /// * `scale` - Noise scale parameter for the gaussian distribution. `scale` == standard_deviation.
-/// * `k` - The noise granularity in terms of 2^k. 
-/// 
+/// * `k` - The noise granularity in terms of 2^k.
+///
 /// # Generics
 /// * `D` - Domain of the data type to be privatized. Valid values are `VectorDomain<AllDomain<T>>` or `AllDomain<T>`.
 /// * `MO` - Output measure. The only valid measure is `ZeroConcentratedDivergence<QO>`, but QO can be any float.
@@ -166,16 +166,21 @@ mod test {
 
     #[test]
     fn test_make_base_discrete_gaussian() -> Fallible<()> {
-        let meas = make_base_discrete_gaussian::<AllDomain<_>, ZeroConcentratedDivergence<_>, f32>(1e30f64)?;
+        let meas = make_base_discrete_gaussian::<AllDomain<_>, ZeroConcentratedDivergence<_>, f32>(
+            1e30f64,
+        )?;
         println!("{:?}", meas.invoke(&0)?);
         assert!(meas.check(&1., &1e30f64.recip().powi(2))?);
 
-        let meas = make_base_discrete_gaussian::<AllDomain<_>, ZeroConcentratedDivergence<_>, i32>(0.)?;
+        let meas =
+            make_base_discrete_gaussian::<AllDomain<_>, ZeroConcentratedDivergence<_>, i32>(0.)?;
         assert_eq!(meas.invoke(&0)?, 0);
         assert_eq!(meas.map(&0)?, 0.);
         assert_eq!(meas.map(&1)?, f64::INFINITY);
 
-        let meas = make_base_discrete_gaussian::<AllDomain<_>, ZeroConcentratedDivergence<_>, f64>(f64::MAX)?;
+        let meas = make_base_discrete_gaussian::<AllDomain<_>, ZeroConcentratedDivergence<_>, f64>(
+            f64::MAX,
+        )?;
         println!("{:?} {:?}", meas.invoke(&0)?, i32::MAX);
 
         Ok(())

--- a/rust/src/measurements/discrete_laplace/cks20/ffi.rs
+++ b/rust/src/measurements/discrete_laplace/cks20/ffi.rs
@@ -4,6 +4,7 @@ use std::os::raw::{c_char, c_void};
 use az::SaturatingCast;
 
 use crate::core::FfiResult;
+use crate::core::IntoAnyMeasurementFfiResultExt;
 use crate::ffi::any::AnyMeasurement;
 use crate::{
     domains::{AllDomain, VectorDomain},
@@ -11,8 +12,6 @@ use crate::{
     measurements::{make_base_discrete_laplace_cks20, DiscreteLaplaceDomain},
     traits::InfCast,
 };
-use crate::core::IntoAnyMeasurementFfiResultExt;
-
 
 #[no_mangle]
 pub extern "C" fn opendp_measurements__make_base_discrete_laplace_cks20(
@@ -20,7 +19,11 @@ pub extern "C" fn opendp_measurements__make_base_discrete_laplace_cks20(
     D: *const c_char,
     QO: *const c_char,
 ) -> FfiResult<*mut AnyMeasurement> {
-    fn monomorphize<T, QO>(scale: *const c_void, D: Type, QO: Type) -> FfiResult<*mut AnyMeasurement>
+    fn monomorphize<T, QO>(
+        scale: *const c_void,
+        D: Type,
+        QO: Type,
+    ) -> FfiResult<*mut AnyMeasurement>
     where
         T: crate::traits::Integer,
         QO: crate::traits::Float + InfCast<T>,
@@ -51,8 +54,6 @@ pub extern "C" fn opendp_measurements__make_base_discrete_laplace_cks20(
         (QO, @floats)
     ], (scale, D, QO))
 }
-
-
 
 #[cfg(test)]
 mod tests {

--- a/rust/src/measurements/discrete_laplace/cks20/mod.rs
+++ b/rust/src/measurements/discrete_laplace/cks20/mod.rs
@@ -21,23 +21,23 @@ mod ffi;
     arguments(scale(c_type = "void *")),
     generics(D(default = "AllDomain<int>"))
 )]
-/// Make a Measurement that adds noise from the discrete_laplace(`scale`) distribution to the input, 
+/// Make a Measurement that adds noise from the discrete_laplace(`scale`) distribution to the input,
 /// using an efficient algorithm on rational bignums.
-/// 
+///
 /// Set `D` to change the input data type and input metric:
 ///
-/// 
+///
 /// | `D`                          | input type   | `D::InputMetric`       |
 /// | ---------------------------- | ------------ | ---------------------- |
 /// | `AllDomain<T>` (default)     | `T`          | `AbsoluteDistance<T>`  |
 /// | `VectorDomain<AllDomain<T>>` | `Vec<T>`     | `L1Distance<T>`        |
-/// 
+///
 /// # Citations
 /// * [CKS20 The Discrete Gaussian for Differential Privacy](https://arxiv.org/pdf/2004.00010.pdf#subsection.5.2)
-/// 
+///
 /// # Arguments
 /// * `scale` - Noise scale parameter for the laplace distribution. `scale` == sqrt(2) * standard_deviation.
-/// 
+///
 /// # Generics
 /// * `D` - Domain of the data type to be privatized. Valid values are `VectorDomain<AllDomain<T>>` or `AllDomain<T>`
 /// * `QO` - Data type of the output distance and scale.
@@ -76,7 +76,7 @@ where
                 return fallible!(InvalidDistance, "sensitivity must be non-negative");
             }
             if d_in.is_zero() {
-                return Ok(QO::zero())
+                return Ok(QO::zero());
             }
             if scale.is_zero() {
                 return Ok(QO::infinity());
@@ -87,22 +87,22 @@ where
     ))
 }
 
-/// Make a Measurement that adds noise from the discrete_laplace(`scale`) distribution to the input, 
+/// Make a Measurement that adds noise from the discrete_laplace(`scale`) distribution to the input,
 /// directly using bignum types from [`rug`].
-/// 
+///
 /// Set `D` to change the input data type and input metric:
 ///
 /// | `D`                                | input type     | `D::InputMetric`            |
 /// | ---------------------------------- | -------------- | --------------------------- |
 /// | `AllDomain<Integer>` (default)     | `Integer`      | `AbsoluteDistance<Integer>` |
 /// | `VectorDomain<AllDomain<Integer>>` | `Vec<Integer>` | `L1Distance<Integer>`       |
-/// 
+///
 /// # Citations
 /// * [CKS20 The Discrete Gaussian for Differential Privacy](https://arxiv.org/pdf/2004.00010.pdf#subsection.5.2)
-/// 
+///
 /// # Arguments
 /// * `scale` - Noise scale parameter for the laplace distribution. `scale` == sqrt(2) * standard_deviation.
-/// 
+///
 /// # Generics
 /// * `D` - Domain of the data type to be privatized. Valid values are `VectorDomain<AllDomain<Integer>>` or `AllDomain<Integer>`
 pub fn make_base_discrete_laplace_cks20_rug<D>(
@@ -160,10 +160,13 @@ mod test {
         assert!(meas.check(&Integer::one(), &_1e30)?);
 
         assert!(make_base_discrete_laplace_cks20_rug::<AllDomain<_>>(Rational::zero()).is_err());
-        
+
         let f64_max = Rational::try_from(f64::MAX).unwrap_test();
         let meas = make_base_discrete_laplace_cks20_rug::<AllDomain<_>>(f64_max)?;
-        println!("sample with scale=f64::MAX: {:?}", meas.invoke(&Integer::zero())?);
+        println!(
+            "sample with scale=f64::MAX: {:?}",
+            meas.invoke(&Integer::zero())?
+        );
 
         Ok(())
     }

--- a/rust/src/measurements/discrete_laplace/ffi.rs
+++ b/rust/src/measurements/discrete_laplace/ffi.rs
@@ -16,9 +16,12 @@ pub extern "C" fn opendp_measurements__make_base_discrete_laplace(
     D: *const c_char,
     QO: *const c_char,
 ) -> FfiResult<*mut AnyMeasurement> {
-
-    #[cfg(feature="use-mpfr")]
-    fn monomorphize<T, QO>(scale: *const c_void, D: Type, QO: Type) -> FfiResult<*mut AnyMeasurement>
+    #[cfg(feature = "use-mpfr")]
+    fn monomorphize<T, QO>(
+        scale: *const c_void,
+        D: Type,
+        QO: Type,
+    ) -> FfiResult<*mut AnyMeasurement>
     where
         T: Integer + SampleDiscreteLaplaceLinear<QO>,
         QO: Float + InfCast<T> + InfCast<T>,
@@ -41,8 +44,12 @@ pub extern "C" fn opendp_measurements__make_base_discrete_laplace(
             (QO, [QO])
         ], (scale))
     }
-    #[cfg(not(feature="use-mpfr"))]
-    fn monomorphize<T, QO>(scale: *const c_void, D: Type, QO: Type) -> FfiResult<*mut AnyMeasurement>
+    #[cfg(not(feature = "use-mpfr"))]
+    fn monomorphize<T, QO>(
+        scale: *const c_void,
+        D: Type,
+        QO: Type,
+    ) -> FfiResult<*mut AnyMeasurement>
     where
         T: Integer + SampleDiscreteLaplaceLinear<QO>,
         QO: Float + InfCast<T>,
@@ -69,7 +76,6 @@ pub extern "C" fn opendp_measurements__make_base_discrete_laplace(
         (QO, @floats)
     ], (scale, D, QO))
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/rust/src/measurements/discrete_laplace/linear/mod.rs
+++ b/rust/src/measurements/discrete_laplace/linear/mod.rs
@@ -15,33 +15,31 @@ use super::DiscreteLaplaceDomain;
     features("contrib"),
     arguments(
         scale(c_type = "void *"),
-        bounds(rust_type = "OptionT", default = b"null")),
-    generics(
-        D(default = "AllDomain<int>")),
-    derived_types(
-        T = "$get_atom(D)",
-        OptionT = "Option<(T, T)>")
+        bounds(rust_type = "OptionT", default = b"null")
+    ),
+    generics(D(default = "AllDomain<int>")),
+    derived_types(T = "$get_atom(D)", OptionT = "Option<(T, T)>")
 )]
-/// Make a Measurement that adds noise from the discrete_laplace(`scale`) distribution to the input, 
+/// Make a Measurement that adds noise from the discrete_laplace(`scale`) distribution to the input,
 /// using a linear-time algorithm on finite data types.
-/// 
+///
 /// This algorithm can be executed in constant time if bounds are passed.
 /// Set `D` to change the input data type and input metric:
 ///
-/// 
+///
 /// | `D`                          | input type   | `D::InputMetric`       |
 /// | ---------------------------- | ------------ | ---------------------- |
 /// | `AllDomain<T>` (default)     | `T`          | `AbsoluteDistance<T>`  |
 /// | `VectorDomain<AllDomain<T>>` | `Vec<T>`     | `L1Distance<T>`        |
 ///
-/// 
+///
 /// # Citations
 /// * [GRS12 Universally Utility-Maximizing Privacy Mechanisms](https://theory.stanford.edu/~tim/papers/priv.pdf)
-/// 
+///
 /// # Arguments
 /// * `scale` - Noise scale parameter for the distribution. `scale` == sqrt(2) * standard_deviation.
 /// * `bounds` - Set bounds on the count to make the algorithm run in constant-time.
-/// 
+///
 /// # Generics
 /// * `D` - Domain of the data type to be privatized. Valid values are `VectorDomain<AllDomain<T>>` or `AllDomain<T>`
 /// * `QO` - Data type of the scale and output distance.
@@ -93,21 +91,19 @@ where
     features("contrib"),
     arguments(
         scale(c_type = "void *"),
-        bounds(rust_type = "OptionT", default = b"null")),
-    generics(
-        D(default = "AllDomain<int>")),
-    derived_types(
-        T = "$get_atom(D)",
-        OptionT = "Option<(T, T)>")
+        bounds(rust_type = "OptionT", default = b"null")
+    ),
+    generics(D(default = "AllDomain<int>")),
+    derived_types(T = "$get_atom(D)", OptionT = "Option<(T, T)>")
 )]
-/// Deprecated. 
-/// Use `make_base_discrete_laplace` instead (more efficient). 
+/// Deprecated.
+/// Use `make_base_discrete_laplace` instead (more efficient).
 /// `make_base_discrete_laplace_linear` has a similar interface with the optional constant-time bounds.
-/// 
+///
 /// # Arguments
 /// * `scale` - Noise scale parameter for the distribution. `scale` == sqrt(2) * standard_deviation.
 /// * `bounds` - Set bounds on the count to make the algorithm run in constant-time.
-/// 
+///
 /// # Arguments
 /// * `D` - Domain of the data type to be privatized. Valid values are `VectorDomain<AllDomain<T>>` or `AllDomain<T>`
 /// * `QO` - Data type of the scale and output distance

--- a/rust/src/measurements/discrete_laplace/mod.rs
+++ b/rust/src/measurements/discrete_laplace/mod.rs
@@ -75,23 +75,23 @@ impl<T: Clone + CheckNull> DiscreteLaplaceDomain for VectorDomain<AllDomain<T>> 
     generics(D(default = "AllDomain<int>"))
 )]
 /// Make a Measurement that adds noise from the discrete_laplace(`scale`) distribution to the input.
-/// 
+///
 /// Set `D` to change the input data type and input metric:
-/// 
+///
 /// | `D`                          | input type   | `D::InputMetric`       |
 /// | ---------------------------- | ------------ | ---------------------- |
 /// | `AllDomain<T>` (default)     | `T`          | `AbsoluteDistance<T>`  |
 /// | `VectorDomain<AllDomain<T>>` | `Vec<T>`     | `L1Distance<T>`        |
-/// 
+///
 /// This uses `make_base_discrete_laplace_cks20` if scale is greater than 10, otherwise it uses `make_base_discrete_laplace_linear`.
 ///
 /// # Citations
 /// * [GRS12 Universally Utility-Maximizing Privacy Mechanisms](https://theory.stanford.edu/~tim/papers/priv.pdf)
 /// * [CKS20 The Discrete Gaussian for Differential Privacy](https://arxiv.org/pdf/2004.00010.pdf#subsection.5.2)
-/// 
+///
 /// # Arguments
 /// * `scale` - Noise scale parameter for the laplace distribution. `scale` == sqrt(2) * standard_deviation.
-/// 
+///
 /// # Generics
 /// * `D` - Domain of the data type to be privatized. Valid values are `VectorDomain<AllDomain<T>>` or `AllDomain<T>`
 /// * `QO` - Data type of the output distance and scale. `f32` or `f64`.

--- a/rust/src/measurements/laplace/ffi.rs
+++ b/rust/src/measurements/laplace/ffi.rs
@@ -7,7 +7,7 @@ use crate::ffi::any::AnyMeasurement;
 use crate::ffi::util::Type;
 use crate::measurements::{make_base_laplace, LaplaceDomain};
 use crate::traits::samplers::SampleDiscreteLaplaceZ2k;
-use crate::traits::{ExactIntCast, FloatBits, Float};
+use crate::traits::{ExactIntCast, Float, FloatBits};
 use crate::{err, try_, try_as_ref};
 
 #[no_mangle]
@@ -18,9 +18,9 @@ pub extern "C" fn opendp_measurements__make_base_laplace(
 ) -> FfiResult<*mut AnyMeasurement> {
     fn monomorphize<D>(scale: *const c_void, k: i32) -> FfiResult<*mut AnyMeasurement>
     where
-    D: 'static + LaplaceDomain,
-    D::Atom: Float + SampleDiscreteLaplaceZ2k,
-    i32: ExactIntCast<<D::Atom as FloatBits>::Bits>,
+        D: 'static + LaplaceDomain,
+        D::Atom: Float + SampleDiscreteLaplaceZ2k,
+        i32: ExactIntCast<<D::Atom as FloatBits>::Bits>,
     {
         let scale = *try_as_ref!(scale as *const D::Atom);
         make_base_laplace::<D>(scale, Some(k)).into_any()

--- a/rust/src/measurements/laplace/mod.rs
+++ b/rust/src/measurements/laplace/mod.rs
@@ -1,16 +1,16 @@
-#[cfg(feature="ffi")]
+#[cfg(feature = "ffi")]
 mod ffi;
 
-use num::{Zero, Float as _};
+use num::{Float as _, Zero};
 use opendp_derive::bootstrap;
 
-use crate::core::{Measurement, PrivacyMap, Metric};
-use crate::measures::MaxDivergence;
-use crate::metrics::{L1Distance, AbsoluteDistance};
+use crate::core::{Measurement, Metric, PrivacyMap};
 use crate::domains::{AllDomain, VectorDomain};
 use crate::error::*;
+use crate::measures::MaxDivergence;
+use crate::metrics::{AbsoluteDistance, L1Distance};
 use crate::traits::samplers::SampleDiscreteLaplaceZ2k;
-use crate::traits::{InfDiv, Float, InfAdd, ExactIntCast, FloatBits, CheckNull};
+use crate::traits::{CheckNull, ExactIntCast, Float, FloatBits, InfAdd, InfDiv};
 
 use super::MappableDomain;
 
@@ -35,63 +35,73 @@ impl<T: Clone + CheckNull> LaplaceDomain for VectorDomain<AllDomain<T>> {
     derived_types(T = "$get_atom_or_infer(D, scale)")
 )]
 /// Make a Measurement that adds noise from the laplace(`scale`) distribution to a scalar value.
-/// 
+///
 /// Set `D` to change the input data type and input metric:
-/// 
+///
 /// | `D`                          | input type   | `D::InputMetric`       |
 /// | ---------------------------- | ------------ | ---------------------- |
 /// | `AllDomain<T>` (default)     | `T`          | `AbsoluteDistance<T>`  |
 /// | `VectorDomain<AllDomain<T>>` | `Vec<T>`     | `L1Distance<T>`        |
-/// 
-/// 
-/// This function takes a noise granularity in terms of 2^k. 
-/// Larger granularities are more computationally efficient, but have a looser privacy map. 
+///
+///
+/// This function takes a noise granularity in terms of 2^k.
+/// Larger granularities are more computationally efficient, but have a looser privacy map.
 /// If k is not set, k defaults to the smallest granularity.
-/// 
+///
 /// # Arguments
 /// * `scale` - Noise scale parameter for the laplace distribution. `scale` == sqrt(2) * standard_deviation.
-/// * `k` - The noise granularity in terms of 2^k. 
-/// 
+/// * `k` - The noise granularity in terms of 2^k.
+///
 /// # Generics
 /// * `D` - Domain of the data type to be privatized. Valid values are `VectorDomain<AllDomain<T>>` or `AllDomain<T>`
-pub fn make_base_laplace<D>(scale: D::Atom, k: Option<i32>) -> Fallible<Measurement<D, D::Carrier, D::InputMetric, MaxDivergence<D::Atom>>>
-    where D: LaplaceDomain,
-          D::Atom: Float + SampleDiscreteLaplaceZ2k,
-          i32: ExactIntCast<<D::Atom as FloatBits>::Bits> {
+pub fn make_base_laplace<D>(
+    scale: D::Atom,
+    k: Option<i32>,
+) -> Fallible<Measurement<D, D::Carrier, D::InputMetric, MaxDivergence<D::Atom>>>
+where
+    D: LaplaceDomain,
+    D::Atom: Float + SampleDiscreteLaplaceZ2k,
+    i32: ExactIntCast<<D::Atom as FloatBits>::Bits>,
+{
     if scale.is_sign_negative() {
-        return fallible!(MakeMeasurement, "scale must not be negative")
+        return fallible!(MakeMeasurement, "scale must not be negative");
     }
 
     let (k, relaxation) = get_discretization_consts(k)?;
 
     Ok(Measurement::new(
         D::default(),
-        D::new_map_function(move |arg: &D::Atom| D::Atom::sample_discrete_laplace_Z2k(*arg, scale, k)),
+        D::new_map_function(move |arg: &D::Atom| {
+            D::Atom::sample_discrete_laplace_Z2k(*arg, scale, k)
+        }),
         D::InputMetric::default(),
         MaxDivergence::default(),
-        PrivacyMap::new_fallible(
-            move |d_in: &D::Atom| {
-                if d_in.is_sign_negative() {
-                    return fallible!(InvalidDistance, "sensitivity must be non-negative")
-                }
-                if scale.is_zero() {
-                    return Ok(D::Atom::infinity())
-                }
+        PrivacyMap::new_fallible(move |d_in: &D::Atom| {
+            if d_in.is_sign_negative() {
+                return fallible!(InvalidDistance, "sensitivity must be non-negative");
+            }
+            if scale.is_zero() {
+                return Ok(D::Atom::infinity());
+            }
 
-                // increase d_in by the worst-case rounding of the discretization
-                let d_in = d_in.inf_add(&relaxation)?;
+            // increase d_in by the worst-case rounding of the discretization
+            let d_in = d_in.inf_add(&relaxation)?;
 
-                // d_in / scale
-                d_in.inf_div(&scale)
-            })
+            // d_in / scale
+            d_in.inf_div(&scale)
+        }),
     ))
 }
 
 // proof should show that the return is always a valid (k, relaxation) pairing
 pub(crate) fn get_discretization_consts<T>(k: Option<i32>) -> Fallible<(i32, T)>
-    where T: Float, i32: ExactIntCast<T::Bits> {
+where
+    T: Float,
+    i32: ExactIntCast<T::Bits>,
+{
     // the discretization may only be as fine as the subnormal ulp
-    let k_min = -i32::exact_int_cast(T::EXPONENT_BIAS)? - i32::exact_int_cast(T::MANTISSA_BITS)? + 1;
+    let k_min =
+        -i32::exact_int_cast(T::EXPONENT_BIAS)? - i32::exact_int_cast(T::MANTISSA_BITS)? + 1;
     let k = k.unwrap_or(k_min).max(k_min);
 
     let _2 = T::exact_int_cast(2)?;
@@ -99,7 +109,7 @@ pub(crate) fn get_discretization_consts<T>(k: Option<i32>) -> Fallible<(i32, T)>
     // input has granularity 2^{k_min} (subnormal float precision)
     let input_gran = _2.neg_inf_pow(&T::exact_int_cast(k_min)?)?;
     // discretization rounds to the nearest 2^k
-    let output_gran = _2.inf_pow(&T::exact_int_cast(k)?)?;  
+    let output_gran = _2.inf_pow(&T::exact_int_cast(k)?)?;
 
     // the worst-case increase in sensitivity due to discretization is
     //     the range, minus the smallest step in the range
@@ -111,14 +121,12 @@ pub(crate) fn get_discretization_consts<T>(k: Option<i32>) -> Fallible<(i32, T)>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{transformations::make_sized_bounded_mean, metrics::SymmetricDistance};
+    use crate::{metrics::SymmetricDistance, transformations::make_sized_bounded_mean};
 
     #[test]
     fn test_chain_laplace() -> Fallible<()> {
-        let chain = (
-            make_sized_bounded_mean::<SymmetricDistance, _>(3, (10.0, 12.0))? >>
-            make_base_laplace(1.0, None)?
-        )?;
+        let chain = (make_sized_bounded_mean::<SymmetricDistance, _>(3, (10.0, 12.0))?
+            >> make_base_laplace(1.0, None)?)?;
         let _ret = chain.invoke(&vec![10.0, 11.0, 12.0])?;
         Ok(())
     }
@@ -149,4 +157,3 @@ mod tests {
         Ok(())
     }
 }
-

--- a/rust/src/measurements/mod.rs
+++ b/rust/src/measurements/mod.rs
@@ -2,37 +2,37 @@
 //!
 //! The different [`crate::core::Measurement`] implementations in this module are accessed by calling the appropriate constructor function.
 //! Constructors are named in the form `make_xxx()`, where `xxx` indicates what the resulting `Measurement` does.
-#[cfg(all(feature="use-mpfr", feature="contrib"))]
+#[cfg(all(feature = "use-mpfr", feature = "contrib"))]
 mod discrete_gaussian;
-#[cfg(all(feature="use-mpfr", feature="contrib"))]
+#[cfg(all(feature = "use-mpfr", feature = "contrib"))]
 pub use crate::measurements::discrete_gaussian::*;
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod discrete_laplace;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::measurements::discrete_laplace::*;
 
-#[cfg(all(feature="floating-point", feature="contrib"))]
+#[cfg(all(feature = "floating-point", feature = "contrib"))]
 mod laplace;
-#[cfg(all(feature="floating-point", feature="contrib"))]
+#[cfg(all(feature = "floating-point", feature = "contrib"))]
 pub use crate::measurements::laplace::*;
 
-#[cfg(all(feature="floating-point", feature="contrib", feature="use-mpfr"))]
+#[cfg(all(feature = "floating-point", feature = "contrib", feature = "use-mpfr"))]
 mod gaussian;
-#[cfg(all(feature="floating-point", feature="contrib", feature="use-mpfr"))]
+#[cfg(all(feature = "floating-point", feature = "contrib", feature = "use-mpfr"))]
 pub use crate::measurements::gaussian::*;
 
-#[cfg(all(feature="floating-point", feature="contrib"))]
+#[cfg(all(feature = "floating-point", feature = "contrib"))]
 mod ptr;
-#[cfg(all(feature="floating-point", feature="contrib"))]
+#[cfg(all(feature = "floating-point", feature = "contrib"))]
 pub use crate::measurements::ptr::*;
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod randomized_response;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::measurements::randomized_response::*;
 
-#[cfg(all(feature="use-mpfr", feature="floating-point", feature="contrib"))]
+#[cfg(all(feature = "use-mpfr", feature = "floating-point", feature = "contrib"))]
 mod alp;
-#[cfg(all(feature="use-mpfr", feature="floating-point", feature="contrib"))]
+#[cfg(all(feature = "use-mpfr", feature = "floating-point", feature = "contrib"))]
 pub use crate::measurements::alp::*;

--- a/rust/src/measurements/ptr/mod.rs
+++ b/rust/src/measurements/ptr/mod.rs
@@ -1,26 +1,24 @@
-#[cfg(feature="ffi")]
+#[cfg(feature = "ffi")]
 mod ffi;
 
 /// Algorithms that depend on the propose-test-release framework.
-
 use std::collections::HashMap;
 
 use opendp_derive::bootstrap;
 
 use crate::core::{Function, Measurement, PrivacyMap};
-use crate::metrics::L1Distance;
-use crate::measures::{SmoothedMaxDivergence, SMDCurve};
 use crate::domains::{AllDomain, MapDomain};
 use crate::error::Fallible;
+use crate::measures::{SMDCurve, SmoothedMaxDivergence};
+use crate::metrics::L1Distance;
 use crate::traits::samplers::SampleDiscreteLaplaceZ2k;
-use crate::traits::{Float, Hashable, ExactIntCast};
+use crate::traits::{ExactIntCast, Float, Hashable};
 
 use super::get_discretization_consts;
 
 // propose-test-release count grouped by unknown categories,
 // IMPORTANT: Assumes that dataset distance is bounded above by d_in.
 //  This assumption holds for count queries in L1-space.
-
 
 #[bootstrap(
     features("contrib", "floating-point"),
@@ -31,30 +29,42 @@ use super::get_discretization_consts;
 )]
 /// Make a Measurement that uses propose-test-release to privatize a hashmap of counts.
 ///
-/// This function takes a noise granularity in terms of 2^k. 
-/// Larger granularities are more computationally efficient, but have a looser privacy map. 
+/// This function takes a noise granularity in terms of 2^k.
+/// Larger granularities are more computationally efficient, but have a looser privacy map.
 /// If k is not set, k defaults to the smallest granularity.
 ///
 /// # Arguments
 /// * `scale` - Noise scale parameter for the laplace distribution. `scale` == sqrt(2) * standard_deviation.
 /// * `threshold` - Exclude counts that are less than this minimum value.
-/// * `k` - The noise granularity in terms of 2^k. 
-/// 
+/// * `k` - The noise granularity in terms of 2^k.
+///
 /// # Generics
 /// * `TK` - Type of Key. Must be hashable/categorical.
 /// * `TV` - Type of Value. Must be float.
 pub fn make_base_ptr<TK, TV>(
-    scale: TV, threshold: TV, k: Option<i32>
-) -> Fallible<Measurement<MapDomain<AllDomain<TK>, AllDomain<TV>>, HashMap<TK, TV>, L1Distance<TV>, SmoothedMaxDivergence<TV>>>
-    where TK: Hashable,
-          TV: Float + SampleDiscreteLaplaceZ2k,
-          i32: ExactIntCast<TV::Bits> {
+    scale: TV,
+    threshold: TV,
+    k: Option<i32>,
+) -> Fallible<
+    Measurement<
+        MapDomain<AllDomain<TK>, AllDomain<TV>>,
+        HashMap<TK, TV>,
+        L1Distance<TV>,
+        SmoothedMaxDivergence<TV>,
+    >,
+>
+where
+    TK: Hashable,
+    TV: Float + SampleDiscreteLaplaceZ2k,
+    i32: ExactIntCast<TV::Bits>,
+{
     let _2 = TV::exact_int_cast(2)?;
     let (k, relaxation) = get_discretization_consts(k)?;
     Ok(Measurement::new(
         MapDomain::new(AllDomain::new(), AllDomain::new()),
         Function::new_fallible(move |data: &HashMap<TK, TV>| {
-            data.clone().into_iter()
+            data.clone()
+                .into_iter()
                 // noise output count
                 .map(|(key, v)| TV::sample_discrete_laplace_Z2k(v, scale, k).map(|v| (key, v)))
                 // remove counts that fall below threshold
@@ -65,32 +75,33 @@ pub fn make_base_ptr<TK, TV>(
         L1Distance::default(),
         SmoothedMaxDivergence::default(),
         PrivacyMap::new_fallible(move |&d_in: &TV| {
-            Ok(SMDCurve::new(
-                move |&del: &TV| {
-                    if del.is_sign_negative() || del.is_zero() {
-                        return fallible!(FailedRelation, "delta must be positive");
-                    }
-                    let d_in = d_in.inf_add(&relaxation)?;
-                    let min_eps = d_in / scale;
-                    let min_threshold = (d_in / (_2 * del)).ln() * scale + d_in;
-                    if threshold < min_threshold {
-                        return fallible!(RelationDebug, "threshold must be at least {:?}", min_threshold);
-                    }
-                    Ok(min_eps)
+            Ok(SMDCurve::new(move |&del: &TV| {
+                if del.is_sign_negative() || del.is_zero() {
+                    return fallible!(FailedRelation, "delta must be positive");
                 }
-            ))
-        })))
+                let d_in = d_in.inf_add(&relaxation)?;
+                let min_eps = d_in / scale;
+                let min_threshold = (d_in / (_2 * del)).ln() * scale + d_in;
+                if threshold < min_threshold {
+                    return fallible!(
+                        RelationDebug,
+                        "threshold must be at least {:?}",
+                        min_threshold
+                    );
+                }
+                Ok(min_eps)
+            }))
+        }),
+    ))
 }
-
 
 #[cfg(test)]
 mod tests {
-    use crate::transformations::make_count_by;
     use super::*;
+    use crate::transformations::make_count_by;
 
     #[test]
     fn test_count_by_ptr() -> Fallible<()> {
-
         let max_influence = 1;
         let sensitivity = max_influence as f64;
         let epsilon = 2.;
@@ -99,12 +110,10 @@ mod tests {
         let threshold = (max_influence as f64 / (2. * delta)).ln() * scale + max_influence as f64;
         println!("{:?}", threshold);
 
-        let measurement = (
-            make_count_by()? >>
-            make_base_ptr::<char, f64>(scale, threshold, None)?
-        )?;
-        let ret = measurement.invoke(
-            &vec!['a', 'b', 'a', 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'a'])?;
+        let measurement =
+            (make_count_by()? >> make_base_ptr::<char, f64>(scale, threshold, None)?)?;
+        let ret =
+            measurement.invoke(&vec!['a', 'b', 'a', 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'a'])?;
         println!("stability eval: {:?}", ret);
 
         let epsilon_p = measurement.map(&max_influence)?.epsilon(&delta)?;

--- a/rust/src/measurements/randomized_response/ffi.rs
+++ b/rust/src/measurements/randomized_response/ffi.rs
@@ -18,8 +18,10 @@ pub extern "C" fn opendp_measurements__make_randomized_response_bool(
     QO: *const c_char,
 ) -> FfiResult<*mut AnyMeasurement> {
     fn monomorphize<QO>(prob: *const c_void, constant_time: bool) -> FfiResult<*mut AnyMeasurement>
-        where bool: SampleBernoulli<QO>,
-              QO: Float {
+    where
+        bool: SampleBernoulli<QO>,
+        QO: Float,
+    {
         let prob = *try_as_ref!(prob as *const QO);
         make_randomized_response_bool::<QO>(prob, constant_time).into_any()
     }
@@ -30,7 +32,6 @@ pub extern "C" fn opendp_measurements__make_randomized_response_bool(
     ], (prob, constant_time))
 }
 
-
 #[no_mangle]
 pub extern "C" fn opendp_measurements__make_randomized_response(
     categories: *const AnyObject,
@@ -40,17 +41,23 @@ pub extern "C" fn opendp_measurements__make_randomized_response(
     QO: *const c_char,
 ) -> FfiResult<*mut AnyMeasurement> {
     fn monomorphize<T, QO>(
-        categories: *const AnyObject, prob: *const c_void,
+        categories: *const AnyObject,
+        prob: *const c_void,
         constant_time: bool,
     ) -> FfiResult<*mut AnyMeasurement>
-        where T: Hashable,
-              bool: SampleBernoulli<QO>,
-              QO: Float {
+    where
+        T: Hashable,
+        bool: SampleBernoulli<QO>,
+        QO: Float,
+    {
         let categories = try_!(try_as_ref!(categories).downcast_ref::<Vec<T>>()).clone();
         let prob = *try_as_ref!(prob as *const QO);
         make_randomized_response::<T, QO>(
             HashSet::from_iter(categories.into_iter()),
-            prob, constant_time).into_any()
+            prob,
+            constant_time,
+        )
+        .into_any()
     }
     let T = try_!(Type::try_from(T));
     let QO = try_!(Type::try_from(QO));

--- a/rust/src/measurements/randomized_response/mod.rs
+++ b/rust/src/measurements/randomized_response/mod.rs
@@ -11,7 +11,7 @@ use crate::error::Fallible;
 use crate::measures::MaxDivergence;
 use crate::metrics::DiscreteDistance;
 use crate::traits::samplers::{SampleBernoulli, SampleUniformIntBelow};
-use crate::traits::{Hashable, Float};
+use crate::traits::{Float, Hashable};
 
 // There are two constructors:
 // 1. make_randomized_response_bool
@@ -25,28 +25,26 @@ use crate::traits::{Hashable, Float};
 // In the case of privatizing a balanced coin flip,
 //     t = 2, p = .75, giving eps = ln(.75 / .25) = ln(3)
 
-
 #[bootstrap(
     features("contrib"),
-    arguments(
-        prob(c_type = "void *"), 
-        constant_time(default = false))
+    arguments(prob(c_type = "void *"), constant_time(default = false))
 )]
 /// Make a Measurement that implements randomized response on a boolean value.
 ///
 /// # Arguments
 /// * `prob` - Probability of returning the correct answer. Must be in `[0.5, 1)`
 /// * `constant_time` - Set to true to enable constant time. Slower.
-/// 
+///
 /// # Generics
 /// * `QO` - Data type of probability and output distance.
 pub fn make_randomized_response_bool<QO>(
     prob: QO,
     constant_time: bool,
 ) -> Fallible<Measurement<AllDomain<bool>, bool, DiscreteDistance, MaxDivergence<QO>>>
-    where bool: SampleBernoulli<QO>,
-          QO: Float {
-
+where
+    bool: SampleBernoulli<QO>,
+    QO: Float,
+{
     // number of categories t is 2, and probability is bounded below by 1/t
     if !(QO::exact_int_cast(2)?.recip()..QO::one()).contains(&prob) {
         return fallible!(MakeTransformation, "probability must be within [0.5, 1)");
@@ -78,10 +76,10 @@ pub fn make_randomized_response_bool<QO>(
     features("contrib"),
     arguments(
         categories(rust_type = "Vec<T>"),
-        prob(c_type = "void *"), 
-        constant_time(default = false)),
-    generics(
-        T(example = "$get_first(categories)"))
+        prob(c_type = "void *"),
+        constant_time(default = false)
+    ),
+    generics(T(example = "$get_first(categories)"))
 )]
 /// Make a Measurement that implements randomized response on a categorical value.
 ///
@@ -89,7 +87,7 @@ pub fn make_randomized_response_bool<QO>(
 /// * `categories` - Set of valid outcomes
 /// * `prob` - Probability of returning the correct answer. Must be in `[1/num_categories, 1)`
 /// * `constant_time` - Set to true to enable constant time. Slower.
-/// 
+///
 /// # Generics
 /// * `T` - Data type of a category.
 /// * `QO` - Data type of probability and output distance.
@@ -98,10 +96,11 @@ pub fn make_randomized_response<T, QO>(
     prob: QO,
     constant_time: bool,
 ) -> Fallible<Measurement<AllDomain<T>, T, DiscreteDistance, MaxDivergence<QO>>>
-    where T: Hashable,
-          bool: SampleBernoulli<QO>,
-          QO: Float {
-
+where
+    T: Hashable,
+    bool: SampleBernoulli<QO>,
+    QO: Float,
+{
     let categories = categories.into_iter().collect::<Vec<_>>();
     if categories.len() < 2 {
         return fallible!(
@@ -167,8 +166,8 @@ pub fn make_randomized_response<T, QO>(
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::iter::FromIterator;
     use num::Float as _;
+    use std::iter::FromIterator;
 
     #[test]
     fn test_bool() -> Fallible<()> {

--- a/rust/src/measures/mod.rs
+++ b/rust/src/measures/mod.rs
@@ -1,8 +1,8 @@
 //! Various implementations of Measures (and associated Distance).
-//! 
-//! A Measure is used to measure the distance between distributions. 
+//!
+//! A Measure is used to measure the distance between distributions.
 //! The distance is expressed in terms of an **associated type**.
-//! 
+//!
 //! # Example
 //! `MaxDivergence<Q>` has an associated distance type of `Q`.
 //! This means that the symmetric distance between vectors is expressed in terms of the type `Q`.
@@ -17,18 +17,18 @@ use std::{
     rc::Rc,
 };
 
-use crate::{error::Fallible, core::Measure, domains::type_name};
+use crate::{core::Measure, domains::type_name, error::Fallible};
 
 /// $\epsilon$-pure differential privacy.
-/// 
+///
 /// The greatest divergence between any randomly selected subset of the support.
-/// 
+///
 /// # Proof Definition
-/// 
+///
 /// ### `d`-closeness
-/// For any two vectors $u, v \in \texttt{D}$ and any $d$ of generic type $\texttt{Q}$, 
+/// For any two vectors $u, v \in \texttt{D}$ and any $d$ of generic type $\texttt{Q}$,
 /// we say that $M(u), M(v)$ are $d$-close under the max divergence measure (abbreviated as $D_{\infty}$) whenever
-/// 
+///
 /// ```math
 /// D_{\infty}(M(u) \| M(v)) = \max_{S \subseteq \textrm{Supp}(Y)} \Big[\ln \dfrac{\Pr[M(u) \in S]}{\Pr[M(v) \in S]} \Big] \leq d.
 /// ```
@@ -62,20 +62,20 @@ impl<Q> Measure for MaxDivergence<Q> {
 }
 
 /// $\epsilon(\delta)$-approximate differential privacy.
-/// 
+///
 /// The greatest divergence between any randomly selected subset of the support,
 /// with an additive tolerance for error.
-/// 
-/// The distance $d$ is of type [`SMDCurve`], so it can be invoked with a $\delta$ 
+///
+/// The distance $d$ is of type [`SMDCurve`], so it can be invoked with a $\delta$
 /// to retrieve the tightest corresponding $\epsilon$.
-/// 
+///
 /// # Proof Definition
-/// 
+///
 /// ### `d`-closeness
-/// For any two vectors $u, v \in \texttt{D}$ 
-/// and any choice of $\epsilon, \delta$ such that $\epsilon \ge d(\delta)$, 
+/// For any two vectors $u, v \in \texttt{D}$
+/// and any choice of $\epsilon, \delta$ such that $\epsilon \ge d(\delta)$,
 /// we say that $M(u), M(v)$ are $d$-close under the smoothed max divergence measure (abbreviated as $D_{S\infty}$) whenever
-/// 
+///
 /// ```math
 /// D_{S\infty}(M(u) \| M(v)) = \max_{S \subseteq \textrm{Supp}(Y)} \Big[\ln \dfrac{\Pr[M(u) \in S] + \delta}{\Pr[M(v) \in S]} \Big] \leq \epsilon.
 /// ```
@@ -108,7 +108,7 @@ impl<Q> Measure for SmoothedMaxDivergence<Q> {
 }
 
 /// A function mapping from $\delta$ to $\epsilon$.
-/// 
+///
 /// SMD stands for "Smoothed Max Divergence".
 /// This is the distance type for [`SmoothedMaxDivergence`].
 pub struct SMDCurve<Q>(Rc<dyn Fn(&Q) -> Fallible<Q>>);
@@ -131,17 +131,17 @@ impl<Q> SMDCurve<Q> {
 }
 
 /// $(\epsilon, \delta)$-approximate differential privacy.
-/// 
+///
 /// The greatest divergence between any randomly selected subset of the support,
 /// with an additive tolerance for error.
-/// 
+///
 /// # Proof Definition
-/// 
+///
 /// ### `d`-closeness
 /// For any two vectors $u, v \in \texttt{D}$ and any $d$ of type $(\texttt{Q}, \texttt{Q})$,
 /// where $d = (\epsilon, \delta)$,
 /// we say that $M(u), M(v)$ are $d$-close under the smoothed max divergence measure (abbreviated as $D_{S\infty}$) whenever
-/// 
+///
 /// ```math
 /// D_{S\infty}(M(u) \| M(v)) = \max_{S \subseteq \textrm{Supp}(Y)} \Big[\ln \dfrac{\Pr[M(u) \in S] + \delta}{\Pr[M(v) \in S]} \Big] \leq \epsilon.
 /// ```
@@ -174,18 +174,17 @@ impl<Q> Measure for FixedSmoothedMaxDivergence<Q> {
     type Distance = (Q, Q);
 }
 
-
 /// $\rho$-zero concentrated differential privacy.
-/// 
+///
 /// The greatest zero-concentrated divergence between any randomly selected subset of the support.
-/// 
+///
 /// # Proof Definition
-/// 
+///
 /// ### `d`-closeness
-/// For any two vectors $u, v \in \texttt{D}$ and any $d$ of generic type $\texttt{Q}$, 
+/// For any two vectors $u, v \in \texttt{D}$ and any $d$ of generic type $\texttt{Q}$,
 /// define $P$ and $Q$ to be the distributions of $M(u)$ and $M(v)$.
 /// We say that $u, v$ are $d$-close under the alpha-Renyi divergence measure (abbreviated as $D_{\alpha}$) whenever
-/// 
+///
 /// ```math
 /// D_{\alpha}(P \| Q) = \frac{1}{1 - \alpha} \mathbb{E}_{x \sim Q} \Big[\ln \left( \dfrac{P(x)}{Q(x)} \right)^\alpha \Big] \leq d \alpha.
 /// ```

--- a/rust/src/metrics/mod.rs
+++ b/rust/src/metrics/mod.rs
@@ -1,20 +1,20 @@
 //! Various implementations of Metrics (and associated Distance).
-//! 
-//! A Metric is used to measure the distance between data. 
+//!
+//! A Metric is used to measure the distance between data.
 //! Metrics are paired with a **domain** on which the metric can measure distance.
 //! The distance is expressed in terms of an **associated type**.
-//! 
+//!
 //! # Example
-//! 
-//! [`SymmetricDistance`] can be paired with a domain: `VectorDomain(AllDomain(T))`. 
-//! In this context, the `SymmetricDistance` is used to measure the distance between any two vectors of elements of type `T`. 
+//!
+//! [`SymmetricDistance`] can be paired with a domain: `VectorDomain(AllDomain(T))`.
+//! In this context, the `SymmetricDistance` is used to measure the distance between any two vectors of elements of type `T`.
 //! The `SymmetricDistance` has an associated distance type of [`u32`].
 //! This means that the symmetric distance between vectors is expressed in terms of a [`u32`].
 
 #[cfg(feature = "ffi")]
 mod ffi;
 
-use std::{marker::PhantomData};
+use std::marker::PhantomData;
 
 use crate::{core::Metric, domains::type_name};
 use std::fmt::{Debug, Formatter};
@@ -23,42 +23,45 @@ use std::fmt::{Debug, Formatter};
 /// It is used as the associated [`Metric`]::Distance type for e.g. [`SymmetricDistance`], [`InsertDeleteDistance`], etc.
 pub type IntDistance = u32;
 
-
 /// The smallest number of additions or removals to make two datasets equivalent.
-/// 
+///
 /// This metric is not sensitive to data ordering.
-/// Because this metric counts additions and removals, 
+/// Because this metric counts additions and removals,
 /// it is an unbounded metric (for unbounded DP).
-/// 
+///
 /// # Proof Definition
-/// 
+///
 /// ### `d`-closeness
-/// For any two vectors $u, v \in \texttt{D}$ and any $d$ of type [`IntDistance`], 
-/// we say that $u, v$ are $d$-close under the symmetric distance metric 
-/// (abbreviated as $d_{Sym}$) whenever 
-/// 
+/// For any two vectors $u, v \in \texttt{D}$ and any $d$ of type [`IntDistance`],
+/// we say that $u, v$ are $d$-close under the symmetric distance metric
+/// (abbreviated as $d_{Sym}$) whenever
+///
 /// ```math
 /// d_{Sym}(u, v) = |u \Delta v| \leq d
 /// ```
 /// # Note
-/// The distance type is hard-coded as [`IntDistance`], 
+/// The distance type is hard-coded as [`IntDistance`],
 /// so this metric is not generic over the distance type like many other metrics.
-/// 
+///
 /// # Compatible Domains
-/// 
+///
 /// * `VectorDomain<D>` for any valid `D`
 /// * `SizedDomain<VectorDomain<D>>` for any valid `D`
-/// 
+///
 /// When this metric is paired with a `VectorDomain`, we instead consider the multisets corresponding to $u, v \in \texttt{D}$.
 #[derive(Clone)]
 pub struct SymmetricDistance;
 
 impl Default for SymmetricDistance {
-    fn default() -> Self { SymmetricDistance }
+    fn default() -> Self {
+        SymmetricDistance
+    }
 }
 
 impl PartialEq for SymmetricDistance {
-    fn eq(&self, _other: &Self) -> bool { true }
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
 }
 impl Debug for SymmetricDistance {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
@@ -70,42 +73,46 @@ impl Metric for SymmetricDistance {
 }
 
 /// The smallest number of insertions or deletions to make two datasets equivalent.
-/// 
+///
 /// An *insertion* to a dataset is an addition of an element at a specific index,
 /// and a *deletion* is the removal of an element at a specific index.
-/// 
+///
 /// Therefore, this metric is sensitive to data ordering.
-/// Because this metric counts insertions and deletions, 
+/// Because this metric counts insertions and deletions,
 /// it is an unbounded metric (for unbounded DP).
-/// 
+///
 /// # Proof Definition
-/// 
+///
 /// ### `d`-closeness
-/// For any two vectors $u, v \in \texttt{D}$ and any $d$ of type [`IntDistance`], 
-/// we say that $u, v$ are $d$-close under the insert-delete distance metric 
-/// (abbreviated as $d_{ID}$) whenever 
-/// 
+/// For any two vectors $u, v \in \texttt{D}$ and any $d$ of type [`IntDistance`],
+/// we say that $u, v$ are $d$-close under the insert-delete distance metric
+/// (abbreviated as $d_{ID}$) whenever
+///
 /// ```math
 /// d_{ID}(u, v) \leq d
 /// ```
-/// 
+///
 /// # Note
-/// The distance type is hard-coded as [`IntDistance`], 
+/// The distance type is hard-coded as [`IntDistance`],
 /// so this metric is not generic over the distance type like many other metrics.
-/// 
+///
 /// # Compatible Domains
-/// 
+///
 /// * `VectorDomain<D>` for any valid `D`
 /// * `SizedDomain<VectorDomain<D>>` for any valid `D`
 #[derive(Clone)]
 pub struct InsertDeleteDistance;
 
 impl Default for InsertDeleteDistance {
-    fn default() -> Self { InsertDeleteDistance }
+    fn default() -> Self {
+        InsertDeleteDistance
+    }
 }
 
 impl PartialEq for InsertDeleteDistance {
-    fn eq(&self, _other: &Self) -> bool { true }
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
 }
 impl Debug for InsertDeleteDistance {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
@@ -116,52 +123,55 @@ impl Metric for InsertDeleteDistance {
     type Distance = IntDistance;
 }
 
-
 /// The smallest number of changes to make two equal-length datasets equivalent.
-/// 
+///
 /// This metric is not sensitive to data ordering.
-/// Since this metric counts the number of changed rows, 
+/// Since this metric counts the number of changed rows,
 /// it is a bounded metric (for bounded DP).
-/// 
+///
 /// Since this metric is bounded, the dataset size must be fixed.
 /// Thus we only consider neighboring datasets with the same fixed size: [`crate::domains::SizedDomain`].
-/// 
+///
 /// # Proof Definition
-/// 
+///
 /// ### `d`-closeness
-/// For any two datasets $u, v \in \texttt{D}$ and any $d$ of type [`IntDistance`], 
+/// For any two datasets $u, v \in \texttt{D}$ and any $d$ of type [`IntDistance`],
 /// we say that $u, v$ are $d$-close under the change-one distance metric (abbreviated as $d_{CO}$) whenever
-/// 
+///
 /// ```math
 /// d_{CO}(u, v) = d_{Sym}(u, v) / 2 \leq d
 /// ```
 /// $d_{Sym}$ is in reference to the [`SymmetricDistance`].
-/// 
+///
 /// # Note
-/// Since the dataset size is fixed, 
+/// Since the dataset size is fixed,
 /// there are always just as many additions as there are removals to reach an adjacent dataset.
-/// Consider an edit as one addition and one removal, 
+/// Consider an edit as one addition and one removal,
 /// therefore the symmetric distance is always even.
-/// 
-/// The distance type is hard-coded as [`IntDistance`], 
+///
+/// The distance type is hard-coded as [`IntDistance`],
 /// so this metric is not generic over the distance type like many other metrics.
-/// 
+///
 /// WLOG, most OpenDP interfaces need only consider unbounded metrics.
-/// Use [`crate::transformations::make_metric_unbounded`] and [`crate::transformations::make_metric_bounded`] 
+/// Use [`crate::transformations::make_metric_unbounded`] and [`crate::transformations::make_metric_bounded`]
 /// to convert to/from the symmetric distance.
-/// 
+///
 /// # Compatible Domains
-/// 
+///
 /// * `SizedDomain<D>` for any valid `D`
 #[derive(Clone)]
 pub struct ChangeOneDistance;
 
 impl Default for ChangeOneDistance {
-    fn default() -> Self { ChangeOneDistance }
+    fn default() -> Self {
+        ChangeOneDistance
+    }
 }
 
 impl PartialEq for ChangeOneDistance {
-    fn eq(&self, _other: &Self) -> bool { true }
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
 }
 impl Debug for ChangeOneDistance {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
@@ -173,45 +183,49 @@ impl Metric for ChangeOneDistance {
 }
 
 /// The number of elements that differ between two equal-length datasets.
-/// 
+///
 /// This metric is sensitive to data ordering.
-/// Since this metric counts the number of changed rows, 
+/// Since this metric counts the number of changed rows,
 /// it is a bounded metric (for bounded DP).
-/// 
+///
 /// Since this metric is bounded, the dataset size must be fixed.
 /// Thus we only consider neighboring datasets with the same fixed size: [`crate::domains::SizedDomain`].
-/// 
+///
 /// # Proof Definition
-/// 
+///
 /// ### `d`-closeness
-/// For any two datasets $u, v \in \texttt{D}$ and any $d$ of type [`IntDistance`], 
+/// For any two datasets $u, v \in \texttt{D}$ and any $d$ of type [`IntDistance`],
 /// we say that $u, v$ are $d$-close under the Hamming distance metric (abbreviated as $d_{Ham}$) whenever
-/// 
+///
 /// ```math
 /// d_{Ham}(u, v) = \#\{i: u_i \neq v_i\} \leq d
 /// ```
-/// 
+///
 /// # Note
-/// 
-/// The distance type is hard-coded as [`IntDistance`], 
+///
+/// The distance type is hard-coded as [`IntDistance`],
 /// so this metric is not generic over the distance type like many other metrics.
-/// 
+///
 /// WLOG, most OpenDP interfaces need only consider unbounded metrics.
-/// Use [`crate::transformations::make_metric_unbounded`] and [`crate::transformations::make_metric_bounded`] 
+/// Use [`crate::transformations::make_metric_unbounded`] and [`crate::transformations::make_metric_bounded`]
 /// to convert to/from the symmetric distance.
-/// 
+///
 /// # Compatible Domains
-/// 
+///
 /// * `SizedDomain<D>` for any valid `D`
 #[derive(Clone)]
 pub struct HammingDistance;
 
 impl Default for HammingDistance {
-    fn default() -> Self { HammingDistance }
+    fn default() -> Self {
+        HammingDistance
+    }
 }
 
 impl PartialEq for HammingDistance {
-    fn eq(&self, _other: &Self) -> bool { true }
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
 }
 impl Debug for HammingDistance {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
@@ -223,38 +237,44 @@ impl Metric for HammingDistance {
 }
 
 /// The $L_p$ distance between two vector-valued aggregates.
-/// 
+///
 /// # Proof Definition
-/// 
+///
 /// ### $d$-closeness
-/// For any two vectors $u, v \in \texttt{D}$ and $d$ of generic type $\texttt{Q}$, 
+/// For any two vectors $u, v \in \texttt{D}$ and $d$ of generic type $\texttt{Q}$,
 /// we say that $u, v$ are $d$-close under the the $L_p$ distance metric (abbreviated as $d_{LP}$) whenever
-/// 
+///
 /// ```math
 /// d_{LP}(u, v) = \|u_i - v_i\|_p \leq d
 /// ```
-/// 
+///
 /// If $u$ and $v$ are different lengths, then
 /// ```math
 /// d_{LP}(u, v) = \infty
 /// ```
-/// 
+///
 /// # Compatible Domains
-/// 
+///
 /// * `VectorDomain<D>` for any valid `D`
 /// * `SizedDomain<VectorDomain<D>>` for any valid `D`
 /// * `MapDomain<D>` for any valid `D`
 /// * `SizedDomain<MapDomain<D>>` for any valid `D`
 pub struct LpDistance<const P: usize, Q>(PhantomData<Q>);
 impl<const P: usize, Q> Default for LpDistance<P, Q> {
-    fn default() -> Self { LpDistance(PhantomData) }
+    fn default() -> Self {
+        LpDistance(PhantomData)
+    }
 }
 
 impl<const P: usize, Q> Clone for LpDistance<P, Q> {
-    fn clone(&self) -> Self { Self::default() }
+    fn clone(&self) -> Self {
+        Self::default()
+    }
 }
 impl<const P: usize, Q> PartialEq for LpDistance<P, Q> {
-    fn eq(&self, _other: &Self) -> bool { true }
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
 }
 impl<const P: usize, Q> Debug for LpDistance<P, Q> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
@@ -266,40 +286,46 @@ impl<const P: usize, Q> Metric for LpDistance<P, Q> {
 }
 
 /// The $L_1$ distance between two vector-valued aggregates.
-/// 
+///
 /// Refer to [`LpDistance`] for details.
 pub type L1Distance<Q> = LpDistance<1, Q>;
 
 /// The $L_2$ distance between two vector-valued aggregates.
-/// 
+///
 /// Refer to [`LpDistance`] for details.
 pub type L2Distance<Q> = LpDistance<2, Q>;
 
 /// The absolute distance between two scalar-valued aggregates.
-/// 
+///
 /// # Proof Definition
-/// 
+///
 /// ### `d`-closeness
-/// For any two scalars $u, v \in \texttt{D}$ and $d$ of generic type $\texttt{Q}$, 
+/// For any two scalars $u, v \in \texttt{D}$ and $d$ of generic type $\texttt{Q}$,
 /// we say that $u, v$ are $d$-close under the the the absolute distance metric (abbreviated as $d_{Abs}$) whenever
-/// 
+///
 /// ```math
 /// d_{Abs}(u, v) = |u - v| \leq d
 /// ```
-/// 
+///
 /// # Compatible Domains
-/// 
+///
 /// * `AllDomain<T>` for any valid `T`
 pub struct AbsoluteDistance<Q>(PhantomData<Q>);
 impl<Q> Default for AbsoluteDistance<Q> {
-    fn default() -> Self { AbsoluteDistance(PhantomData) }
+    fn default() -> Self {
+        AbsoluteDistance(PhantomData)
+    }
 }
 
 impl<Q> Clone for AbsoluteDistance<Q> {
-    fn clone(&self) -> Self { Self::default() }
+    fn clone(&self) -> Self {
+        Self::default()
+    }
 }
 impl<Q> PartialEq for AbsoluteDistance<Q> {
-    fn eq(&self, _other: &Self) -> bool { true }
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
 }
 impl<Q> Debug for AbsoluteDistance<Q> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
@@ -311,35 +337,39 @@ impl<Q> Metric for AbsoluteDistance<Q> {
 }
 
 /// Indicates if two elements are equal to each other.
-/// 
-/// This is used in the context of randomized response, 
+///
+/// This is used in the context of randomized response,
 /// to capture the distance between adjacent inputs (they are either equivalent or not).
-/// 
+///
 /// # Proof Definition
-/// 
+///
 /// ### `d`-closeness
-/// For any two datasets $u, v \in$ `AllDomain<T>` and any $d$ of type [`IntDistance`], 
+/// For any two datasets $u, v \in$ `AllDomain<T>` and any $d$ of type [`IntDistance`],
 /// we say that $u, v$ are $d$-close under the discrete metric (abbreviated as $d_{Eq}$) whenever
-/// 
+///
 /// ```math
 /// d_{Eq}(u, v) = \mathbb{1}[u = v] \leq d
 /// ```
-/// 
+///
 /// # Notes
 /// Clearly, `d` is bounded above by 1.
 /// 1 is the expected argument on measurements that use this distance.
-/// 
+///
 /// # Compatible Domains
 /// * AllDomain<T> for any valid `T`.
 #[derive(Clone)]
 pub struct DiscreteDistance;
 
 impl Default for DiscreteDistance {
-    fn default() -> Self { DiscreteDistance }
+    fn default() -> Self {
+        DiscreteDistance
+    }
 }
 
 impl PartialEq for DiscreteDistance {
-    fn eq(&self, _other: &Self) -> bool { true }
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
 }
 impl Debug for DiscreteDistance {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
@@ -351,7 +381,7 @@ impl Metric for DiscreteDistance {
 }
 
 /// A dummy to fill the metric position in postprocessors.
-/// 
+///
 /// Postprocessors don't necessarily care about matching metrics.
 #[derive(Clone, Default, PartialEq)]
 pub struct AgnosticMetric;

--- a/rust/src/traits/arithmetic/mod.rs
+++ b/rust/src/traits/arithmetic/mod.rs
@@ -1,15 +1,13 @@
-#[cfg(feature = "use-mpfr")]
-use rug::ops::{AddAssignRound, DivAssignRound, MulAssignRound, SubAssignRound, PowAssignRound};
 use crate::traits::{ExactIntCast, InfCast};
+#[cfg(feature = "use-mpfr")]
+use rug::ops::{AddAssignRound, DivAssignRound, MulAssignRound, PowAssignRound, SubAssignRound};
 
 use crate::error::Fallible;
-#[cfg(feature="use-mpfr")]
+#[cfg(feature = "use-mpfr")]
 use rug::Float;
 
-
-
 /// Fallible absolute value that returns an error if overflowing.
-/// 
+///
 /// This can return an error when a signed integer is the smallest negative value.
 /// Avoids unrecoverable panics that could leak private information.
 /// ```
@@ -23,7 +21,7 @@ pub trait AlertingAbs: Sized {
 }
 
 /// Fallible addition that returns an error if overflowing.
-/// 
+///
 /// Avoids unrecoverable panics that could leak private information.
 /// ```
 /// use opendp::traits::AlertingAdd;
@@ -37,7 +35,7 @@ pub trait AlertingAdd: Sized {
 }
 
 /// Fallible subtraction that returns an error if overflowing.
-/// 
+///
 /// Avoids unrecoverable panics that could leak private information.
 /// ```
 /// use opendp::traits::AlertingSub;
@@ -51,7 +49,7 @@ pub trait AlertingSub: Sized {
 }
 
 /// Fallible multiplication that returns an error if overflowing.
-/// 
+///
 /// Avoids unrecoverable panics that could leak private information.
 /// ```
 /// use opendp::traits::AlertingMul;
@@ -65,7 +63,7 @@ pub trait AlertingMul: Sized {
 }
 
 /// Fallible division that returns an error if overflowing.
-/// 
+///
 /// Avoids unrecoverable panics that could leak private information.
 /// ```
 /// use opendp::traits::AlertingDiv;
@@ -79,8 +77,8 @@ pub trait AlertingDiv: Sized {
 }
 
 /// Fallibly raise to the power.
-/// 
-/// Returns an error if overflowing. 
+///
+/// Returns an error if overflowing.
 /// Avoids unrecoverable panics that could leak private information.
 /// ```
 /// use opendp::traits::AlertingPow;
@@ -94,7 +92,7 @@ pub trait AlertingPow: Sized {
 }
 
 /// Addition that saturates at the numeric bounds instead of overflowing.
-/// 
+///
 /// Avoids unrecoverable panics that could leak private information.
 /// ```
 /// use opendp::traits::SaturatingAdd;
@@ -108,7 +106,7 @@ pub trait SaturatingAdd: Sized {
 }
 
 /// Multiplication that saturates at the numeric bounds instead of overflowing.
-/// 
+///
 /// Avoids unrecoverable panics that could leak private information.
 /// ```
 /// use opendp::traits::SaturatingMul;
@@ -122,176 +120,176 @@ pub trait SaturatingMul: Sized {
 }
 
 /// Fallible exponentiation with specified rounding.
-/// 
+///
 /// Throws an error if the ideal output is not finite or representable.
 pub trait InfExp: Sized {
     /// # Proof Definition
-    /// For any `self` of type `Self`, 
-    /// `self.inf_exp()` either returns `Ok(out)`, 
+    /// For any `self` of type `Self`,
+    /// `self.inf_exp()` either returns `Ok(out)`,
     /// where $out \ge \exp(self)$, or `Err(e)`.
     fn inf_exp(self) -> Fallible<Self>;
     /// # Proof Definition
-    /// For any `self` of type `Self`, 
-    /// `self.neg_inf_exp()` either returns `Ok(out)`, 
+    /// For any `self` of type `Self`,
+    /// `self.neg_inf_exp()` either returns `Ok(out)`,
     /// where $out \le \exp(self)$, or `Err(e)`.
     fn neg_inf_exp(self) -> Fallible<Self>;
 }
 
 /// Fallible natural logarithm with specified rounding.
-/// 
+///
 /// Throws an error if the ideal output is not finite or representable.
 pub trait InfLn: Sized {
     /// # Proof Definition
-    /// For any `self` of type `Self`, 
-    /// `self.inf_ln()` either returns `Ok(out)`, 
+    /// For any `self` of type `Self`,
+    /// `self.inf_ln()` either returns `Ok(out)`,
     /// where $out \ge \ln(self)$, or `Err(e)`.
     fn inf_ln(self) -> Fallible<Self>;
     /// # Proof Definition
-    /// For any `self` of type `Self`, 
-    /// `self.neg_inf_ln()` either returns `Ok(out)`, 
+    /// For any `self` of type `Self`,
+    /// `self.neg_inf_ln()` either returns `Ok(out)`,
     /// where $out \le \ln(self)$, or `Err(e)`.
     fn neg_inf_ln(self) -> Fallible<Self>;
 }
 
 /// Fallible base-2 logarithm with specified rounding.
-/// 
+///
 /// Throws an error if the ideal output is not finite or representable.
 pub trait InfLog2: Sized {
     /// # Proof Definition
-    /// For any `self` of type `Self`, 
-    /// `self.inf_log2()` either returns `Ok(out)`, 
+    /// For any `self` of type `Self`,
+    /// `self.inf_log2()` either returns `Ok(out)`,
     /// where $out \ge \log_2(self)$, or `Err(e)`.
     fn inf_log2(self) -> Fallible<Self>;
     /// # Proof Definition
-    /// For any `self` of type `Self`, 
-    /// `self.neg_inf_log2()` either returns `Ok(out)`, 
+    /// For any `self` of type `Self`,
+    /// `self.neg_inf_log2()` either returns `Ok(out)`,
     /// where $out \le \log_2(self)$, or `Err(e)`.
     fn neg_inf_log2(self) -> Fallible<Self>;
 }
 
 /// Fallible square root with specified rounding.
-/// 
+///
 /// Throws an error if the ideal output is not finite or representable.
 pub trait InfSqrt: Sized {
     /// # Proof Definition
-    /// For any `self` of type `Self`, 
-    /// `self.inf_log2()` either returns `Ok(out)`, 
+    /// For any `self` of type `Self`,
+    /// `self.inf_log2()` either returns `Ok(out)`,
     /// where $out \ge \sqrt{self}$, or `Err(e)`.
     fn inf_sqrt(self) -> Fallible<Self>;
     /// # Proof Definition
-    /// For any `self` of type `Self`, 
-    /// `self.neg_inf_log2()` either returns `Ok(out)`, 
+    /// For any `self` of type `Self`,
+    /// `self.neg_inf_log2()` either returns `Ok(out)`,
     /// where $out \le \sqrt{self}$, or `Err(e)`.
     fn neg_inf_sqrt(self) -> Fallible<Self>;
 }
 
 /// Fallibly raise self to the power with specified rounding.
-/// 
+///
 /// Throws an error if the ideal output is not finite or representable.
 pub trait InfPow: Sized + AlertingPow {
     /// # Proof Definition
-    /// For any two values `self` and `p` of type `Self`, 
-    /// `self.inf_pow(p)` either returns `Ok(out)`, 
+    /// For any two values `self` and `p` of type `Self`,
+    /// `self.inf_pow(p)` either returns `Ok(out)`,
     /// where $out \ge self^{p}$, or `Err(e)`.
     fn inf_pow(&self, p: &Self) -> Fallible<Self>;
     /// # Proof Definition
-    /// For any two values `self` and `p` of type `Self`, 
-    /// `self.neg_inf_pow(p)` either returns `Ok(out)`, 
+    /// For any two values `self` and `p` of type `Self`,
+    /// `self.neg_inf_pow(p)` either returns `Ok(out)`,
     /// where $out \le self^{p}$, or `Err(e)`.
     fn neg_inf_pow(&self, p: &Self) -> Fallible<Self>;
 }
 
 /// Fallible addition with specified rounding.
-/// 
+///
 /// Throws an error if the ideal output is not finite or representable.
 pub trait InfAdd: Sized + AlertingAdd {
     /// # Proof Definition
-    /// For any two values `self` and `v` of type `Self`, 
-    /// `self.inf_add(v)` either returns `Ok(out)`, 
+    /// For any two values `self` and `v` of type `Self`,
+    /// `self.inf_add(v)` either returns `Ok(out)`,
     /// where $out \ge self + v$, or `Err(e)`.
     fn inf_add(&self, v: &Self) -> Fallible<Self>;
     /// # Proof Definition
-    /// For any two values `self` and `v` of type `Self`, 
-    /// `self.neg_inf_add(v)` either returns `Ok(out)`, 
+    /// For any two values `self` and `v` of type `Self`,
+    /// `self.neg_inf_add(v)` either returns `Ok(out)`,
     /// where $out \le self + v$, or `Err(e)`.
     fn neg_inf_add(&self, v: &Self) -> Fallible<Self>;
 }
 
 /// Fallible subtraction with specified rounding.
-/// 
+///
 /// Throws an error if the ideal output is not finite or representable.
 pub trait InfSub: Sized + AlertingSub {
     /// # Proof Definition
-    /// For any two values `self` and `v` of type `Self`, 
-    /// `self.inf_sub(v)` either returns `Ok(out)`, 
+    /// For any two values `self` and `v` of type `Self`,
+    /// `self.inf_sub(v)` either returns `Ok(out)`,
     /// where $out \ge self - v$, or `Err(e)`.
     fn inf_sub(&self, v: &Self) -> Fallible<Self>;
     /// # Proof Definition
-    /// For any two values `self` and `v` of type `Self`, 
-    /// `self.neg_inf_sub(v)` either returns `Ok(out)`, 
+    /// For any two values `self` and `v` of type `Self`,
+    /// `self.neg_inf_sub(v)` either returns `Ok(out)`,
     /// where $out \le self - v$, or `Err(e)`.
     fn neg_inf_sub(&self, v: &Self) -> Fallible<Self>;
 }
 
 /// Fallible multiplication with specified rounding.
-/// 
+///
 /// Throws an error if the ideal output is not finite or representable.
 pub trait InfMul: Sized + AlertingMul {
     /// # Proof Definition
-    /// For any two values `self` and `v` of type `Self`, 
-    /// `self.inf_mul(v)` either returns `Ok(out)`, 
+    /// For any two values `self` and `v` of type `Self`,
+    /// `self.inf_mul(v)` either returns `Ok(out)`,
     /// where $out \ge self \cdot v$, or `Err(e)`.
     fn inf_mul(&self, v: &Self) -> Fallible<Self>;
     /// # Proof Definition
-    /// For any two values `self` and `v` of type `Self`, 
-    /// `self.neg_inf_mul(v)` either returns `Ok(out)`, 
+    /// For any two values `self` and `v` of type `Self`,
+    /// `self.neg_inf_mul(v)` either returns `Ok(out)`,
     /// where $out \le self \cdot v$, or `Err(e)`.
     fn neg_inf_mul(&self, v: &Self) -> Fallible<Self>;
 }
 
 /// Fallible division with specified rounding.
-/// 
+///
 /// Throws an error if the ideal output is not finite or representable.
 pub trait InfDiv: Sized + AlertingDiv {
     /// # Proof Definition
-    /// For any two values `self` and `v` of type `Self`, 
-    /// `self.inf_div(v)` either returns `Ok(out)`, 
+    /// For any two values `self` and `v` of type `Self`,
+    /// `self.inf_div(v)` either returns `Ok(out)`,
     /// where $out \ge self / v$, or `Err(e)`.
     fn inf_div(&self, v: &Self) -> Fallible<Self>;
     /// # Proof Definition
-    /// For any two values `self` and `v` of type `Self`, 
-    /// `self.neg_inf_div(v)` either returns `Ok(out)`, 
+    /// For any two values `self` and `v` of type `Self`,
+    /// `self.neg_inf_div(v)` either returns `Ok(out)`,
     /// where $out \le self / v$, or `Err(e)`.
     fn neg_inf_div(&self, v: &Self) -> Fallible<Self>;
 }
 
- /// Fallibly exponentiate and subtract one with specified rounding.
- /// 
- /// Throws an error if the ideal output is not finite or representable.
- /// This provides more numerical stability than computing the quantity outright.
+/// Fallibly exponentiate and subtract one with specified rounding.
+///
+/// Throws an error if the ideal output is not finite or representable.
+/// This provides more numerical stability than computing the quantity outright.
 pub trait InfExpM1: Sized {
     /// # Proof Definition
-    /// For any `self` of type `Self`, 
-    /// `self.inf_exp_m1()` either returns `Ok(out)`, 
+    /// For any `self` of type `Self`,
+    /// `self.inf_exp_m1()` either returns `Ok(out)`,
     /// where $out \ge \exp(self) - 1$, or `Err(e)`.
     fn inf_exp_m1(self) -> Fallible<Self>;
     /// # Proof Definition
-    /// For any `self` of type `Self`, 
-    /// `self.neg_inf_exp_m1()` either returns `Ok(out)`, 
+    /// For any `self` of type `Self`,
+    /// `self.neg_inf_exp_m1()` either returns `Ok(out)`,
     /// where $out \le \exp(self) - 1$, or `Err(e)`.
     fn neg_inf_exp_m1(self) -> Fallible<Self>;
 }
 
- /// Fallible logarithm of the argument plus one with specified rounding.
- pub trait InfLn1P: Sized {
+/// Fallible logarithm of the argument plus one with specified rounding.
+pub trait InfLn1P: Sized {
     /// # Proof Definition
-    /// For any `self` of type `Self`, 
-    /// `self.inf_ln_1p()` either returns `Ok(out)`, 
+    /// For any `self` of type `Self`,
+    /// `self.inf_ln_1p()` either returns `Ok(out)`,
     /// where $out \ge \ln(self + 1)$, or `Err(e)`.
     fn inf_ln_1p(self) -> Fallible<Self>;
     /// # Proof Definition
-    /// For any `self` of type `Self`, 
-    /// `self.neg_inf_ln_1p()` either returns `Ok(out)`, 
+    /// For any `self` of type `Self`,
+    /// `self.neg_inf_ln_1p()` either returns `Ok(out)`,
     /// where $out \le \ln(self + 1)$, or `Err(e)`.
     fn neg_inf_ln_1p(self) -> Fallible<Self>;
 }
@@ -324,8 +322,6 @@ macro_rules! impl_alerting_abs_float {
     })+)
 }
 impl_alerting_abs_float!(f32, f64);
-
-
 
 // TRAIT Alerting*, Saturating*
 macro_rules! impl_alerting_int {
@@ -453,7 +449,6 @@ macro_rules! impl_alerting_float {
 }
 impl_alerting_float!(f32, f64);
 
-
 // TRAIT InfSqrt, InfLn, InfExp (univariate)
 macro_rules! impl_float_inf_uni {
     ($($ty:ty),+; $name:ident, $method_inf:ident, $method_neg_inf:ident, $op:ident, $fallback:ident) => {
@@ -506,7 +501,6 @@ impl_float_inf_uni!(f64, f32; InfExp, inf_exp, neg_inf_exp, exp_round, exp);
 impl_float_inf_uni!(f64, f32; InfLn1P, inf_ln_1p, neg_inf_ln_1p, ln_1p_round, ln_1p);
 impl_float_inf_uni!(f64, f32; InfExpM1, inf_exp_m1, neg_inf_exp_m1, exp_m1_round, exp_m1);
 impl_float_inf_uni!(f64, f32; InfSqrt, inf_sqrt, neg_inf_sqrt, sqrt_round, sqrt);
-
 
 // TRAIT InfAdd, InfSub, InfMul, InfDiv (bivariate)
 macro_rules! impl_int_inf {

--- a/rust/src/traits/bounded/mod.rs
+++ b/rust/src/traits/bounded/mod.rs
@@ -14,4 +14,3 @@ macro_rules! impl_finite_bounds {
     })+)
 }
 impl_finite_bounds!(f64 f32 i8 i16 i32 i64 i128 isize u8 u16 u32 u64 u128 usize);
-

--- a/rust/src/traits/mod.rs
+++ b/rust/src/traits/mod.rs
@@ -3,7 +3,7 @@
 use crate::metrics::IntDistance;
 use num::{One, Zero};
 use std::hash::Hash;
-use std::ops::{AddAssign, SubAssign, MulAssign, DivAssign};
+use std::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
 
 mod bounded;
 pub use bounded::*;
@@ -20,19 +20,19 @@ pub use operations::*;
 pub mod samplers;
 
 /// A type that can be used as a stability or privacy constant to scale a distance.
-/// 
+///
 /// Encapsulates the necessary traits for the new_from_constant method on maps.
 /// Making a map from a constant has the general form:
-/// 
+///
 /// ```text
 /// d_out = TO::distance_cast(d_in.clone())?.inf_mul(c)?
 /// ```
 /// (where d_out and c are of type TO, which implements DistanceConstant)
-/// 
+///
 /// - InfCast<TI> is for casting where the distance after the cast is gte the distance before the cast
 /// - InfMul is to multiply with the constant `c` in a way that doesn't round down
 /// - TotalOrd is now only for convenience
-/// 
+///
 /// # Example
 /// ```
 /// use opendp::traits::DistanceConstant;
@@ -40,7 +40,7 @@ pub mod samplers;
 /// fn example_map<TI, TO: DistanceConstant<TI>>(d_in: TI, c: TO) -> Fallible<TO> {
 ///     TO::inf_cast(d_in)?.inf_mul(&c)
 /// }
-/// 
+///
 /// assert_eq!(example_map(3.14159_f32, 2_i8).ok(), Some(8_i8));
 /// // same thing, but annotate types in a different way
 /// assert_eq!(example_map::<f32, i8>(3.14159, 2).ok(), Some(8));
@@ -50,41 +50,41 @@ pub trait DistanceConstant<TI>: 'static + InfCast<TI> + InfMul + TotalOrd {}
 impl<TI, TO> DistanceConstant<TI> for TO where TO: 'static + InfCast<TI> + InfMul + TotalOrd {}
 
 /// A shorthand to indicate the set of types that implement the most common traits, like Clone and Debug.
-/// 
+///
 /// The other rollup traits [`Hashable`], [`Number`], [`Integer`] and [`Float`] inherit from this trait.
-/// 
+///
 /// Examples: u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, bool, String.
-/// 
+///
 /// Refer to the constituent traits to see proof definitions on methods.
-/// 
+///
 /// # Example
 /// ```
 /// use opendp::traits::Primitive;
 /// fn test_func<T: Primitive>(value: T) {
 ///     // can be debugged
 ///     println!("{value:?}");
-/// 
+///
 ///     // default values exist and members of type T can be compared
 ///     assert_eq!(T::default(), T::default());
-/// 
+///
 ///     // can check if is null
 ///     value.is_null();
 /// }
-/// 
+///
 /// test_func(1i8);
 /// ```
 pub trait Primitive: 'static + Clone + std::fmt::Debug + CheckNull + PartialEq + Default {}
 impl<T> Primitive for T where T: 'static + Clone + std::fmt::Debug + CheckNull + PartialEq + Default {}
 
 /// The subset of [`Primitive`] types that implement Eq and Hash.
-/// 
+///
 /// Hashable types can be used as HashMap keys and in HashSets.
-/// 
+///
 /// Examples: u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, bool, String
-/// 
-/// This trait lists the traits that are implemented for hashable types. 
+///
+/// This trait lists the traits that are implemented for hashable types.
 /// Refer to the constituent traits to see proof definitions on methods.
-/// 
+///
 /// # Example
 /// ```
 /// use opendp::traits::Hashable;
@@ -97,22 +97,22 @@ impl<T> Primitive for T where T: 'static + Clone + std::fmt::Debug + CheckNull +
 ///     let mut hashset = HashSet::new();
 ///     hashset.insert(value);
 /// }
-/// 
+///
 /// test_func("apple".to_string());
 /// ```
 pub trait Hashable: Primitive + Eq + Hash {}
 impl<T> Hashable for T where T: Primitive + Eq + Hash {}
 
 /// The subset of [`Primitive`] types that have numerical operations.
-/// 
+///
 /// Examples: u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64
-/// 
-/// This trait lists many traits that are implemented for numerical types. 
+///
+/// This trait lists many traits that are implemented for numerical types.
 /// It is a shorthand to provide broad numerical functionality to a generic type,
 /// without polluting trait bounds with a large number of highly-specific traits.
 ///
 /// Refer to the constituent traits to see proof definitions on methods.
-/// 
+///
 /// # Example
 /// ```
 /// use opendp::traits::Number;
@@ -123,7 +123,7 @@ impl<T> Hashable for T where T: Primitive + Eq + Hash {}
 ///     // supports basic arithmetic and numerical properties
 ///     assert_eq!(T::zero().inf_mul(&value).ok(), Some(T::zero()));
 /// }
-/// 
+///
 /// test_func(1i8);
 /// ```
 
@@ -186,17 +186,17 @@ impl<T> Number for T where
 {
 }
 
-/// The intersection of [`Number`] types and [`Hashable`] types. 
+/// The intersection of [`Number`] types and [`Hashable`] types.
 /// This happens to be integers.
-/// 
+///
 /// Examples: u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize
-/// 
-/// This trait lists many traits that are implemented for integer types. 
+///
+/// This trait lists many traits that are implemented for integer types.
 /// It is a shorthand to provide broad integer functionality to a generic type,
 /// without polluting trait bounds with a large number of highly-specific traits.
-/// 
+///
 /// Refer to the constituent traits to see proof definitions on methods.
-/// 
+///
 /// # Example
 /// ```
 /// use opendp::traits::Integer;
@@ -204,7 +204,7 @@ impl<T> Number for T where
 /// fn test_func<T: Integer>(value: T) {
 ///     // can be debugged
 ///     println!("{value:?}");
-/// 
+///
 ///     // supports arithmetic and has numerical properties
 ///     assert_eq!(T::zero().inf_mul(&value).ok(), Some(T::zero()));
 ///     
@@ -212,20 +212,20 @@ impl<T> Number for T where
 ///     let mut hashset = HashSet::new();
 ///     hashset.insert(value);
 /// }
-/// 
+///
 /// test_func(1i8);
 /// ```
 pub trait Integer: Number + Hashable {}
 impl<T> Integer for T where T: Number + Hashable {}
 
 /// Floating-point types.
-/// 
+///
 /// Examples: f32, f64
-/// 
-/// This trait lists many traits that are implemented for floating-point types. 
+///
+/// This trait lists many traits that are implemented for floating-point types.
 /// It is a shorthand to provide broad floating-point functionality to a generic type,
 /// without polluting trait bounds with a large number of highly-specific traits.
-/// 
+///
 /// Refer to the constituent traits to see proof definitions on methods.
 ///
 /// # Example
@@ -234,11 +234,11 @@ impl<T> Integer for T where T: Number + Hashable {}
 /// fn test_func<T: Float>(value: T) {
 ///     // can be debugged, as Integer inherits all traits from Primitive:
 ///     println!("{value:?}");
-/// 
+///
 ///     // supports arithmetic and has numerical properties
 ///     assert_eq!(T::zero().inf_mul(&value).ok(), Some(T::zero()));
 /// }
-/// 
+///
 /// test_func(3.14159);
 /// ```
 pub trait Float:

--- a/rust/src/traits/samplers/bernoulli/mod.rs
+++ b/rust/src/traits/samplers/bernoulli/mod.rs
@@ -59,10 +59,10 @@ impl SampleStandardBernoulli for bool {
 /// ```
 pub trait SampleBernoulli<T>: Sized {
     /// # Proof Definition
-    /// For any setting of `prob`, returns `Ok(out)`, 
-    /// where `out` is a sample from the Bernoulli(prob) distribution, 
+    /// For any setting of `prob`, returns `Ok(out)`,
+    /// where `out` is a sample from the Bernoulli(prob) distribution,
     /// or `Err(e)` if there is not enough system entropy.
-    /// 
+    ///
     /// If `constant_time` is set, the algorithm should also run in constant time.
     fn sample_bernoulli(prob: T, constant_time: bool) -> Fallible<Self>;
 }

--- a/rust/src/traits/samplers/geometric/mod.rs
+++ b/rust/src/traits/samplers/geometric/mod.rs
@@ -17,7 +17,7 @@ pub trait SampleGeometric<P>: Sized {
     /// ```text
     ///     [Self::MIN, Self::MAX]
     /// ```
-    /// 
+    ///
     /// If `trials` is Some, execution runs in constant time, and the support is
     /// ```text
     ///     [Self::MIN, Self::MAX] ∩ {shift ± {0, 1, 2, ..., trials}}
@@ -110,7 +110,7 @@ pub trait SampleDiscreteLaplaceLinear<P>: SampleGeometric<P> {
     /// ```text
     ///     [Self::MIN, Self::MAX]
     /// ```
-    /// 
+    ///
     /// If `bounds` is Some, execution runs in constant time, and the support is
     /// ```text
     ///     [Self::MIN, Self::MAX] ∩ {shift ± {1, 2, 3, ..., trials}}
@@ -204,15 +204,15 @@ where
 }
 
 /// Sample from a specific discrete/geometric distribution.
-/// 
+///
 /// Used for exact bernoulli samples.
-/// 
+///
 /// # Proof Definition
-/// For any setting of the input arguments, return 
+/// For any setting of the input arguments, return
 /// `Err(e)` if there is insufficient system entropy, or
 /// `Ok(sample)` where `sample` is from a discrete distribution.
-/// 
-/// `sample` is either 
+///
+/// `sample` is either
 /// `None` with probability $2^{-buffer_len * 8}$, or
 /// `Some(geo)` where `geo` is a sample from the Geometric(p=0.5) distribution.
 ///
@@ -249,12 +249,11 @@ pub(super) fn sample_geometric_buffer(
     })
 }
 
-
-#[cfg(all(test, feature="test-plot"))]
+#[cfg(all(test, feature = "test-plot"))]
 mod test_plotting {
-    use crate::traits::samplers::Fallible;
-    use crate::error::ExplainUnwrap;
     use super::*;
+    use crate::error::ExplainUnwrap;
+    use crate::traits::samplers::Fallible;
     #[test]
     fn plot_geometric() -> Fallible<()> {
         let shift = 0;

--- a/rust/src/transformations/b_ary_tree/ffi.rs
+++ b/rust/src/transformations/b_ary_tree/ffi.rs
@@ -29,7 +29,10 @@ pub extern "C" fn opendp_transformations__make_b_ary_tree(
     where
         Q: Number,
     {
-        fn monomorphize2<M, TA>(leaf_count: usize, branching_factor: usize) -> FfiResult<*mut AnyTransformation>
+        fn monomorphize2<M, TA>(
+            leaf_count: usize,
+            branching_factor: usize,
+        ) -> FfiResult<*mut AnyTransformation>
         where
             TA: Integer,
             M: 'static + BAryTreeMetric,
@@ -54,11 +57,8 @@ pub extern "C" fn opendp_transformations__make_b_ary_tree(
     ], (leaf_count, branching_factor, M, TA))
 }
 
-
 #[no_mangle]
-pub extern "C" fn opendp_transformations__choose_branching_factor(
-    size_guess: c_uint,
-) -> c_uint {
+pub extern "C" fn opendp_transformations__choose_branching_factor(size_guess: c_uint) -> c_uint {
     let size_guess = size_guess as usize;
     choose_branching_factor(size_guess) as c_uint
 }

--- a/rust/src/transformations/b_ary_tree/mod.rs
+++ b/rust/src/transformations/b_ary_tree/mod.rs
@@ -1,29 +1,26 @@
 use crate::{
     core::{Function, Metric, StabilityMap, Transformation},
-    metrics::LpDistance,
     domains::{AllDomain, VectorDomain},
     error::Fallible,
+    metrics::LpDistance,
     traits::{InfCast, Integer, Number},
 };
 
-#[cfg(feature="ffi")]
+#[cfg(feature = "ffi")]
 mod ffi;
 
 mod consistency_postprocessor;
 pub use consistency_postprocessor::*;
 use opendp_derive::bootstrap;
 
-#[bootstrap(
-    features("contrib"),
-    generics(TA(default = "int"))
-)]
-/// Expand a vector of counts into a b-ary tree of counts, 
+#[bootstrap(features("contrib"), generics(TA(default = "int")))]
+/// Expand a vector of counts into a b-ary tree of counts,
 /// where each branch is the sum of its `b` immediate children.
-/// 
+///
 /// # Arguments
 /// * `leaf_count` - The number of leaf nodes in the b-ary tree.
 /// * `branching_factor` - The number of children on each branch of the resulting tree. Larger branching factors result in shallower trees.
-/// 
+///
 /// # Generics
 /// * `M` - Metric. Must be `L1Distance<Q>` or `L2Distance<Q>`
 /// * `TA` - Atomic Type of the input data.
@@ -86,7 +83,6 @@ where
     ))
 }
 
-
 // find i such that b^i >= x
 // returns 0 when x == 0
 fn log_b_ceil(x: usize, b: usize) -> usize {
@@ -116,12 +112,10 @@ fn num_nodes_from_num_layers(num_layers: usize, b: usize) -> usize {
 pub trait BAryTreeMetric: Metric {}
 impl<const P: usize, T> BAryTreeMetric for LpDistance<P, T> {}
 
-#[bootstrap(
-    features("contrib")
-)]
-/// Returns an approximation to the ideal `branching_factor` for a dataset of a given size, 
+#[bootstrap(features("contrib"))]
+/// Returns an approximation to the ideal `branching_factor` for a dataset of a given size,
 /// that minimizes error in cdf and quantile estimates based on b-ary trees.
-/// 
+///
 /// # Citations
 /// * [QYL13 Understanding Hierarchical Methods for Differentially Private Histograms](http://www.vldb.org/pvldb/vol6/p1954-qardaji.pdf)
 ///
@@ -142,10 +136,9 @@ pub fn choose_branching_factor(size_guess: usize) -> usize {
         .unwrap_or(size_guess)
 }
 
-
 #[cfg(test)]
 pub mod test_b_trees {
-    use crate::{metrics::L1Distance, measurements::make_base_discrete_laplace};
+    use crate::{measurements::make_base_discrete_laplace, metrics::L1Distance};
 
     use super::*;
 
@@ -246,7 +239,11 @@ pub mod test_b_trees {
 
         let noisy_tree = meas.invoke(&vec![1; 10])?;
         // casting should not lose data, as noise was integral
-        let consi_leaves = post.eval(&noisy_tree)?.into_iter().map(|v| v as i32).collect();
+        let consi_leaves = post
+            .eval(&noisy_tree)?
+            .into_iter()
+            .map(|v| v as i32)
+            .collect();
         let consi_tree = make_b_ary_tree::<L1Distance<f64>, i32>(10, b)?.invoke(&consi_leaves)?;
 
         println!("noisy      leaves {:?}", noisy_tree[15..].to_vec());

--- a/rust/src/transformations/cast/ffi.rs
+++ b/rust/src/transformations/cast/ffi.rs
@@ -2,23 +2,26 @@ use std::convert::TryFrom;
 use std::os::raw::c_char;
 
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
-use crate::traits::InherentNull;
 use crate::err;
 use crate::ffi::any::AnyTransformation;
 use crate::ffi::util::Type;
+use crate::traits::InherentNull;
 use crate::traits::{CheckNull, RoundCast};
 use crate::transformations::{make_cast, make_cast_default, make_cast_inherent};
 
 #[no_mangle]
 pub extern "C" fn opendp_transformations__make_cast(
-    TIA: *const c_char, TOA: *const c_char,
+    TIA: *const c_char,
+    TOA: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     let TIA = try_!(Type::try_from(TIA));
     let TOA = try_!(Type::try_from(TOA));
 
     fn monomorphize<TIA, TOA>() -> FfiResult<*mut AnyTransformation>
-        where TIA: 'static + Clone + CheckNull,
-              TOA: 'static + RoundCast<TIA> + CheckNull {
+    where
+        TIA: 'static + Clone + CheckNull,
+        TOA: 'static + RoundCast<TIA> + CheckNull,
+    {
         make_cast::<TIA, TOA>().into_any()
     }
     dispatch!(monomorphize, [(TIA, @primitives), (TOA, @primitives)], ())
@@ -26,14 +29,17 @@ pub extern "C" fn opendp_transformations__make_cast(
 
 #[no_mangle]
 pub extern "C" fn opendp_transformations__make_cast_default(
-    TIA: *const c_char, TOA: *const c_char,
+    TIA: *const c_char,
+    TOA: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     let TIA = try_!(Type::try_from(TIA));
     let TOA = try_!(Type::try_from(TOA));
 
     fn monomorphize<TIA, TOA>() -> FfiResult<*mut AnyTransformation>
-        where TIA: 'static + Clone + CheckNull,
-              TOA: 'static + RoundCast<TIA> + Default + CheckNull {
+    where
+        TIA: 'static + Clone + CheckNull,
+        TOA: 'static + RoundCast<TIA> + Default + CheckNull,
+    {
         make_cast_default::<TIA, TOA>().into_any()
     }
     dispatch!(monomorphize, [(TIA, @primitives), (TOA, @primitives)], ())
@@ -41,19 +47,21 @@ pub extern "C" fn opendp_transformations__make_cast_default(
 
 #[no_mangle]
 pub extern "C" fn opendp_transformations__make_cast_inherent(
-    TIA: *const c_char, TOA: *const c_char,
+    TIA: *const c_char,
+    TOA: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     let TIA = try_!(Type::try_from(TIA));
     let TOA = try_!(Type::try_from(TOA));
 
     fn monomorphize<TIA, TOA>() -> FfiResult<*mut AnyTransformation>
-        where TIA: 'static + Clone + CheckNull,
-              TOA: 'static + RoundCast<TIA> + InherentNull {
+    where
+        TIA: 'static + Clone + CheckNull,
+        TOA: 'static + RoundCast<TIA> + InherentNull,
+    {
         make_cast_inherent::<TIA, TOA>().into_any()
     }
     dispatch!(monomorphize, [(TIA, @primitives), (TOA, @floats)], ())
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/rust/src/transformations/cast/mod.rs
+++ b/rust/src/transformations/cast/mod.rs
@@ -1,74 +1,107 @@
-#[cfg(feature="ffi")]
+#[cfg(feature = "ffi")]
 mod ffi;
 
 use opendp_derive::bootstrap;
 
 use crate::core::Transformation;
-use crate::metrics::SymmetricDistance;
 use crate::domains::{AllDomain, InherentNullDomain, OptionNullDomain, VectorDomain};
 use crate::error::Fallible;
-use crate::traits::{RoundCast, CheckNull, InherentNull};
+use crate::metrics::SymmetricDistance;
+use crate::traits::{CheckNull, InherentNull, RoundCast};
 use crate::transformations::make_row_by_row;
 
 #[bootstrap(features("contrib"))]
 /// Make a Transformation that casts a vector of data from type `TIA` to type `TOA`.
 /// For each element, failure to parse results in `None`, else `Some(out)`.
-/// 
+///
 /// Can be chained with `make_impute_constant` or `make_drop_null` to handle nullity.
-/// 
+///
 /// # Generics
 /// * `TIA` - Atomic Input Type to cast from
 /// * `TOA` - Atomic Output Type to cast into
-pub fn make_cast<TIA, TOA>() -> Fallible<Transformation<VectorDomain<AllDomain<TIA>>, VectorDomain<OptionNullDomain<AllDomain<TOA>>>, SymmetricDistance, SymmetricDistance>>
-    where TIA: 'static + Clone + CheckNull, TOA: 'static + RoundCast<TIA> + CheckNull {
+pub fn make_cast<TIA, TOA>() -> Fallible<
+    Transformation<
+        VectorDomain<AllDomain<TIA>>,
+        VectorDomain<OptionNullDomain<AllDomain<TOA>>>,
+        SymmetricDistance,
+        SymmetricDistance,
+    >,
+>
+where
+    TIA: 'static + Clone + CheckNull,
+    TOA: 'static + RoundCast<TIA> + CheckNull,
+{
     make_row_by_row(
         AllDomain::new(),
         OptionNullDomain::new(AllDomain::new()),
-        |v| TOA::round_cast(v.clone()).ok()
-            .and_then(|v| if v.is_null() {None} else {Some(v)}))
+        |v| {
+            TOA::round_cast(v.clone())
+                .ok()
+                .and_then(|v| if v.is_null() { None } else { Some(v) })
+        },
+    )
 }
 
 #[bootstrap(features("contrib"))]
-/// Make a Transformation that casts a vector of data from type `TIA` to type `TOA`. 
+/// Make a Transformation that casts a vector of data from type `TIA` to type `TOA`.
 /// Any element that fails to cast is filled with default.
-/// 
-/// 
+///
+///
 /// | `TIA`  | `TIA::default()` |
 /// | ------ | ---------------- |
 /// | float  | `0.`             |
 /// | int    | `0`              |
 /// | string | `""`             |
-/// | bool   | `false`          | 
-/// 
+/// | bool   | `false`          |
+///
 /// # Generics
 /// * `TIA` - Atomic Input Type to cast from
 /// * `TOA` - Atomic Output Type to cast into
-pub fn make_cast_default<TIA, TOA>() -> Fallible<Transformation<VectorDomain<AllDomain<TIA>>, VectorDomain<AllDomain<TOA>>, SymmetricDistance, SymmetricDistance>>
-    where TIA: 'static + Clone + CheckNull, TOA: 'static + RoundCast<TIA> + Default + CheckNull {
-    make_row_by_row(
-        AllDomain::new(),
-        AllDomain::new(),
-        |v| TOA::round_cast(v.clone()).unwrap_or_default())
+pub fn make_cast_default<TIA, TOA>() -> Fallible<
+    Transformation<
+        VectorDomain<AllDomain<TIA>>,
+        VectorDomain<AllDomain<TOA>>,
+        SymmetricDistance,
+        SymmetricDistance,
+    >,
+>
+where
+    TIA: 'static + Clone + CheckNull,
+    TOA: 'static + RoundCast<TIA> + Default + CheckNull,
+{
+    make_row_by_row(AllDomain::new(), AllDomain::new(), |v| {
+        TOA::round_cast(v.clone()).unwrap_or_default()
+    })
 }
 
 #[bootstrap(features("contrib"))]
-/// Make a Transformation that casts a vector of data from type `TIA` to a type that can represent nullity `TOA`. 
+/// Make a Transformation that casts a vector of data from type `TIA` to a type that can represent nullity `TOA`.
 /// If cast fails, fill with `TOA`'s null value.
-/// 
+///
 /// | `TIA`  | `TIA::default()` |
 /// | ------ | ---------------- |
 /// | float  | NaN              |
-/// 
+///
 /// # Generics
 /// * `TIA` - Atomic Input Type to cast from
 /// * `TOA` - Atomic Output Type to cast into
-pub fn make_cast_inherent<TIA, TOA>(
-) -> Fallible<Transformation<VectorDomain<AllDomain<TIA>>, VectorDomain<InherentNullDomain<AllDomain<TOA>>>, SymmetricDistance, SymmetricDistance>>
-    where TIA: 'static + Clone + CheckNull, TOA: 'static + RoundCast<TIA> + InherentNull + CheckNull {
+pub fn make_cast_inherent<TIA, TOA>() -> Fallible<
+    Transformation<
+        VectorDomain<AllDomain<TIA>>,
+        VectorDomain<InherentNullDomain<AllDomain<TOA>>>,
+        SymmetricDistance,
+        SymmetricDistance,
+    >,
+>
+where
+    TIA: 'static + Clone + CheckNull,
+    TOA: 'static + RoundCast<TIA> + InherentNull + CheckNull,
+{
     make_row_by_row(
         AllDomain::new(),
         InherentNullDomain::new(AllDomain::new()),
-        |v| TOA::round_cast(v.clone()).unwrap_or(TOA::NULL))
+        |v| TOA::round_cast(v.clone()).unwrap_or(TOA::NULL),
+    )
 }
 
 #[cfg(test)]
@@ -77,19 +110,20 @@ mod tests {
 
     use super::*;
 
-
     #[test]
     fn test_cast() -> Fallible<()> {
         let data = vec![1., 1e10, 0.5, f64::NAN, f64::NEG_INFINITY, f64::INFINITY];
         let caster = make_cast::<f64, i64>()?;
         assert_eq!(
             caster.invoke(&data)?,
-            vec![Some(1), Some(10000000000), Some(0), None, None, None]);
+            vec![Some(1), Some(10000000000), Some(0), None, None, None]
+        );
 
         let caster = make_cast::<f64, u8>()?;
         assert_eq!(
             caster.invoke(&vec![-1., f64::NAN, f64::NEG_INFINITY, f64::INFINITY])?,
-            vec![None; 4]);
+            vec![None; 4]
+        );
         Ok(())
     }
 
@@ -98,10 +132,10 @@ mod tests {
         macro_rules! test_pair {
             ($from:ty, $to:ty) => {
                 let caster = make_cast::<$from, $to>().unwrap_test();
-                caster.invoke(&vec!(<$from>::default())).unwrap_test();
+                caster.invoke(&vec![<$from>::default()]).unwrap_test();
                 let caster = make_cast::<$from, $to>().unwrap_test();
-                caster.invoke(&vec!(<$from>::default())).unwrap_test();
-            }
+                caster.invoke(&vec![<$from>::default()]).unwrap_test();
+            };
         }
         macro_rules! test_cartesian {
             ([];[$first:ty, $($end:ty),*]) => {
@@ -122,7 +156,7 @@ mod tests {
                 $(test_pair!($last, $start);)*
             };
         }
-        test_cartesian!{[];[u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String, bool]}
+        test_cartesian! {[];[u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, String, bool]}
     }
 
     #[test]
@@ -134,13 +168,24 @@ mod tests {
 
     #[test]
     fn test_cast_default_parse() -> Fallible<()> {
-        let data = vec!["2".to_string(), "3".to_string(), "a".to_string(), "".to_string()];
+        let data = vec![
+            "2".to_string(),
+            "3".to_string(),
+            "a".to_string(),
+            "".to_string(),
+        ];
 
         let caster = make_cast_default::<String, u8>()?;
-        assert_eq!(caster.invoke(&data)?, vec![2, 3, u8::default(), u8::default()]);
+        assert_eq!(
+            caster.invoke(&data)?,
+            vec![2, 3, u8::default(), u8::default()]
+        );
 
         let caster = make_cast_default::<String, f64>()?;
-        assert_eq!(caster.invoke(&data)?, vec![2., 3., f64::default(), f64::default()]);
+        assert_eq!(
+            caster.invoke(&data)?,
+            vec![2., 3., f64::default(), f64::default()]
+        );
         Ok(())
     }
 
@@ -150,15 +195,28 @@ mod tests {
         let caster = make_cast_default::<f64, String>()?;
         assert_eq!(
             caster.invoke(&data)?,
-            vec!["NaN".to_string(), "-inf".to_string(), "inf".to_string()]);
+            vec!["NaN".to_string(), "-inf".to_string(), "inf".to_string()]
+        );
 
         let caster = make_cast_default::<f64, u8>()?;
         assert_eq!(
             caster.invoke(&vec![f64::NAN, f64::NEG_INFINITY, f64::INFINITY])?,
-            vec![u8::default(), u8::default(), u8::default()]);
+            vec![u8::default(), u8::default(), u8::default()]
+        );
 
-        let data = vec!["1e+2", "1e2", "1e+02", "1.e+02", "1.0E+02", "1.0E+00002", "01.E+02", "1.0E2"]
-            .into_iter().map(|v| v.to_string()).collect();
+        let data = vec![
+            "1e+2",
+            "1e2",
+            "1e+02",
+            "1.e+02",
+            "1.0E+02",
+            "1.0E+00002",
+            "01.E+02",
+            "1.0E2",
+        ]
+        .into_iter()
+        .map(|v| v.to_string())
+        .collect();
         let caster = make_cast_default::<String, f64>()?;
         assert!(caster.invoke(&data)?.into_iter().all(|v| v == 100.));
         Ok(())

--- a/rust/src/transformations/cast_metric/mod.rs
+++ b/rust/src/transformations/cast_metric/mod.rs
@@ -1,16 +1,14 @@
 use opendp_derive::bootstrap;
 
 use crate::{
+    combinators::IsSizedDomain,
     core::{Domain, Function, StabilityMap, Transformation},
+    error::Fallible,
     metrics::IntDistance,
-    error::Fallible, 
     traits::samplers::Shuffle,
-    combinators::IsSizedDomain
 };
 
-use self::traits::{
-    BoundedMetric, OrderedMetric, UnboundedMetric, UnorderedMetric,
-};
+use self::traits::{BoundedMetric, OrderedMetric, UnboundedMetric, UnorderedMetric};
 
 #[cfg(feature = "ffi")]
 mod ffi;
@@ -28,7 +26,7 @@ mod traits;
 /// | ----------------- | -------------------- |
 /// | SymmetricDistance | InsertDeleteDistance |
 /// | ChangeOneDistance | HammingDistance      |
-/// 
+///
 /// # Generics
 /// * `D` - Domain
 /// * `MI` - Input Metric
@@ -54,7 +52,6 @@ where
     ))
 }
 
-
 #[bootstrap(
     features("contrib"),
     arguments(domain(c_type = "AnyDomain *")),
@@ -62,12 +59,12 @@ where
 )]
 /// Make a Transformation that converts the ordered dataset metric `MI`
 /// to the respective ordered dataset metric with a no-op.
-/// 
+///
 /// | `MI`                 | `MI::UnorderedMetric` |
 /// | -------------------- | --------------------- |
 /// | InsertDeleteDistance | SymmetricDistance     |
 /// | HammingDistance      | ChangeOneDistance     |
-/// 
+///
 /// # Generics
 /// * `D` - Domain
 /// * `MI` - Input Metric
@@ -92,17 +89,17 @@ where
     arguments(domain(c_type = "AnyDomain *")),
     generics(D(example = "domain"), MI(default = "ChangeOneDistance"))
 )]
-/// Make a Transformation that converts the bounded dataset metric `MI` 
-/// to the respective unbounded dataset metric with a no-op. 
-/// 
+/// Make a Transformation that converts the bounded dataset metric `MI`
+/// to the respective unbounded dataset metric with a no-op.
+///
 /// | `MI`              | `MI::UnboundedMetric` |
 /// | ----------------- | --------------------- |
 /// | ChangeOneDistance | SymmetricDistance     |
 /// | HammingDistance   | InsertDeleteDistance  |
-/// 
+///
 /// # Arguments
 /// * `size` - Number of records in input data.
-/// 
+///
 /// # Generics
 /// * `D` - Domain. The function is a no-op so input and output domains are the same.
 /// * `MI` - Input Metric.
@@ -130,12 +127,12 @@ where
     arguments(domain(c_type = "AnyDomain *")),
     generics(D(example = "domain"), MI(default = "SymmetricDistance"))
 )]
-/// Make a Transformation that converts the unbounded dataset metric `MI` 
-/// to the respective bounded dataset metric with a no-op. 
-/// 
-/// The constructor enforces that the input domain has known size, 
+/// Make a Transformation that converts the unbounded dataset metric `MI`
+/// to the respective bounded dataset metric with a no-op.
+///
+/// The constructor enforces that the input domain has known size,
 /// because it must have known size to be valid under a bounded dataset metric.
-/// 
+///
 /// | `MI`                 | `MI::BoundedMetric` |
 /// | -------------------- | ------------------- |
 /// | SymmetricDistance    | ChangeOneDistance   |
@@ -143,7 +140,7 @@ where
 ///
 /// # Arguments
 /// * `size` - Number of records in input data.
-/// 
+///
 /// # Generics
 /// * `D` - Domain
 /// * `MI` - Input Metric
@@ -166,10 +163,9 @@ where
     ))
 }
 
-
 #[cfg(test)]
 mod test {
-    use crate::domains::{VectorDomain, SizedDomain};
+    use crate::domains::{SizedDomain, VectorDomain};
     use crate::metrics::SymmetricDistance;
 
     use super::*;
@@ -180,7 +176,6 @@ mod test {
         let ord_trans = make_ordered_random::<_, SymmetricDistance>(domain.clone())?;
         let data = vec![1i32, 2, 3];
         assert_eq!(ord_trans.invoke(&data)?.len(), 3);
-
 
         let ident_trans = (ord_trans >> make_unordered(domain)?)?;
         assert_eq!(ident_trans.invoke(&data)?.len(), 3);
@@ -193,7 +188,6 @@ mod test {
         let bdd_trans = make_metric_bounded::<_, SymmetricDistance>(domain.clone())?;
         let data = vec![1i32, 2, 3];
         assert_eq!(bdd_trans.invoke(&data)?.len(), 3);
-
 
         let ident_trans = (bdd_trans >> make_metric_unbounded(domain)?)?;
         assert_eq!(ident_trans.invoke(&data)?.len(), 3);

--- a/rust/src/transformations/cast_metric/traits.rs
+++ b/rust/src/transformations/cast_metric/traits.rs
@@ -1,6 +1,6 @@
 use crate::{
     core::Metric,
-    metrics::{ChangeOneDistance, HammingDistance, InsertDeleteDistance, SymmetricDistance}
+    metrics::{ChangeOneDistance, HammingDistance, InsertDeleteDistance, SymmetricDistance},
 };
 
 pub trait UnorderedMetric: Metric {

--- a/rust/src/transformations/clamp/ffi.rs
+++ b/rust/src/transformations/clamp/ffi.rs
@@ -17,7 +17,9 @@ pub extern "C" fn opendp_transformations__make_clamp(
     let TA = try_!(Type::try_from(TA));
 
     fn monomorphize_dataset<TA>(bounds: *const AnyObject) -> FfiResult<*mut AnyTransformation>
-        where TA: 'static + Clone + TotalOrd + CheckNull {
+    where
+        TA: 'static + Clone + TotalOrd + CheckNull,
+    {
         let bounds = try_!(try_as_ref!(bounds).downcast_ref::<(TA, TA)>()).clone();
         make_clamp::<TA>(bounds).into_any()
     }
@@ -26,7 +28,6 @@ pub extern "C" fn opendp_transformations__make_clamp(
     ], (bounds))
 }
 
-
 #[no_mangle]
 pub extern "C" fn opendp_transformations__make_unclamp(
     bounds: *const AnyObject,
@@ -34,7 +35,9 @@ pub extern "C" fn opendp_transformations__make_unclamp(
 ) -> FfiResult<*mut AnyTransformation> {
     let TA = try_!(Type::try_from(TA));
     fn monomorphize_dataset<TA>(bounds: *const AnyObject) -> FfiResult<*mut AnyTransformation>
-        where TA: 'static + Clone + TotalOrd + CheckNull {
+    where
+        TA: 'static + Clone + TotalOrd + CheckNull,
+    {
         let (lower, upper) = try_!(try_as_ref!(bounds).downcast_ref::<(TA, TA)>()).clone();
         make_unclamp::<TA>((Bound::Included(lower), Bound::Included(upper))).into_any()
     }
@@ -42,7 +45,6 @@ pub extern "C" fn opendp_transformations__make_unclamp(
         (TA, @numbers)
     ], (bounds))
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/rust/src/transformations/clamp/mod.rs
+++ b/rust/src/transformations/clamp/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(feature="ffi")]
+#[cfg(feature = "ffi")]
 mod ffi;
 
 use std::collections::Bound;
@@ -6,58 +6,68 @@ use std::collections::Bound;
 use opendp_derive::bootstrap;
 
 use crate::core::Transformation;
-use crate::metrics::SymmetricDistance;
 use crate::domains::{AllDomain, BoundedDomain, VectorDomain};
 use crate::error::*;
+use crate::metrics::SymmetricDistance;
 use crate::traits::{CheckNull, TotalOrd};
 use crate::transformations::{make_row_by_row, make_row_by_row_fallible};
 
-#[bootstrap(
-    features("contrib"),
-    generics(TA(example = "$get_first(bounds)"))
-)]
+#[bootstrap(features("contrib"), generics(TA(example = "$get_first(bounds)")))]
 /// Make a Transformation that clamps numeric data in `Vec<TA>` to `bounds`.
-/// 
-/// If datum is less than lower, let datum be lower. 
+///
+/// If datum is less than lower, let datum be lower.
 /// If datum is greater than upper, let datum be upper.
-/// 
+///
 /// # Arguments
 /// * `bounds` - Tuple of inclusive lower and upper bounds.
-/// 
+///
 /// # Generics
 /// * `TA` - Atomic Type
 pub fn make_clamp<TA: 'static + Clone + TotalOrd + CheckNull>(
-    bounds: (TA, TA)
-) -> Fallible<Transformation<VectorDomain<AllDomain<TA>>, VectorDomain<BoundedDomain<TA>>, SymmetricDistance, SymmetricDistance>> {
+    bounds: (TA, TA),
+) -> Fallible<
+    Transformation<
+        VectorDomain<AllDomain<TA>>,
+        VectorDomain<BoundedDomain<TA>>,
+        SymmetricDistance,
+        SymmetricDistance,
+    >,
+> {
     make_row_by_row_fallible(
         AllDomain::new(),
         BoundedDomain::new_closed(bounds.clone())?,
-        move |arg: &TA| arg.clone().total_clamp(bounds.0.clone(), bounds.1.clone()))
+        move |arg: &TA| arg.clone().total_clamp(bounds.0.clone(), bounds.1.clone()),
+    )
 }
 
 #[bootstrap(
     features("contrib"),
     arguments(bounds(rust_type = "(TA, TA)")),
-    generics(TA(example = "$get_first(bounds)")),
+    generics(TA(example = "$get_first(bounds)"))
 )]
 /// Make a Transformation that unclamps numeric data in `Vec<T>`.
-/// 
+///
 /// Used to convert a `VectorDomain<BoundedDomain<T>>` to a `VectorDomain<AllDomain<T>>`.
-/// 
+///
 /// # Arguments
 /// * `bounds` - Tuple of lower and upper bounds.
-/// 
+///
 /// # Generics
 /// * `TA` - Atomic Type
 pub fn make_unclamp<TA: 'static + Clone + TotalOrd + CheckNull>(
-    bounds: (Bound<TA>, Bound<TA>)
-) -> Fallible<Transformation<VectorDomain<BoundedDomain<TA>>, VectorDomain<AllDomain<TA>>, SymmetricDistance, SymmetricDistance>> {
-    make_row_by_row(
-        BoundedDomain::new(bounds)?,
-        AllDomain::new(),
-        |arg| arg.clone())
+    bounds: (Bound<TA>, Bound<TA>),
+) -> Fallible<
+    Transformation<
+        VectorDomain<BoundedDomain<TA>>,
+        VectorDomain<AllDomain<TA>>,
+        SymmetricDistance,
+        SymmetricDistance,
+    >,
+> {
+    make_row_by_row(BoundedDomain::new(bounds)?, AllDomain::new(), |arg| {
+        arg.clone()
+    })
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/rust/src/transformations/count/ffi.rs
+++ b/rust/src/transformations/count/ffi.rs
@@ -3,13 +3,16 @@ use std::os::raw::c_char;
 
 use crate::core::Metric;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
-use crate::metrics::{L1Distance, L2Distance};
 use crate::err;
-use crate::ffi::any::{AnyObject, AnyTransformation};
 use crate::ffi::any::Downcast;
-use crate::ffi::util::{Type, c_bool, to_bool};
-use crate::traits::{Number, Hashable, Primitive, Float};
-use crate::transformations::{CountByCategoriesConstant, CountByConstant, make_count, make_count_by, make_count_by_categories, make_count_distinct};
+use crate::ffi::any::{AnyObject, AnyTransformation};
+use crate::ffi::util::{c_bool, to_bool, Type};
+use crate::metrics::{L1Distance, L2Distance};
+use crate::traits::{Float, Hashable, Number, Primitive};
+use crate::transformations::{
+    make_count, make_count_by, make_count_by_categories, make_count_distinct,
+    CountByCategoriesConstant, CountByConstant,
+};
 
 #[no_mangle]
 pub extern "C" fn opendp_transformations__make_count(
@@ -17,8 +20,10 @@ pub extern "C" fn opendp_transformations__make_count(
     TO: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<TIA, TO>() -> FfiResult<*mut AnyTransformation>
-        where TIA: Primitive,
-              TO: Number {
+    where
+        TIA: Primitive,
+        TO: Number,
+    {
         make_count::<TIA, TO>().into_any()
     }
     let TIA = try_!(Type::try_from(TIA));
@@ -29,15 +34,16 @@ pub extern "C" fn opendp_transformations__make_count(
     ], ())
 }
 
-
 #[no_mangle]
 pub extern "C" fn opendp_transformations__make_count_distinct(
     TIA: *const c_char,
     TO: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<TIA, TO: 'static>() -> FfiResult<*mut AnyTransformation>
-        where TIA: Hashable,
-              TO: Number {
+    where
+        TIA: Hashable,
+        TO: Number,
+    {
         make_count_distinct::<TIA, TO>().into_any()
     }
     let TIA = try_!(Type::try_from(TIA));
@@ -48,27 +54,34 @@ pub extern "C" fn opendp_transformations__make_count_distinct(
     ], ())
 }
 
-
 #[no_mangle]
 pub extern "C" fn opendp_transformations__make_count_by_categories(
     categories: *const AnyObject,
     null_category: c_bool,
-    MO: *const c_char, TI: *const c_char, TO: *const c_char,
+    MO: *const c_char,
+    TI: *const c_char,
+    TO: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<QO>(
         categories: *const AnyObject,
         null_category: bool,
-        MO: Type, TI: Type, TO: Type,
+        MO: Type,
+        TI: Type,
+        TO: Type,
     ) -> FfiResult<*mut AnyTransformation>
-        where QO: Number {
+    where
+        QO: Number,
+    {
         fn monomorphize2<MO, TI, TO>(
-            categories: *const AnyObject, 
-            null_category: bool
+            categories: *const AnyObject,
+            null_category: bool,
         ) -> FfiResult<*mut AnyTransformation>
-            where MO: 'static + Metric + CountByCategoriesConstant<MO::Distance>,
-                  MO::Distance: Number,
-                  TI: Hashable,
-                  TO: Number {
+        where
+            MO: 'static + Metric + CountByCategoriesConstant<MO::Distance>,
+            MO::Distance: Number,
+            TI: Hashable,
+            TO: Number,
+        {
             let categories = try_!(try_as_ref!(categories).downcast_ref::<Vec<TI>>()).clone();
             make_count_by_categories::<MO, TI, TO>(categories, null_category).into_any()
         }
@@ -90,17 +103,21 @@ pub extern "C" fn opendp_transformations__make_count_by_categories(
 
 #[no_mangle]
 pub extern "C" fn opendp_transformations__make_count_by(
-    MO: *const c_char, TK: *const c_char, TV: *const c_char,
+    MO: *const c_char,
+    TK: *const c_char,
+    TV: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<QO>(
-        MO: Type, TK: Type, TV: Type,
-    ) -> FfiResult<*mut AnyTransformation>
-        where QO: Float {
+    fn monomorphize<QO>(MO: Type, TK: Type, TV: Type) -> FfiResult<*mut AnyTransformation>
+    where
+        QO: Float,
+    {
         fn monomorphize2<MO, TK, TV>() -> FfiResult<*mut AnyTransformation>
-            where MO: 'static + Metric + CountByConstant<MO::Distance>,
-                  MO::Distance: Float,
-                  TK: Hashable,
-                  TV: Number {
+        where
+            MO: 'static + Metric + CountByConstant<MO::Distance>,
+            MO::Distance: Float,
+            TK: Hashable,
+            TV: Number,
+        {
             make_count_by::<MO, TK, TV>().into_any()
         }
         dispatch!(monomorphize2, [

--- a/rust/src/transformations/count/mod.rs
+++ b/rust/src/transformations/count/mod.rs
@@ -1,31 +1,39 @@
-#[cfg(feature="ffi")]
+#[cfg(feature = "ffi")]
 mod ffi;
 
-use std::collections::{HashMap, HashSet};
 use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet};
 
 use num::One;
 use opendp_derive::bootstrap;
 
 use crate::core::{Function, Metric, StabilityMap, Transformation};
-use crate::metrics::{AbsoluteDistance, SymmetricDistance, LpDistance};
 use crate::domains::{AllDomain, MapDomain, VectorDomain};
 use crate::error::*;
-use crate::traits::{Number, Hashable, Primitive, Float, CollectionSize};
+use crate::metrics::{AbsoluteDistance, LpDistance, SymmetricDistance};
+use crate::traits::{CollectionSize, Float, Hashable, Number, Primitive};
 
 #[bootstrap(features("contrib"), generics(TO(default = "int")))]
 /// Make a Transformation that computes a count of the number of records in data.
-/// 
+///
 /// # Citations
 /// * [GRS12 Universally Utility-Maximizing Privacy Mechanisms](https://theory.stanford.edu/~tim/papers/priv.pdf)
-/// 
+///
 /// # Generics
 /// * `TIA` - Atomic Input Type. Input data is expected to be of the form `Vec<TIA>`.
 /// * `TO` - Output Type. Must be numeric.
-pub fn make_count<TIA, TO>(
-) -> Fallible<Transformation<VectorDomain<AllDomain<TIA>>, AllDomain<TO>, SymmetricDistance, AbsoluteDistance<TO>>>
-    where TIA: Primitive,
-          TO: Number {
+pub fn make_count<TIA, TO>() -> Fallible<
+    Transformation<
+        VectorDomain<AllDomain<TIA>>,
+        AllDomain<TO>,
+        SymmetricDistance,
+        AbsoluteDistance<TO>,
+    >,
+>
+where
+    TIA: Primitive,
+    TO: Number,
+{
     Ok(Transformation::new(
         VectorDomain::new_all(),
         AllDomain::new(),
@@ -33,29 +41,37 @@ pub fn make_count<TIA, TO>(
         Function::new(move |arg: &Vec<TIA>| {
             // get size via the CollectionSize trait
             let size = arg.size();
-            
+
             // cast to TO, and if cast fails (due to overflow) fill with largest value
             TO::exact_int_cast(size).unwrap_or(TO::MAX_CONSECUTIVE)
         }),
         SymmetricDistance::default(),
         AbsoluteDistance::default(),
-        StabilityMap::new_from_constant(TO::one())))
+        StabilityMap::new_from_constant(TO::one()),
+    ))
 }
-
 
 #[bootstrap(features("contrib"), generics(TO(default = "int")))]
 /// Make a Transformation that computes a count of the number of unique, distinct records in data.
-/// 
+///
 /// # Citations
 /// * [GRS12 Universally Utility-Maximizing Privacy Mechanisms](https://theory.stanford.edu/~tim/papers/priv.pdf)
-/// 
+///
 /// # Generics
 /// * `TIA` - Atomic Input Type. Input data is expected to be of the form Vec<TIA>.
 /// * `TO` - Output Type. Must be numeric.
-pub fn make_count_distinct<TIA, TO>(
-) -> Fallible<Transformation<VectorDomain<AllDomain<TIA>>, AllDomain<TO>, SymmetricDistance, AbsoluteDistance<TO>>>
-    where TIA: Hashable,
-          TO: Number {
+pub fn make_count_distinct<TIA, TO>() -> Fallible<
+    Transformation<
+        VectorDomain<AllDomain<TIA>>,
+        AllDomain<TO>,
+        SymmetricDistance,
+        AbsoluteDistance<TO>,
+    >,
+>
+where
+    TIA: Hashable,
+    TO: Number,
+{
     Ok(Transformation::new(
         VectorDomain::new_all(),
         AllDomain::new(),
@@ -65,7 +81,8 @@ pub fn make_count_distinct<TIA, TO>(
         }),
         SymmetricDistance::default(),
         AbsoluteDistance::default(),
-        StabilityMap::new_from_constant(TO::one())))
+        StabilityMap::new_from_constant(TO::one()),
+    ))
 }
 
 #[doc(hidden)]
@@ -73,71 +90,94 @@ pub trait CountByCategoriesConstant<QO> {
     fn get_stability_constant() -> QO;
 }
 impl<const P: usize, Q: One> CountByCategoriesConstant<Q> for LpDistance<P, Q> {
-    fn get_stability_constant() -> Q { Q::one() }
+    fn get_stability_constant() -> Q {
+        Q::one()
+    }
 }
 
 #[bootstrap(
-    features("contrib"), 
-    arguments(
-        null_category(default = true)),
+    features("contrib"),
+    arguments(null_category(default = true)),
     generics(
-        MO(hint = "SensitivityMetric", default = "L1Distance<int>"), 
-        TOA(default = "int"))
+        MO(hint = "SensitivityMetric", default = "L1Distance<int>"),
+        TOA(default = "int")
+    )
 )]
-/// Make a Transformation that computes the number of times each category appears in the data. 
+/// Make a Transformation that computes the number of times each category appears in the data.
 /// This assumes that the category set is known.
-/// 
+///
 /// # Citations
 /// * [GRS12 Universally Utility-Maximizing Privacy Mechanisms](https://theory.stanford.edu/~tim/papers/priv.pdf)
 /// * [BV17 Differential Privacy on Finite Computers](https://arxiv.org/abs/1709.05396)
-/// 
+///
 /// # Arguments
 /// * `categories` - The set of categories to compute counts for.
 /// * `null_category` - Include a count of the number of elements that were not in the category set at the end of the vector.
-/// 
+///
 /// # Generics
 /// * `MO` - Output Metric.
 /// * `TIA` - Atomic Input Type that is categorical/hashable. Input data must be `Vec<TIA>`
 /// * `TOA` - Atomic Output Type that is numeric.
-/// 
+///
 /// # Returns
 /// The carrier type is `HashMap<TK, TV>`, a hashmap of the count (`TV`) for each unique data input (`TK`).
 pub fn make_count_by_categories<MO, TIA, TOA>(
     categories: Vec<TIA>,
-    null_category: bool
-) -> Fallible<Transformation<VectorDomain<AllDomain<TIA>>, VectorDomain<AllDomain<TOA>>, SymmetricDistance, MO>>
-    where MO: CountByCategoriesConstant<MO::Distance> + Metric,
-          MO::Distance: Number,
-          TIA: Hashable,
-          TOA: Number {
+    null_category: bool,
+) -> Fallible<
+    Transformation<
+        VectorDomain<AllDomain<TIA>>,
+        VectorDomain<AllDomain<TOA>>,
+        SymmetricDistance,
+        MO,
+    >,
+>
+where
+    MO: CountByCategoriesConstant<MO::Distance> + Metric,
+    MO::Distance: Number,
+    TIA: Hashable,
+    TOA: Number,
+{
     let mut uniques = HashSet::new();
     if categories.iter().any(move |x| !uniques.insert(x)) {
-        return fallible!(MakeTransformation, "categories must be distinct")
+        return fallible!(MakeTransformation, "categories must be distinct");
     }
     Ok(Transformation::new(
         VectorDomain::new_all(),
         VectorDomain::new_all(),
         Function::new(move |data: &Vec<TIA>| {
-            let mut counts = categories.iter()
-                .map(|cat| (cat, TOA::zero())).collect::<HashMap<&TIA, TOA>>();
+            let mut counts = categories
+                .iter()
+                .map(|cat| (cat, TOA::zero()))
+                .collect::<HashMap<&TIA, TOA>>();
             let mut null_count = TOA::zero();
 
             data.iter().for_each(|v| {
                 let count = match counts.entry(v) {
                     Entry::Occupied(v) => v.into_mut(),
-                    Entry::Vacant(_v) => &mut null_count
+                    Entry::Vacant(_v) => &mut null_count,
                 };
                 *count = TOA::one().saturating_add(count)
             });
 
-            categories.iter().map(|cat| counts.remove(cat)
-                .unwrap_assert("categories are distinct and every category is in the map"))
-                .chain(if null_category {vec![null_count]} else {vec![]})
+            categories
+                .iter()
+                .map(|cat| {
+                    counts
+                        .remove(cat)
+                        .unwrap_assert("categories are distinct and every category is in the map")
+                })
+                .chain(if null_category {
+                    vec![null_count]
+                } else {
+                    vec![]
+                })
                 .collect()
         }),
         SymmetricDistance::default(),
         MO::default(),
-        StabilityMap::new_from_constant(MO::get_stability_constant())))
+        StabilityMap::new_from_constant(MO::get_stability_constant()),
+    ))
 }
 
 #[doc(hidden)]
@@ -146,35 +186,44 @@ pub trait CountByConstant<QO> {
 }
 impl<const P: usize, Q: One> CountByConstant<Q> for LpDistance<P, Q> {
     fn get_stability_constant() -> Fallible<Q> {
-        if P == 0 {return fallible!(MakeTransformation, "P must be positive")}
+        if P == 0 {
+            return fallible!(MakeTransformation, "P must be positive");
+        }
         Ok(Q::one())
     }
 }
 
-
 #[bootstrap(
-    features("contrib"), 
+    features("contrib"),
     generics(MO(hint = "SensitivityMetric"), TV(default = "int"))
 )]
-/// Make a Transformation that computes the count of each unique value in data. 
+/// Make a Transformation that computes the count of each unique value in data.
 /// This assumes that the category set is unknown.
-/// 
+///
 /// # Citations
 /// * [BV17 Differential Privacy on Finite Computers](https://arxiv.org/abs/1709.05396)
-/// 
+///
 /// # Generics
 /// * `MO` - Output Metric.
 /// * `TK` - Type of Key. Categorical/hashable input data type. Input data must be `Vec<TK>`.
 /// * `TV` - Type of Value. Express counts in terms of this integral type.
-/// 
+///
 /// # Returns
 /// The carrier type is `HashMap<TK, TV>`, a hashmap of the count (`TV`) for each unique data input (`TK`).
-pub fn make_count_by<MO, TK, TV>(
-) -> Fallible<Transformation<VectorDomain<AllDomain<TK>>, MapDomain<AllDomain<TK>, AllDomain<TV>>, SymmetricDistance, MO>>
-    where MO: CountByConstant<MO::Distance> + Metric,
-          MO::Distance: Float,
-          TK: Hashable,
-          TV: Number {
+pub fn make_count_by<MO, TK, TV>() -> Fallible<
+    Transformation<
+        VectorDomain<AllDomain<TK>>,
+        MapDomain<AllDomain<TK>, AllDomain<TV>>,
+        SymmetricDistance,
+        MO,
+    >,
+>
+where
+    MO: CountByConstant<MO::Distance> + Metric,
+    MO::Distance: Float,
+    TK: Hashable,
+    TV: Number,
+{
     Ok(Transformation::new(
         VectorDomain::new_all(),
         MapDomain::new(AllDomain::new(), AllDomain::new()),
@@ -188,9 +237,9 @@ pub fn make_count_by<MO, TK, TV>(
         }),
         SymmetricDistance::default(),
         MO::default(),
-        StabilityMap::new_from_constant(MO::get_stability_constant()?)))
+        StabilityMap::new_from_constant(MO::get_stability_constant()?),
+    ))
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -222,15 +271,14 @@ mod tests {
         let transformation = make_count_distinct::<_, i32>().unwrap_test();
         let arg = vec![1, 1, 3, 4, 4];
         let ret = transformation.invoke(&arg).unwrap_test();
-        let expected = 3 ;
+        let expected = 3;
         assert_eq!(ret, expected);
     }
 
     #[test]
     fn test_make_count_by_categories() {
-        let transformation = make_count_by_categories::<L2Distance<f64>, i64, i8>(
-            vec![2, 1, 3], true
-        ).unwrap_test();
+        let transformation =
+            make_count_by_categories::<L2Distance<f64>, i64, i8>(vec![2, 1, 3], true).unwrap_test();
         let arg = vec![1, 2, 3, 4, 5, 1, 1, 1, 2];
         let ret = transformation.invoke(&arg).unwrap_test();
         let expected = vec![2, 4, 1, 2];
@@ -242,7 +290,9 @@ mod tests {
 
     #[test]
     fn test_make_count_by() -> Fallible<()> {
-        let arg = vec![true, true, true, false, true, false, false, false, true, true];
+        let arg = vec![
+            true, true, true, false, true, false, false, false, true, true,
+        ];
         let transformation = make_count_by::<L2Distance<f64>, bool, i8>()?;
         let ret = transformation.invoke(&arg)?;
         let mut expected = HashMap::new();

--- a/rust/src/transformations/count_cdf/ffi.rs
+++ b/rust/src/transformations/count_cdf/ffi.rs
@@ -3,7 +3,7 @@ use std::{convert::TryFrom, os::raw::c_char};
 use crate::{
     core::{FfiResult, IntoAnyFunctionFfiResultExt},
     ffi::{
-        any::{AnyObject, Downcast, AnyFunction},
+        any::{AnyFunction, AnyObject, Downcast},
         util::{to_str, Type},
     },
     traits::{Float, Number, RoundCast},
@@ -11,7 +11,9 @@ use crate::{
 };
 
 #[no_mangle]
-pub extern "C" fn opendp_transformations__make_cdf(TA: *const c_char) -> FfiResult<*mut AnyFunction> {
+pub extern "C" fn opendp_transformations__make_cdf(
+    TA: *const c_char,
+) -> FfiResult<*mut AnyFunction> {
     fn monomorphize<TA: Float>() -> FfiResult<*mut AnyFunction> {
         make_cdf::<TA>().into_any()
     }
@@ -46,7 +48,10 @@ pub extern "C" fn opendp_transformations__make_quantiles_from_counts(
     let interpolation = match try_!(to_str(interpolation)) {
         i if i == "linear" => Interpolation::Linear,
         i if i == "nearest" => Interpolation::Nearest,
-        _ => try_!(fallible!(FFI, "interpolation must be `linear` or `nearest`"))
+        _ => try_!(fallible!(
+            FFI,
+            "interpolation must be `linear` or `nearest`"
+        )),
     };
     let TA = try_!(Type::try_from(TA));
     let F = try_!(Type::try_from(F));

--- a/rust/src/transformations/covariance/ffi.rs
+++ b/rust/src/transformations/covariance/ffi.rs
@@ -1,4 +1,7 @@
-use std::{os::raw::{c_char, c_uint}, convert::TryFrom};
+use std::{
+    convert::TryFrom,
+    os::raw::{c_char, c_uint},
+};
 
 use crate::{
     core::{FfiResult, IntoAnyTransformationFfiResultExt},
@@ -6,8 +9,8 @@ use crate::{
         any::{AnyObject, AnyTransformation, Downcast},
         util::Type,
     },
+    traits::Float,
     transformations::{make_sized_bounded_covariance, Pairwise, Sequential, UncheckedSum},
-    traits::Float
 };
 
 // no entry in bootstrap.json because there's no way to get data into it

--- a/rust/src/transformations/covariance/mod.rs
+++ b/rust/src/transformations/covariance/mod.rs
@@ -1,19 +1,17 @@
 use crate::{
-    core::{StabilityMap, Transformation, Function},
-    metrics::{AbsoluteDistance, SymmetricDistance},
+    core::{Function, StabilityMap, Transformation},
     domains::{AllDomain, BoundedDomain, SizedDomain, VectorDomain},
     error::Fallible,
-    traits::{ExactIntCast, InfCast, InfAdd, InfDiv, InfMul, InfSub, Float},
+    metrics::{AbsoluteDistance, SymmetricDistance},
+    traits::{ExactIntCast, Float, InfAdd, InfCast, InfDiv, InfMul, InfSub},
 };
 
-use num::{Zero, One};
+use num::{One, Zero};
 
 use super::UncheckedSum;
 
-
-#[cfg(feature="ffi")]
+#[cfg(feature = "ffi")]
 mod ffi;
-
 
 type CovarianceDomain<T> = SizedDomain<VectorDomain<BoundedDomain<(T, T)>>>;
 
@@ -32,13 +30,13 @@ pub fn make_sized_bounded_covariance<S>(
 >
 where
     S: UncheckedSum,
-    S::Item: 'static + Float
+    S::Item: 'static + Float,
 {
     if size == 0 {
-        return fallible!(MakeTransformation, "size must be greater than zero")
+        return fallible!(MakeTransformation, "size must be greater than zero");
     }
     if ddof >= size {
-        return fallible!(MakeTransformation, "size - ddof must be greater than zero")
+        return fallible!(MakeTransformation, "size - ddof must be greater than zero");
     }
     let _size = S::Item::exact_int_cast(size)?;
     let _ddof = S::Item::exact_int_cast(ddof)?;
@@ -99,9 +97,13 @@ where
             let (sum_l, sum_r) = (S::unchecked_sum(&l), S::unchecked_sum(&r));
             let (mean_l, mean_r) = (sum_l / _size, sum_r / _size);
 
-            let ssd = S::unchecked_sum(&arg.iter().copied()
-                .map(|(v_l, v_r)| (v_l - mean_l) * (v_r - mean_r)).collect::<Vec<S::Item>>());
-            
+            let ssd = S::unchecked_sum(
+                &arg.iter()
+                    .copied()
+                    .map(|(v_l, v_r)| (v_l - mean_l) * (v_r - mean_r))
+                    .collect::<Vec<S::Item>>(),
+            );
+
             ssd / (_size - _ddof)
         })),
         SymmetricDistance::default(),
@@ -137,8 +139,7 @@ mod test {
         let ret = transformation_pop.invoke(&arg)?;
         let expected = 2.0;
         assert_eq!(ret, expected);
-        assert!(transformation_pop
-            .check(&1, &(100. * 4. / 25.))?);
+        assert!(transformation_pop.check(&1, &(100. * 4. / 25.))?);
         Ok(())
     }
 }

--- a/rust/src/transformations/dataframe/apply/ffi.rs
+++ b/rust/src/transformations/dataframe/apply/ffi.rs
@@ -38,7 +38,6 @@ pub extern "C" fn opendp_transformations__make_df_cast_default(
     ], (column_name))
 }
 
-
 #[no_mangle]
 pub extern "C" fn opendp_transformations__make_df_is_equal(
     column_name: *const AnyObject,
@@ -67,14 +66,12 @@ pub extern "C" fn opendp_transformations__make_df_is_equal(
     ], (column_name, value))
 }
 
-
-
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
 
     use crate::data::Column;
-    use crate::error::{Fallible, ExplainUnwrap};
+    use crate::error::{ExplainUnwrap, Fallible};
     use crate::transformations::DataFrame;
 
     use crate::core;
@@ -99,22 +96,18 @@ mod tests {
             "String".to_char_p(),
             "bool".to_char_p(),
         ))?;
-        let arg = AnyObject::new_raw(dataframe(vec![
-            ("A", Column::new(to_owned(&["1", "", "1"]))),
-        ]));
+        let arg = AnyObject::new_raw(dataframe(vec![(
+            "A",
+            Column::new(to_owned(&["1", "", "1"])),
+        )]));
         let res = core::opendp_core__transformation_invoke(&transformation, arg);
         let res: HashMap<String, Column> = Fallible::from(res)?.downcast()?;
-        
-        let subset = res
-            .get("A")
-            .unwrap_test()
-            .as_form::<Vec<bool>>()?
-            .clone();
-        
+
+        let subset = res.get("A").unwrap_test().as_form::<Vec<bool>>()?.clone();
+
         assert_eq!(subset, vec![true, false, true]);
         Ok(())
     }
-
 
     #[test]
     fn test_df_is_equal() -> Fallible<()> {
@@ -124,18 +117,15 @@ mod tests {
             "String".to_char_p(),
             "String".to_char_p(),
         ))?;
-        let arg = AnyObject::new_raw(dataframe(vec![
-            ("A", Column::new(to_owned(&["yes", "no", "yes"]))),
-        ]));
+        let arg = AnyObject::new_raw(dataframe(vec![(
+            "A",
+            Column::new(to_owned(&["yes", "no", "yes"])),
+        )]));
         let res = core::opendp_core__transformation_invoke(&transformation, arg);
         let res: HashMap<String, Column> = Fallible::from(res)?.downcast()?;
-        
-        let subset = res
-            .get("A")
-            .unwrap_test()
-            .as_form::<Vec<bool>>()?
-            .clone();
-        
+
+        let subset = res.get("A").unwrap_test().as_form::<Vec<bool>>()?.clone();
+
         assert_eq!(subset, vec![true, false, true]);
         Ok(())
     }

--- a/rust/src/transformations/dataframe/apply/mod.rs
+++ b/rust/src/transformations/dataframe/apply/mod.rs
@@ -51,20 +51,20 @@ fn make_apply_transformation_dataframe<K: Hashable, VI: Primitive, VO: Primitive
 }
 
 #[bootstrap(features("contrib"))]
-/// Make a Transformation that casts the elements in a column in a dataframe from type `TIA` to type `TOA`. 
+/// Make a Transformation that casts the elements in a column in a dataframe from type `TIA` to type `TOA`.
 /// If cast fails, fill with default.
-/// 
-/// 
+///
+///
 /// | `TIA`  | `TIA::default()` |
 /// | ------ | ---------------- |
 /// | float  | `0.`             |
 /// | int    | `0`              |
 /// | string | `""`             |
-/// | bool   | `false`          | 
-/// 
+/// | bool   | `false`          |
+///
 /// # Arguments
 /// * `column_name` - column name to be transformed
-/// 
+///
 /// # Generics
 /// * `TK` - Type of the column name
 /// * `TIA` - Atomic Input Type to cast from
@@ -84,11 +84,11 @@ where
 
 #[bootstrap(features("contrib"))]
 /// Make a Transformation that checks if each element in a column in a dataframe is equivalent to `value`.
-/// 
+///
 /// # Arguments
 /// * `column_name` - Column name to be transformed
 /// * `value` - Value to check for equality
-/// 
+///
 /// # Generics
 /// * `TK` - Type of the column name
 /// * `TIA` - Atomic Input Type to cast from
@@ -149,11 +149,7 @@ mod test {
         df.insert(1, vec![12., 23., 94., 128.].into());
         let res = trans.invoke(&df)?;
 
-        let filter = res
-            .get(&0)
-            .unwrap_test()
-            .as_form::<Vec<bool>>()?
-            .clone();
+        let filter = res.get(&0).unwrap_test().as_form::<Vec<bool>>()?.clone();
 
         assert_eq!(filter, vec![false, true, true, false]);
 

--- a/rust/src/transformations/dataframe/create/ffi.rs
+++ b/rust/src/transformations/dataframe/create/ffi.rs
@@ -1,4 +1,4 @@
-use std::{os::raw::c_char, convert::TryFrom};
+use std::{convert::TryFrom, os::raw::c_char};
 
 use crate::{
     core::{FfiResult, IntoAnyTransformationFfiResultExt},
@@ -62,7 +62,6 @@ pub extern "C" fn opendp_transformations__make_split_dataframe(
 
     dispatch!(monomorphize, [(K, @hashable)], (separator, col_names))
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/rust/src/transformations/dataframe/create/mod.rs
+++ b/rust/src/transformations/dataframe/create/mod.rs
@@ -63,10 +63,10 @@ fn create_dataframe<K: Hashable>(col_names: Vec<K>, records: &[Vec<&str>]) -> Da
 
 #[bootstrap(features("contrib"))]
 /// Make a Transformation that constructs a dataframe from a `Vec<Vec<String>>` (a vector of records).
-/// 
+///
 /// # Arguments
 /// * `col_names` - Column names for each record entry.
-/// 
+///
 /// # Generics
 /// * `K` - categorical/hashable data type of column names
 pub fn make_create_dataframe<K>(
@@ -103,16 +103,16 @@ fn split_dataframe<K: Hashable>(separator: &str, col_names: Vec<K>, s: &str) -> 
 }
 
 #[bootstrap(
-    features("contrib"), 
+    features("contrib"),
     arguments(separator(c_type = "char *", rust_type = b"null"))
 )]
 /// Make a Transformation that splits each record in a String into a `Vec<Vec<String>>`,
 /// and loads the resulting table into a dataframe keyed by `col_names`.
-/// 
+///
 /// # Arguments
 /// * `separator` - The token(s) that separate entries in each record.
 /// * `col_names` - Column names for each record entry.
-/// 
+///
 /// # Generics
 /// * `K` - categorical/hashable data type of column names
 pub fn make_split_dataframe<K>(
@@ -180,11 +180,11 @@ fn split_records<'a>(separator: &str, lines: &[&'a str]) -> Vec<Vec<&'a str>> {
 }
 
 #[bootstrap(
-    features("contrib"), 
+    features("contrib"),
     arguments(separator(c_type = "char *", rust_type = b"null"))
 )]
 /// Make a Transformation that splits each record in a `Vec<String>` into a `Vec<Vec<String>>`.
-/// 
+///
 /// # Arguments
 /// * `separator` - The token(s) that separate entries in each record.
 pub fn make_split_records(

--- a/rust/src/transformations/dataframe/select/mod.rs
+++ b/rust/src/transformations/dataframe/select/mod.rs
@@ -1,18 +1,24 @@
 use opendp_derive::bootstrap;
 
-use crate::{core::{Transformation, Function, StabilityMap}, error::Fallible, domains::{VectorDomain, AllDomain}, metrics::SymmetricDistance, traits::{Hashable, Primitive}};
+use crate::{
+    core::{Function, StabilityMap, Transformation},
+    domains::{AllDomain, VectorDomain},
+    error::Fallible,
+    metrics::SymmetricDistance,
+    traits::{Hashable, Primitive},
+};
 
-use super::{DataFrameDomain, DataFrame};
+use super::{DataFrame, DataFrameDomain};
 
 #[cfg(feature = "ffi")]
 mod ffi;
 
 #[bootstrap(features("contrib"))]
 /// Make a Transformation that retrieves the column `key` from a dataframe as `Vec<TOA>`.
-/// 
+///
 /// # Arguments
 /// * `key` - categorical/hashable data type of the key/column name
-/// 
+///
 /// # Generics
 /// * `K` - data type of key
 /// * `TOA` - Atomic Output Type to downcast vector to
@@ -50,7 +56,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{error::ExplainUnwrap, data::Column};
+    use crate::{data::Column, error::ExplainUnwrap};
 
     #[test]
     fn test_make_select_column() {

--- a/rust/src/transformations/dataframe/subset/ffi.rs
+++ b/rust/src/transformations/dataframe/subset/ffi.rs
@@ -24,7 +24,8 @@ pub extern "C" fn opendp_transformations__make_subset_by(
     {
         let indicator_column: TK =
             try_!(try_as_ref!(indicator_column).downcast_ref::<TK>()).clone();
-        let keep_columns: Vec<TK> = try_!(try_as_ref!(keep_columns).downcast_ref::<Vec<TK>>()).clone();
+        let keep_columns: Vec<TK> =
+            try_!(try_as_ref!(keep_columns).downcast_ref::<Vec<TK>>()).clone();
         make_subset_by::<TK>(indicator_column, keep_columns).into_any()
     }
     let TK = try_!(Type::try_from(TK));
@@ -34,13 +35,12 @@ pub extern "C" fn opendp_transformations__make_subset_by(
     ], (indicator_column, keep_columns))
 }
 
-
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
 
     use crate::data::Column;
-    use crate::error::{Fallible, ExplainUnwrap};
+    use crate::error::{ExplainUnwrap, Fallible};
     use crate::transformations::DataFrame;
 
     use crate::core;
@@ -66,17 +66,13 @@ mod tests {
         ))?;
         let arg = AnyObject::new_raw(dataframe(vec![
             ("A", Column::new(vec![true, false, false])),
-            ("B", Column::new(to_owned(&["1.0", "2.0", "3.0"])))
+            ("B", Column::new(to_owned(&["1.0", "2.0", "3.0"]))),
         ]));
         let res = core::opendp_core__transformation_invoke(&transformation, arg);
         let res: HashMap<String, Column> = Fallible::from(res)?.downcast()?;
-        
-        let subset = res
-            .get("B")
-            .unwrap_test()
-            .as_form::<Vec<String>>()?
-            .clone();
-        
+
+        let subset = res.get("B").unwrap_test().as_form::<Vec<String>>()?.clone();
+
         assert_eq!(subset, vec!["1.0".to_string()]);
         Ok(())
     }

--- a/rust/src/transformations/dataframe/subset/mod.rs
+++ b/rust/src/transformations/dataframe/subset/mod.rs
@@ -14,11 +14,11 @@ mod ffi;
 
 #[bootstrap(features("contrib"))]
 /// Make a Transformation that subsets a dataframe by a boolean column.
-/// 
+///
 /// # Arguments
 /// * `indicator_column` - name of the boolean column that indicates inclusion in the subset
 /// * `keep_columns` - list of column names to apply subset to
-/// 
+///
 /// # Generics
 /// * `TK` - Type of the column name
 pub fn make_subset_by<TK: Hashable>(

--- a/rust/src/transformations/impute/mod.rs
+++ b/rust/src/transformations/impute/mod.rs
@@ -1,132 +1,171 @@
-#[cfg(feature="ffi")]
+#[cfg(feature = "ffi")]
 mod ffi;
 
 use opendp_derive::bootstrap;
 
-use crate::core::{Domain, Transformation, Function, StabilityMap};
-use crate::domains::{AllDomain, InherentNullDomain, VectorDomain, OptionNullDomain};
+use crate::core::{Domain, Function, StabilityMap, Transformation};
+use crate::domains::{AllDomain, InherentNullDomain, OptionNullDomain, VectorDomain};
 use crate::error::Fallible;
-use crate::traits::samplers::SampleUniform;
-use crate::transformations::{make_row_by_row, make_row_by_row_fallible};
 use crate::metrics::SymmetricDistance;
-use crate::traits::{CheckNull, InherentNull, Float};
+use crate::traits::samplers::SampleUniform;
+use crate::traits::{CheckNull, Float, InherentNull};
+use crate::transformations::{make_row_by_row, make_row_by_row_fallible};
 
-#[bootstrap(
-    features("contrib"), 
-    generics(TA(example = "$get_first(bounds)"))
-)]
+#[bootstrap(features("contrib"), generics(TA(example = "$get_first(bounds)")))]
 /// Make a Transformation that replaces NaN values in `Vec<TA>` with uniformly distributed floats within `bounds`.
-/// 
+///
 /// # Arguments
 /// * `bounds` - Tuple of inclusive lower and upper bounds.
-/// 
+///
 /// # Generics
 /// * `TA` - Atomic Type of data being imputed. One of `f32` or `f64`
 pub fn make_impute_uniform_float<TA>(
-    bounds: (TA, TA)
-) -> Fallible<Transformation<VectorDomain<InherentNullDomain<AllDomain<TA>>>, VectorDomain<AllDomain<TA>>, SymmetricDistance, SymmetricDistance>>
-    where TA: Float + SampleUniform {
+    bounds: (TA, TA),
+) -> Fallible<
+    Transformation<
+        VectorDomain<InherentNullDomain<AllDomain<TA>>>,
+        VectorDomain<AllDomain<TA>>,
+        SymmetricDistance,
+        SymmetricDistance,
+    >,
+>
+where
+    TA: Float + SampleUniform,
+{
     let (lower, upper) = bounds;
-    if lower.is_nan() { return fallible!(MakeTransformation, "lower may not be nan"); }
-    if upper.is_nan() { return fallible!(MakeTransformation, "upper may not be nan"); }
-    if lower > upper { return fallible!(MakeTransformation, "lower may not be greater than upper") }
+    if lower.is_nan() {
+        return fallible!(MakeTransformation, "lower may not be nan");
+    }
+    if upper.is_nan() {
+        return fallible!(MakeTransformation, "upper may not be nan");
+    }
+    if lower > upper {
+        return fallible!(MakeTransformation, "lower may not be greater than upper");
+    }
     let scale = upper - lower;
 
     make_row_by_row_fallible(
         InherentNullDomain::new(AllDomain::new()),
         AllDomain::new(),
-        move |v| if v.is_null() {
-            TA::sample_standard_uniform(false).map(|v| v * scale + lower)
-        } else { Ok(*v) })
+        move |v| {
+            if v.is_null() {
+                TA::sample_standard_uniform(false).map(|v| v * scale + lower)
+            } else {
+                Ok(*v)
+            }
+        },
+    )
 }
 
 /// Utility trait to impute with a constant, regardless of the representation of nullity.
 pub trait ImputeConstantDomain: Domain {
     /// This is the type of `Self::Carrier` after imputation.
-    /// 
-    /// On any type `D` for which the `ImputeConstantDomain` trait is implemented, 
+    ///
+    /// On any type `D` for which the `ImputeConstantDomain` trait is implemented,
     /// the syntax `D::Imputed` refers to this associated type.
     /// For example, consider `D` to be `OptionNullDomain<T>`, the domain of all `Option<T>`.
-    /// The implementation of this trait for `OptionNullDomain<T>` designates that `type Imputed = T`. 
+    /// The implementation of this trait for `OptionNullDomain<T>` designates that `type Imputed = T`.
     /// Thus `OptionNullDomain<T>::Imputed` is `T`.
-    /// 
+    ///
     /// # Proof Definition
     /// `Self::Imputed` can represent the set of possible output values after imputation.
     type Imputed;
 
     /// A function that replaces a potentially-null carrier type with a non-null imputed type.
-    /// 
+    ///
     /// # Proof Definition
     /// For any setting of the input parameters, where `constant` is non-null,
     /// the function returns a non-null value.
-    fn impute_constant<'a>(default: &'a Self::Carrier, constant: &'a Self::Imputed) -> &'a Self::Imputed;
-    
+    fn impute_constant<'a>(
+        default: &'a Self::Carrier,
+        constant: &'a Self::Imputed,
+    ) -> &'a Self::Imputed;
 }
 // how to impute, when null represented as Option<T>
 impl<T: CheckNull> ImputeConstantDomain for OptionNullDomain<AllDomain<T>> {
     type Imputed = T;
-    fn impute_constant<'a>(default: &'a Self::Carrier, constant: &'a Self::Imputed) -> &'a Self::Imputed {
+    fn impute_constant<'a>(
+        default: &'a Self::Carrier,
+        constant: &'a Self::Imputed,
+    ) -> &'a Self::Imputed {
         default.as_ref().unwrap_or(constant)
     }
 }
 // how to impute, when null represented as T with internal nullity
 impl<T: InherentNull> ImputeConstantDomain for InherentNullDomain<AllDomain<T>> {
     type Imputed = Self::Carrier;
-    fn impute_constant<'a>(default: &'a Self::Carrier, constant: &'a Self::Imputed) -> &'a Self::Imputed {
-        if default.is_null() { constant } else { default }
+    fn impute_constant<'a>(
+        default: &'a Self::Carrier,
+        constant: &'a Self::Imputed,
+    ) -> &'a Self::Imputed {
+        if default.is_null() {
+            constant
+        } else {
+            default
+        }
     }
 }
 
 #[bootstrap(
-    features("contrib"), 
-    arguments(constant(rust_type = "TA", c_type="AnyObject *")),
+    features("contrib"),
+    arguments(constant(rust_type = "TA", c_type = "AnyObject *")),
     generics(DIA(default = "OptionNullDomain<AllDomain<TA>>", generics = "TA")),
     derived_types(TA = "$get_atom_or_infer(DIA, constant)")
 )]
 /// Make a Transformation that replaces null/None data with `constant`.
-/// 
+///
 /// By default, the input type is `Vec<Option<TA>>`, as emitted by make_cast.
-/// Set `DA` to `InherentNullDomain<AllDomain<TA>>` for imputing on types 
+/// Set `DA` to `InherentNullDomain<AllDomain<TA>>` for imputing on types
 /// that have an inherent representation of nullity, like floats.
-/// 
+///
 /// | Atom Input Domain `DIA`             |  Input Type       | `DIA::Imputed` |
 /// | ----------------------------------- | ----------------- | -------------- |
 /// | `OptionNullDomain<AllDomain<TA>>`   | `Vec<Option<TA>>` | `TA`           |
 /// | `InherentNullDomain<AllDomain<TA>>` | `Vec<TA>`         | `TA`           |
-/// 
+///
 /// # Arguments
 /// * `constant` - Value to replace nulls with.
-/// 
+///
 /// # Generics
 /// * `DIA` - Atomic Input Domain of data being imputed.
 pub fn make_impute_constant<DIA>(
-    constant: DIA::Imputed
-) -> Fallible<Transformation<VectorDomain<DIA>, VectorDomain<AllDomain<DIA::Imputed>>, SymmetricDistance, SymmetricDistance>>
-    where DIA: ImputeConstantDomain + Default,
-          DIA::Imputed: 'static + Clone + CheckNull,
-          DIA::Carrier: 'static {
-    if constant.is_null() { return fallible!(MakeTransformation, "Constant may not be null.") }
+    constant: DIA::Imputed,
+) -> Fallible<
+    Transformation<
+        VectorDomain<DIA>,
+        VectorDomain<AllDomain<DIA::Imputed>>,
+        SymmetricDistance,
+        SymmetricDistance,
+    >,
+>
+where
+    DIA: ImputeConstantDomain + Default,
+    DIA::Imputed: 'static + Clone + CheckNull,
+    DIA::Carrier: 'static,
+{
+    if constant.is_null() {
+        return fallible!(MakeTransformation, "Constant may not be null.");
+    }
 
-    make_row_by_row(
-        DIA::default(),
-        AllDomain::new(),
-        move |v| DIA::impute_constant(v, &constant).clone())
+    make_row_by_row(DIA::default(), AllDomain::new(), move |v| {
+        DIA::impute_constant(v, &constant).clone()
+    })
 }
 
 /// Utility trait to drop null values from a dataset, regardless of the representation of nullity.
 pub trait DropNullDomain: Domain {
     /// This is the type of `Self::Carrier` after dropping null.
-    /// 
-    /// On any type `D` for which the `DropNullDomain` trait is implemented, 
+    ///
+    /// On any type `D` for which the `DropNullDomain` trait is implemented,
     /// the syntax `D::Imputed` refers to this associated type.
     /// For example, consider `D` to be `OptionNullDomain<T>`, the domain of all `Option<T>`.
-    /// The implementation of this trait for `DropNullDomain<T>` designates that `type Imputed = T`. 
+    /// The implementation of this trait for `DropNullDomain<T>` designates that `type Imputed = T`.
     /// Thus `DropNullDomain<T>::Imputed` is `T`.
     type Imputed;
 
     /// Standardizes `D::Carrier` into an `Option<D::Imputed>`, where `D::Imputed` is never null.
-    /// 
-    /// `Self::Imputed` may have the capacity to represent null (like `f64`), 
+    ///
+    /// `Self::Imputed` may have the capacity to represent null (like `f64`),
     /// but implementations of this function must guarantee that `Self::Imputed` is never null.
     fn option(value: &Self::Carrier) -> Option<Self::Imputed>;
 }
@@ -135,43 +174,57 @@ pub trait DropNullDomain: Domain {
 impl<T: CheckNull + Clone> DropNullDomain for OptionNullDomain<AllDomain<T>> {
     type Imputed = T;
     fn option(value: &Self::Carrier) -> Option<T> {
-        if value.is_null() { None } else { value.clone() }
+        if value.is_null() {
+            None
+        } else {
+            value.clone()
+        }
     }
 }
 /// how to standardize into an option, when null represented as T with internal nullity
 impl<T: InherentNull + Clone> DropNullDomain for InherentNullDomain<AllDomain<T>> {
     type Imputed = T;
     fn option(value: &Self::Carrier) -> Option<T> {
-        if value.is_null() { None } else { Some(value.clone()) }
+        if value.is_null() {
+            None
+        } else {
+            Some(value.clone())
+        }
     }
 }
 
 #[bootstrap(features("contrib"))]
 /// Make a Transformation that drops null values.
-/// 
-/// 
+///
+///
 /// | `DA`                                | `DA::Imputed` |
 /// | ----------------------------------- | ------------- |
 /// | `OptionNullDomain<AllDomain<TA>>`   | `TA`          |
 /// | `InherentNullDomain<AllDomain<TA>>` | `TA`          |
-/// 
+///
 /// # Generics
 /// * `DA` - atomic domain of input data that contains nulls.
-pub fn make_drop_null<DA>(
-) -> Fallible<Transformation<VectorDomain<DA>, VectorDomain<AllDomain<DA::Imputed>>, SymmetricDistance, SymmetricDistance>>
-    where DA: DropNullDomain + Default, 
-          DA::Imputed: CheckNull {
+pub fn make_drop_null<DA>() -> Fallible<
+    Transformation<
+        VectorDomain<DA>,
+        VectorDomain<AllDomain<DA::Imputed>>,
+        SymmetricDistance,
+        SymmetricDistance,
+    >,
+>
+where
+    DA: DropNullDomain + Default,
+    DA::Imputed: CheckNull,
+{
     Ok(Transformation::new(
         VectorDomain::new(DA::default()),
         VectorDomain::new_all(),
-        Function::new(|arg: &Vec<DA::Carrier>|
-            arg.iter().filter_map(DA::option).collect()),
+        Function::new(|arg: &Vec<DA::Carrier>| arg.iter().filter_map(DA::option).collect()),
         SymmetricDistance::default(),
         SymmetricDistance::default(),
-        StabilityMap::new_from_constant(1)
+        StabilityMap::new_from_constant(1),
     ))
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/rust/src/transformations/index/ffi.rs
+++ b/rust/src/transformations/index/ffi.rs
@@ -3,8 +3,8 @@ use std::os::raw::c_char;
 
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::err;
-use crate::ffi::any::{AnyObject, AnyTransformation};
 use crate::ffi::any::Downcast;
+use crate::ffi::any::{AnyObject, AnyTransformation};
 use crate::ffi::util::Type;
 use crate::traits::{Hashable, Number, Primitive};
 use crate::transformations::{make_find, make_find_bin, make_index};
@@ -14,10 +14,10 @@ pub extern "C" fn opendp_transformations__make_find(
     categories: *const AnyObject,
     TIA: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<TIA>(
-        categories: *const AnyObject
-    ) -> FfiResult<*mut AnyTransformation>
-        where TIA: Hashable {
+    fn monomorphize<TIA>(categories: *const AnyObject) -> FfiResult<*mut AnyTransformation>
+    where
+        TIA: Hashable,
+    {
         let categories = try_!(try_as_ref!(categories).downcast_ref::<Vec<TIA>>()).clone();
         make_find::<TIA>(categories).into_any()
     }
@@ -32,10 +32,10 @@ pub extern "C" fn opendp_transformations__make_find_bin(
     edges: *const AnyObject,
     TIA: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<TIA>(
-        edges: *const AnyObject
-    ) -> FfiResult<*mut AnyTransformation>
-        where TIA: Number {
+    fn monomorphize<TIA>(edges: *const AnyObject) -> FfiResult<*mut AnyTransformation>
+    where
+        TIA: Number,
+    {
         let edges = try_!(try_as_ref!(edges).downcast_ref::<Vec<TIA>>()).clone();
         make_find_bin::<TIA>(edges).into_any()
     }
@@ -55,7 +55,9 @@ pub extern "C" fn opendp_transformations__make_index(
         edges: *const AnyObject,
         null: *const AnyObject,
     ) -> FfiResult<*mut AnyTransformation>
-        where TOA: Primitive {
+    where
+        TOA: Primitive,
+    {
         let edges = try_!(try_as_ref!(edges).downcast_ref::<Vec<TOA>>()).clone();
         let null = try_!(try_as_ref!(null).downcast_ref::<TOA>()).clone();
         make_index::<TOA>(edges, null).into_any()

--- a/rust/src/transformations/index/mod.rs
+++ b/rust/src/transformations/index/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(feature="ffi")]
+#[cfg(feature = "ffi")]
 mod ffi;
 
 use std::collections::HashMap;
@@ -7,89 +7,121 @@ use std::iter::FromIterator;
 use opendp_derive::bootstrap;
 
 use crate::core::Transformation;
-use crate::metrics::SymmetricDistance;
-use crate::domains::{AllDomain, VectorDomain, OptionNullDomain};
+use crate::domains::{AllDomain, OptionNullDomain, VectorDomain};
 use crate::error::Fallible;
+use crate::metrics::SymmetricDistance;
 use crate::traits::{Hashable, Number, Primitive};
 use crate::transformations::make_row_by_row;
 
 #[bootstrap(features("contrib"))]
 /// Find the index of a data value in a set of categories.
-/// 
+///
 /// For each value in the input vector, finds the index of the value in `categories`.
 /// If an index is found, returns `Some(index)`, else `None`.
 /// Chain with `make_impute_constant` or `make_drop_null` to handle nullity.
-/// 
+///
 /// # Arguments
 /// * `categories` - The set of categories to find indexes from.
-/// 
+///
 /// # Generics
 /// * `TIA` - Atomic Input Type that is categorical/hashable
 pub fn make_find<TIA>(
-    categories: Vec<TIA>
-) -> Fallible<Transformation<VectorDomain<AllDomain<TIA>>, VectorDomain<OptionNullDomain<AllDomain<usize>>>, SymmetricDistance, SymmetricDistance>>
-    where TIA: Hashable {
+    categories: Vec<TIA>,
+) -> Fallible<
+    Transformation<
+        VectorDomain<AllDomain<TIA>>,
+        VectorDomain<OptionNullDomain<AllDomain<usize>>>,
+        SymmetricDistance,
+        SymmetricDistance,
+    >,
+>
+where
+    TIA: Hashable,
+{
     let categories_len = categories.len();
-    let indexes = HashMap::<TIA, usize>::from_iter(categories.into_iter()
-        .enumerate().map(|(i, v)| (v, i)));
+    let indexes =
+        HashMap::<TIA, usize>::from_iter(categories.into_iter().enumerate().map(|(i, v)| (v, i)));
 
     if indexes.len() != categories_len {
-        return fallible!(MakeTransformation, "categories must be unique")
+        return fallible!(MakeTransformation, "categories must be unique");
     }
 
     make_row_by_row(
-        AllDomain::new(), OptionNullDomain::new(AllDomain::new()),
-        move |v| indexes.get(v).cloned())
+        AllDomain::new(),
+        OptionNullDomain::new(AllDomain::new()),
+        move |v| indexes.get(v).cloned(),
+    )
 }
 
 #[bootstrap(features("contrib"))]
 /// Make a transformation that finds the bin index in a monotonically increasing vector of edges.
-/// 
+///
 /// For each value in the input vector, finds the index of the bin the value falls into.
-/// `edges` splits the entire range of `TIA` into bins. 
+/// `edges` splits the entire range of `TIA` into bins.
 /// The first bin at index zero ranges from negative infinity to the first edge, non-inclusive.
 /// The last bin at index `edges.len()` ranges from the last bin, inclusive, to positive infinity.
-/// 
+///
 /// To be valid, `edges` must be unique and ordered.
 /// `edges` are left inclusive, right exclusive.
-/// 
+///
 /// # Arguments
 /// * `edges` - The set of edges to split bins by.
-/// 
+///
 /// # Generics
 /// * `TIA` - Atomic Input Type that is numeric
 pub fn make_find_bin<TIA>(
-    edges: Vec<TIA>
-) -> Fallible<Transformation<VectorDomain<AllDomain<TIA>>, VectorDomain<AllDomain<usize>>, SymmetricDistance, SymmetricDistance>>
-    where TIA: Number {
+    edges: Vec<TIA>,
+) -> Fallible<
+    Transformation<
+        VectorDomain<AllDomain<TIA>>,
+        VectorDomain<AllDomain<usize>>,
+        SymmetricDistance,
+        SymmetricDistance,
+    >,
+>
+where
+    TIA: Number,
+{
     if !edges.windows(2).all(|pair| pair[0] < pair[1]) {
-        return fallible!(MakeTransformation, "edges must be unique and ordered")
+        return fallible!(MakeTransformation, "edges must be unique and ordered");
     }
-    make_row_by_row(
-        AllDomain::new(), AllDomain::new(),
-        move |v| edges.iter().enumerate()
-            .find(|(_, edge)| v < edge).map(|(i, _)| i)
-            .unwrap_or(edges.len()))
+    make_row_by_row(AllDomain::new(), AllDomain::new(), move |v| {
+        edges
+            .iter()
+            .enumerate()
+            .find(|(_, edge)| v < edge)
+            .map(|(i, _)| i)
+            .unwrap_or(edges.len())
+    })
 }
 
 #[bootstrap(features("contrib"))]
 /// Make a transformation that treats each element as an index into a vector of categories.
-/// 
+///
 /// # Arguments
 /// * `categories` - The set of categories to index into.
 /// * `null` - Category to return if the index is out-of-range of the category set.
-/// 
+///
 /// # Generics
 /// * `TOA` - Atomic Output Type. Output data will be `Vec<TOA>`.
 pub fn make_index<TOA>(
-    categories: Vec<TOA>, null: TOA
-) -> Fallible<Transformation<VectorDomain<AllDomain<usize>>, VectorDomain<AllDomain<TOA>>, SymmetricDistance, SymmetricDistance>>
-    where TOA: Primitive {
-    make_row_by_row(
-        AllDomain::new(), AllDomain::new(),
-        move |v| categories.get(*v).unwrap_or(&null).clone())
+    categories: Vec<TOA>,
+    null: TOA,
+) -> Fallible<
+    Transformation<
+        VectorDomain<AllDomain<usize>>,
+        VectorDomain<AllDomain<TOA>>,
+        SymmetricDistance,
+        SymmetricDistance,
+    >,
+>
+where
+    TOA: Primitive,
+{
+    make_row_by_row(AllDomain::new(), AllDomain::new(), move |v| {
+        categories.get(*v).unwrap_or(&null).clone()
+    })
 }
-
 
 #[cfg(test)]
 mod test {
@@ -100,7 +132,8 @@ mod test {
         let find = make_find(vec!["1", "3", "4"])?;
         assert_eq!(
             find.invoke(&vec!["1", "2", "3", "4", "5"])?,
-            vec![Some(0), None, Some(1), Some(2), None]);
+            vec![Some(0), None, Some(1), Some(2), None]
+        );
         Ok(())
     }
 
@@ -109,7 +142,8 @@ mod test {
         let bin = make_find_bin(vec![2, 3, 5])?;
         assert_eq!(
             bin.invoke(&(1..10).collect())?,
-            vec![0, 1, 2, 2, 3, 3, 3, 3, 3]);
+            vec![0, 1, 2, 2, 3, 3, 3, 3, 3]
+        );
         Ok(())
     }
 
@@ -118,7 +152,8 @@ mod test {
         let index = make_index(vec!["A", "B", "C"], "NA")?;
         assert_eq!(
             index.invoke(&vec![0, 1, 3, 1, 5])?,
-            vec!["A", "B", "NA", "B", "NA"]);
+            vec!["A", "B", "NA", "B", "NA"]
+        );
         Ok(())
     }
 }

--- a/rust/src/transformations/lipschitz_mul/ffi.rs
+++ b/rust/src/transformations/lipschitz_mul/ffi.rs
@@ -1,17 +1,16 @@
 use std::{convert::TryFrom, ffi::c_void, os::raw::c_char};
 
-
 use crate::{
     core::{FfiResult, IntoAnyTransformationFfiResultExt},
-    metrics::{AbsoluteDistance, L1Distance, L2Distance},
     domains::{AllDomain, VectorDomain},
     ffi::{
         any::{AnyObject, AnyTransformation, Downcast},
         util::Type,
     },
+    metrics::{AbsoluteDistance, L1Distance, L2Distance},
+    traits::Float,
     traits::SaturatingMul,
     transformations::{make_lipschitz_float_mul, LipschitzMulFloatDomain, LipschitzMulFloatMetric},
-    traits::Float
 };
 
 #[no_mangle]

--- a/rust/src/transformations/lipschitz_mul/mod.rs
+++ b/rust/src/transformations/lipschitz_mul/mod.rs
@@ -3,15 +3,14 @@ use opendp_derive::bootstrap;
 
 use crate::{
     core::{Domain, Function, Metric, StabilityMap, Transformation},
-    metrics::{AbsoluteDistance, LpDistance},
     domains::{AllDomain, VectorDomain},
     error::Fallible,
+    metrics::{AbsoluteDistance, LpDistance},
     traits::{
-        AlertingAbs, CheckNull, ExactIntCast, FloatBits, InfAdd, InfMul, InfPow, InfSub,
-        SaturatingMul, TotalOrd, Float
+        AlertingAbs, CheckNull, ExactIntCast, Float, FloatBits, InfAdd, InfMul, InfPow, InfSub,
+        SaturatingMul, TotalOrd,
     },
 };
-
 
 #[cfg(feature = "ffi")]
 mod ffi;
@@ -19,21 +18,23 @@ mod ffi;
 #[bootstrap(
     features("contrib"),
     arguments(
-        constant(rust_type = "T", c_type = "void *"), 
-        bounds(rust_type = "(T, T)")),
+        constant(rust_type = "T", c_type = "void *"),
+        bounds(rust_type = "(T, T)")
+    ),
     generics(
         D(default = "AllDomain<T>", generics = "T"),
-        M(default = "AbsoluteDistance<T>", generics = "T")),
+        M(default = "AbsoluteDistance<T>", generics = "T")
+    ),
     derived_types(T = "$get_atom_or_infer(D, constant)")
 )]
 /// Make a transformation that multiplies an aggregate by a constant.
-/// 
+///
 /// The bounds clamp the input, in order to bound the increase in sensitivity from float rounding.
-/// 
+///
 /// # Arguments
 /// * `constant` - The constant to multiply aggregates by.
 /// * `bounds` - Tuple of inclusive lower and upper bounds.
-/// 
+///
 /// # Generics
 /// * `D` - Domain of the function. Must be `AllDomain<T>` or `VectorDomain<AllDomain<T>>`
 /// * `M` - Metric. Must be `AbsoluteDistance<T>`, `L1Distance<T>` or `L2Distance<T>`

--- a/rust/src/transformations/manipulation/mod.rs
+++ b/rust/src/transformations/manipulation/mod.rs
@@ -1,106 +1,129 @@
-#[cfg(feature="ffi")]
+#[cfg(feature = "ffi")]
 mod ffi;
 
 use num::One;
 use opendp_derive::bootstrap;
 
 use crate::core::{Domain, Function, Metric, StabilityMap, Transformation};
+use crate::domains::{AllDomain, VectorDomain};
 use crate::error::*;
-use crate::traits::{DistanceConstant, CheckNull};
-use crate::domains::{VectorDomain, AllDomain};
-use crate::metrics::{SymmetricDistance, IntDistance};
-
+use crate::metrics::{IntDistance, SymmetricDistance};
+use crate::traits::{CheckNull, DistanceConstant};
 
 /// Constructs a [`Transformation`] representing an arbitrary row-by-row transformation.
 pub(crate) fn make_row_by_row<DIA, DOA, M>(
     atom_input_domain: DIA,
     atom_output_domain: DOA,
-    atom_function: impl 'static + Fn(&DIA::Carrier) -> DOA::Carrier
+    atom_function: impl 'static + Fn(&DIA::Carrier) -> DOA::Carrier,
 ) -> Fallible<Transformation<VectorDomain<DIA>, VectorDomain<DOA>, M, M>>
-    where DIA: Domain, DOA: Domain,
-          DIA::Carrier: 'static,
-          M: Metric<Distance=IntDistance> {
+where
+    DIA: Domain,
+    DOA: Domain,
+    DIA::Carrier: 'static,
+    M: Metric<Distance = IntDistance>,
+{
     Ok(Transformation::new(
         VectorDomain::new(atom_input_domain),
         VectorDomain::new(atom_output_domain),
-        Function::new(move |arg: &Vec<DIA::Carrier>|
-            arg.iter().map(&atom_function).collect()),
+        Function::new(move |arg: &Vec<DIA::Carrier>| arg.iter().map(&atom_function).collect()),
         M::default(),
         M::default(),
-        StabilityMap::new_from_constant(1)))
+        StabilityMap::new_from_constant(1),
+    ))
 }
 
 /// Constructs a [`Transformation`] representing an arbitrary row-by-row transformation.
 pub(crate) fn make_row_by_row_fallible<DIA, DOA, M>(
     atom_input_domain: DIA,
     atom_output_domain: DOA,
-    atom_function: impl 'static + Fn(&DIA::Carrier) -> Fallible<DOA::Carrier>
+    atom_function: impl 'static + Fn(&DIA::Carrier) -> Fallible<DOA::Carrier>,
 ) -> Fallible<Transformation<VectorDomain<DIA>, VectorDomain<DOA>, M, M>>
-    where DIA: Domain, DOA: Domain,
-          DIA::Carrier: 'static,
-          M: Metric<Distance=IntDistance> {
+where
+    DIA: Domain,
+    DOA: Domain,
+    DIA::Carrier: 'static,
+    M: Metric<Distance = IntDistance>,
+{
     Ok(Transformation::new(
         VectorDomain::new(atom_input_domain),
         VectorDomain::new(atom_output_domain),
-        Function::new_fallible(move |arg: &Vec<DIA::Carrier>|
-            arg.iter().map(&atom_function).collect()),
+        Function::new_fallible(move |arg: &Vec<DIA::Carrier>| {
+            arg.iter().map(&atom_function).collect()
+        }),
         M::default(),
         M::default(),
-        StabilityMap::new_from_constant(1)))
+        StabilityMap::new_from_constant(1),
+    ))
 }
 
 /// Constructs a [`Transformation`] representing the identity function.
 pub fn make_identity<D, M>(domain: D, metric: M) -> Fallible<Transformation<D, D, M, M>>
-    where D: Domain, D::Carrier: Clone,
-          M: Metric, M::Distance: DistanceConstant<M::Distance> + One + Clone {
+where
+    D: Domain,
+    D::Carrier: Clone,
+    M: Metric,
+    M::Distance: DistanceConstant<M::Distance> + One + Clone,
+{
     Ok(Transformation::new(
         domain.clone(),
         domain,
         Function::new(|arg: &D::Carrier| arg.clone()),
         metric.clone(),
         metric,
-        StabilityMap::new_from_constant(M::Distance::one())))
+        StabilityMap::new_from_constant(M::Distance::one()),
+    ))
 }
 
 #[bootstrap(features("contrib"))]
 /// Make a Transformation that checks if each element is equal to `value`.
-/// 
+///
 /// # Arguments
 /// * `value` - value to check against
-/// 
+///
 /// # Generics
 /// * `TIA` - Atomic Input Type. Type of elements in the input vector
 pub fn make_is_equal<TIA>(
-    value: TIA
-) -> Fallible<Transformation<VectorDomain<AllDomain<TIA>>, VectorDomain<AllDomain<bool>>, SymmetricDistance, SymmetricDistance>>
-    where TIA: 'static + PartialEq + CheckNull {
-    make_row_by_row(
-        AllDomain::new(),
-        AllDomain::new(),
-        move |v| v == &value)
+    value: TIA,
+) -> Fallible<
+    Transformation<
+        VectorDomain<AllDomain<TIA>>,
+        VectorDomain<AllDomain<bool>>,
+        SymmetricDistance,
+        SymmetricDistance,
+    >,
+>
+where
+    TIA: 'static + PartialEq + CheckNull,
+{
+    make_row_by_row(AllDomain::new(), AllDomain::new(), move |v| v == &value)
 }
 
 #[bootstrap(features("contrib"))]
 /// Make a Transformation that checks if each element in a vector is null.
-/// 
+///
 /// # Generics
 /// * `DIA` - Atomic Input Domain. Can be any domain for which the carrier type has a notion of nullity.
-pub fn make_is_null<DIA>() -> Fallible<Transformation<VectorDomain<DIA>, VectorDomain<AllDomain<bool>>, SymmetricDistance, SymmetricDistance>>
-    where DIA: Domain + Default,
-          DIA::Carrier: 'static + CheckNull {
-    make_row_by_row(
-        DIA::default(),
-        AllDomain::default(),
-        |v| v.is_null())
+pub fn make_is_null<DIA>() -> Fallible<
+    Transformation<
+        VectorDomain<DIA>,
+        VectorDomain<AllDomain<bool>>,
+        SymmetricDistance,
+        SymmetricDistance,
+    >,
+>
+where
+    DIA: Domain + Default,
+    DIA::Carrier: 'static + CheckNull,
+{
+    make_row_by_row(DIA::default(), AllDomain::default(), |v| v.is_null())
 }
-
 
 #[cfg(test)]
 mod tests {
 
     use super::*;
-    use crate::metrics::ChangeOneDistance;
     use crate::domains::{AllDomain, InherentNullDomain};
+    use crate::metrics::ChangeOneDistance;
 
     #[test]
     fn test_identity() {

--- a/rust/src/transformations/mean/ffi.rs
+++ b/rust/src/transformations/mean/ffi.rs
@@ -4,11 +4,11 @@ use std::os::raw::{c_char, c_uint};
 use num::Float;
 
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt, Metric};
-use crate::metrics::{AbsoluteDistance, InsertDeleteDistance, SymmetricDistance};
 use crate::domains::AllDomain;
 use crate::err;
 use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
 use crate::ffi::util::Type;
+use crate::metrics::{AbsoluteDistance, InsertDeleteDistance, SymmetricDistance};
 use crate::traits::{ExactIntCast, InfMul};
 use crate::transformations::{
     make_sized_bounded_mean, LipschitzMulFloatDomain, LipschitzMulFloatMetric, MakeSizedBoundedSum,

--- a/rust/src/transformations/mean/mod.rs
+++ b/rust/src/transformations/mean/mod.rs
@@ -20,7 +20,7 @@ use super::{
     generics(MI(default = "SymmetricDistance"), T(example = "$get_first(bounds)"))
 )]
 /// Make a Transformation that computes the mean of bounded data.
-/// 
+///
 /// This uses a restricted-sensitivity proof that takes advantage of known dataset size.
 /// Use `make_clamp` to bound data and `make_resize` to establish dataset size.
 ///

--- a/rust/src/transformations/mod.rs
+++ b/rust/src/transformations/mod.rs
@@ -3,88 +3,87 @@
 //! The different [`crate::core::Transformation`] implementations in this module are accessed by calling the appropriate constructor function.
 //! Constructors are named in the form `make_xxx()`, where `xxx` indicates what the resulting `Transformation` does.
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod covariance;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::transformations::covariance::*;
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod b_ary_tree;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::transformations::b_ary_tree::*;
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod dataframe;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::transformations::dataframe::*;
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod manipulation;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::transformations::manipulation::*;
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod sum;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::transformations::sum::*;
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod sum_of_squared_deviations;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::transformations::sum_of_squared_deviations::*;
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod count;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::transformations::count::*;
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod count_cdf;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::transformations::count_cdf::*;
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod mean;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::transformations::mean::*;
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod variance;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::transformations::variance::*;
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod impute;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::transformations::impute::*;
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod index;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::transformations::index::*;
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod lipschitz_mul;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::transformations::lipschitz_mul::*;
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod clamp;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::transformations::clamp::*;
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod cast;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::transformations::cast::*;
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod cast_metric;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::transformations::cast_metric::*;
 
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 mod resize;
-#[cfg(feature="contrib")]
+#[cfg(feature = "contrib")]
 pub use crate::transformations::resize::*;
-

--- a/rust/src/transformations/resize/ffi.rs
+++ b/rust/src/transformations/resize/ffi.rs
@@ -1,7 +1,6 @@
 use std::convert::TryFrom;
 use std::os::raw::{c_char, c_uint};
 
-
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::domains::{AllDomain, BoundedDomain};
 use crate::err;
@@ -29,7 +28,7 @@ pub extern "C" fn opendp_transformations__make_resize(
     let MO = try_!(Type::try_from(MO));
 
     if DA != atom_domain.type_ {
-        return err!(FFI, "DA must match atom_domain's type").into()
+        return err!(FFI, "DA must match atom_domain's type").into();
     }
 
     fn monomorphize_all<MI, MO, T: 'static + CheckNull + Clone>(
@@ -60,22 +59,28 @@ pub extern "C" fn opendp_transformations__make_resize(
     }
 
     match atom_domain.type_.contents {
-        TypeContents::GENERIC { name: "AllDomain", .. } => 
-            dispatch!(monomorphize_all, [
+        TypeContents::GENERIC {
+            name: "AllDomain", ..
+        } => dispatch!(monomorphize_all, [
                 (MI, [SymmetricDistance, InsertDeleteDistance]),
                 (MO, [SymmetricDistance, InsertDeleteDistance]),
                 (atom_domain.carrier_type, @primitives)
             ], (size, atom_domain, constant)),
-        TypeContents::GENERIC { name: "BoundedDomain", .. } => 
-            dispatch!(monomorphize_bounded, [
+        TypeContents::GENERIC {
+            name: "BoundedDomain",
+            ..
+        } => dispatch!(monomorphize_bounded, [
                 (MI, [SymmetricDistance, InsertDeleteDistance]),
                 (MO, [SymmetricDistance, InsertDeleteDistance]),
                 (atom_domain.carrier_type, @numbers)
             ], (size, atom_domain, constant)),
-        _ => err!(FFI, "VectorDomain constructors only support AllDomain and BoundedDomain atoms").into()
+        _ => err!(
+            FFI,
+            "VectorDomain constructors only support AllDomain and BoundedDomain atoms"
+        )
+        .into(),
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -108,7 +113,9 @@ mod tests {
     fn test_make_bounded_resize() -> Fallible<()> {
         let transformation = Result::from(opendp_transformations__make_resize(
             4 as c_uint,
-            util::into_raw(AnyDomain::new(BoundedDomain::<i32>::new_closed((0i32, 10)).unwrap())),
+            util::into_raw(AnyDomain::new(
+                BoundedDomain::<i32>::new_closed((0i32, 10)).unwrap(),
+            )),
             AnyObject::new_raw(0i32),
             "BoundedDomain<i32>".to_char_p(),
             "SymmetricDistance".to_char_p(),

--- a/rust/src/transformations/resize/mod.rs
+++ b/rust/src/transformations/resize/mod.rs
@@ -3,10 +3,10 @@ mod ffi;
 
 use opendp_derive::bootstrap;
 
-use crate::core::{Transformation, Function, StabilityMap, Domain, Metric};
-use crate::metrics::{SymmetricDistance, InsertDeleteDistance, IntDistance};
-use crate::domains::{VectorDomain, SizedDomain};
+use crate::core::{Domain, Function, Metric, StabilityMap, Transformation};
+use crate::domains::{SizedDomain, VectorDomain};
 use crate::error::Fallible;
+use crate::metrics::{InsertDeleteDistance, IntDistance, SymmetricDistance};
 use crate::traits::samplers::Shuffle;
 use crate::traits::CheckNull;
 use std::cmp::Ordering;
@@ -25,26 +25,24 @@ impl IsMetricOrdered for InsertDeleteDistance {
 #[bootstrap(
     features("contrib"),
     arguments(
-        atom_domain(c_type = "AnyDomain *", hint = "Domain"), 
-        constant(c_type = "AnyObject *", rust_type = "$get_atom(DA)")),
-    generics(
-        MI(default = "SymmetricDistance"),
-        MO(default = "SymmetricDistance")
-    )
+        atom_domain(c_type = "AnyDomain *", hint = "Domain"),
+        constant(c_type = "AnyObject *", rust_type = "$get_atom(DA)")
+    ),
+    generics(MI(default = "SymmetricDistance"), MO(default = "SymmetricDistance"))
 )]
-/// Make a Transformation that either truncates or imputes records 
+/// Make a Transformation that either truncates or imputes records
 /// with `constant` to match a provided `size`.
-/// 
+///
 /// # Arguments
 /// * `size` - Number of records in output data.
 /// * `atom_domain` - Domain of elements.
 /// * `constant` - Value to impute with.
-/// 
+///
 /// # Generics
 /// * `DA` - Atomic Domain.
 /// * `MI` - Input Metric. One of `InsertDeleteDistance` or `SymmetricDistance`
 /// * `MO` - Output Metric. One of `InsertDeleteDistance` or `SymmetricDistance`
-/// 
+///
 /// # Returns
 /// A vector of the same type `TA`, but with the provided `size`.
 pub fn make_resize<DA, MI, MO>(
@@ -111,11 +109,8 @@ mod test {
 
     #[test]
     fn test() -> Fallible<()> {
-        let trans = make_resize::<_, SymmetricDistance, SymmetricDistance>(
-            3,
-            AllDomain::new(),
-            "x",
-        )?;
+        let trans =
+            make_resize::<_, SymmetricDistance, SymmetricDistance>(3, AllDomain::new(), "x")?;
         assert_eq!(trans.invoke(&vec!["A"; 2])?, vec!["A", "A", "x"]);
         assert_eq!(trans.invoke(&vec!["A"; 3])?, vec!["A"; 3]);
         assert_eq!(trans.invoke(&vec!["A"; 4])?, vec!["A", "A", "A"]);

--- a/rust/src/transformations/sum/ffi.rs
+++ b/rust/src/transformations/sum/ffi.rs
@@ -3,10 +3,10 @@ use std::os::raw::{c_char, c_uint};
 
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt, Metric};
 
-use crate::metrics::{InsertDeleteDistance, SymmetricDistance};
 use crate::err;
 use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
 use crate::ffi::util::Type;
+use crate::metrics::{InsertDeleteDistance, SymmetricDistance};
 use crate::transformations::sum::{MakeBoundedSum, MakeSizedBoundedSum};
 use crate::transformations::{make_bounded_sum, make_sized_bounded_sum};
 

--- a/rust/src/transformations/sum/float/checked/ffi.rs
+++ b/rust/src/transformations/sum/float/checked/ffi.rs
@@ -8,8 +8,8 @@ use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
 use crate::ffi::util::Type;
 use crate::traits::Float;
 use crate::transformations::{
-    make_bounded_float_checked_sum, make_sized_bounded_float_checked_sum, Pairwise,
-    Sequential, UncheckedSum, CanFloatSumOverflow,
+    make_bounded_float_checked_sum, make_sized_bounded_float_checked_sum, CanFloatSumOverflow,
+    Pairwise, Sequential, UncheckedSum,
 };
 
 #[no_mangle]
@@ -25,8 +25,8 @@ pub extern "C" fn opendp_transformations__make_bounded_float_checked_sum(
     ) -> FfiResult<*mut AnyTransformation>
     where
         T: 'static + Float,
-        Sequential<T>: CanFloatSumOverflow<Item=T>, 
-        Pairwise<T>: CanFloatSumOverflow<Item=T>
+        Sequential<T>: CanFloatSumOverflow<Item = T>,
+        Pairwise<T>: CanFloatSumOverflow<Item = T>,
     {
         fn monomorphize2<S>(
             size_limit: usize,
@@ -80,8 +80,6 @@ pub extern "C" fn opendp_transformations__make_sized_bounded_float_checked_sum(
     dispatch!(monomorphize, [(T, @floats)], (S, size, bounds))
 }
 
-
-
 #[cfg(test)]
 mod tests {
     use crate::core;
@@ -108,11 +106,13 @@ mod tests {
 
     #[test]
     fn test_make_sized_bounded_float_checked_sum_ffi() -> Fallible<()> {
-        let transformation = Result::from(opendp_transformations__make_sized_bounded_float_checked_sum(
-            3 as c_uint,
-            util::into_raw(AnyObject::new((0., 10.))),
-            "Sequential<f64>".to_char_p(),
-        ))?;
+        let transformation = Result::from(
+            opendp_transformations__make_sized_bounded_float_checked_sum(
+                3 as c_uint,
+                util::into_raw(AnyObject::new((0., 10.))),
+                "Sequential<f64>".to_char_p(),
+            ),
+        )?;
         let arg = AnyObject::new_raw(vec![1.0, 2.0, 3.0]);
         let res = core::opendp_core__transformation_invoke(&transformation, arg);
         let res: f64 = Fallible::from(res)?.downcast()?;

--- a/rust/src/transformations/sum/float/checked/mod.rs
+++ b/rust/src/transformations/sum/float/checked/mod.rs
@@ -1,19 +1,20 @@
 use crate::{
-    core::{Function, Transformation, StabilityMap},
-    metrics::{AbsoluteDistance, IntDistance, SymmetricDistance},
+    core::{Function, StabilityMap, Transformation},
     domains::{AllDomain, BoundedDomain, SizedDomain, VectorDomain},
     error::Fallible,
-    traits::{InfAdd, InfCast, InfMul, InfSub, TotalOrd, AlertingAbs, ExactIntCast, samplers::Shuffle},
+    metrics::{AbsoluteDistance, IntDistance, SymmetricDistance},
+    traits::{
+        samplers::Shuffle, AlertingAbs, ExactIntCast, InfAdd, InfCast, InfMul, InfSub, TotalOrd,
+    },
 };
 
-use num::{Zero, One};
+use num::{One, Zero};
 use opendp_derive::bootstrap;
 
 use super::{Float, Pairwise, Sequential, SumRelaxation};
 
 #[cfg(feature = "ffi")]
 mod ffi;
-
 
 #[bootstrap(
     features("contrib"),
@@ -22,30 +23,30 @@ mod ffi;
     returns(c_type = "FfiResult<AnyTransformation *>"),
     derived_types(T = "$get_atom_or_infer(S, get_first(bounds))")
 )]
-/// Make a Transformation that computes the sum of bounded data with known dataset size. 
-/// 
-/// This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility. 
+/// Make a Transformation that computes the sum of bounded data with known dataset size.
+///
+/// This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility.
 /// Use `make_clamp` to bound data and `make_resize` to establish dataset size.
-/// 
+///
 /// | S (summation algorithm) | input type     |
 /// | ----------------------- | -------------- |
 /// | `Sequential<S::Item>`   | `Vec<S::Item>` |
 /// | `Pairwise<S::Item>`     | `Vec<S::Item>` |
-/// 
-/// `S::Item` is the type of all of the following: 
+///
+/// `S::Item` is the type of all of the following:
 /// each bound, each element in the input data, the output data, and the output sensitivity.
-/// 
+///
 /// For example, to construct a transformation that pairwise-sums `f32` half-precision floats,
 /// set `S` to `Pairwise<f32>`.
-/// 
+///
 /// # Citations
 /// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
 /// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
-/// 
+///
 /// # Arguments
 /// * `size_limit` - Upper bound on number of records to keep in the input data.
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
-/// 
+///
 /// # Generics
 /// * `S` - Summation algorithm to use over some data type `T` (`T` is shorthand for `S::Item`)
 pub fn make_bounded_float_checked_sum<S>(
@@ -71,7 +72,9 @@ where
     }
 
     let (lower, upper) = bounds;
-    let ideal_sensitivity = upper.inf_sub(&lower)?.total_max(lower.alerting_abs()?.total_max(upper)?)?;
+    let ideal_sensitivity = upper
+        .inf_sub(&lower)?
+        .total_max(lower.alerting_abs()?.total_max(upper)?)?;
     let relaxation = S::relaxation(size_limit, lower, upper)?;
 
     Ok(Transformation::new(
@@ -105,29 +108,29 @@ where
     returns(c_type = "FfiResult<AnyTransformation *>"),
     derived_types(T = "$get_atom_or_infer(S, get_first(bounds))")
 )]
-/// Make a Transformation that computes the sum of bounded floats with known dataset size. 
-/// 
+/// Make a Transformation that computes the sum of bounded floats with known dataset size.
+///
 /// This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility.
-/// 
+///
 /// | S (summation algorithm) | input type     |
 /// | ----------------------- | -------------- |
 /// | `Sequential<S::Item>`   | `Vec<S::Item>` |
 /// | `Pairwise<S::Item>`     | `Vec<S::Item>` |
-/// 
-/// `S::Item` is the type of all of the following: 
+///
+/// `S::Item` is the type of all of the following:
 /// each bound, each element in the input data, the output data, and the output sensitivity.
-/// 
+///
 /// For example, to construct a transformation that pairwise-sums `f32` half-precision floats,
 /// set `S` to `Pairwise<f32>`.
-/// 
+///
 /// # Citations
-/// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf) 
+/// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
 /// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
-/// 
+///
 /// # Arguments
 /// * `size` - Number of records in input data.
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
-/// 
+///
 /// # Generics
 /// * `S` - Summation algorithm to use over some data type `T` (`T` is shorthand for `S::Item`)
 pub fn make_sized_bounded_float_checked_sum<S>(
@@ -290,7 +293,6 @@ where
     _2.inf_pow(&pow)
 }
 
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -328,8 +330,6 @@ mod test {
     }
 }
 
-
-
 #[cfg(test)]
 mod test_checks {
     use super::*;
@@ -357,7 +357,7 @@ mod test_checks {
         // should barely fail first check and significantly fail second check
         let can_of = Sequential::<f64>::float_sum_can_overflow(largest_size, (0., ulp_max / 2.))?;
         assert!(can_of);
-        
+
         // should barely pass first check
         let can_of = Sequential::<f64>::float_sum_can_overflow(largest_size, (0., ulp_max / 4.))?;
         assert!(!can_of);
@@ -367,7 +367,7 @@ mod test_checks {
         assert!(!can_of);
         Ok(())
     }
-    
+
     #[test]
     fn test_float_sum_overflows_pairwise() -> Fallible<()> {
         let almost_max = f64::from_bits(f64::MAX.to_bits() - 1);
@@ -379,15 +379,22 @@ mod test_checks {
         assert!(can_of);
 
         // should barely fail first check and pass second check
-        let can_of = Pairwise::<f64>::float_sum_can_overflow(largest_size, (0., ulp_max / (largest_size as f64)))?;
+        let can_of = Pairwise::<f64>::float_sum_can_overflow(
+            largest_size,
+            (0., ulp_max / (largest_size as f64)),
+        )?;
         assert!(!can_of);
-        
+
         // should barely pass first check
-        let can_of = Pairwise::<f64>::float_sum_can_overflow(largest_size, (0., ulp_max / (largest_size as f64) / 2.))?;
+        let can_of = Pairwise::<f64>::float_sum_can_overflow(
+            largest_size,
+            (0., ulp_max / (largest_size as f64) / 2.),
+        )?;
         assert!(!can_of);
 
         // should barely fail first check and significantly pass second check
-        let can_of = Pairwise::<f64>::float_sum_can_overflow(10, (0., ulp_max / (largest_size as f64)))?;
+        let can_of =
+            Pairwise::<f64>::float_sum_can_overflow(10, (0., ulp_max / (largest_size as f64)))?;
         assert!(!can_of);
         Ok(())
     }

--- a/rust/src/transformations/sum/float/mod.rs
+++ b/rust/src/transformations/sum/float/mod.rs
@@ -14,7 +14,6 @@ use crate::{
 /// Marker type to represent sequential, or recursive summation
 pub struct Sequential<T>(PhantomData<T>);
 
-
 /// Marker type to represent pairwise, or cascading summation
 pub struct Pairwise<T>(PhantomData<T>);
 
@@ -50,13 +49,10 @@ impl<T: Float> SumRelaxation for Pairwise<T> {
         let _2 = T::exact_int_cast(2)?;
 
         // u * k where k = log_2(n)
-        let uk = size
-            .inf_log2()?
-            .inf_div(&_2.inf_pow(&mantissa_bits)?)?;
+        let uk = size.inf_log2()?.inf_div(&_2.inf_pow(&mantissa_bits)?)?;
 
         // (uk / (1 - uk)) n max(|L|, U)
-        uk
-            .inf_div(&T::one().neg_inf_sub(&uk)?)?
+        uk.inf_div(&T::one().neg_inf_sub(&uk)?)?
             .inf_mul(&size)?
             .inf_mul(&lower.alerting_abs()?.total_max(upper)?)
     }

--- a/rust/src/transformations/sum/float/ordered/ffi.rs
+++ b/rust/src/transformations/sum/float/ordered/ffi.rs
@@ -8,8 +8,8 @@ use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
 use crate::ffi::util::Type;
 use crate::traits::Float;
 use crate::transformations::{
-    make_bounded_float_ordered_sum, make_sized_bounded_float_ordered_sum, Pairwise,
-    SaturatingSum, Sequential,
+    make_bounded_float_ordered_sum, make_sized_bounded_float_ordered_sum, Pairwise, SaturatingSum,
+    Sequential,
 };
 
 #[no_mangle]
@@ -106,11 +106,13 @@ mod tests {
 
     #[test]
     fn test_make_sized_bounded_float_ordered_sum_ffi() -> Fallible<()> {
-        let transformation = Result::from(opendp_transformations__make_sized_bounded_float_ordered_sum(
-            3 as c_uint,
-            util::into_raw(AnyObject::new((0., 10.))),
-            "Pairwise<f64>".to_char_p(),
-        ))?;
+        let transformation = Result::from(
+            opendp_transformations__make_sized_bounded_float_ordered_sum(
+                3 as c_uint,
+                util::into_raw(AnyObject::new((0., 10.))),
+                "Pairwise<f64>".to_char_p(),
+            ),
+        )?;
         let arg = AnyObject::new_raw(vec![1., 2., 3.]);
         let res = core::opendp_core__transformation_invoke(&transformation, arg);
         let res: f64 = Fallible::from(res)?.downcast()?;

--- a/rust/src/transformations/sum/float/ordered/mod.rs
+++ b/rust/src/transformations/sum/float/ordered/mod.rs
@@ -1,10 +1,10 @@
 use opendp_derive::bootstrap;
 
 use crate::{
-    core::{Function, Transformation, StabilityMap},
-    metrics::{AbsoluteDistance, InsertDeleteDistance, IntDistance},
+    core::{Function, StabilityMap, Transformation},
     domains::{AllDomain, BoundedDomain, SizedDomain, VectorDomain},
     error::Fallible,
+    metrics::{AbsoluteDistance, InsertDeleteDistance, IntDistance},
     traits::{AlertingAbs, InfAdd, InfCast, InfMul, InfSub, TotalOrd},
 };
 
@@ -19,31 +19,31 @@ mod ffi;
     generics(S(default = "Pairwise<T>", generics = "T")),
     derived_types(T = "$get_atom_or_infer(S, get_first(bounds))")
 )]
-/// Make a Transformation that computes the sum of bounded floats with known ordering. 
-/// 
+/// Make a Transformation that computes the sum of bounded floats with known ordering.
+///
 /// Only useful when `make_bounded_float_checked_sum` returns an error due to potential for overflow.
 /// You may need to use `make_ordered_random` to impose an ordering on the data.
 /// The utility loss from overestimating the `size_limit` is small.
-/// 
+///
 /// | S (summation algorithm) | input type     |
 /// | ----------------------- | -------------- |
 /// | `Sequential<S::Item>`   | `Vec<S::Item>` |
 /// | `Pairwise<S::Item>`     | `Vec<S::Item>` |
-/// 
-/// `S::Item` is the type of all of the following: 
+///
+/// `S::Item` is the type of all of the following:
 /// each bound, each element in the input data, the output data, and the output sensitivity.
-/// 
+///
 /// For example, to construct a transformation that pairwise-sums `f32` half-precision floats,
 /// set `S` to `Pairwise<f32>`.
-/// 
+///
 /// # Citations
 /// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
 /// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
-/// 
+///
 /// # Arguments
 /// * `size_limit` - Upper bound on the number of records in input data. Used to bound sensitivity.
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
-/// 
+///
 /// # Generics
 /// * `S` - Summation algorithm to use over some data type `T` (`T` is shorthand for `S::Item`)
 pub fn make_bounded_float_ordered_sum<S>(
@@ -62,7 +62,9 @@ where
     S::Item: 'static + Float,
 {
     let (lower, upper) = bounds;
-    let ideal_sensitivity = upper.inf_sub(&lower)?.total_max(lower.alerting_abs()?.total_max(upper)?)?;
+    let ideal_sensitivity = upper
+        .inf_sub(&lower)?
+        .total_max(lower.alerting_abs()?.total_max(upper)?)?;
     let relaxation = S::relaxation(size_limit, lower, upper)?;
 
     Ok(Transformation::new(
@@ -91,31 +93,31 @@ where
     generics(S(default = "Pairwise<T>", generics = "T")),
     derived_types(T = "$get_atom_or_infer(S, get_first(bounds))")
 )]
-/// Make a Transformation that computes the sum of bounded floats with known ordering and dataset size. 
-/// 
+/// Make a Transformation that computes the sum of bounded floats with known ordering and dataset size.
+///
 /// Only useful when `make_bounded_float_checked_sum` returns an error due to potential for overflow.
-/// This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility. 
+/// This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility.
 /// You may need to use `make_ordered_random` to impose an ordering on the data.
-/// 
+///
 /// | S (summation algorithm) | input type     |
 /// | ----------------------- | -------------- |
 /// | `Sequential<S::Item>`   | `Vec<S::Item>` |
 /// | `Pairwise<S::Item>`     | `Vec<S::Item>` |
-/// 
-/// `S::Item` is the type of all of the following: 
+///
+/// `S::Item` is the type of all of the following:
 /// each bound, each element in the input data, the output data, and the output sensitivity.
-/// 
+///
 /// For example, to construct a transformation that pairwise-sums `f32` half-precision floats,
 /// set `S` to `Pairwise<f32>`.
-/// 
+///
 /// # Citations
 /// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
 /// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
-/// 
+///
 /// # Arguments
 /// * `size` - Number of records in input data.
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
-/// 
+///
 /// # Generics
 /// * `S` - Summation algorithm to use over some data type `T` (`T` is shorthand for `S::Item`)
 pub fn make_sized_bounded_float_ordered_sum<S>(
@@ -179,7 +181,6 @@ impl<T: Float> SaturatingSum for Pairwise<T> {
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -206,7 +207,7 @@ mod test {
         let trans = make_sized_bounded_float_ordered_sum::<Pairwise<f32>>(4, (1., 10.))?;
         let sum = trans.invoke(&vec![1., 2., 3., 4.])?;
         assert_eq!(sum, 10.);
-        
+
         Ok(())
     }
 }

--- a/rust/src/transformations/sum/int/checked/ffi.rs
+++ b/rust/src/transformations/sum/int/checked/ffi.rs
@@ -42,11 +42,12 @@ mod tests {
 
     #[test]
     fn test_make_sized_bounded_int_checked_sum_ffi() -> Fallible<()> {
-        let transformation = Result::from(opendp_transformations__make_sized_bounded_int_checked_sum(
-            3 as c_uint,
-            util::into_raw(AnyObject::new((0i32, 10i32))),
-            "i32".to_char_p(),
-        ))?;
+        let transformation =
+            Result::from(opendp_transformations__make_sized_bounded_int_checked_sum(
+                3 as c_uint,
+                util::into_raw(AnyObject::new((0i32, 10i32))),
+                "i32".to_char_p(),
+            ))?;
         let arg = AnyObject::new_raw(vec![1, 2, 3]);
         let res = core::opendp_core__transformation_invoke(&transformation, arg);
         let res: i32 = Fallible::from(res)?.downcast()?;

--- a/rust/src/transformations/sum/int/checked/mod.rs
+++ b/rust/src/transformations/sum/int/checked/mod.rs
@@ -4,9 +4,9 @@ use opendp_derive::bootstrap;
 
 use crate::{
     core::{Function, StabilityMap, Transformation},
-    metrics::{AbsoluteDistance, IntDistance, SymmetricDistance},
     domains::{AllDomain, BoundedDomain, SizedDomain, VectorDomain},
     error::Fallible,
+    metrics::{AbsoluteDistance, IntDistance, SymmetricDistance},
     traits::Number,
     transformations::CanIntSumOverflow,
 };
@@ -16,21 +16,18 @@ use super::AddIsExact;
 #[cfg(feature = "ffi")]
 mod ffi;
 
-#[bootstrap(
-    features("contrib"),
-    generics(T(example = "$get_first(bounds)"))
-)]
-/// Make a Transformation that computes the sum of bounded ints. 
+#[bootstrap(features("contrib"), generics(T(example = "$get_first(bounds)")))]
+/// Make a Transformation that computes the sum of bounded ints.
 /// The effective range is reduced, as (bounds * size) must not overflow.
-/// 
+///
 /// # Citations
 /// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
 /// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
-/// 
+///
 /// # Arguments
 /// * `size` - Number of records in input data.
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
-/// 
+///
 /// # Generics
 /// * `T` - Atomic Input Type and Output Type
 pub fn make_sized_bounded_int_checked_sum<T>(

--- a/rust/src/transformations/sum/int/mod.rs
+++ b/rust/src/transformations/sum/int/mod.rs
@@ -27,7 +27,9 @@ pub trait CanIntSumOverflow: Sized {
     fn int_sum_can_overflow(size: usize, bounds: (Self, Self)) -> Fallible<bool>;
 }
 
-impl<T: ExactIntCast<usize> + AlertingAbs + TotalOrd + InfMul + AddIsExact> CanIntSumOverflow for T {
+impl<T: ExactIntCast<usize> + AlertingAbs + TotalOrd + InfMul + AddIsExact> CanIntSumOverflow
+    for T
+{
     fn int_sum_can_overflow(size: usize, (lower, upper): (Self, Self)) -> Fallible<bool> {
         let size = T::exact_int_cast(size)?;
         let mag = lower.alerting_abs()?.total_max(upper)?;

--- a/rust/src/transformations/sum/int/monotonic/ffi.rs
+++ b/rust/src/transformations/sum/int/monotonic/ffi.rs
@@ -72,11 +72,13 @@ mod tests {
 
     #[test]
     fn test_make_sized_bounded_int_monotonic_sum_ffi() -> Fallible<()> {
-        let transformation = Result::from(opendp_transformations__make_sized_bounded_int_monotonic_sum(
-            3 as c_uint,
-            util::into_raw(AnyObject::new((0i32, 10))),
-            "i32".to_char_p(),
-        ))?;
+        let transformation = Result::from(
+            opendp_transformations__make_sized_bounded_int_monotonic_sum(
+                3 as c_uint,
+                util::into_raw(AnyObject::new((0i32, 10))),
+                "i32".to_char_p(),
+            ),
+        )?;
         let arg = AnyObject::new_raw(vec![1i32, 2, 3]);
         let res = core::opendp_core__transformation_invoke(&transformation, arg);
         let res: i32 = Fallible::from(res)?.downcast()?;

--- a/rust/src/transformations/sum/int/monotonic/mod.rs
+++ b/rust/src/transformations/sum/int/monotonic/mod.rs
@@ -2,9 +2,9 @@ use opendp_derive::bootstrap;
 
 use crate::{
     core::{Function, StabilityMap, Transformation},
-    metrics::{AbsoluteDistance, IntDistance, SymmetricDistance},
     domains::{AllDomain, BoundedDomain, SizedDomain, VectorDomain},
     error::Fallible,
+    metrics::{AbsoluteDistance, IntDistance, SymmetricDistance},
     traits::Number,
 };
 
@@ -13,20 +13,17 @@ use super::AddIsExact;
 #[cfg(feature = "ffi")]
 mod ffi;
 
-#[bootstrap(
-    features("contrib"),
-    generics(T(example = "$get_first(bounds)"))
-)]
-/// Make a Transformation that computes the sum of bounded ints, 
+#[bootstrap(features("contrib"), generics(T(example = "$get_first(bounds)")))]
+/// Make a Transformation that computes the sum of bounded ints,
 /// where all values share the same sign.
-/// 
+///
 /// # Citations
 /// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
 /// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
-/// 
+///
 /// # Arguments
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
-/// 
+///
 /// # Generics
 /// * `T` - Atomic Input Type and Output Type
 pub fn make_bounded_int_monotonic_sum<T>(
@@ -61,21 +58,18 @@ where
     ))
 }
 
-#[bootstrap(
-    features("contrib"),
-    generics(T(example = "$get_first(bounds)"))
-)]
-/// Make a Transformation that computes the sum of bounded ints, 
+#[bootstrap(features("contrib"), generics(T(example = "$get_first(bounds)")))]
+/// Make a Transformation that computes the sum of bounded ints,
 /// where all values share the same sign.
-/// 
+///
 /// # Citations
 /// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
 /// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
-/// 
+///
 /// # Arguments
 /// * `size` - Number of records in input data.
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
-/// 
+///
 /// # Generics
 /// * `T` - Atomic Input Type and Output Type
 pub fn make_sized_bounded_int_monotonic_sum<T>(

--- a/rust/src/transformations/sum/int/ordered/ffi.rs
+++ b/rust/src/transformations/sum/int/ordered/ffi.rs
@@ -7,7 +7,9 @@ use crate::err;
 use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
 use crate::ffi::util::Type;
 use crate::traits::Number;
-use crate::transformations::{make_bounded_int_ordered_sum, make_sized_bounded_int_ordered_sum, AddIsExact};
+use crate::transformations::{
+    make_bounded_int_ordered_sum, make_sized_bounded_int_ordered_sum, AddIsExact,
+};
 
 #[no_mangle]
 pub extern "C" fn opendp_transformations__make_bounded_int_ordered_sum(
@@ -70,11 +72,12 @@ mod tests {
 
     #[test]
     fn test_make_sized_bounded_int_ordered_sum_ffi() -> Fallible<()> {
-        let transformation = Result::from(opendp_transformations__make_sized_bounded_int_ordered_sum(
-            3 as c_uint,
-            util::into_raw(AnyObject::new((0i32, 10))),
-            "i32".to_char_p(),
-        ))?;
+        let transformation =
+            Result::from(opendp_transformations__make_sized_bounded_int_ordered_sum(
+                3 as c_uint,
+                util::into_raw(AnyObject::new((0i32, 10))),
+                "i32".to_char_p(),
+            ))?;
         let arg = AnyObject::new_raw(vec![1i32, 2, 3]);
         let res = core::opendp_core__transformation_invoke(&transformation, arg);
         let res: i32 = Fallible::from(res)?.downcast()?;

--- a/rust/src/transformations/sum/int/ordered/mod.rs
+++ b/rust/src/transformations/sum/int/ordered/mod.rs
@@ -2,9 +2,9 @@ use opendp_derive::bootstrap;
 
 use crate::{
     core::{Function, StabilityMap, Transformation},
-    metrics::{AbsoluteDistance, InsertDeleteDistance, IntDistance},
     domains::{AllDomain, BoundedDomain, SizedDomain, VectorDomain},
     error::Fallible,
+    metrics::{AbsoluteDistance, InsertDeleteDistance, IntDistance},
     traits::Number,
 };
 
@@ -13,21 +13,17 @@ use super::AddIsExact;
 #[cfg(feature = "ffi")]
 mod ffi;
 
-
-#[bootstrap(
-    features("contrib"),
-    generics(T(example = "$get_first(bounds)"))
-)]
+#[bootstrap(features("contrib"), generics(T(example = "$get_first(bounds)")))]
 /// Make a Transformation that computes the sum of bounded ints.
 /// You may need to use `make_ordered_random` to impose an ordering on the data.
-/// 
+///
 /// # Citations
 /// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
 /// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
-/// 
+///
 /// # Arguments
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
-/// 
+///
 /// # Generics
 /// * `T` - Atomic Input Type and Output Type
 pub fn make_bounded_int_ordered_sum<T>(
@@ -54,23 +50,20 @@ where
     ))
 }
 
-#[bootstrap(
-    features("contrib"),
-    generics(T(example = "$get_first(bounds)"))
-)]
-/// Make a Transformation that computes the sum of bounded ints with known dataset size. 
-/// 
-/// This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility. 
+#[bootstrap(features("contrib"), generics(T(example = "$get_first(bounds)")))]
+/// Make a Transformation that computes the sum of bounded ints with known dataset size.
+///
+/// This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility.
 /// You may need to use `make_ordered_random` to impose an ordering on the data.
-/// 
+///
 /// # Citations
 /// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
 /// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
-/// 
+///
 /// # Arguments
 /// * `size` - Number of records in input data.
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
-/// 
+///
 /// # Generics
 /// * `T` - Atomic Input Type and Output Type
 pub fn make_sized_bounded_int_ordered_sum<T>(

--- a/rust/src/transformations/sum/int/split/ffi.rs
+++ b/rust/src/transformations/sum/int/split/ffi.rs
@@ -18,7 +18,7 @@ pub extern "C" fn opendp_transformations__make_bounded_int_split_sum(
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<T>(bounds: *const AnyObject) -> FfiResult<*mut AnyTransformation>
     where
-        T: Number + SplitSatSum + AddIsExact
+        T: Number + SplitSatSum + AddIsExact,
     {
         let bounds = try_!(try_as_ref!(bounds).downcast_ref::<(T, T)>()).clone();
         make_bounded_int_split_sum::<T>(bounds).into_any()
@@ -37,7 +37,7 @@ pub extern "C" fn opendp_transformations__make_sized_bounded_int_split_sum(
 ) -> FfiResult<*mut AnyTransformation> {
     fn monomorphize<T>(size: usize, bounds: *const AnyObject) -> FfiResult<*mut AnyTransformation>
     where
-        T: Number + SplitSatSum + AddIsExact
+        T: Number + SplitSatSum + AddIsExact,
     {
         let bounds = try_!(try_as_ref!(bounds).downcast_ref::<(T, T)>()).clone();
         make_sized_bounded_int_split_sum::<T>(size, bounds).into_any()
@@ -72,11 +72,12 @@ mod tests {
 
     #[test]
     fn test_make_sized_bounded_int_split_sum_ffi() -> Fallible<()> {
-        let transformation = Result::from(opendp_transformations__make_sized_bounded_int_split_sum(
-            3 as c_uint,
-            util::into_raw(AnyObject::new((0i32, 10i32))),
-            "i32".to_char_p(),
-        ))?;
+        let transformation =
+            Result::from(opendp_transformations__make_sized_bounded_int_split_sum(
+                3 as c_uint,
+                util::into_raw(AnyObject::new((0i32, 10i32))),
+                "i32".to_char_p(),
+            ))?;
         let arg = AnyObject::new_raw(vec![1i32, 2, 3]);
         let res = core::opendp_core__transformation_invoke(&transformation, arg);
         let res: i32 = Fallible::from(res)?.downcast()?;

--- a/rust/src/transformations/sum/int/split/mod.rs
+++ b/rust/src/transformations/sum/int/split/mod.rs
@@ -4,9 +4,9 @@ use opendp_derive::bootstrap;
 
 use crate::{
     core::{Function, StabilityMap, Transformation},
-    metrics::{AbsoluteDistance, IntDistance, SymmetricDistance},
     domains::{AllDomain, BoundedDomain, SizedDomain, VectorDomain},
     error::Fallible,
+    metrics::{AbsoluteDistance, IntDistance, SymmetricDistance},
     traits::{Number, SaturatingAdd},
 };
 
@@ -48,21 +48,17 @@ macro_rules! impl___signed_int_split_sat_sum {
 impl_unsigned_int_split_sat_sum! { u8 u16 u32 u64 u128 usize }
 impl___signed_int_split_sat_sum! { i8 i16 i32 i64 i128 isize }
 
-
-#[bootstrap(
-    features("contrib"),
-    generics(T(example = "$get_first(bounds)"))
-)]
-/// Make a Transformation that computes the sum of bounded ints. 
+#[bootstrap(features("contrib"), generics(T(example = "$get_first(bounds)")))]
+/// Make a Transformation that computes the sum of bounded ints.
 /// Adds the saturating sum of the positives to the saturating sum of the negatives.
-/// 
+///
 /// # Citations
 /// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
 /// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
-/// 
+///
 /// # Arguments
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
-/// 
+///
 /// # Generics
 /// * `T` - Atomic Input Type and Output Type
 pub fn make_bounded_int_split_sum<T>(
@@ -76,7 +72,7 @@ pub fn make_bounded_int_split_sum<T>(
     >,
 >
 where
-    T: Number + SplitSatSum + AddIsExact
+    T: Number + SplitSatSum + AddIsExact,
 {
     let (lower, upper) = bounds.clone();
 
@@ -90,23 +86,20 @@ where
     ))
 }
 
-#[bootstrap(
-    features("contrib"),
-    generics(T(example = "$get_first(bounds)"))
-)]
-/// Make a Transformation that computes the sum of bounded ints with known dataset size. 
-/// 
-/// This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility. 
+#[bootstrap(features("contrib"), generics(T(example = "$get_first(bounds)")))]
+/// Make a Transformation that computes the sum of bounded ints with known dataset size.
+///
+/// This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility.
 /// Adds the saturating sum of the positives to the saturating sum of the negatives.
-/// 
+///
 /// # Citations
 /// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
 /// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
-/// 
+///
 /// # Arguments
 /// * `size` - Number of records in input data.
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
-/// 
+///
 /// # Generics
 /// * `T` - Atomic Input Type and Output Type
 pub fn make_sized_bounded_int_split_sum<T>(
@@ -121,7 +114,7 @@ pub fn make_sized_bounded_int_split_sum<T>(
     >,
 >
 where
-    T: Number + SplitSatSum + AddIsExact
+    T: Number + SplitSatSum + AddIsExact,
 {
     let (lower, upper) = bounds.clone();
     let range = upper.inf_sub(&lower)?;
@@ -171,7 +164,7 @@ mod test {
         let trans = make_sized_bounded_int_split_sum(4, (1i32, 10))?;
         let sum = trans.invoke(&vec![1, 2, 3, 4])?;
         assert_eq!(sum, 10);
-        
+
         Ok(())
     }
 }

--- a/rust/src/transformations/sum/mod.rs
+++ b/rust/src/transformations/sum/mod.rs
@@ -9,29 +9,27 @@ pub use float::*;
 use opendp_derive::bootstrap;
 
 use crate::core::{Metric, Transformation};
-use crate::metrics::{AbsoluteDistance, InsertDeleteDistance, SymmetricDistance};
 use crate::domains::{AllDomain, BoundedDomain, SizedDomain, VectorDomain};
 use crate::error::*;
+use crate::metrics::{AbsoluteDistance, InsertDeleteDistance, SymmetricDistance};
 use crate::traits::{CheckNull, TotalOrd};
 use crate::transformations::{make_ordered_random, make_unordered};
 
 #[bootstrap(
     features("contrib"),
-    generics(
-        MI(default = "SymmetricDistance"),
-        T(example = "$get_first(bounds)")),
+    generics(MI(default = "SymmetricDistance"), T(example = "$get_first(bounds)")),
     returns(c_type = "FfiResult<AnyTransformation *>")
 )]
-/// Make a Transformation that computes the sum of bounded data. 
+/// Make a Transformation that computes the sum of bounded data.
 /// Use `make_clamp` to bound data.
-/// 
+///
 /// # Citations
 /// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
 /// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
-/// 
+///
 /// # Arguments
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
-/// 
+///
 /// # Generics
 /// * `MI` - Input Metric. One of `SymmetricDistance` or `InsertDeleteDistance`.
 /// * `T` - Atomic Input Type and Output Type.
@@ -45,24 +43,22 @@ where
 
 #[bootstrap(
     features("contrib"),
-    generics(
-        MI(default = "SymmetricDistance"),
-        T(example = "$get_first(bounds)")),
+    generics(MI(default = "SymmetricDistance"), T(example = "$get_first(bounds)")),
     returns(c_type = "FfiResult<AnyTransformation *>")
 )]
-/// Make a Transformation that computes the sum of bounded data with known dataset size. 
-/// 
-/// This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility. 
+/// Make a Transformation that computes the sum of bounded data with known dataset size.
+///
+/// This uses a restricted-sensitivity proof that takes advantage of known dataset size for better utility.
 /// Use `make_clamp` to bound data and `make_resize` to establish dataset size.
-/// 
+///
 /// # Citations
 /// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
 /// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
-/// 
+///
 /// # Arguments
 /// * `size` - Number of records in input data.
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
-/// 
+///
 /// # Generics
 /// * `MI` - Input Metric. One of `SymmetricDistance` or `InsertDeleteDistance`.
 /// * `T` - Atomic Input Type and Output Type.
@@ -247,7 +243,6 @@ macro_rules! impl_make_sized_bounded_sum_float {
     };
 }
 impl_make_sized_bounded_sum_float! { f32 f64 }
-
 
 #[cfg(test)]
 mod tests {

--- a/rust/src/transformations/sum_of_squared_deviations/ffi.rs
+++ b/rust/src/transformations/sum_of_squared_deviations/ffi.rs
@@ -6,7 +6,9 @@ use crate::err;
 use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
 use crate::ffi::util::Type;
 use crate::traits::Float;
-use crate::transformations::{make_sized_bounded_sum_of_squared_deviations, UncheckedSum, Sequential, Pairwise};
+use crate::transformations::{
+    make_sized_bounded_sum_of_squared_deviations, Pairwise, Sequential, UncheckedSum,
+};
 
 #[no_mangle]
 pub extern "C" fn opendp_transformations__make_sized_bounded_sum_of_squared_deviations(

--- a/rust/src/transformations/sum_of_squared_deviations/mod.rs
+++ b/rust/src/transformations/sum_of_squared_deviations/mod.rs
@@ -5,10 +5,10 @@ use num::{Float as _, One, Zero};
 use opendp_derive::bootstrap;
 
 use crate::core::{Function, StabilityMap, Transformation};
-use crate::metrics::{AbsoluteDistance, SymmetricDistance};
 use crate::domains::{AllDomain, BoundedDomain, SizedDomain, VectorDomain};
 use crate::error::Fallible;
-use crate::traits::{ExactIntCast, InfAdd, InfCast, InfDiv, InfMul, InfSub, Float};
+use crate::metrics::{AbsoluteDistance, SymmetricDistance};
+use crate::traits::{ExactIntCast, Float, InfAdd, InfCast, InfDiv, InfMul, InfSub};
 
 use super::UncheckedSum;
 
@@ -18,30 +18,30 @@ use super::UncheckedSum;
     generics(S(default = "Pairwise<T>", generics = "T")),
     derived_types(T = "$get_atom_or_infer(S, get_first(bounds))")
 )]
-/// Make a Transformation that computes the sum of squared deviations of bounded data. 
-/// 
-/// This uses a restricted-sensitivity proof that takes advantage of known dataset size. 
+/// Make a Transformation that computes the sum of squared deviations of bounded data.
+///
+/// This uses a restricted-sensitivity proof that takes advantage of known dataset size.
 /// Use `make_clamp` to bound data and `make_resize` to establish dataset size.
 ///
 /// | S (summation algorithm) | input type     |
 /// | ----------------------- | -------------- |
 /// | `Sequential<S::Item>`   | `Vec<S::Item>` |
 /// | `Pairwise<S::Item>`     | `Vec<S::Item>` |
-/// 
-/// `S::Item` is the type of all of the following: 
+///
+/// `S::Item` is the type of all of the following:
 /// each bound, each element in the input data, the output data, and the output sensitivity.
-/// 
+///
 /// For example, to construct a transformation that computes the SSD of `f32` half-precision floats,
 /// set `S` to `Pairwise<f32>`.
-/// 
+///
 /// # Citations
 /// * [CSVW22 Widespread Underestimation of Sensitivity...](https://arxiv.org/pdf/2207.10635.pdf)
 /// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
-/// 
+///
 /// # Arguments
 /// * `size` - Number of records in input data.
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
-/// 
+///
 /// # Generics
 /// * `S` - Summation algorithm to use on data type `T`. One of `Sequential<T>` or `Pairwise<T>`.
 pub fn make_sized_bounded_sum_of_squared_deviations<S>(
@@ -60,7 +60,7 @@ where
     S::Item: 'static + Float,
 {
     if size == 0 {
-        return fallible!(MakeTransformation, "size must be greater than zero")
+        return fallible!(MakeTransformation, "size must be greater than zero");
     }
     let size_ = S::Item::exact_int_cast(size)?;
     let (lower, upper) = bounds;

--- a/rust/src/transformations/variance/ffi.rs
+++ b/rust/src/transformations/variance/ffi.rs
@@ -2,13 +2,16 @@ use std::convert::TryFrom;
 use std::os::raw::{c_char, c_uint};
 
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
-use crate::metrics::AbsoluteDistance;
 use crate::domains::AllDomain;
 use crate::err;
 use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
 use crate::ffi::util::Type;
-use crate::transformations::{make_sized_bounded_variance, UncheckedSum, LipschitzMulFloatDomain, LipschitzMulFloatMetric, Sequential, Pairwise};
+use crate::metrics::AbsoluteDistance;
 use crate::traits::Float;
+use crate::transformations::{
+    make_sized_bounded_variance, LipschitzMulFloatDomain, LipschitzMulFloatMetric, Pairwise,
+    Sequential, UncheckedSum,
+};
 
 #[no_mangle]
 pub extern "C" fn opendp_transformations__make_sized_bounded_variance(
@@ -29,7 +32,7 @@ pub extern "C" fn opendp_transformations__make_sized_bounded_variance(
         fn monomorphize2<S>(
             size: usize,
             bounds: (S::Item, S::Item),
-            ddof: usize
+            ddof: usize,
         ) -> FfiResult<*mut AnyTransformation>
         where
             S: UncheckedSum,

--- a/rust/src/transformations/variance/mod.rs
+++ b/rust/src/transformations/variance/mod.rs
@@ -5,10 +5,10 @@ use num::{Float as _, Zero};
 use opendp_derive::bootstrap;
 
 use crate::core::Transformation;
-use crate::metrics::{AbsoluteDistance, SymmetricDistance};
 use crate::domains::{AllDomain, BoundedDomain, SizedDomain, VectorDomain};
 use crate::error::Fallible;
-use crate::traits::{AlertingSub, ExactIntCast, InfDiv, InfMul, InfPow, InfSub, Float};
+use crate::metrics::{AbsoluteDistance, SymmetricDistance};
+use crate::traits::{AlertingSub, ExactIntCast, Float, InfDiv, InfMul, InfPow, InfSub};
 
 use super::{
     make_lipschitz_float_mul, make_sized_bounded_sum_of_squared_deviations,
@@ -17,25 +17,23 @@ use super::{
 
 #[bootstrap(
     features("contrib"),
-    arguments(
-        bounds(rust_type = "(T, T)"),
-        ddof(default = 1)),
+    arguments(bounds(rust_type = "(T, T)"), ddof(default = 1)),
     generics(S(default = "Pairwise<T>", generics = "T")),
     derived_types(T = "$get_atom_or_infer(S, get_first(bounds))")
 )]
-/// Make a Transformation that computes the variance of bounded data. 
-/// 
-/// This uses a restricted-sensitivity proof that takes advantage of known dataset size. 
+/// Make a Transformation that computes the variance of bounded data.
+///
+/// This uses a restricted-sensitivity proof that takes advantage of known dataset size.
 /// Use `make_clamp` to bound data and `make_resize` to establish dataset size.
-/// 
+///
 /// # Citations
 /// * [DHK15 Differential Privacy for Social Science Inference](http://hona.kr/papers/files/DOrazioHonakerKingPrivacy.pdf)
-/// 
+///
 /// # Arguments
 /// * `size` - Number of records in input data.
 /// * `bounds` - Tuple of lower and upper bounds for data in the input domain.
 /// * `ddof` - Delta degrees of freedom. Set to 0 if not a sample, 1 for sample estimate.
-/// 
+///
 /// # Generics
 /// * `S` - Summation algorithm to use on data type `T`. One of `Sequential<T>` or `Pairwise<T>`.
 pub fn make_sized_bounded_variance<S>(


### PR DESCRIPTION
Closes #668 

This PR also tweaks the code that strips Rust doc comments for use in Python to treat empty doc comments `///` as newlines. Previously, only `/// ` (with a space) was treated as a newline.