### PR TITLE
add `make_base_discrete_exponential`

### DIFF
--- a/rust/src/measurements/discrete_exponential/mod.rs
+++ b/rust/src/measurements/discrete_exponential/mod.rs
@@ -1,0 +1,178 @@
+use crate::{
+    core::{Function, Measurement, PrivacyMap},
+    domains::{AtomDomain, VectorDomain},
+    error::Fallible,
+    measures::MaxDivergence,
+    metrics::LInfDiffDistance,
+    traits::{Float, Number},
+};
+
+#[cfg(feature = "use-mpfr")]
+use crate::traits::{
+    samplers::{CastInternalRational, GumbelPSRN},
+    DistanceConstant,
+};
+#[cfg(feature = "use-mpfr")]
+use rug::ops::NegAssign;
+
+#[cfg(not(feature = "use-mpfr"))]
+use crate::traits::{samplers::SampleUniform, CheckNull, InfCast, RoundCast};
+
+#[derive(PartialEq)]
+pub enum Optimize {
+    Max,
+    Min,
+}
+
+#[cfg(feature = "use-mpfr")]
+/// Make a Measurement that takes a vector of scores and privately selects the index of the highest score.
+///
+/// # Arguments
+/// * `input_domain` - Domain of the input vector. Must be a non-nullable VectorDomain.
+/// * `input_metric` - Metric on the input domain. Must be LInfDiffDistance
+/// * `temperature` - Higher temperatures are more private.
+/// * `optimize` - Indicate whether to privately return the "Max" or "Min"
+///
+/// # Generics
+/// * `TIA` - Atom Input Type. Type of each element in the score vector.
+/// * `QO` - Output Distance Type.
+pub fn make_base_discrete_exponential<TIA, QO>(
+    input_domain: VectorDomain<AtomDomain<TIA>>,
+    input_metric: LInfDiffDistance<TIA>,
+    temperature: QO,
+    optimize: Optimize,
+) -> Fallible<
+    Measurement<VectorDomain<AtomDomain<TIA>>, usize, LInfDiffDistance<TIA>, MaxDivergence<QO>>,
+>
+where
+    TIA: Number + CastInternalRational,
+    QO: CastInternalRational + DistanceConstant<TIA> + Float,
+{
+    if input_domain.element_domain.nullable() {
+        return fallible!(FailedFunction, "input domain must be non-nullable");
+    }
+
+    if temperature.is_sign_negative() || temperature.is_zero() {
+        return fallible!(FailedFunction, "temperature must be positive");
+    }
+
+    let temp_frac = temperature.clone().into_rational()?;
+
+    Measurement::new(
+        input_domain,
+        Function::new_fallible(move |arg: &Vec<TIA>| {
+            (arg.iter().cloned().enumerate())
+                .map(|(i, v)| {
+                    let mut shift = v.into_rational()? / &temp_frac;
+                    if optimize == Optimize::Min {
+                        shift.neg_assign();
+                    }
+                    Ok((i, GumbelPSRN::new(shift)))
+                })
+                .reduce(|l, r| {
+                    let (mut l, mut r) = (l?, r?);
+                    Ok(if l.1.greater_than(&mut r.1)? { l } else { r })
+                })
+                .ok_or_else(|| err!(FailedFunction, "there must be at least one candidate"))?
+                .map(|v| v.0)
+        }),
+        input_metric,
+        MaxDivergence::default(),
+        PrivacyMap::new_fallible(move |d_in: &TIA| {
+            let d_in = QO::inf_cast(d_in.clone())?;
+            if d_in.is_sign_negative() {
+                return fallible!(InvalidDistance, "sensitivity must be non-negative");
+            }
+            if temperature.is_zero() {
+                return Ok(QO::infinity());
+            }
+            // d_out >= d_in / temperature
+            d_in.inf_div(&temperature)
+        }),
+    )
+}
+
+#[cfg(not(feature = "use-mpfr"))]
+pub fn make_base_discrete_exponential<TIA, QO>(
+    input_domain: VectorDomain<AtomDomain<TIA>>,
+    input_metric: LInfDiffDistance<TIA>,
+    temperature: QO,
+    optimize: Optimize,
+) -> Fallible<
+    Measurement<VectorDomain<AtomDomain<TIA>>, usize, LInfDiffDistance<TIA>, MaxDivergence<QO>>,
+>
+where
+    TIA: Clone + Number,
+    QO: 'static
+        + crate::traits::DistanceConstant<TIA>
+        + crate::traits::RoundCast<TIA>
+        + Float
+        + crate::traits::samplers::SampleUniform,
+{
+    if input_domain.element_domain.nullable() {
+        return fallible!(FailedFunction, "input domain must be non-nullable");
+    }
+
+    if temperature.is_sign_negative() || temperature.is_zero() {
+        return fallible!(MakeMeasurement, "temperature must be positive");
+    }
+
+    let sign = match optimize {
+        Optimize::Max => QO::one(),
+        Optimize::Min => QO::one().neg(),
+    };
+
+    Measurement::new(
+        input_domain,
+        Function::new_fallible(move |arg: &Vec<TIA>| {
+            arg.iter()
+                .cloned()
+                .map(|v| QO::round_cast(v).map(|v| sign * v / temperature))
+                // enumerate before sampling so that indexes are inside the result
+                .enumerate()
+                // gumbel samples are porous
+                .map(|(i, llik)| {
+                    let llik = llik?;
+                    QO::sample_standard_uniform(false).map(|u| (i, llik - u.ln().neg().ln()))
+                })
+                // retrieve the highest noisy likelihood pair
+                .try_fold((arg.len(), QO::neg_infinity()), |acc: (usize, QO), res| {
+                    res.map(|v| if acc.1 > v.1 { acc } else { v })
+                })
+                // only return the index
+                .map(|v| v.0)
+        }),
+        input_metric,
+        MaxDivergence::default(),
+        PrivacyMap::new_fallible(move |d_in: &TIA| {
+            let d_in = QO::inf_cast(d_in.clone())?;
+            if d_in.is_sign_negative() {
+                return fallible!(InvalidDistance, "sensitivity must be non-negative");
+            }
+            if d_in.is_zero() {
+                return Ok(QO::zero());
+            }
+            // d_out >= d_in / temperature
+            d_in.inf_div(&temperature)
+        }),
+    )
+}
+
+#[cfg(feature = "floating-point")]
+#[cfg(test)]
+pub mod test_exponential {
+    use crate::error::Fallible;
+
+    use super::*;
+
+    #[test]
+    fn test_exponential() -> Fallible<()> {
+        let input_domain = VectorDomain::new(AtomDomain::default());
+        let input_metric = LInfDiffDistance::default();
+        let de = make_base_discrete_exponential(input_domain, input_metric, 1., Optimize::Max)?;
+        let release = de.invoke(&vec![1., 2., 3., 2., 1.])?;
+        println!("{:?}", release);
+
+        Ok(())
+    }
+}

