### PR TITLE
add `make_quantile_score_candidates`

### DIFF
--- a/rust/src/metrics/mod.rs
+++ b/rust/src/metrics/mod.rs
@@ -454,3 +454,47 @@ impl<T: CheckAtom> MetricSpace for (AtomDomain<T>, DiscreteDistance) {
         true
     }
 }
+
+/// Distance between score vectors for the exponential mechanism.
+///
+/// # Proof Definition
+///
+/// ### `d`-closeness
+/// For any two datasets $u, v \in$ `VectorDomain<AtomDomain<T>>` and any $d$ of type `T`,
+/// we say that $u, v$ are $d$-close under the inf-difference metric (abbreviated as $d_{IDD}$) whenever
+///
+/// ```math
+/// d_{\infty'}(u, v) = max_{ij} |(u_i - v_i) - (u_j - v_j)|
+/// ```
+pub struct LInfDiffDistance<Q>(PhantomData<Q>);
+impl<Q> Default for LInfDiffDistance<Q> {
+    fn default() -> Self {
+        LInfDiffDistance(PhantomData)
+    }
+}
+
+impl<Q> Clone for LInfDiffDistance<Q> {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+impl<Q> PartialEq for LInfDiffDistance<Q> {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+impl<Q> Debug for LInfDiffDistance<Q> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "LInfDiffDistance({})", type_name!(Q))
+    }
+}
+
+impl<Q> Metric for LInfDiffDistance<Q> {
+    type Distance = Q;
+}
+
+impl<T: CheckAtom, Q> MetricSpace for (VectorDomain<AtomDomain<T>>, LInfDiffDistance<Q>) {
+    fn check(&self) -> bool {
+        !self.0.element_domain.nullable()
+    }
+}

