### PR TITLE
optimize backtrace handling

### DIFF
--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -40,7 +40,8 @@ else:
 # This enables backtraces in Rust by default.
 # It can be disabled by setting RUST_BACKTRACE=0.
 # Binary searches disable backtraces for performance reasons.
-os.environ["RUST_BACKTRACE"] = "1"
+if "RUST_BACKTRACE" not in os.environ:
+    os.environ["RUST_BACKTRACE"] = "1"
 
 
 class FfiSlice(ctypes.Structure):

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -37,6 +37,12 @@ else:
     raise ValueError("Unable to find lib directory. Consider setting OPENDP_LIB_DIR to a valid directory.")
 
 
+# This enables backtraces in Rust by default.
+# It can be disabled by setting RUST_BACKTRACE=0.
+# Binary searches disable backtraces for performance reasons.
+os.environ["RUST_BACKTRACE"] = "1"
+
+
 class FfiSlice(ctypes.Structure):
     _fields_ = [
         ("ptr", ctypes.c_void_p),

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -459,7 +459,7 @@ class OpenDPException(Exception):
     def frames(self):
         def format_frame(frame):
             return "\n  ".join(l.strip() for l in frame.split("\n"))
-        return [format_frame(f) for f in self.raw_frames() if f.startswith("opendp")]
+        return [format_frame(f) for f in self.raw_frames() if f.startswith("opendp") or f.startswith("<opendp")]
 
     def __str__(self) -> str:
         response = ''

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -36,7 +36,6 @@ opendp_derive = { path = "opendp_derive" }
 rand = "0.7.3"
 num = "0.3.1"
 thiserror = "1.0.24"
-backtrace = "0.3"
 statrs = "0.13.0"
 rug = { version = "1.14.0", default-features = false, features = ["integer", "float", "rational", "num-traits", "rand"], optional = true }
 az = { version = "1.2.0", optional = true }

--- a/rust/src/combinators/measure_cast/zCDP_to_approxDP/cdp_epsilon.rs
+++ b/rust/src/combinators/measure_cast/zCDP_to_approxDP/cdp_epsilon.rs
@@ -13,6 +13,10 @@ pub(crate) fn cdp_epsilon<Q: Float>(rho: Q, delta: Q) -> Fallible<Q> {
         return Ok(Q::zero());
     }
 
+    if rho.is_infinite() {
+        return Ok(Q::infinity());
+    }
+
     let _1 = Q::one();
     let _2 = _1 + _1;
 

--- a/rust/src/core/ffi.rs
+++ b/rust/src/core/ffi.rs
@@ -56,21 +56,14 @@ impl FfiError {
 }
 
 impl From<Error> for FfiError {
-    fn from(mut error: Error) -> Self {
+    fn from(error: Error) -> Self {
         Self {
             variant: try_!(util::into_c_char_p(format!("{:?}", error.variant))),
             message: try_!(error.message.map_or(
                 Ok(ptr::null::<c_char>() as *mut c_char),
                 util::into_c_char_p
             )),
-            backtrace: try_!(util::into_c_char_p(
-                if let ErrorVariant::RelationDebug = error.variant {
-                    String::default()
-                } else {
-                    error.backtrace.resolve();
-                    format!("{:?}", error.backtrace)
-                }
-            )),
+            backtrace: try_!(util::into_c_char_p(error.backtrace.to_string())),
         }
     }
 }
@@ -202,7 +195,7 @@ impl From<FfiError> for Error {
             message: util::to_option_str(val.message)
                 .unwrap_test()
                 .map(|s| s.to_owned()),
-            backtrace: backtrace::Backtrace::new_unresolved(),
+            backtrace: std::backtrace::Backtrace::capture(),
         }
     }
 }

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -31,7 +31,6 @@ macro_rules! err {
     ($variant:ident, $template:expr, $($args:expr),+) =>
         (err!($variant, format!($template, $($args,)+)));
 
-    // only resolve stacktraces in test mode
     (@backtrace) => (std::backtrace::Backtrace::capture());
 }
 

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -31,8 +31,8 @@ macro_rules! err {
     ($variant:ident, $template:expr, $($args:expr),+) =>
         (err!($variant, format!($template, $($args,)+)));
 
-    // always resolve backtraces in debug mode
-    (@backtrace) => (if cfg!(debug_assertions) {
+    // only resolve stacktraces in test mode
+    (@backtrace) => (if cfg!(test) {
         backtrace::Backtrace::new()
     } else {
         backtrace::Backtrace::new_unresolved()

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 use std::fmt::Debug;
 
-use backtrace::Backtrace as _Backtrace;
+use std::backtrace::Backtrace as _Backtrace;
 
 /// Create an instance of [`Fallible`]
 #[macro_export]
@@ -32,11 +32,7 @@ macro_rules! err {
         (err!($variant, format!($template, $($args,)+)));
 
     // only resolve stacktraces in test mode
-    (@backtrace) => (if cfg!(test) {
-        backtrace::Backtrace::new()
-    } else {
-        backtrace::Backtrace::new_unresolved()
-    });
+    (@backtrace) => (std::backtrace::Backtrace::capture());
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -117,7 +113,7 @@ impl From<ErrorVariant> for Error {
         Self {
             variant,
             message: None,
-            backtrace: _Backtrace::new(),
+            backtrace: std::backtrace::Backtrace::capture(),
         }
     }
 }

--- a/rust/src/transformations/cast/ffi.rs
+++ b/rust/src/transformations/cast/ffi.rs
@@ -2,7 +2,6 @@ use std::convert::TryFrom;
 use std::os::raw::c_char;
 
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
-use crate::err;
 use crate::ffi::any::AnyTransformation;
 use crate::ffi::util::Type;
 use crate::traits::{CheckAtom, InherentNull, RoundCast};

--- a/rust/src/transformations/manipulation/mod.rs
+++ b/rust/src/transformations/manipulation/mod.rs
@@ -138,11 +138,8 @@ mod tests {
 
     #[test]
     fn test_identity() {
-        let identity = make_identity(
-            VectorDomain::new(AtomDomain::default()),
-            SymmetricDistance,
-        )
-        .unwrap_test();
+        let identity = make_identity(VectorDomain::new(AtomDomain::default()), SymmetricDistance)
+            .unwrap_test();
         let arg = vec![99];
         let ret = identity.invoke(&arg).unwrap_test();
         assert_eq!(ret, arg);


### PR DESCRIPTION
Closes #670 

RelationDebug doesn't have significant performance issues, resolving backtraces does. This PR changes the default behavior to only resolve backtraces in `test` mode, not debug mode.

- remove backtrace crate in favor of Rust 1.65's stabilized std backtrace
- disable backtraces via an environment variable when conducting binary searches 
- avoids a performance cliff when calling the ffi for `atom_domain`, as the dispatch used to rely on error handling
    - added a trait that makes it possible to return `None` from `dispatch!`
- avoids a performance cliff when calling `cdp_epsilon` when `rho` is infinity (scale is zero). Instead of overflowing and resolving a backtrace, the function now simply returns `epsilon = infinity` 