--- a/rust/src/measurements/mod.rs
+++ b/rust/src/measurements/mod.rs
@@ -2,6 +2,11 @@
 //!
 //! The different [`crate::core::Measurement`] implementations in this module are accessed by calling the appropriate constructor function.
 //! Constructors are named in the form `make_xxx()`, where `xxx` indicates what the resulting `Measurement` does.
+#[cfg(feature = "contrib")]
+mod discrete_exponential;
+#[cfg(feature = "contrib")]
+pub use crate::measurements::discrete_exponential::*;
+
 #[cfg(all(feature = "contrib", feature = "use-mpfr"))]
 mod gaussian;
 #[cfg(all(feature = "contrib", feature = "use-mpfr"))]

--- a/rust/src/traits/samplers/mod.rs
+++ b/rust/src/traits/samplers/mod.rs
@@ -16,6 +16,11 @@ pub use discretize::*;
 mod geometric;
 pub use geometric::*;
 
+#[cfg(feature = "use-mpfr")]
+mod psrn;
+#[cfg(feature = "use-mpfr")]
+pub use psrn::*;
+
 mod uniform;
 pub use uniform::*;
 

--- a/rust/src/traits/samplers/psrn/mod.rs
+++ b/rust/src/traits/samplers/psrn/mod.rs
@@ -9,7 +9,8 @@ use crate::{error::Fallible, traits::samplers::SampleStandardBernoulli};
 #[derive(Default)]
 pub struct UniformPSRN {
     pub numer: Integer,
-    pub denom: u32,
+    /// The denominator is 2^denom_pow.
+    pub denom_pow: u32,
 }
 
 impl UniformPSRN {
@@ -20,12 +21,12 @@ impl UniformPSRN {
             Round::Down => 0,
             _ => panic!("value must be rounded Up or Down"),
         };
-        Rational::from((self.numer.clone() + round, Integer::from(1) << self.denom))
+        Rational::from((self.numer.clone() + round, Integer::from(1) << self.denom_pow))
     }
     // Randomly discard the lower or upper half of the remaining interval.
     fn refine(&mut self) -> Fallible<()> {
         self.numer <<= 1;
-        self.denom += 1;
+        self.denom_pow += 1;
         if bool::sample_standard_bernoulli()? {
             self.numer += 1;
         }

--- a/rust/src/traits/samplers/psrn/mod.rs
+++ b/rust/src/traits/samplers/psrn/mod.rs
@@ -1,0 +1,151 @@
+use std::ops::AddAssign;
+
+use rug::{float::Round, ops::NegAssign, Float, Integer, Rational};
+
+use crate::{error::Fallible, traits::samplers::SampleStandardBernoulli};
+
+/// A partially sampled uniform random number.
+/// Initializes to the interval [0, 1].
+#[derive(Default)]
+pub struct UniformPSRN {
+    pub numer: Integer,
+    pub denom: u32,
+}
+
+impl UniformPSRN {
+    // Retrieve either the lower or upper edge of the uniform interval.
+    fn value(&self, round: Round) -> Rational {
+        let round = match round {
+            Round::Up => 1,
+            Round::Down => 0,
+            _ => panic!("value must be rounded Up or Down"),
+        };
+        Rational::from((self.numer.clone() + round, Integer::from(1) << self.denom))
+    }
+    // Randomly discard the lower or upper half of the remaining interval.
+    fn refine(&mut self) -> Fallible<()> {
+        self.numer <<= 1;
+        self.denom += 1;
+        if bool::sample_standard_bernoulli()? {
+            self.numer += 1;
+        }
+        Ok(())
+    }
+}
+
+/// A partially sampled Gumbel random number.
+/// Initializes to span all reals.
+pub struct GumbelPSRN {
+    shift: Rational,
+    uniform: UniformPSRN,
+    precision: u32,
+}
+
+impl GumbelPSRN {
+    pub fn new(shift: Rational) -> Self {
+        GumbelPSRN {
+            shift,
+            uniform: UniformPSRN::default(),
+            precision: 1,
+        }
+    }
+
+    /// Retrieve either the lower or upper edge of the Gumbel interval.
+    /// The PSRN is refined until a valid value can be retrieved.
+    pub fn value(&mut self, round: Round) -> Fallible<Rational> {
+        // The first few rounds are susceptible to NaN due to the uniform PSRN initializing at zero.
+        loop {
+            let uniform = Float::with_val_round(self.precision, self.uniform.value(round), round).0;
+
+            if let Some(mut gumbel) = Self::inverse_cdf(uniform, round).to_rational() {
+                gumbel.add_assign(&self.shift);
+                return Ok(gumbel);
+            } else {
+                self.refine()?;
+            }
+        }
+    }
+
+    /// Computes the inverse cdf of the standard Gumbel with controlled rounding:
+    /// $-ln(-ln(u))$ where $u \sim \mathrm{Uniform}(0, 1)$
+    fn inverse_cdf(mut sample: Float, round: Round) -> Float {
+        fn complement(value: Round) -> Round {
+            match value {
+                Round::Up => Round::Down,
+                Round::Down => Round::Up,
+                _ => panic!("complement is only supported for Up/Down"),
+            }
+        }
+
+        // This round is behind two negations, so the rounding direction is preserved
+        sample.ln_round(round);
+        sample.neg_assign();
+
+        // This round is behind a negation, so the rounding direction is reversed
+        sample.ln_round(complement(round));
+        sample.neg_assign();
+
+        sample
+    }
+
+    /// Improves the precision of the inverse transform,
+    /// and halves the interval spanned by the uniform PSRN.
+    pub fn refine(&mut self) -> Fallible<()> {
+        self.precision += 1;
+        self.uniform.refine()
+    }
+
+    /// Checks if `self` is greater than `other`,
+    /// by refining the estimates for `self` and `other` until their intervals are disjoint.
+    pub fn greater_than(&mut self, other: &mut Self) -> Fallible<bool> {
+        Ok(loop {
+            if self.value(Round::Down)? > other.value(Round::Up)? {
+                break true;
+            }
+            if self.value(Round::Up)? < other.value(Round::Down)? {
+                break false;
+            }
+            if self.precision < other.precision {
+                self.refine()?
+            } else {
+                other.refine()?
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_sample_gumbel_interval_progression() -> Fallible<()> {
+        let mut gumbel = GumbelPSRN::new(Rational::from(0));
+        for _ in 0..10 {
+            println!(
+                "{:?}, {:?}, {}",
+                gumbel.value(Round::Down)?.to_f64(),
+                gumbel.value(Round::Up)?.to_f64(),
+                gumbel.precision
+            );
+            gumbel.refine()?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_gumbel_psrn() -> Fallible<()> {
+        fn sample_gumbel() -> Fallible<f64> {
+            let mut gumbel = GumbelPSRN::new(Rational::from(0));
+            for _ in 0..10 {
+                gumbel.refine()?;
+            }
+            Ok(gumbel.value(Round::Down)?.to_f64())
+        }
+        let samples = (0..1000)
+            .map(|_| sample_gumbel())
+            .collect::<Fallible<Vec<_>>>()?;
+        println!("{:?}", samples);
+        Ok(())
+    }
+}

--- a/rust/src/traits/samplers/vulnerable_fallbacks/mod.rs
+++ b/rust/src/traits/samplers/vulnerable_fallbacks/mod.rs
@@ -44,6 +44,4 @@ impl SampleDiscreteGaussianZ2k for f32 {
 }
 
 pub trait CastInternalRational {}
-
-impl CastInternalRational for f32 {}
-impl CastInternalRational for f64 {}
+impl<T> CastInternalRational for T {}


### PR DESCRIPTION
This PR implements a floating-point-safe exponential mechanism via partially sampled random numbers (PSRN). 

This implementation exploits the nice property of the Gumbel noisy-max algorithm wherein each Gumbel variate only needs to be known with sufficient precision to guarantee that no other Gumbel variate can be greater than the best-scoring Gumbel variate (or top k).

The sampling starts with a uniform PSRN, initialized to the interval [0, 1]. The next bit of the uniform random number is acquired by randomly halving the interval. The lower and upper edge of the interval can be retrieved at any given time.

There is similarly a Gumbel(μ, 1) PSRN supported on the reals with rational μ. It contains a uniform PSRN, an inverse transform precision u32, and a shift Rational. In each refinement of the Gumbel, the uniform sampler is refined and the precision is increased. To retrieve the lower or upper edge of the Gumbel, first retrieve the lower or upper edge of the uniform PSRN and then apply the inverse transform with controlled rounding. 

The Gumbel exponential mechanism maps over each score, exactly-scaling it by the temperature parameter and wrapping it in an exactly-shifted Gumbel PSRN. The mechanism then reduces over all pairs of Gumbel PSRNs, refining each PSRN until their intervals are disjoint and in each case discarding the smaller Gumbel PSRN. The differentially private release is the index of the last-surviving Gumbel PSRN.

This work is based on the [interval refining paper from Tumult,](https://tpdp.journalprivacyconfidentiality.org/2022/papers/HaneyDHSH22.pdf) and [Peter Occil's website](https://peteroupc.github.io/randomfunc.html#Inverse_Transform_Sampling).
