### PR TITLE
dom/met signature: `make_row_by_row`

### DIFF
--- a/python/src/opendp/transformations.py
+++ b/python/src/opendp/transformations.py
@@ -982,7 +982,7 @@ def make_count_distinct(
     * Input Metric:   `SymmetricDistance`
     * Output Metric:  `AbsoluteDistance<TO>`
     
-    :param TIA: Atomic Input Type. Input data is expected to be of the form Vec<TIA>.
+    :param TIA: Atomic Input Type. Input data is expected to be of the form `Vec<TIA>`.
     :type TIA: :py:ref:`RuntimeTypeDescriptor`
     :param TO: Output Type. Must be numeric.
     :type TO: :py:ref:`RuntimeTypeDescriptor`

--- a/rust/src/transformations/cast/mod.rs
+++ b/rust/src/transformations/cast/mod.rs
@@ -104,7 +104,7 @@ where
     make_row_by_row(
         VectorDomain::new(AtomDomain::default()),
         SymmetricDistance::default(),
-        AtomDomain::default(),
+        AtomDomain::new_nullable(),
         |v| TOA::round_cast(v.clone()).unwrap_or(TOA::NULL),
     )
 }

--- a/rust/src/transformations/cast/mod.rs
+++ b/rust/src/transformations/cast/mod.rs
@@ -32,8 +32,9 @@ where
     TOA: 'static + RoundCast<TIA> + CheckAtom,
 {
     make_row_by_row(
-        AtomDomain::default(),
-        OptionDomain::new(AtomDomain::default()),
+        VectorDomain::new(AtomDomain::default()),
+        SymmetricDistance::default(),
+        VectorDomain::new(OptionDomain::new(AtomDomain::default())),
         |v| {
             TOA::round_cast(v.clone())
                 .ok()
@@ -69,9 +70,12 @@ where
     TIA: 'static + Clone + CheckAtom,
     TOA: 'static + RoundCast<TIA> + Default + CheckAtom,
 {
-    make_row_by_row(AtomDomain::default(), AtomDomain::default(), |v| {
-        TOA::round_cast(v.clone()).unwrap_or_default()
-    })
+    make_row_by_row(
+        VectorDomain::new(AtomDomain::default()),
+        SymmetricDistance::default(),
+        VectorDomain::new(AtomDomain::default()),
+        |v| TOA::round_cast(v.clone()).unwrap_or_default(),
+    )
 }
 
 #[bootstrap(features("contrib"))]
@@ -97,9 +101,12 @@ where
     TIA: 'static + Clone + CheckAtom,
     TOA: 'static + RoundCast<TIA> + InherentNull + CheckAtom,
 {
-    make_row_by_row(AtomDomain::default(), AtomDomain::new_nullable(), |v| {
-        TOA::round_cast(v.clone()).unwrap_or(TOA::NULL)
-    })
+    make_row_by_row(
+        VectorDomain::new(AtomDomain::default()),
+        SymmetricDistance::default(),
+        VectorDomain::new(AtomDomain::default()),
+        |v| TOA::round_cast(v.clone()).unwrap_or(TOA::NULL),
+    )
 }
 
 #[cfg(test)]

--- a/rust/src/transformations/cast/mod.rs
+++ b/rust/src/transformations/cast/mod.rs
@@ -34,7 +34,7 @@ where
     make_row_by_row(
         VectorDomain::new(AtomDomain::default()),
         SymmetricDistance::default(),
-        VectorDomain::new(OptionDomain::new(AtomDomain::default())),
+        OptionDomain::new(AtomDomain::default()),
         |v| {
             TOA::round_cast(v.clone())
                 .ok()
@@ -73,7 +73,7 @@ where
     make_row_by_row(
         VectorDomain::new(AtomDomain::default()),
         SymmetricDistance::default(),
-        VectorDomain::new(AtomDomain::default()),
+        AtomDomain::default(),
         |v| TOA::round_cast(v.clone()).unwrap_or_default(),
     )
 }
@@ -104,7 +104,7 @@ where
     make_row_by_row(
         VectorDomain::new(AtomDomain::default()),
         SymmetricDistance::default(),
-        VectorDomain::new(AtomDomain::default()),
+        AtomDomain::default(),
         |v| TOA::round_cast(v.clone()).unwrap_or(TOA::NULL),
     )
 }

--- a/rust/src/transformations/clamp/mod.rs
+++ b/rust/src/transformations/clamp/mod.rs
@@ -34,7 +34,7 @@ pub fn make_clamp<TA: 'static + Clone + TotalOrd + CheckAtom>(
     make_row_by_row_fallible(
         VectorDomain::new(AtomDomain::default()),
         SymmetricDistance::default(),
-        VectorDomain::new(AtomDomain::new_closed(bounds.clone())?),
+        AtomDomain::new_closed(bounds.clone())?,
         move |arg: &TA| arg.clone().total_clamp(bounds.0.clone(), bounds.1.clone()),
     )
 }

--- a/rust/src/transformations/clamp/mod.rs
+++ b/rust/src/transformations/clamp/mod.rs
@@ -32,8 +32,9 @@ pub fn make_clamp<TA: 'static + Clone + TotalOrd + CheckAtom>(
     >,
 > {
     make_row_by_row_fallible(
-        AtomDomain::default(),
-        AtomDomain::new_closed(bounds.clone())?,
+        VectorDomain::new(AtomDomain::default()),
+        SymmetricDistance::default(),
+        VectorDomain::new(AtomDomain::new_closed(bounds.clone())?),
         move |arg: &TA| arg.clone().total_clamp(bounds.0.clone(), bounds.1.clone()),
     )
 }

--- a/rust/src/transformations/impute/mod.rs
+++ b/rust/src/transformations/impute/mod.rs
@@ -45,8 +45,9 @@ where
     let scale = upper - lower;
 
     make_row_by_row_fallible(
-        AtomDomain::new_nullable(),
-        AtomDomain::default(),
+        VectorDomain::new(AtomDomain::new_nullable()),
+        SymmetricDistance::default(),
+        VectorDomain::new(AtomDomain::default()),
         move |v| {
             if v.is_null() {
                 TA::sample_standard_uniform(false).map(|v| v * scale + lower)
@@ -152,9 +153,12 @@ where
         return fallible!(MakeTransformation, "Constant may not be null.");
     }
 
-    make_row_by_row(atom_domain, AtomDomain::default(), move |v| {
-        DIA::impute_constant(v, &constant).clone()
-    })
+    make_row_by_row(
+        VectorDomain::new(atom_domain),
+        SymmetricDistance::default(),
+        VectorDomain::new(AtomDomain::default()),
+        move |v| DIA::impute_constant(v, &constant).clone(),
+    )
 }
 
 /// Utility trait to drop null values from a dataset, regardless of the representation of nullity.

--- a/rust/src/transformations/impute/mod.rs
+++ b/rust/src/transformations/impute/mod.rs
@@ -47,7 +47,7 @@ where
     make_row_by_row_fallible(
         VectorDomain::new(AtomDomain::new_nullable()),
         SymmetricDistance::default(),
-        VectorDomain::new(AtomDomain::default()),
+        AtomDomain::default(),
         move |v| {
             if v.is_null() {
                 TA::sample_standard_uniform(false).map(|v| v * scale + lower)
@@ -156,7 +156,7 @@ where
     make_row_by_row(
         VectorDomain::new(atom_domain),
         SymmetricDistance::default(),
-        VectorDomain::new(AtomDomain::default()),
+        AtomDomain::default(),
         move |v| DIA::impute_constant(v, &constant).clone(),
     )
 }

--- a/rust/src/transformations/index/mod.rs
+++ b/rust/src/transformations/index/mod.rs
@@ -49,7 +49,7 @@ where
     make_row_by_row(
         VectorDomain::new(AtomDomain::default()),
         SymmetricDistance::default(),
-        VectorDomain::new(OptionDomain::new(AtomDomain::default())),
+        OptionDomain::new(AtomDomain::default()),
         move |v| indexes.get(v).cloned(),
     )
 }
@@ -89,7 +89,7 @@ where
     make_row_by_row(
         VectorDomain::new(AtomDomain::default()),
         SymmetricDistance::default(),
-        VectorDomain::new(AtomDomain::default()),
+        AtomDomain::default(),
         move |v| {
             edges
                 .iter()
@@ -127,7 +127,7 @@ where
     make_row_by_row(
         VectorDomain::new(AtomDomain::default()),
         SymmetricDistance::default(),
-        VectorDomain::new(AtomDomain::default()),
+        AtomDomain::default(),
         move |v| categories.get(*v).unwrap_or(&null).clone(),
     )
 }

--- a/rust/src/transformations/index/mod.rs
+++ b/rust/src/transformations/index/mod.rs
@@ -47,8 +47,9 @@ where
     }
 
     make_row_by_row(
-        AtomDomain::default(),
-        OptionDomain::new(AtomDomain::default()),
+        VectorDomain::new(AtomDomain::default()),
+        SymmetricDistance::default(),
+        VectorDomain::new(OptionDomain::new(AtomDomain::default())),
         move |v| indexes.get(v).cloned(),
     )
 }
@@ -85,14 +86,19 @@ where
     if !edges.windows(2).all(|pair| pair[0] < pair[1]) {
         return fallible!(MakeTransformation, "edges must be unique and ordered");
     }
-    make_row_by_row(AtomDomain::default(), AtomDomain::default(), move |v| {
-        edges
-            .iter()
-            .enumerate()
-            .find(|(_, edge)| v < edge)
-            .map(|(i, _)| i)
-            .unwrap_or(edges.len())
-    })
+    make_row_by_row(
+        VectorDomain::new(AtomDomain::default()),
+        SymmetricDistance::default(),
+        VectorDomain::new(AtomDomain::default()),
+        move |v| {
+            edges
+                .iter()
+                .enumerate()
+                .find(|(_, edge)| v < edge)
+                .map(|(i, _)| i)
+                .unwrap_or(edges.len())
+        },
+    )
 }
 
 #[bootstrap(features("contrib"))]
@@ -118,9 +124,12 @@ pub fn make_index<TOA>(
 where
     TOA: Primitive,
 {
-    make_row_by_row(AtomDomain::default(), AtomDomain::default(), move |v| {
-        categories.get(*v).unwrap_or(&null).clone()
-    })
+    make_row_by_row(
+        VectorDomain::new(AtomDomain::default()),
+        SymmetricDistance::default(),
+        VectorDomain::new(AtomDomain::default()),
+        move |v| categories.get(*v).unwrap_or(&null).clone(),
+    )
 }
 
 #[cfg(test)]

--- a/rust/src/transformations/manipulation/mod.rs
+++ b/rust/src/transformations/manipulation/mod.rs
@@ -13,8 +13,8 @@ use crate::metrics::{
 use crate::traits::{CheckAtom, CheckNull, DistanceConstant};
 
 /// A [`Domain`] representing a dataset.
-/// 
-/// This is distinguished from other domains 
+///
+/// This is distinguished from other domains
 /// because each element in the dataset corresponds to an individual.
 pub trait DatasetDomain: Domain {
     /// The domain of each element in the dataset.
@@ -90,7 +90,9 @@ pub(crate) fn make_row_by_row_fallible<DI, DO, M>(
     input_metric: M,
     output_row_domain: DO::ElementDomain,
     row_function: impl 'static
-        + Fn(&<DI::ElementDomain as Domain>::Carrier) -> Fallible<<DO::ElementDomain as Domain>::Carrier>,
+        + Fn(
+            &<DI::ElementDomain as Domain>::Carrier,
+        ) -> Fallible<<DO::ElementDomain as Domain>::Carrier>,
 ) -> Fallible<Transformation<DI, DO, M, M>>
 where
     DI: RowByRowDomain<DO>,

--- a/rust/src/transformations/manipulation/mod.rs
+++ b/rust/src/transformations/manipulation/mod.rs
@@ -28,6 +28,7 @@ impl DatasetMetric for ChangeOneDistance {}
 impl DatasetMetric for HammingDistance {}
 
 pub trait RowByRowDomain<DO: DatasetDomain>: DatasetDomain {
+    fn translate(&self, output_row_domain: DO::RowDomain) -> DO;
     fn apply_rows(
         value: &Self::Carrier,
         row_function: &impl Fn(
@@ -37,6 +38,16 @@ pub trait RowByRowDomain<DO: DatasetDomain>: DatasetDomain {
 }
 
 impl<DIA: Domain, DOA: Domain> RowByRowDomain<VectorDomain<DOA>> for VectorDomain<DIA> {
+    fn translate(
+        &self,
+        output_row_domain: <VectorDomain<DOA> as DatasetDomain>::RowDomain,
+    ) -> VectorDomain<DOA> {
+        VectorDomain {
+            element_domain: output_row_domain,
+            size: self.size,
+        }
+    }
+
     fn apply_rows(
         value: &Self::Carrier,
         row_function: &impl Fn(&DIA::Carrier) -> Fallible<DOA::Carrier>,
@@ -49,7 +60,7 @@ impl<DIA: Domain, DOA: Domain> RowByRowDomain<VectorDomain<DOA>> for VectorDomai
 pub(crate) fn make_row_by_row<DI, DO, M>(
     input_domain: DI,
     input_metric: M,
-    output_domain: DO,
+    output_row_domain: DO::RowDomain,
     row_function: impl 'static
         + Fn(&<DI::RowDomain as Domain>::Carrier) -> <DO::RowDomain as Domain>::Carrier,
 ) -> Fallible<Transformation<DI, DO, M, M>>
@@ -61,14 +72,14 @@ where
     (DO, M): MetricSpace,
 {
     let row_function = move |arg: &<DI::RowDomain as Domain>::Carrier| Ok(row_function(arg));
-    make_row_by_row_fallible(input_domain, input_metric, output_domain, row_function)
+    make_row_by_row_fallible(input_domain, input_metric, output_row_domain, row_function)
 }
 
 /// Constructs a [`Transformation`] representing an arbitrary row-by-row transformation.
 pub(crate) fn make_row_by_row_fallible<DI, DO, M>(
     input_domain: DI,
     input_metric: M,
-    output_domain: DO,
+    output_row_domain: DO::RowDomain,
     row_function: impl 'static
         + Fn(&<DI::RowDomain as Domain>::Carrier) -> Fallible<<DO::RowDomain as Domain>::Carrier>,
 ) -> Fallible<Transformation<DI, DO, M, M>>
@@ -79,6 +90,7 @@ where
     (DI, M): MetricSpace,
     (DO, M): MetricSpace,
 {
+    let output_domain = input_domain.translate(output_row_domain);
     Transformation::new(
         input_domain,
         output_domain,
@@ -132,7 +144,7 @@ where
     make_row_by_row(
         VectorDomain::new(AtomDomain::default()),
         SymmetricDistance::default(),
-        VectorDomain::new(AtomDomain::default()),
+        AtomDomain::default(),
         move |v| v == &value,
     )
 }
@@ -162,7 +174,7 @@ where
     make_row_by_row(
         VectorDomain::new(input_atom_domain),
         SymmetricDistance::default(),
-        VectorDomain::new(AtomDomain::default()),
+        AtomDomain::default(),
         |v| v.is_null(),
     )
 }

--- a/rust/src/transformations/manipulation/mod.rs
+++ b/rust/src/transformations/manipulation/mod.rs
@@ -10,52 +10,72 @@ use crate::error::*;
 use crate::metrics::{IntDistance, SymmetricDistance};
 use crate::traits::{CheckAtom, CheckNull, DistanceConstant};
 
-/// Constructs a [`Transformation`] representing an arbitrary row-by-row transformation.
-pub(crate) fn make_row_by_row<DIA, DOA, M>(
-    atom_input_domain: DIA,
-    atom_output_domain: DOA,
-    atom_function: impl 'static + Fn(&DIA::Carrier) -> DOA::Carrier,
-) -> Fallible<Transformation<VectorDomain<DIA>, VectorDomain<DOA>, M, M>>
-where
-    DIA: Domain,
-    DOA: Domain,
-    DIA::Carrier: 'static,
-    M: Metric<Distance = IntDistance>,
-    (VectorDomain<DIA>, M): MetricSpace,
-    (VectorDomain<DOA>, M): MetricSpace,
-{
-    Transformation::new(
-        VectorDomain::new(atom_input_domain),
-        VectorDomain::new(atom_output_domain),
-        Function::new(move |arg: &Vec<DIA::Carrier>| arg.iter().map(&atom_function).collect()),
-        M::default(),
-        M::default(),
-        StabilityMap::new_from_constant(1),
-    )
+pub trait DatasetDomain: Domain {
+    type RowDomain: Domain;
+}
+
+impl<D: Domain> DatasetDomain for VectorDomain<D> {
+    type RowDomain = D;
+}
+
+pub trait RowByRowDomain<DO: DatasetDomain>: DatasetDomain {
+    fn apply_rows(
+        value: &Self::Carrier,
+        row_function: &impl Fn(
+            &<Self::RowDomain as Domain>::Carrier,
+        ) -> Fallible<<DO::RowDomain as Domain>::Carrier>,
+    ) -> Fallible<DO::Carrier>;
+}
+
+impl<DIA: Domain, DOA: Domain> RowByRowDomain<VectorDomain<DOA>> for VectorDomain<DIA> {
+    fn apply_rows(
+        value: &Self::Carrier,
+        row_function: &impl Fn(&DIA::Carrier) -> Fallible<DOA::Carrier>,
+    ) -> Fallible<Vec<DOA::Carrier>> {
+        value.iter().map(row_function).collect()
+    }
 }
 
 /// Constructs a [`Transformation`] representing an arbitrary row-by-row transformation.
-pub(crate) fn make_row_by_row_fallible<DIA, DOA, M>(
-    atom_input_domain: DIA,
-    atom_output_domain: DOA,
-    atom_function: impl 'static + Fn(&DIA::Carrier) -> Fallible<DOA::Carrier>,
-) -> Fallible<Transformation<VectorDomain<DIA>, VectorDomain<DOA>, M, M>>
+pub(crate) fn make_row_by_row<DI, DO, M>(
+    input_domain: DI,
+    input_metric: M,
+    output_domain: DO,
+    row_function: impl 'static
+        + Fn(&<DI::RowDomain as Domain>::Carrier) -> <DO::RowDomain as Domain>::Carrier,
+) -> Fallible<Transformation<DI, DO, M, M>>
 where
-    DIA: Domain,
-    DOA: Domain,
-    DIA::Carrier: 'static,
+    DI: RowByRowDomain<DO>,
+    DO: DatasetDomain,
     M: Metric<Distance = IntDistance>,
-    (VectorDomain<DIA>, M): MetricSpace,
-    (VectorDomain<DOA>, M): MetricSpace,
+    (DI, M): MetricSpace,
+    (DO, M): MetricSpace,
+{
+    let row_function = move |arg: &<DI::RowDomain as Domain>::Carrier| Ok(row_function(arg));
+    make_row_by_row_fallible(input_domain, input_metric, output_domain, row_function)
+}
+
+/// Constructs a [`Transformation`] representing an arbitrary row-by-row transformation.
+pub(crate) fn make_row_by_row_fallible<DI, DO, M>(
+    input_domain: DI,
+    input_metric: M,
+    output_domain: DO,
+    row_function: impl 'static
+        + Fn(&<DI::RowDomain as Domain>::Carrier) -> Fallible<<DO::RowDomain as Domain>::Carrier>,
+) -> Fallible<Transformation<DI, DO, M, M>>
+where
+    DI: RowByRowDomain<DO>,
+    DO: DatasetDomain,
+    M: Metric<Distance = IntDistance>,
+    (DI, M): MetricSpace,
+    (DO, M): MetricSpace,
 {
     Transformation::new(
-        VectorDomain::new(atom_input_domain),
-        VectorDomain::new(atom_output_domain),
-        Function::new_fallible(move |arg: &Vec<DIA::Carrier>| {
-            arg.iter().map(&atom_function).collect()
-        }),
-        M::default(),
-        M::default(),
+        input_domain,
+        output_domain,
+        Function::new_fallible(move |arg: &DI::Carrier| DI::apply_rows(arg, &row_function)),
+        input_metric.clone(),
+        input_metric,
         StabilityMap::new_from_constant(1),
     )
 }
@@ -100,9 +120,12 @@ pub fn make_is_equal<TIA>(
 where
     TIA: 'static + PartialEq + CheckAtom,
 {
-    make_row_by_row(AtomDomain::default(), AtomDomain::default(), move |v| {
-        v == &value
-    })
+    make_row_by_row(
+        VectorDomain::new(AtomDomain::default()),
+        SymmetricDistance::default(),
+        VectorDomain::new(AtomDomain::default()),
+        move |v| v == &value,
+    )
 }
 
 #[bootstrap(
@@ -127,7 +150,12 @@ where
     DIA: Domain + Default,
     DIA::Carrier: 'static + CheckNull,
 {
-    make_row_by_row(input_atom_domain, AtomDomain::default(), |v| v.is_null())
+    make_row_by_row(
+        VectorDomain::new(input_atom_domain),
+        SymmetricDistance::default(),
+        VectorDomain::new(AtomDomain::default()),
+        |v| v.is_null(),
+    )
 }
 
 #[cfg(test)]

--- a/rust/src/transformations/manipulation/mod.rs
+++ b/rust/src/transformations/manipulation/mod.rs
@@ -12,12 +12,21 @@ use crate::metrics::{
 };
 use crate::traits::{CheckAtom, CheckNull, DistanceConstant};
 
+/// A [`Domain`] representing a dataset.
+/// 
+/// This is distinguished from other domains 
+/// because each element in the dataset corresponds to an individual.
 pub trait DatasetDomain: Domain {
-    type RowDomain: Domain;
+    /// The domain of each element in the dataset.
+    ///
+    /// For vectors, this is the domain of the vector elements,
+    /// for dataframes, this is the domain of the dataframe rows,
+    /// and so on.
+    type ElementDomain: Domain;
 }
 
 impl<D: Domain> DatasetDomain for VectorDomain<D> {
-    type RowDomain = D;
+    type ElementDomain = D;
 }
 
 pub trait DatasetMetric: Metric<Distance = IntDistance> {}
@@ -28,19 +37,19 @@ impl DatasetMetric for ChangeOneDistance {}
 impl DatasetMetric for HammingDistance {}
 
 pub trait RowByRowDomain<DO: DatasetDomain>: DatasetDomain {
-    fn translate(&self, output_row_domain: DO::RowDomain) -> DO;
+    fn translate(&self, output_row_domain: DO::ElementDomain) -> DO;
     fn apply_rows(
         value: &Self::Carrier,
         row_function: &impl Fn(
-            &<Self::RowDomain as Domain>::Carrier,
-        ) -> Fallible<<DO::RowDomain as Domain>::Carrier>,
+            &<Self::ElementDomain as Domain>::Carrier,
+        ) -> Fallible<<DO::ElementDomain as Domain>::Carrier>,
     ) -> Fallible<DO::Carrier>;
 }
 
 impl<DIA: Domain, DOA: Domain> RowByRowDomain<VectorDomain<DOA>> for VectorDomain<DIA> {
     fn translate(
         &self,
-        output_row_domain: <VectorDomain<DOA> as DatasetDomain>::RowDomain,
+        output_row_domain: <VectorDomain<DOA> as DatasetDomain>::ElementDomain,
     ) -> VectorDomain<DOA> {
         VectorDomain {
             element_domain: output_row_domain,
@@ -60,9 +69,9 @@ impl<DIA: Domain, DOA: Domain> RowByRowDomain<VectorDomain<DOA>> for VectorDomai
 pub(crate) fn make_row_by_row<DI, DO, M>(
     input_domain: DI,
     input_metric: M,
-    output_row_domain: DO::RowDomain,
+    output_row_domain: DO::ElementDomain,
     row_function: impl 'static
-        + Fn(&<DI::RowDomain as Domain>::Carrier) -> <DO::RowDomain as Domain>::Carrier,
+        + Fn(&<DI::ElementDomain as Domain>::Carrier) -> <DO::ElementDomain as Domain>::Carrier,
 ) -> Fallible<Transformation<DI, DO, M, M>>
 where
     DI: RowByRowDomain<DO>,
@@ -71,7 +80,7 @@ where
     (DI, M): MetricSpace,
     (DO, M): MetricSpace,
 {
-    let row_function = move |arg: &<DI::RowDomain as Domain>::Carrier| Ok(row_function(arg));
+    let row_function = move |arg: &<DI::ElementDomain as Domain>::Carrier| Ok(row_function(arg));
     make_row_by_row_fallible(input_domain, input_metric, output_row_domain, row_function)
 }
 
@@ -79,9 +88,9 @@ where
 pub(crate) fn make_row_by_row_fallible<DI, DO, M>(
     input_domain: DI,
     input_metric: M,
-    output_row_domain: DO::RowDomain,
+    output_row_domain: DO::ElementDomain,
     row_function: impl 'static
-        + Fn(&<DI::RowDomain as Domain>::Carrier) -> Fallible<<DO::RowDomain as Domain>::Carrier>,
+        + Fn(&<DI::ElementDomain as Domain>::Carrier) -> Fallible<<DO::ElementDomain as Domain>::Carrier>,
 ) -> Fallible<Transformation<DI, DO, M, M>>
 where
     DI: RowByRowDomain<DO>,

--- a/rust/src/transformations/manipulation/mod.rs
+++ b/rust/src/transformations/manipulation/mod.rs
@@ -7,7 +7,9 @@ use opendp_derive::bootstrap;
 use crate::core::{Domain, Function, Metric, MetricSpace, StabilityMap, Transformation};
 use crate::domains::{AtomDomain, VectorDomain};
 use crate::error::*;
-use crate::metrics::{IntDistance, SymmetricDistance};
+use crate::metrics::{
+    ChangeOneDistance, HammingDistance, InsertDeleteDistance, IntDistance, SymmetricDistance,
+};
 use crate::traits::{CheckAtom, CheckNull, DistanceConstant};
 
 pub trait DatasetDomain: Domain {
@@ -17,6 +19,13 @@ pub trait DatasetDomain: Domain {
 impl<D: Domain> DatasetDomain for VectorDomain<D> {
     type RowDomain = D;
 }
+
+pub trait DatasetMetric: Metric<Distance = IntDistance> {}
+
+impl DatasetMetric for SymmetricDistance {}
+impl DatasetMetric for InsertDeleteDistance {}
+impl DatasetMetric for ChangeOneDistance {}
+impl DatasetMetric for HammingDistance {}
 
 pub trait RowByRowDomain<DO: DatasetDomain>: DatasetDomain {
     fn apply_rows(
@@ -47,7 +56,7 @@ pub(crate) fn make_row_by_row<DI, DO, M>(
 where
     DI: RowByRowDomain<DO>,
     DO: DatasetDomain,
-    M: Metric<Distance = IntDistance>,
+    M: DatasetMetric<Distance = IntDistance>,
     (DI, M): MetricSpace,
     (DO, M): MetricSpace,
 {
@@ -66,7 +75,7 @@ pub(crate) fn make_row_by_row_fallible<DI, DO, M>(
 where
     DI: RowByRowDomain<DO>,
     DO: DatasetDomain,
-    M: Metric<Distance = IntDistance>,
+    M: DatasetMetric<Distance = IntDistance>,
     (DI, M): MetricSpace,
     (DO, M): MetricSpace,
 {


### PR DESCRIPTION
Closes #724 

Reorders arguments to be consistent with the partials API. 
Generalizes the constructor to be able to support row-by-row maps between different database domains.

Tweaked the function contract to prepare for the privacy proof.