### PR TITLE
add sparse vector technique

### DIFF
--- a/rust/src/domains/mod.rs
+++ b/rust/src/domains/mod.rs
@@ -499,6 +499,59 @@ impl<D: Domain> Domain for OptionDomain<D> {
     }
 }
 
+/// A domain that represents all values of a given type.
+///
+/// This is a simpler alternative to `AtomDomain`, for when the value is not an atomic/primitive,
+/// and thus the usual descriptors do not apply: no bounds, no nullity.
+///
+/// # Proof Definition
+/// `AllDomain(T)` is the domain of all values of type `T`.
+///
+/// # Example
+/// ```
+/// use opendp::domains::AllDomain;
+/// use opendp::interactive::Queryable;
+/// let all_domain = AllDomain::<Queryable<i32, f64>>::default();
+///
+/// use opendp::core::Domain;
+/// let queryable = Queryable::new_external(move |x: &i32| Ok(*x as f64))?;
+/// assert!(all_domain.member(&queryable)?);
+///
+/// # opendp::error::Fallible::Ok(())
+/// ```
+pub struct AllDomain<T>(PhantomData<T>);
+
+impl<T> Debug for AllDomain<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "AllDomain({})", type_name!(T))
+    }
+}
+
+impl<T> Default for AllDomain<T> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<T> Domain for AllDomain<T> {
+    type Carrier = T;
+    fn member(&self, _value: &Self::Carrier) -> Fallible<bool> {
+        Ok(true)
+    }
+}
+
+impl<T> Clone for AllDomain<T> {
+    fn clone(&self) -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<T> PartialEq for AllDomain<T> {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
 /// retrieves the type_name for a given type
 macro_rules! type_name {
     ($ty:ty) => {

--- a/rust/src/domains/mod.rs
+++ b/rust/src/domains/mod.rs
@@ -21,6 +21,7 @@ use std::ops::Bound;
 
 use crate::core::Domain;
 use crate::error::Fallible;
+use crate::metrics::AbsoluteDistance;
 use crate::traits::{CheckAtom, InherentNull, TotalOrd};
 use std::fmt::{Debug, Formatter};
 
@@ -548,6 +549,17 @@ impl<T> Clone for AllDomain<T> {
 
 impl<T> PartialEq for AllDomain<T> {
     fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl<Q: ?Sized, A, QD> crate::core::MetricSpace
+    for (
+        AllDomain<crate::interactive::Queryable<Q, A>>,
+        AbsoluteDistance<QD>,
+    )
+{
+    fn check(&self) -> bool {
         true
     }
 }

--- a/rust/src/interactive/mod.rs
+++ b/rust/src/interactive/mod.rs
@@ -53,12 +53,12 @@ impl<Q: ?Sized, A> Queryable<Q, A> {
 }
 
 // in the Queryable struct definition, this 'a lifetime is supplied by an HRTB after `dyn`, and then elided
-pub(crate) enum Query<'a, Q: ?Sized> {
+pub enum Query<'a, Q: ?Sized> {
     External(&'a Q),
     Internal(&'a dyn Any),
 }
 
-pub(crate) enum Answer<A> {
+pub enum Answer<A> {
     External(A),
     Internal(Box<dyn Any>),
 }
@@ -145,7 +145,7 @@ impl<Q: ?Sized, A> Queryable<Q, A>
 where
     Self: IntoPolyQueryable + FromPolyQueryable,
 {
-    pub(crate) fn new(
+    pub fn new(
         transition: impl FnMut(&Self, Query<Q>) -> Fallible<Answer<A>> + 'static,
     ) -> Fallible<Self> {
         let queryable = Queryable::new_raw(transition);
@@ -156,7 +156,7 @@ where
         })
     }
 
-    pub(crate) fn new_raw(
+    pub fn new_raw(
         transition: impl FnMut(&Self, Query<Q>) -> Fallible<Answer<A>> + 'static,
     ) -> Self {
         Queryable(Rc::new(RefCell::new(transition)))

--- a/rust/src/interactive/mod.rs
+++ b/rust/src/interactive/mod.rs
@@ -163,7 +163,7 @@ where
     }
 
     #[allow(dead_code)]
-    pub(crate) fn new_external(
+    pub fn new_external(
         mut transition: impl FnMut(&Q) -> Fallible<A> + 'static,
     ) -> Fallible<Self> {
         Queryable::new(

--- a/rust/src/measurements/above_threshold/mod.rs
+++ b/rust/src/measurements/above_threshold/mod.rs
@@ -22,6 +22,8 @@ macro_rules! float {
 }
 
 pub fn make_above_threshold<TI, QI: Number, QO: Float>(
+    input_domain: AllDomain<Queryable<TI, QI>>,
+    input_metric: RangeDistance<QI>,
     scale: QO,
     threshold: QI,
 ) -> Fallible<
@@ -44,7 +46,7 @@ where
     let threshold = float!(threshold, Up);
 
     Measurement::new(
-        AllDomain::default(),
+        input_domain,
         Function::new_fallible(move |arg: &Queryable<TI, QI>| {
             let scale = float!(scale.inf_mul(&_2)?, Up);
 
@@ -71,7 +73,7 @@ where
                 })
             })
         }),
-        RangeDistance::default(),
+        input_metric,
         MaxDivergence::default(),
         PrivacyMap::new_fallible(move |d_in: &QI| {
             let d_in = QO::inf_cast(d_in.clone())?;
@@ -100,6 +102,8 @@ mod test {
     #[test]
     fn test_sparse_vector() -> Fallible<()> {
         let sv_meas = make_above_threshold::<f64, f64, f64>(
+            AllDomain::default(),
+            RangeDistance::default(),
             100., // threshold
             4.,   // noise scale for threshold
         )?;

--- a/rust/src/measurements/above_threshold/mod.rs
+++ b/rust/src/measurements/above_threshold/mod.rs
@@ -8,12 +8,10 @@ use crate::{
     traits::{samplers::SampleDiscreteLaplaceZ2k, CheckNull, Float, InfCast},
 };
 
-pub fn make_sparse_vector<DI: 'static + Domain, T: Float, QI, MODE>(
+pub fn make_above_threshold<DI: 'static + Domain, T: Float, QI, MODE>(
     threshold: T,
     scale_threshold: T,
     scale_aggregate: T,
-    scale_release: MODE::Scale,
-    query_limit: usize,
 ) -> Fallible<
     Measurement<
         AllDomain<Queryable<DI::Carrier, T>>,
@@ -126,24 +124,24 @@ where
 mod test {
     use super::*;
 
-    #[test]
-    fn test_sparse_vector() -> Fallible<()> {
-        let sv_meas = make_sparse_vector::<AllDomain<f64>, f64, f64, OnlyBool>(
-            100., // threshold
-            4.,   // noise scale for threshold
-            6.,   // noise scale for aggregates
-            (),   // noise scale for releases
-            3,    // limit on number of queries released
-        )?;
+    // #[test]
+    // fn test_sparse_vector() -> Fallible<()> {
+    //     let sv_meas = make_above_threshold::<AllDomain<f64>, f64, f64, OnlyBool>(
+    //         100., // threshold
+    //         4.,   // noise scale for threshold
+    //         6.,   // noise scale for aggregates
+    //         (),   // noise scale for releases
+    //         3,    // limit on number of queries released
+    //     )?;
 
-        let mut sv = sv_meas.invoke(&Queryable::new_external(|query: &f64| Ok(*query))?)?;
+    //     let mut sv = sv_meas.invoke(&Queryable::new_external(|query: &f64| Ok(*query))?)?;
 
-        println!("too small       : {:?}", sv.eval(&1.)?);
-        println!("maybe true      : {:?}", sv.eval(&100.)?);
-        println!("definitely true : {:?}", sv.eval(&1000.)?);
-        println!("maybe exhausted : {:?}", sv.eval(&1000.).is_err());
-        println!("exhausted       : {:?}", sv.eval(&1000.).is_err());
+    //     println!("too small       : {:?}", sv.eval(&1.)?);
+    //     println!("maybe true      : {:?}", sv.eval(&100.)?);
+    //     println!("definitely true : {:?}", sv.eval(&1000.)?);
+    //     println!("maybe exhausted : {:?}", sv.eval(&1000.).is_err());
+    //     println!("exhausted       : {:?}", sv.eval(&1000.).is_err());
 
-        Ok(())
-    }
+    //     Ok(())
+    // }
 }

--- a/rust/src/measurements/gumbel_max/mod.rs
+++ b/rust/src/measurements/gumbel_max/mod.rs
@@ -14,7 +14,7 @@ use crate::{
 
 #[cfg(feature = "use-mpfr")]
 use crate::traits::{
-    samplers::{CastInternalRational, GumbelPSRN},
+    samplers::{CastInternalRational, GumbelPSRN, PSRN},
     DistanceConstant,
 };
 #[cfg(feature = "use-mpfr")]

--- a/rust/src/measurements/mod.rs
+++ b/rust/src/measurements/mod.rs
@@ -38,6 +38,8 @@ mod alp;
 #[cfg(all(feature = "use-mpfr", feature = "floating-point", feature = "contrib"))]
 pub use alp::*;
 
+// Where "int_trans" is short for interactive transformation.
+// This is a sparse vector mechanism that operates over interactive transformations.
 #[cfg(all(feature = "use-mpfr", feature = "floating-point", feature = "contrib"))]
 mod sparse_vector_int_trans;
 #[cfg(all(feature = "use-mpfr", feature = "floating-point", feature = "contrib"))]

--- a/rust/src/measurements/mod.rs
+++ b/rust/src/measurements/mod.rs
@@ -37,3 +37,8 @@ pub use randomized_response::*;
 mod alp;
 #[cfg(all(feature = "use-mpfr", feature = "floating-point", feature = "contrib"))]
 pub use alp::*;
+
+#[cfg(all(feature = "use-mpfr", feature = "floating-point", feature = "contrib"))]
+mod sparse_vector_int_trans;
+#[cfg(all(feature = "use-mpfr", feature = "floating-point", feature = "contrib"))]
+pub use crate::measurements::sparse_vector_int_trans::*;

--- a/rust/src/measurements/mod.rs
+++ b/rust/src/measurements/mod.rs
@@ -38,9 +38,7 @@ mod alp;
 #[cfg(all(feature = "use-mpfr", feature = "floating-point", feature = "contrib"))]
 pub use alp::*;
 
-// Where "int_trans" is short for interactive transformation.
-// This is a sparse vector mechanism that operates over interactive transformations.
 #[cfg(all(feature = "use-mpfr", feature = "floating-point", feature = "contrib"))]
 mod above_threshold;
 #[cfg(all(feature = "use-mpfr", feature = "floating-point", feature = "contrib"))]
-pub use crate::measurements::above_threshold::*;
+pub use above_threshold::*;

--- a/rust/src/measurements/mod.rs
+++ b/rust/src/measurements/mod.rs
@@ -41,6 +41,6 @@ pub use alp::*;
 // Where "int_trans" is short for interactive transformation.
 // This is a sparse vector mechanism that operates over interactive transformations.
 #[cfg(all(feature = "use-mpfr", feature = "floating-point", feature = "contrib"))]
-mod sparse_vector_int_trans;
+mod above_threshold;
 #[cfg(all(feature = "use-mpfr", feature = "floating-point", feature = "contrib"))]
-pub use crate::measurements::sparse_vector_int_trans::*;
+pub use crate::measurements::above_threshold::*;

--- a/rust/src/measurements/sparse_vector_int_trans/mod.rs
+++ b/rust/src/measurements/sparse_vector_int_trans/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core::{Domain, Function, Measure, Measurement, PrivacyMap},
+    core::{Domain, Function, Measure, Measurement, MetricSpace, PrivacyMap},
     domains::AllDomain,
     error::Fallible,
     interactive::Queryable,
@@ -28,8 +28,9 @@ where
     MaxDivergence<T>: Measure<Distance = T>,
     QI: Clone,
     MODE: SVMode<T>,
+    (AllDomain<Queryable<DI::Carrier, T>>, AbsoluteDistance<QI>): MetricSpace,
 {
-    Ok(Measurement::new(
+    Measurement::new(
         AllDomain::default(),
         Function::new_fallible(enclose!(scale_release, move |arg: &Queryable<
             DI::Carrier,
@@ -81,7 +82,7 @@ where
 
             eps_threshold.inf_add(&eps_aggregate)?.inf_add(&eps_release)
         }),
-    ))
+    )
 }
 
 pub trait SVMode<T> {

--- a/rust/src/measurements/sparse_vector_int_trans/mod.rs
+++ b/rust/src/measurements/sparse_vector_int_trans/mod.rs
@@ -1,0 +1,148 @@
+use crate::{
+    core::{Domain, Function, Measure, Measurement, PrivacyMap},
+    domains::AllDomain,
+    error::Fallible,
+    interactive::Queryable,
+    measures::MaxDivergence,
+    metrics::AbsoluteDistance,
+    traits::{samplers::SampleDiscreteLaplaceZ2k, CheckNull, Float, InfCast},
+};
+
+pub fn make_sparse_vector<DI: 'static + Domain, T: Float, QI, MODE>(
+    threshold: T,
+    scale_threshold: T,
+    scale_aggregate: T,
+    scale_release: MODE::Scale,
+    query_limit: usize,
+) -> Fallible<
+    Measurement<
+        AllDomain<Queryable<DI::Carrier, T>>,
+        Queryable<DI::Carrier, MODE::Output>,
+        AbsoluteDistance<QI>,
+        MaxDivergence<T>,
+    >,
+>
+where
+    DI::Carrier: 'static + Clone,
+    T: 'static + Clone + SampleDiscreteLaplaceZ2k + PartialOrd + InfCast<QI>,
+    MaxDivergence<T>: Measure<Distance = T>,
+    QI: Clone,
+    MODE: SVMode<T>,
+{
+    Ok(Measurement::new(
+        AllDomain::new(),
+        Function::new_fallible(enclose!(scale_release, move |arg: &Queryable<
+            DI::Carrier,
+            T,
+        >| {
+            let mut trans_queryable = arg.clone();
+
+            let threshold =
+                T::sample_discrete_laplace_Z2k(threshold, scale_threshold.clone(), -100)?;
+            let scale_aggregate = scale_aggregate.clone();
+            let scale_release = scale_release.clone();
+            let mut query_limit = query_limit.clone();
+
+            Ok(Queryable::new_external(move |query: &DI::Carrier| {
+                if query_limit == 0 {
+                    return fallible!(FailedFunction, "queries exhausted");
+                }
+
+                let aggregate = trans_queryable.eval(query)?;
+                let aggregate =
+                    T::sample_discrete_laplace_Z2k(aggregate, scale_aggregate.clone(), -100)?;
+
+                if aggregate >= threshold {
+                    query_limit -= 1;
+                }
+
+                Ok(MODE::eval_release(
+                    aggregate >= threshold,
+                    aggregate,
+                    scale_release.clone(),
+                )?)
+            }))
+        })),
+        AbsoluteDistance::default(),
+        MaxDivergence::default(),
+        PrivacyMap::new_fallible(move |d_in: &QI| {
+            let d_in = T::inf_cast(d_in.clone())?;
+            let _2 = T::one() + T::one();
+            let k_ = T::exact_int_cast(query_limit)?;
+
+            let eps_threshold = d_in.inf_div(&scale_threshold)?;
+            let eps_aggregate = _2.inf_mul(&k_)?.inf_mul(&d_in)?.inf_div(&scale_aggregate)?;
+            let eps_release = if let Some(scale_release) = MODE::option_scale(scale_release.clone())
+            {
+                k_.inf_mul(&d_in)?.inf_div(&scale_release)?
+            } else {
+                T::zero()
+            };
+
+            eps_threshold.inf_add(&eps_aggregate)?.inf_add(&eps_release)
+        }),
+    ))
+}
+
+pub trait SVMode<T> {
+    type Output: 'static + CheckNull;
+    type Scale: 'static + Clone;
+    fn eval_release(passes: bool, value: T, scale: Self::Scale) -> Fallible<Self::Output>;
+    fn option_scale(scale: Self::Scale) -> Option<T>;
+}
+
+struct OnlyBool;
+struct WithValue;
+
+impl<T> SVMode<T> for OnlyBool {
+    type Output = bool;
+    type Scale = ();
+    fn eval_release(passes: bool, _value: T, _scale: Self::Scale) -> Fallible<Self::Output> {
+        Ok(passes)
+    }
+    fn option_scale(_scale: Self::Scale) -> Option<T> {
+        None
+    }
+}
+
+impl<T: 'static + Clone + CheckNull> SVMode<T> for WithValue
+where
+    T: SampleDiscreteLaplaceZ2k,
+{
+    type Output = Option<T>;
+    type Scale = T;
+    fn eval_release(passes: bool, value: T, scale: Self::Scale) -> Fallible<Self::Output> {
+        passes
+            .then(|| T::sample_discrete_laplace_Z2k(value, scale, -100))
+            .transpose()
+    }
+    fn option_scale(scale: Self::Scale) -> Option<T> {
+        Some(scale)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_sparse_vector() -> Fallible<()> {
+        let sv_meas = make_sparse_vector::<AllDomain<f64>, f64, f64, OnlyBool>(
+            100., // threshold
+            4.,   // noise scale for threshold
+            6.,   // noise scale for aggregates
+            (),   // noise scale for releases
+            3,    // limit on number of queries released
+        )?;
+
+        let mut sv = sv_meas.invoke(&Queryable::new_external(|query: &f64| Ok(*query)))?;
+
+        println!("too small       : {:?}", sv.eval(&1.)?);
+        println!("maybe true      : {:?}", sv.eval(&100.)?);
+        println!("definitely true : {:?}", sv.eval(&1000.)?);
+        println!("maybe exhausted : {:?}", sv.eval(&1000.).is_err());
+        println!("exhausted       : {:?}", sv.eval(&1000.).is_err());
+
+        Ok(())
+    }
+}

--- a/rust/src/measurements/sparse_vector_int_trans/mod.rs
+++ b/rust/src/measurements/sparse_vector_int_trans/mod.rs
@@ -43,7 +43,7 @@ where
             let scale_release = scale_release.clone();
             let mut query_limit = query_limit.clone();
 
-            Ok(Queryable::new_external(move |query: &DI::Carrier| {
+            Queryable::new_external(move |query: &DI::Carrier| {
                 if query_limit == 0 {
                     return fallible!(FailedFunction, "queries exhausted");
                 }
@@ -61,7 +61,7 @@ where
                     aggregate,
                     scale_release.clone(),
                 )?)
-            }))
+            })
         })),
         AbsoluteDistance::default(),
         MaxDivergence::default(),

--- a/rust/src/measurements/sparse_vector_int_trans/mod.rs
+++ b/rust/src/measurements/sparse_vector_int_trans/mod.rs
@@ -30,7 +30,7 @@ where
     MODE: SVMode<T>,
 {
     Ok(Measurement::new(
-        AllDomain::new(),
+        AllDomain::default(),
         Function::new_fallible(enclose!(scale_release, move |arg: &Queryable<
             DI::Carrier,
             T,

--- a/rust/src/measurements/sparse_vector_int_trans/mod.rs
+++ b/rust/src/measurements/sparse_vector_int_trans/mod.rs
@@ -135,7 +135,7 @@ mod test {
             3,    // limit on number of queries released
         )?;
 
-        let mut sv = sv_meas.invoke(&Queryable::new_external(|query: &f64| Ok(*query)))?;
+        let mut sv = sv_meas.invoke(&Queryable::new_external(|query: &f64| Ok(*query))?)?;
 
         println!("too small       : {:?}", sv.eval(&1.)?);
         println!("maybe true      : {:?}", sv.eval(&100.)?);

--- a/rust/src/metrics/mod.rs
+++ b/rust/src/metrics/mod.rs
@@ -19,8 +19,8 @@ use std::marker::PhantomData;
 
 use crate::{
     core::{Domain, Metric, MetricSpace},
-    domains::{type_name, AtomDomain, MapDomain, VectorDomain},
-    traits::CheckAtom,
+    domains::{type_name, AtomDomain, MapDomain, VectorDomain, AllDomain},
+    traits::{CheckAtom, Number}, interactive::Queryable,
 };
 #[cfg(feature = "contrib")]
 use crate::{traits::Hashable, transformations::DataFrameDomain};
@@ -496,5 +496,11 @@ impl<Q> Metric for RangeDistance<Q> {
 impl<T: CheckAtom> MetricSpace for (VectorDomain<AtomDomain<T>>, RangeDistance<T>) {
     fn check(&self) -> bool {
         !self.0.element_domain.nullable()
+    }
+}
+
+impl<Q, A: Number> MetricSpace for (AllDomain<Queryable<Q, A>>, RangeDistance<A>) {
+    fn check(&self) -> bool {
+        true
     }
 }

--- a/rust/src/traits/samplers/psrn/gumbel/mod.rs
+++ b/rust/src/traits/samplers/psrn/gumbel/mod.rs
@@ -1,0 +1,101 @@
+use rug::{ops::NegAssign, Float, Rational};
+
+use crate::error::Fallible;
+
+use super::{Bound, UniformPSRN, PSRN};
+
+/// A partially sampled Gumbel random number.
+/// Initializes to span all reals.
+pub struct GumbelPSRN {
+    shift: Rational,
+    uniform: UniformPSRN,
+    precision: u32,
+}
+
+impl GumbelPSRN {
+    pub fn new(shift: Rational) -> Self {
+        GumbelPSRN {
+            shift,
+            uniform: UniformPSRN::default(),
+            precision: 1,
+        }
+    }
+
+    /// Computes the inverse cdf of the standard Gumbel with controlled rounding:
+    /// $-ln(-ln(u))$ where $u \sim \mathrm{Uniform}(0, 1)$
+    fn inverse_cdf(&self, mut sample: Float, bound: Bound) -> Option<Rational> {
+        // This round is behind two negations, so the rounding direction is preserved
+        sample.ln_round(bound.into());
+        sample.neg_assign();
+
+        // This round is behind a negation, so the rounding direction is reversed
+        sample.ln_round(bound.complement().into());
+        sample.neg_assign();
+
+        Some(sample.to_rational()? + &self.shift)
+    }
+}
+
+impl PSRN for GumbelPSRN {
+    type Edge = Rational;
+    /// Retrieve either the lower or upper edge of the Gumbel interval.
+    /// The PSRN is refined until a valid value can be retrieved.
+    fn edge(&mut self, bound: Bound) -> Fallible<Rational> {
+        // The first few rounds are susceptible to NaN due to the uniform PSRN initializing at zero.
+        loop {
+            let uniform = self.uniform.edge(bound)?;
+            let uniform = Float::with_val_round(self.precision, uniform, bound.into()).0;
+            if let Some(gumbel) = self.inverse_cdf(uniform, bound) {
+                return Ok(gumbel);
+            }
+            self.refine()?;
+        }
+    }
+
+    /// Improves the precision of the inverse transform,
+    /// and halves the interval spanned by the uniform PSRN.
+    fn refine(&mut self) -> Fallible<()> {
+        self.precision += 1;
+        self.uniform.refine()
+    }
+
+    fn refinements(&self) -> u32 {
+        self.precision
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_sample_gumbel_interval_progression() -> Fallible<()> {
+        let mut gumbel = GumbelPSRN::new(Rational::from(0));
+        for _ in 0..10 {
+            println!(
+                "{:?}, {:?}, {}",
+                gumbel.edge(Bound::Lower)?.to_f64(),
+                gumbel.edge(Bound::Upper)?.to_f64(),
+                gumbel.precision
+            );
+            gumbel.refine()?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_gumbel_psrn() -> Fallible<()> {
+        fn sample_gumbel() -> Fallible<f64> {
+            let mut gumbel = GumbelPSRN::new(Rational::from(0));
+            for _ in 0..10 {
+                gumbel.refine()?;
+            }
+            Ok(gumbel.edge(Bound::Lower)?.to_f64())
+        }
+        let samples = (0..1000)
+            .map(|_| sample_gumbel())
+            .collect::<Fallible<Vec<_>>>()?;
+        println!("{:?}", samples);
+        Ok(())
+    }
+}

--- a/rust/src/traits/samplers/psrn/laplace/mod.rs
+++ b/rust/src/traits/samplers/psrn/laplace/mod.rs
@@ -1,0 +1,108 @@
+use crate::traits::samplers::SampleStandardBernoulli;
+use rug::ops::NegAssign;
+use rug::Float;
+
+use crate::error::Fallible;
+
+use super::{Bound, UniformPSRN, PSRN};
+
+/// A partially sampled Laplace random number.
+/// Initializes to span all reals.
+pub struct LaplacePSRN {
+    shift: Float,
+    scale: Float,
+    uniform: UniformPSRN,
+    precision: u32,
+}
+
+impl LaplacePSRN {
+    pub fn new(shift: Float, scale: Float) -> Self {
+        LaplacePSRN {
+            shift,
+            scale,
+            uniform: UniformPSRN::default(),
+            precision: 1,
+        }
+    }
+
+    /// Computes the inverse cdf of the standard Laplace with controlled rounding:
+    /// $+/- ln(u)$ where $u \sim \mathrm{Uniform}(0, 1)$
+    fn inverse_cdf(&self, mut sample: Float, bound: Bound) -> Fallible<Float> {
+        if bool::sample_standard_bernoulli()? {
+            sample.ln_round(bound.into());
+            sample.neg_assign();
+        } else {
+            sample.ln_round(bound.complement().into());
+        }
+
+        sample.mul_add_round(&self.scale, &self.shift, bound.into());
+        Ok(sample)
+    }
+}
+
+impl PSRN for LaplacePSRN {
+    type Edge = Float;
+    /// Retrieve either the lower or upper edge of the Laplace interval.
+    /// The PSRN is refined until a valid value can be retrieved.
+    fn edge(&mut self, bound: Bound) -> Fallible<Float> {
+        // The first few rounds are susceptible to NaN due to the uniform PSRN initializing at zero.
+        loop {
+            let uniform = self.uniform.edge(bound)?;
+            let uniform = Float::with_val_round(self.precision, uniform, bound.into()).0;
+            let laplace = self.inverse_cdf(uniform, bound)?;
+
+            if !laplace.is_nan() {
+                return Ok(laplace);
+            }
+
+            self.refine()?;
+        }
+    }
+
+    /// Improves the precision of the inverse transform,
+    /// and halves the interval spanned by the uniform PSRN.
+    fn refine(&mut self) -> Fallible<()> {
+        self.precision += 1;
+        self.uniform.refine()
+    }
+
+    fn refinements(&self) -> u32 {
+        self.precision
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_sample_laplace_interval_progression() -> Fallible<()> {
+        let mut laplace = LaplacePSRN::new(Float::with_val(53, 0.), Float::with_val(53, 1.));
+        for _ in 0..10 {
+            println!(
+                "{:?}, {:?}, {}",
+                laplace.edge(Bound::Lower)?.to_f64(),
+                laplace.edge(Bound::Upper)?.to_f64(),
+                laplace.precision
+            );
+            laplace.refine()?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_laplace_psrn() -> Fallible<()> {
+        fn sample_laplace() -> Fallible<f64> {
+            let mut laplace = LaplacePSRN::new(Float::with_val(53, 0.), Float::with_val(53, 1.));
+            for _ in 0..10 {
+                laplace.refine()?;
+            }
+            Ok(laplace.edge(Bound::Lower)?.to_f64())
+        }
+        let samples = (0..1000)
+            .map(|_| sample_laplace())
+            .collect::<Fallible<Vec<_>>>()?;
+        println!("{:?}", samples);
+        Ok(())
+    }
+}

--- a/rust/src/traits/samplers/psrn/mod.rs
+++ b/rust/src/traits/samplers/psrn/mod.rs
@@ -1,112 +1,32 @@
-use std::ops::AddAssign;
+use crate::error::Fallible;
+use rug::float::Round;
 
-use rug::{float::Round, ops::NegAssign, Float, Integer, Rational};
+mod gumbel;
+pub use gumbel::GumbelPSRN;
 
-use crate::{error::Fallible, traits::samplers::SampleStandardBernoulli};
+mod laplace;
+pub use laplace::LaplacePSRN;
 
-/// A partially sampled uniform random number.
-/// Initializes to the interval [0, 1].
-#[derive(Default)]
-pub struct UniformPSRN {
-    pub numer: Integer,
-    /// The denominator is 2^denom_pow.
-    pub denom_pow: u32,
-}
+mod uniform;
+pub use uniform::UniformPSRN;
 
-impl UniformPSRN {
-    // Retrieve either the lower or upper edge of the uniform interval.
-    fn value(&self, round: Round) -> Rational {
-        let round = match round {
-            Round::Up => 1,
-            Round::Down => 0,
-            _ => panic!("value must be rounded Up or Down"),
-        };
-        Rational::from((self.numer.clone() + round, Integer::from(1) << self.denom_pow))
-    }
-    // Randomly discard the lower or upper half of the remaining interval.
-    fn refine(&mut self) -> Fallible<()> {
-        self.numer <<= 1;
-        self.denom_pow += 1;
-        if bool::sample_standard_bernoulli()? {
-            self.numer += 1;
-        }
-        Ok(())
-    }
-}
-
-/// A partially sampled Gumbel random number.
-/// Initializes to span all reals.
-pub struct GumbelPSRN {
-    shift: Rational,
-    uniform: UniformPSRN,
-    precision: u32,
-}
-
-impl GumbelPSRN {
-    pub fn new(shift: Rational) -> Self {
-        GumbelPSRN {
-            shift,
-            uniform: UniformPSRN::default(),
-            precision: 1,
-        }
-    }
-
-    /// Retrieve either the lower or upper edge of the Gumbel interval.
-    /// The PSRN is refined until a valid value can be retrieved.
-    pub fn value(&mut self, round: Round) -> Fallible<Rational> {
-        // The first few rounds are susceptible to NaN due to the uniform PSRN initializing at zero.
-        loop {
-            let uniform = Float::with_val_round(self.precision, self.uniform.value(round), round).0;
-
-            if let Some(mut gumbel) = Self::inverse_cdf(uniform, round).to_rational() {
-                gumbel.add_assign(&self.shift);
-                return Ok(gumbel);
-            } else {
-                self.refine()?;
-            }
-        }
-    }
-
-    /// Computes the inverse cdf of the standard Gumbel with controlled rounding:
-    /// $-ln(-ln(u))$ where $u \sim \mathrm{Uniform}(0, 1)$
-    fn inverse_cdf(mut sample: Float, round: Round) -> Float {
-        fn complement(value: Round) -> Round {
-            match value {
-                Round::Up => Round::Down,
-                Round::Down => Round::Up,
-                _ => panic!("complement is only supported for Up/Down"),
-            }
-        }
-
-        // This round is behind two negations, so the rounding direction is preserved
-        sample.ln_round(round);
-        sample.neg_assign();
-
-        // This round is behind a negation, so the rounding direction is reversed
-        sample.ln_round(complement(round));
-        sample.neg_assign();
-
-        sample
-    }
-
-    /// Improves the precision of the inverse transform,
-    /// and halves the interval spanned by the uniform PSRN.
-    pub fn refine(&mut self) -> Fallible<()> {
-        self.precision += 1;
-        self.uniform.refine()
-    }
+pub trait PSRN {
+    type Edge: PartialOrd;
+    fn edge(&mut self, bound: Bound) -> Fallible<Self::Edge>;
+    fn refine(&mut self) -> Fallible<()>;
+    fn refinements(&self) -> u32;
 
     /// Checks if `self` is greater than `other`,
     /// by refining the estimates for `self` and `other` until their intervals are disjoint.
-    pub fn greater_than(&mut self, other: &mut Self) -> Fallible<bool> {
+    fn greater_than(&mut self, other: &mut Self) -> Fallible<bool> {
         Ok(loop {
-            if self.value(Round::Down)? > other.value(Round::Up)? {
+            if self.edge(Lower)? > other.edge(Upper)? {
                 break true;
             }
-            if self.value(Round::Up)? < other.value(Round::Down)? {
+            if self.edge(Upper)? < other.edge(Lower)? {
                 break false;
             }
-            if self.precision < other.precision {
+            if self.refinements() < other.refinements() {
                 self.refine()?
             } else {
                 other.refine()?
@@ -115,38 +35,36 @@ impl GumbelPSRN {
     }
 }
 
-#[cfg(test)]
-mod test {
-    use super::*;
+// fn psrn_value<TI: PSRN<Edge = Rational>, TO: CastInternalRational + PartialEq>(
+//     psrn: &mut TI,
+// ) -> Fallible<TO> {
+//     while TO::from_rational(psrn.edge(Lower)?) != TO::from_rational(psrn.edge(Upper)?) {
+//         psrn.refine()?;
+//     }
+//     Ok(TO::from_rational(psrn.edge(Lower)?))
+// }
 
-    #[test]
-    fn test_sample_gumbel_interval_progression() -> Fallible<()> {
-        let mut gumbel = GumbelPSRN::new(Rational::from(0));
-        for _ in 0..10 {
-            println!(
-                "{:?}, {:?}, {}",
-                gumbel.value(Round::Down)?.to_f64(),
-                gumbel.value(Round::Up)?.to_f64(),
-                gumbel.precision
-            );
-            gumbel.refine()?;
+#[derive(Copy, Clone)]
+pub enum Bound {
+    Lower = 0,
+    Upper = 1,
+}
+use Bound::*;
+
+impl Bound {
+    fn complement(&self) -> Bound {
+        match self {
+            Lower => Upper,
+            Upper => Lower,
         }
-        Ok(())
     }
+}
 
-    #[test]
-    fn test_gumbel_psrn() -> Fallible<()> {
-        fn sample_gumbel() -> Fallible<f64> {
-            let mut gumbel = GumbelPSRN::new(Rational::from(0));
-            for _ in 0..10 {
-                gumbel.refine()?;
-            }
-            Ok(gumbel.value(Round::Down)?.to_f64())
+impl From<Bound> for Round {
+    fn from(value: Bound) -> Self {
+        match value {
+            Lower => Round::Down,
+            Upper => Round::Up,
         }
-        let samples = (0..1000)
-            .map(|_| sample_gumbel())
-            .collect::<Fallible<Vec<_>>>()?;
-        println!("{:?}", samples);
-        Ok(())
     }
 }

--- a/rust/src/traits/samplers/psrn/uniform/mod.rs
+++ b/rust/src/traits/samplers/psrn/uniform/mod.rs
@@ -1,0 +1,37 @@
+use crate::{error::Fallible, traits::samplers::SampleStandardBernoulli};
+use rug::{Integer, Rational};
+
+use super::{PSRN, Bound};
+
+/// A partially sampled uniform random number.
+/// Initializes to the interval [0, 1].
+#[derive(Default)]
+pub struct UniformPSRN {
+    pub numer: Integer,
+    /// The denominator is 2^denom_pow.
+    pub denom_pow: u32,
+}
+
+impl PSRN for UniformPSRN {
+    type Edge = Rational;
+    // Retrieve either the lower or upper edge of the uniform interval.
+    fn edge(&mut self, bound: Bound) -> Fallible<Rational> {
+        Ok(Rational::from((
+            self.numer.clone() + bound as u8,
+            Integer::from(1) << self.denom_pow,
+        )))
+    }
+    // Randomly discard the lower or upper half of the remaining interval.
+    fn refine(&mut self) -> Fallible<()> {
+        self.numer <<= 1;
+        self.denom_pow += 1;
+        if bool::sample_standard_bernoulli()? {
+            self.numer += 1;
+        }
+        Ok(())
+    }
+
+    fn refinements(&self) -> u32 {
+        self.denom_pow
+    }
+}


### PR DESCRIPTION
Closes #683


This SV IM's input is a queryable that emits a stream of bounded-sensitivity aggregates, but we don't have any interactive transformations at the moment, much less any that behave this way. 

May consider refactoring this IM to take a sensitivity in the constructor arguments. If a sensitivity is passed in the constructor arguments, then the input could be a dataset, and the query type a measurement. 