--- a/rust/src/transformations/cast_metric/mod.rs
+++ b/rust/src/transformations/cast_metric/mod.rs
@@ -12,7 +12,7 @@ use self::traits::{BoundedMetric, OrderedMetric, UnboundedMetric, UnorderedMetri
 
 #[cfg(feature = "ffi")]
 mod ffi;
-mod traits;
+pub mod traits;
 
 #[bootstrap(features("contrib"), generics(D(suppress), MI(suppress)))]
 /// Make a Transformation that converts the unordered dataset metric `SymmetricDistance`

--- a/rust/src/transformations/cast_metric/traits.rs
+++ b/rust/src/transformations/cast_metric/traits.rs
@@ -1,9 +1,9 @@
 use crate::{
     core::Metric,
-    metrics::{ChangeOneDistance, HammingDistance, InsertDeleteDistance, SymmetricDistance},
+    metrics::{ChangeOneDistance, HammingDistance, InsertDeleteDistance, SymmetricDistance, IntDistance},
 };
 
-pub trait UnorderedMetric: Metric {
+pub trait UnorderedMetric: Metric<Distance = IntDistance> {
     type OrderedMetric: Metric<Distance = Self::Distance>;
 }
 impl UnorderedMetric for SymmetricDistance {
@@ -13,7 +13,7 @@ impl UnorderedMetric for ChangeOneDistance {
     type OrderedMetric = HammingDistance;
 }
 
-pub trait OrderedMetric: Metric {
+pub trait OrderedMetric: Metric<Distance = IntDistance> {
     type UnorderedMetric: Metric<Distance = Self::Distance>;
 }
 impl OrderedMetric for InsertDeleteDistance {
@@ -23,7 +23,7 @@ impl OrderedMetric for HammingDistance {
     type UnorderedMetric = ChangeOneDistance;
 }
 
-pub trait BoundedMetric: Metric {
+pub trait BoundedMetric: Metric<Distance = IntDistance> {
     type UnboundedMetric: Metric<Distance = Self::Distance>;
 }
 impl BoundedMetric for ChangeOneDistance {
@@ -33,7 +33,7 @@ impl BoundedMetric for HammingDistance {
     type UnboundedMetric = InsertDeleteDistance;
 }
 
-pub trait UnboundedMetric: Metric {
+pub trait UnboundedMetric: Metric<Distance = IntDistance> {
     type BoundedMetric: Metric<Distance = Self::Distance>;
 }
 impl UnboundedMetric for SymmetricDistance {

--- a/rust/src/transformations/manipulation/mod.rs
+++ b/rust/src/transformations/manipulation/mod.rs
@@ -28,12 +28,27 @@ impl<D: Domain> DatasetDomain for VectorDomain<D> {
     type ElementDomain = D;
 }
 
-pub trait DatasetMetric: Metric<Distance = IntDistance> {}
+pub trait DatasetMetric: Metric<Distance = IntDistance> {
+    const ORDERED: bool;
+    const SIZED: bool;
+}
 
-impl DatasetMetric for SymmetricDistance {}
-impl DatasetMetric for InsertDeleteDistance {}
-impl DatasetMetric for ChangeOneDistance {}
-impl DatasetMetric for HammingDistance {}
+impl DatasetMetric for SymmetricDistance {
+    const ORDERED: bool = false;
+    const SIZED: bool = false;
+}
+impl DatasetMetric for InsertDeleteDistance {
+    const ORDERED: bool = true;
+    const SIZED: bool = false;
+}
+impl DatasetMetric for ChangeOneDistance {
+    const ORDERED: bool = false;
+    const SIZED: bool = true;
+}
+impl DatasetMetric for HammingDistance {
+    const ORDERED: bool = true;
+    const SIZED: bool = false;
+}
 
 pub trait RowByRowDomain<DO: DatasetDomain>: DatasetDomain {
     fn translate(&self, output_row_domain: DO::ElementDomain) -> DO;

--- a/rust/src/transformations/mod.rs
+++ b/rust/src/transformations/mod.rs
@@ -19,6 +19,11 @@ mod dataframe;
 pub use crate::transformations::dataframe::*;
 
 #[cfg(feature = "contrib")]
+pub mod quantile_score_candidates;
+#[cfg(feature = "contrib")]
+pub use crate::transformations::quantile_score_candidates::*;
+
+#[cfg(feature = "contrib")]
 mod manipulation;
 #[cfg(feature = "contrib")]
 pub use crate::transformations::manipulation::*;

--- a/rust/src/transformations/quantile_score_candidates/mod.rs
+++ b/rust/src/transformations/quantile_score_candidates/mod.rs
@@ -1,0 +1,388 @@
+use std::cmp::Ordering;
+
+use crate::{
+    core::{Function, MetricSpace, StabilityMap, Transformation},
+    domains::{AtomDomain, VectorDomain},
+    error::Fallible,
+    metrics::LInfDiffDistance,
+    traits::{AlertingMul, ExactIntCast, InfDiv, Number, RoundCast},
+};
+
+use super::traits::UnboundedMetric;
+
+/// Makes a Transformation that scores how similar each candidate is to the given `alpha`-quantile on the input dataset.
+///
+///
+/// # Arguments
+/// * `input_domain` - Uses a tighter sensitivity when the size of vectors in the input domain is known.
+/// * `input_metric` - Either SymmetricDistance or InsertDeleteDistance.
+/// * `candidates` - Potential quantiles to score
+/// * `alpha` - a value in [0, 1]. Choose 0.5 for median
+///
+/// # Generics
+/// * `MI` - Input Metric.
+/// * `TIA` - Atomic Input Type. Type of elements in the input vector
+pub fn make_quantile_score_candidates<MI: UnboundedMetric, TIA: Number>(
+    input_domain: VectorDomain<AtomDomain<TIA>>,
+    input_metric: MI,
+    candidates: Vec<TIA>,
+    alpha: f64,
+) -> Fallible<
+    Transformation<
+        VectorDomain<AtomDomain<TIA>>,
+        VectorDomain<AtomDomain<usize>>,
+        MI,
+        LInfDiffDistance<usize>,
+    >,
+>
+where
+    (VectorDomain<AtomDomain<TIA>>, MI): MetricSpace,
+{
+    if input_domain.element_domain.nullable() {
+        return fallible!(MakeTransformation, "input must be non-null");
+    }
+
+    if candidates.windows(2).any(|w| w[0] >= w[1]) {
+        return fallible!(MakeTransformation, "candidates must be increasing");
+    }
+
+    let alpha_den = if let Some(size) = input_domain.size {
+        // choose the finest granularity that won't overflow
+        // must have that size * denom < MAX, so let denom = MAX // size
+        (usize::MAX).neg_inf_div(&size)?
+    } else {
+        // default to an alpha granularity of .00001
+        10_000
+    };
+    // numer = alpha * denom
+    let alpha_num = usize::round_cast(alpha * f64::round_cast(alpha_den.clone())?)?;
+    if alpha_num > alpha_den || alpha_den == 0 {
+        return fallible!(MakeTransformation, "alpha must be within [0, 1]");
+    }
+
+    let size_limit = if let Some(size_limit) = input_domain.size {
+        // ensures that there is no overflow
+        size_limit.alerting_mul(&alpha_den)?;
+        size_limit
+    } else {
+        (usize::MAX).neg_inf_div(&alpha_den)?
+    };
+
+    let stability_map = if input_domain.size.is_some() {
+        StabilityMap::new_fallible(move |d_in| {
+            usize::exact_int_cast(d_in / 2)?
+                .alerting_mul(&4)?
+                .alerting_mul(&alpha_den)
+        })
+    } else {
+        let abs_dist_const = alpha_num.max(alpha_den - alpha_num);
+        let inf_diff_dist_const = abs_dist_const.alerting_mul(&2)?;
+        StabilityMap::new_from_constant(inf_diff_dist_const)
+    };
+
+    Transformation::<_, VectorDomain<AtomDomain<usize>>, _, _>::new(
+        input_domain,
+        VectorDomain::default().with_size(candidates.len()),
+        Function::new(move |arg: &Vec<TIA>| {
+            compute_score(arg.clone(), &candidates, alpha_num, alpha_den, size_limit)
+        }),
+        input_metric,
+        LInfDiffDistance::default(),
+        stability_map,
+    )
+}
+
+/// Compute score of each candidate on a dataset
+///
+/// # Proof Definition
+///
+/// Under the precondition that `x` is non-null,
+/// that `candidates` is strictly increasing,
+/// that `alpha_numer / alpha_denom` is in [0, 1],
+/// and that `size_limit * alpha_denom` does not overflow,
+/// computes the score of each candidate in `candidates` on the dataset `x`.
+///
+/// The score for each `c` in `candidates` is computed as follows:
+/// |alpha_denom * min(#(x < c), size_limit) -
+///  alpha_numer * min(n - #(x = c)), size_limit)|
+///
+/// # Intuition
+/// Lower score is better.
+/// Score is roughly |observed_value - ideal_value|, where ideal_value is a rescaled `alpha`-quantile.
+/// We want greater scores when observed value is near ideal value.
+/// The further away the observed value is from the ideal value, the more negative it gets
+///
+/// # Arguments
+/// * `x` - dataset to score against. Must be non-null
+/// * `candidates` - values to be scored. Must be strictly increasing
+/// * `alpha_num` - numerator of alpha fraction
+/// * `alpha_den` - denominator of alpha fraction. alpha fraction is {0: min, 0.5: median, 1: max, ...}
+/// * `size_limit` - maximum size of `x`. If `x` is larger than `size_limit`, scores are truncated
+fn compute_score<TIA: PartialOrd>(
+    mut x: Vec<TIA>,
+    candidates: &Vec<TIA>,
+    alpha_num: usize,
+    alpha_den: usize,
+    size_limit: usize,
+) -> Vec<usize> {
+    // x must be sorted because counts are done via binary search
+    x.sort_by(|a, b| a.partial_cmp(&b).unwrap_or(Ordering::Equal));
+
+    // compute #(`x` < c) and #(`x` = c) for each c in candidates
+    let mut num_lt = vec![0; candidates.len()];
+    let mut num_eq = vec![0; candidates.len()];
+    count_lt_eq_recursive(
+        num_lt.as_mut_slice(),
+        num_eq.as_mut_slice(),
+        candidates.as_slice(),
+        x.as_slice(),
+        0,
+    );
+
+    // now that we have num_lt and num_eq for each candidate, score all candidates
+    num_lt
+        .into_iter()
+        .zip(num_eq.into_iter())
+        // score function cannot overflow.
+        //     lt <= size_limit, so 0 <= alpha_denom * lt <= usize::MAX
+        //     n - eq <= size_limit, so 0 <= size_limit - eq
+        .map(|(lt, eq)| {
+            // |α_den * #(x < c) - α_num * (n - #(x = c))|
+            (alpha_den * lt.min(size_limit)).abs_diff(alpha_num * (x.len() - eq).min(size_limit))
+        })
+        .collect()
+}
+
+/// Compute number of elements less than and equal to each edge
+/// Formula is (#(`x` < `e`), #(`x` == `e`)) for each e in `edges`.
+///
+/// # Arguments
+/// * `count_lt` - location to write the count of elements less than each edge
+/// * `count_eq` - location to write the count of elements equal to each edge
+/// * `edges` - edges to collect counts for. Must be sorted
+/// * `x` - dataset to count against
+/// * `x_start_idx` - value to add to the count. Useful for recursion on subslices
+fn count_lt_eq_recursive<TI: PartialOrd>(
+    count_lt: &mut [usize],
+    count_eq: &mut [usize],
+    edges: &[TI],
+    x: &[TI],
+    x_start_idx: usize,
+) {
+    if edges.is_empty() {
+        return;
+    }
+    if edges.len() == 1 {
+        let (num_lt, num_eq) = count_lt_eq(x, &edges[0]);
+        count_lt[0] = x_start_idx + num_lt;
+        count_eq[0] = num_eq;
+        return;
+    }
+    // use binary search to find #(x < middle edge) = |{i; x[i] < middle edge}|
+    let mid_edge_idx = (edges.len() + 1) / 2;
+    let mid_edge = &edges[mid_edge_idx];
+    let (num_lt, num_eq) = count_lt_eq(x, mid_edge);
+    count_lt[mid_edge_idx] = x_start_idx + num_lt;
+    count_eq[mid_edge_idx] = num_eq;
+
+    count_lt_eq_recursive(
+        &mut count_lt[..mid_edge_idx],
+        &mut count_eq[..mid_edge_idx],
+        &edges[..mid_edge_idx],
+        &x[..num_lt + num_eq],
+        x_start_idx,
+    );
+
+    count_lt_eq_recursive(
+        &mut count_lt[mid_edge_idx + 1..],
+        &mut count_eq[mid_edge_idx + 1..],
+        &edges[mid_edge_idx + 1..],
+        &x[num_lt + num_eq..],
+        x_start_idx + num_lt + num_eq,
+    );
+}
+
+/// Find the number of elements in `x` < `target` and number of elements in `x` == `target`.
+/// Formula is (#(`x` < `target`), #(`x` == `target`))
+///
+/// # Arguments
+/// * `x` - dataset to count against
+/// * `target` - value to compare against
+fn count_lt_eq<TI: PartialOrd>(x: &[TI], target: &TI) -> (usize, usize) {
+    if x.is_empty() {
+        return (0, 0);
+    }
+    let (mut lower, mut upper) = (0, x.len());
+    let mut eq_upper = upper;
+
+    while upper - lower > 1 {
+        let middle = lower + (upper - lower) / 2;
+
+        if &x[middle] < target {
+            lower = middle;
+        } else {
+            upper = middle;
+            // tighten eq_upper to last middle where x[middle] was still greater than target
+            if &x[middle] > target {
+                eq_upper = middle;
+            }
+        }
+    }
+    let lt = if &x[lower] < target { upper } else { lower };
+
+    // run another search to find the greatest index equal to target
+    // search starting from the first index equal to target
+    lower = lt;
+    // search for the smallest middle where x[middle] is greater than target
+    upper = eq_upper;
+    while upper - lower > 1 {
+        let middle = lower + (upper - lower) / 2;
+
+        if &x[middle] == target {
+            lower = middle;
+        } else {
+            upper = middle;
+        }
+    }
+
+    let eq = if lower == upper || &x[lower] == target {
+        upper
+    } else {
+        lower
+    } - lt;
+
+    (lt, eq)
+}
+
+#[cfg(test)]
+mod test_scorer {
+    use super::*;
+
+    #[test]
+    fn test_count_lte() {
+        let x = (5..20).collect::<Vec<i32>>();
+        let edges = vec![2, 4, 7, 12, 22];
+        let mut count_lt = vec![0; edges.len()];
+        let mut count_eq = vec![0; edges.len()];
+        count_lt_eq_recursive(
+            count_lt.as_mut_slice(),
+            count_eq.as_mut_slice(),
+            edges.as_slice(),
+            x.as_slice(),
+            0,
+        );
+        println!("{:?}", count_lt);
+        println!("{:?}", count_eq);
+        assert_eq!(count_lt, vec![0, 0, 2, 7, 15]);
+        assert_eq!(count_eq, vec![0, 0, 1, 1, 0]);
+    }
+
+    #[test]
+    fn test_count_lte_repetition() {
+        let x = vec![0, 2, 2, 3, 5, 7, 7, 7];
+        let edges = vec![-1, 2, 4, 7, 12, 22];
+        let mut count_lt = vec![0; edges.len()];
+        let mut count_eq = vec![0; edges.len()];
+        count_lt_eq_recursive(
+            count_lt.as_mut_slice(),
+            count_eq.as_mut_slice(),
+            edges.as_slice(),
+            x.as_slice(),
+            0,
+        );
+        println!("{:?}", count_lt);
+        println!("{:?}", count_eq);
+        assert_eq!(count_lt, vec![0, 1, 4, 5, 8, 8]);
+        assert_eq!(count_eq, vec![0, 2, 0, 3, 0, 0]);
+    }
+
+    fn test_case(x: Vec<i32>, edges: Vec<i32>, true_lt: Vec<usize>, true_eq: Vec<usize>) {
+        let mut count_lt = vec![0; edges.len()];
+        let mut count_eq = vec![0; edges.len()];
+        count_lt_eq_recursive(
+            count_lt.as_mut_slice(),
+            count_eq.as_mut_slice(),
+            edges.as_slice(),
+            x.as_slice(),
+            0,
+        );
+        println!("LT");
+        println!("{:?}", true_lt);
+        println!("{:?}", count_lt);
+
+        println!("EQ");
+        println!("{:?}", true_eq);
+        println!("{:?}", count_eq);
+
+        assert_eq!(true_lt, count_lt);
+        assert_eq!(true_eq, count_eq);
+    }
+
+    #[test]
+    fn test_count_lte_edge_cases() {
+        // check constant x
+        test_case(vec![0; 10], vec![-1], vec![0], vec![0]);
+        test_case(vec![0; 10], vec![0], vec![0], vec![10]);
+        test_case(vec![0; 10], vec![1], vec![10], vec![0]);
+
+        // below first split
+        test_case(vec![1, 2, 3, 3, 3, 3], vec![2], vec![1], vec![1]);
+        test_case(vec![1, 2, 3, 3, 3, 3, 3], vec![2], vec![1], vec![1]);
+        // above first split
+        test_case(vec![1, 1, 1, 1, 2, 3], vec![2], vec![4], vec![1]);
+        test_case(vec![1, 1, 1, 1, 2, 3, 3], vec![2], vec![4], vec![1]);
+    }
+
+    #[test]
+    fn test_scorer() -> Fallible<()> {
+        let edges = vec![-1, 2, 4, 7, 12, 22];
+
+        let x = vec![0, 2, 2, 3, 5, 7, 7, 7];
+        let scores = compute_score(x, &edges, 1, 2, 8);
+        println!("{:?}", scores);
+
+        let x = vec![0, 2, 2, 3, 4, 7, 7, 7];
+        let scores = compute_score(x, &edges, 1, 2, 8);
+        println!("{:?}", scores);
+        Ok(())
+    }
+}
+
+// feature-gated because non-mpfr InfCast errors on numbers greater than 2^52
+#[cfg(all(test, feature = "use-mpfr"))]
+mod test_trans {
+    use crate::metrics::SymmetricDistance;
+
+    use super::*;
+
+    #[test]
+    fn test_scorer() -> Fallible<()> {
+        let candidates = vec![7, 12, 14, 72, 76];
+        let input_domain = VectorDomain::new(AtomDomain::default());
+        let input_metric = SymmetricDistance::default();
+        let trans =
+            make_quantile_score_candidates(input_domain, input_metric, candidates.clone(), 0.75)?;
+
+        let input_domain = VectorDomain::new(AtomDomain::default()).with_size(100);
+        let input_metric = SymmetricDistance::default();
+        let trans_sized =
+            make_quantile_score_candidates(input_domain, input_metric, candidates, 0.75)?;
+
+        let _scores = trans.invoke(&(0..100).collect())?;
+        let _scores_sized = trans_sized.invoke(&(0..100).collect())?;
+
+        // because alpha is .75, sensitivity is 1.5 (because not monotonic)
+        // granularity of quantile is .00001, so scores are integerized at a scale of 10000x
+        assert_eq!(trans.map(&1)?, 15000);
+
+        // alpha does not affect sensitivity- it's solely based on the size of the input domain
+        // using all of the range of the usize, 
+        //     so scores can be scaled up by a factor of usize::MAX / 100 before being converted to integers and not overflow
+        // factor of 4 breaks into:
+        //   * a factor of 2 from non-monotonicity
+        //   * a factor of 2 from difference in score after moving one record from above to below a candidate
+        assert_eq!(trans_sized.map(&2)?, usize::MAX / 100 * 4);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Closes #325 

* adds a new scorer transformation `make_quantile_score_candidates`
    * the constructor accepts a vector of quantile candidates
    * the transformation transforms a dataset to a vector of scores, one per candidate
* adds a new metric `LInfDiffDistance<U>` for representing the sensitivity of score vectors