### PR TITLE
0.7.0 release prep

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,26 +33,6 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: bash test
-        run: |
-          for X in ant bat cat; do
-            echo $X
-            FOO=bar
-            echo set FOO
-
-            if [ x = y ]; then
-              echo in first if
-              BAR=baz
-
-              if [ a = b]; then
-                echo in second if
-                EAT="my shorts"
-                echo $EAT
-              fi
-            fi
-          done
-          exit 1
-
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
@@ -146,18 +126,29 @@ jobs:
         with:
           repository: 'opendp/artifacts'
           path: ./artifacts
-      
+
       - name: Populate docs site with pdfs
         run: |
+          # get the hash of the stable branch
+          stable_hash=$(git rev-parse origin/stable 2>/dev/null || true)
+
           # copy each folder over
           for folder in en/*; do
-            source=artifacts/release/$(basename $folder)
+            release=$(basename $folder)
+            source=artifacts/release/$release
             target=$folder/proofs
 
             if [ -d "$source" ]; then
-              mkdir -p "$target";
-              mv "$source"/* "$target";
-            fi;
+              mkdir -p "$target"
+              mv "$source"/* "$target"
+
+              # if this release is the stable branch, duplicate it
+              release_hash=$(git rev-parse origin/$release 2>/dev/null || true)
+              if [[ "$release_hash" == "$stable_hash" ]]; then
+                mkdir -p en/stable/proofs
+                cp -rp "$target"/* en/stable/proofs
+              fi
+            fi
           done
           
           # discard unused pdfs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
           ref: ${{ env.SOURCE_REF }}
           # Make sure we get all refs needed to build docs for different versions
           fetch-depth: 0
-        
+
       - name: Collect file listing
         id: "collect"
         run: |
@@ -139,14 +139,17 @@ jobs:
             target=$folder/proofs
 
             if [ -d "$source" ]; then
+              echo "moving $source/* to $target"
               mkdir -p "$target"
               mv "$source"/* "$target"
 
               # if this release is the stable branch, duplicate it
-              release_hash=$(git rev-parse origin/$release 2>/dev/null || true)
+              release_hash=$(git rev-parse $release 2>/dev/null || true)
               if [[ "$release_hash" == "$stable_hash" ]]; then
-                mkdir -p en/stable/proofs
-                cp -rp "$target"/* en/stable/proofs
+                stable_target=en/stable/proofs
+                echo "copying $target/* to $stable_target"
+                mkdir -p "$stable_target"
+                cp -rp "$target"/* "$stable_target"
               fi
             fi
           done

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,14 @@ on:
   workflow_run:
     workflows: ["Sync Branches"]
     types: [completed]
+  # Allows us to regenerate proofs for a previous release
+  workflow_dispatch:
+    inputs:
+      # We need the option of choosing a different ref, rather than just using the ref that the workflow is manually
+      # started on, because this version of the workflow may not be available on the desired branch.
+      override_ref:
+        description: Branch or tag to use as basis
+        type: string
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -18,14 +26,38 @@ jobs:
     env:
       # don't attempt to load binaries when sourcing the library
       OPENDP_HEADLESS: true
+      # Use the explicit ref if any, otherwise use the branch of the triggering workflow.
+      SOURCE_REF: ${{ inputs.override_ref || github.event.workflow_run.head_branch }}
 
-    # Run only if sync-branches workflow succeeded.
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Run only if sync-branches workflow succeeded, or if manually launched.
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      - name: bash test
+        run: |
+          for X in ant bat cat; do
+            echo $X
+            FOO=bar
+            echo set FOO
+
+            if [ x = y ]; then
+              echo in first if
+              BAR=baz
+
+              if [ a = b]; then
+                echo in second if
+                EAT="my shorts"
+                echo $EAT
+              fi
+            fi
+          done
+          exit 1
+
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
+          # Point to the correct ref (for proofs only)
+          ref: ${{ env.SOURCE_REF }}
           # Make sure we get all refs needed to build docs for different versions
           fetch-depth: 0
         

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -129,9 +129,6 @@ jobs:
 
       - name: Populate docs site with pdfs
         run: |
-          # get the hash of the stable branch
-          stable_hash=$(git rev-parse origin/stable 2>/dev/null || true)
-
           # copy each folder over
           for folder in en/*; do
             release=$(basename $folder)
@@ -142,15 +139,6 @@ jobs:
               echo "moving $source/* to $target"
               mkdir -p "$target"
               mv "$source"/* "$target"
-
-              # if this release is the stable branch, duplicate it
-              release_hash=$(git rev-parse $release 2>/dev/null || true)
-              if [[ "$release_hash" == "$stable_hash" ]]; then
-                stable_target=en/stable/proofs
-                echo "copying $target/* to $stable_target"
-                mkdir -p "$stable_target"
-                cp -rp "$target"/* "$stable_target"
-              fi
             fi
           done
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       # If we're on a test branch, make sure this is a dry run.
       - name: Check branch / dry run compatibility
         env:
-          BRANCH_DRY_RUN_OK: ${{ (startsWith(github.ref, 'release/') || inputs.dry_run) && 'true' || 'false' }}
+          BRANCH_DRY_RUN_OK: ${{ (startsWith(github.ref, 'refs/tags/v') || inputs.dry_run) && 'true' || 'false' }}
         run: if [[ $BRANCH_DRY_RUN_OK == true ]]; then echo OK; else echo 'Disabled dry run on non-release branch!'; exit 1; fi
 
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,12 @@
 name: Release
 on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Dry run (DISABLE WITH CARE)
+        required: true
+        type: boolean
+        default: true
   release:
     types:
       - published
@@ -17,6 +24,12 @@ jobs:
           permission: admin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # If we're on a test branch, make sure this is a dry run.
+      - name: Check branch / dry run compatibility
+        env:
+          BRANCH_DRY_RUN_OK: ${{ (startsWith(github.ref, 'release/') || inputs.dry_run) && 'true' || 'false' }}
+        run: if [[ $BRANCH_DRY_RUN_OK == true ]]; then echo OK; else echo 'Disabled dry run on non-release branch!'; exit 1; fi
 
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -206,9 +219,11 @@ jobs:
         run: bash tools/python_build.sh -i
 
       - name: Publish Python package
+        env:
+          DRY_RUN_FLAG: ${{ inputs.dry_run && '-n' || '-nn' }}
         run: |
           pip install -r tools/requirements-publish_tool.txt
-          python tools/publish_tool.py python
+          echo python tools/publish_tool.py python $DRY_RUN_FLAG
 
 
   rust-publish:
@@ -227,6 +242,8 @@ jobs:
           cache: pip
 
       - name: Publish Rust crate
+        env:
+          DRY_RUN_FLAG: ${{ inputs.dry_run && '-n' || '-nn' }}
         run: |
           pip install -r tools/requirements-publish_tool.txt
-          python tools/publish_tool.py rust
+          echo python tools/publish_tool.py rust $DRY_RUN_FLAG

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,7 @@ jobs:
           DRY_RUN_FLAG: ${{ inputs.dry_run && '-n' || '-nn' }}
         run: |
           pip install -r tools/requirements-publish_tool.txt
-          echo python tools/publish_tool.py python $DRY_RUN_FLAG
+          python tools/publish_tool.py python $DRY_RUN_FLAG
 
 
   rust-publish:
@@ -246,4 +246,4 @@ jobs:
           DRY_RUN_FLAG: ${{ inputs.dry_run && '-n' || '-nn' }}
         run: |
           pip install -r tools/requirements-publish_tool.txt
-          echo python tools/publish_tool.py rust $DRY_RUN_FLAG
+          python tools/publish_tool.py rust $DRY_RUN_FLAG

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [ python-pre-publish-windows, python-pre-publish-mac, python-pre-publish-linux ]
     env:
-      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+      PYPI_API_TOKEN: ${{ inputs.dry_run && secrets.TEST_PYPI_API_TOKEN || secrets.PYPI_API_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Please keep this up to date, following the [instructions](#instructions) below.
 
 ### Added
 - FFI and Python interfaces for creating and accessing Domains, Metrics, and Measures ([#637](https://github.com/opendp/opendp/pull/637))
-- Queryables and supporting infrastructure for interactive Measurements ([#618](https://github.com/opendp/opendp/pull/675)), ([#675](https://github.com/opendp/opendp/pull/675))
+- Queryables and supporting infrastructure for interactive Measurements ([#618](https://github.com/opendp/opendp/pull/618)), ([#675](https://github.com/opendp/opendp/pull/675))
 - Constructor for sequential compostion interactive Measurement ([#674](https://github.com/opendp/opendp/pull/674))
 - Checks for compatibility between pairings of Domains and Metrics/Measures ([#604](https://github.com/opendp/opendp/pull/604))
 - Python `opendp.extrinsics` module for code contributions and proofs outside of Rust ([#693](https://github.com/opendp/opendp/pull/693))
@@ -33,6 +33,7 @@ Please keep this up to date, following the [instructions](#instructions) below.
 - The `output_domain` field of Measurement struct ([#647](https://github.com/opendp/opendp/pull/647))
 
 ### Fixed
+- Switched to from `backtrace` crate to `std::backtrace`, and fixed some corner cases, for much faster backtrace resolution ([#691](https://github.com/opendp/opendp/pull/691))
 - Whole-codebase reformat using `rustfmt` to minimize spurious churn in the future ([#669](https://github.com/opendp/opendp/pull/669))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ Please keep this up to date, following the [instructions](#instructions) below.
 ### Added
 - FFI and Python interfaces for creating and accessing Domains, Metrics, and Measures ([#637](https://github.com/opendp/opendp/pull/637))
 - Queryables and supporting infrastructure for interactive Measurements ([#618](https://github.com/opendp/opendp/pull/618)), ([#675](https://github.com/opendp/opendp/pull/675))
-- Constructor for sequential compostion interactive Measurement ([#674](https://github.com/opendp/opendp/pull/674))
+- Constructor for sequential composition of Measurements ([#674](https://github.com/opendp/opendp/pull/674))
 - Checks for compatibility between pairings of Domains and Metrics/Measures ([#604](https://github.com/opendp/opendp/pull/604))
 - Python `opendp.extrinsics` module for code contributions and proofs outside of Rust ([#693](https://github.com/opendp/opendp/pull/693))
-- Docs: [First Look at DP](https://docs.opendp.org/en/stable/user/first-look-at-DP.html) notebook ([#666](https://github.com/opendp/opendp/pull/666))
+- Docs: [First Look at DP](https://docs.opendp.org/en/v0.7.0/user/first-look-at-DP.html) notebook ([#666](https://github.com/opendp/opendp/pull/666))
+- Docs: [Compositors](https://docs.opendp.org/en/v0.7.0/user/combinators/compositors.html) notebook, with usage of interactive Measurements ([#735](https://github.com/opendp/opendp/pull/735))
 
 ### Changed
 - Incorporated Domain instances into some constructor signatures ([#650](https://github.com/opendp/opendp/pull/650))
@@ -23,8 +24,10 @@ Please keep this up to date, following the [instructions](#instructions) below.
   - Remove SizedDomain in favor of a runtime size descriptor on VectorDomain
   - Remove BoundedDomain in favor of a runtime bounds descriptor on AtomDomain
   - Remove InherentNullDomain in favor of a runtime nullity descriptor on AtomDomain
-- Docs: Restructured and improved the [User Guide](https://docs.opendp.org/en/stable/user/index.html) ([#639](https://github.com/opendp/opendp/pull/639))
-- Docs: Renamed the Developer Guide to [Contributor Guide](https://docs.opendp.org/en/stable/contributor/index.html) ([#639](https://github.com/opendp/opendp/pull/639))
+- Removed the default Domain limitation on [user-defined callbacks](https://docs.opendp.org/en/v0.7.0/user/combinators.html#user-defined-callbacks),
+  and renamed constructors from `make_default_user_XXX()` to `make_user_XXX` ([#650](https://github.com/opendp/opendp/pull/650))
+- Docs: Improved the clarity of the [User Guide](https://docs.opendp.org/en/v0.7.0/user/index.html) based on feedback ([#639](https://github.com/opendp/opendp/pull/639))
+- Docs: Renamed the Developer Guide to [Contributor Guide](https://docs.opendp.org/en/v0.7.0/contributor/index.html) ([#639](https://github.com/opendp/opendp/pull/639))
 
 ### Deprecated
 - AllDomain in the Python bindings, with a warning to switch to AtomDomain ([#645](https://github.com/opendp/opendp/pull/645))
@@ -41,7 +44,7 @@ Please keep this up to date, following the [instructions](#instructions) below.
 [0.6.2]: https://github.com/opendp/opendp/compare/v0.6.1...v0.6.2
 
 ### Added
-- [support for user-defined callbacks under explicit opt-in](https://docs.opendp.org/en/latest/user/combinators.html#user-defined-callbacks)
+- [support for user-defined callbacks under explicit opt-in](https://docs.opendp.org/en/v0.6.2/user/combinators.html#user-defined-callbacks)
     - researchers may construct their own transformations, measurements and postprocessors in Python
     - these "custom" components may be interleaved with other components in the library
 - expanded docs.opendp.org User Guide with more explanatory notebooks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,38 @@ Please keep this up to date, following the [instructions](#instructions) below.
 
 ## [Unreleased](https://github.com/opendp/opendp/compare/stable...HEAD)
 
+### Added
+- FFI and Python interfaces for creating and accessing Domains, Metrics, and Measures ([#637](https://github.com/opendp/opendp/pull/637))
+- Queryables and supporting infrastructure for interactive Measurements ([#618](https://github.com/opendp/opendp/pull/675)), ([#675](https://github.com/opendp/opendp/pull/675))
+- Constructor for sequential compostion interactive Measurement ([#674](https://github.com/opendp/opendp/pull/674))
+- Checks for compatibility between pairings of Domains and Metrics/Measures ([#604](https://github.com/opendp/opendp/pull/604))
+- Python `opendp.extrinsics` module for code contributions and proofs outside of Rust ([#693](https://github.com/opendp/opendp/pull/693))
+- Docs: [First Look at DP](https://docs.opendp.org/en/stable/user/first-look-at-DP.html) notebook ([#666](https://github.com/opendp/opendp/pull/666))
+
+### Changed
+- Incorporated Domain instances into some constructor signatures ([#650](https://github.com/opendp/opendp/pull/650))
+- Simplified postprocessors to Function (from previous full Transformation) ([#648](https://github.com/opendp/opendp/pull/648))
+- Moved some Domain logic from type-inherent constraints to runtime checks of more general types ([#645](https://github.com/opendp/opendp/pull/645)), ([#696](https://github.com/opendp/opendp/pull/696))
+  - Remove SizedDomain in favor of a runtime size descriptor on VectorDomain
+  - Remove BoundedDomain in favor of a runtime bounds descriptor on AtomDomain
+  - Remove InherentNullDomain in favor of a runtime nullity descriptor on AtomDomain
+- Docs: Restructured and improved the [User Guide](https://docs.opendp.org/en/stable/user/index.html) ([#639](https://github.com/opendp/opendp/pull/639))
+- Docs: Renamed the Developer Guide to [Contributor Guide](https://docs.opendp.org/en/stable/contributor/index.html) ([#639](https://github.com/opendp/opendp/pull/639))
+
+### Deprecated
+- AllDomain in the Python bindings, with a warning to switch to AtomDomain ([#645](https://github.com/opendp/opendp/pull/645))
+
+### Removed
+- The `output_domain` field of Measurement struct ([#647](https://github.com/opendp/opendp/pull/647))
+
+### Fixed
+- Whole-codebase reformat using `rustfmt` to minimize spurious churn in the future ([#669](https://github.com/opendp/opendp/pull/669))
+
 
 ## [0.6.2] - 2023-02-06
 [0.6.2]: https://github.com/opendp/opendp/compare/v0.6.1...v0.6.2
 
 ### Added
-
 - [support for user-defined callbacks under explicit opt-in](https://docs.opendp.org/en/latest/user/combinators.html#user-defined-callbacks)
     - researchers may construct their own transformations, measurements and postprocessors in Python
     - these "custom" components may be interleaved with other components in the library

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -42,7 +42,7 @@ doctest: doctest-rust doctest-python
 	@echo "Doctest finished. The output is in $(BUILDDIR)/doctest/output.txt."
 
 doctest-rust:
-	cd ../rust && $(CARGO) test --doc
+	cd ../rust && $(CARGO) test --doc --features untrusted,ffi
 
 doctest-python: html
 	$(SPHINXBUILD) $(SPHINXOPTS) -b doctest source $(BUILDDIR)/doctest

--- a/rust/src/combinators/fix_delta/mod.rs
+++ b/rust/src/combinators/fix_delta/mod.rs
@@ -17,7 +17,7 @@ mod ffi;
 /// * `DI` - Input Domain
 /// * `TO` - Output Type
 /// * `MI` - Input Metric.
-/// * `MO` - Output Measure of the input argument. Must be SmoothedMaxDivergence<Q>
+/// * `MO` - Output Measure of the input argument. Must be `SmoothedMaxDivergence<Q>`
 pub fn make_fix_delta<DI, TO, MI, MO>(
     measurement: &Measurement<DI, TO, MI, MO>,
     delta: MO::Atom,

--- a/rust/src/data/ffi.rs
+++ b/rust/src/data/ffi.rs
@@ -4,6 +4,7 @@ use std::ffi::{c_void, CString};
 use std::fmt::Formatter;
 use std::hash::Hash;
 use std::os::raw::c_char;
+#[cfg(feature = "derive")]
 use std::path::PathBuf;
 use std::slice;
 

--- a/rust/src/metrics/mod.rs
+++ b/rust/src/metrics/mod.rs
@@ -53,7 +53,6 @@ pub type IntDistance = u32;
 /// # Compatible Domains
 ///
 /// * `VectorDomain<D>` for any valid `D`
-/// * `SizedDomain<VectorDomain<D>>` for any valid `D`
 ///
 /// When this metric is paired with a `VectorDomain`, we instead consider the multisets corresponding to $u, v \in \texttt{D}$.
 #[derive(Clone)]
@@ -126,7 +125,6 @@ impl<K: Hashable> MetricSpace for (DataFrameDomain<K>, SymmetricDistance) {
 /// # Compatible Domains
 ///
 /// * `VectorDomain<D>` for any valid `D`
-/// * `SizedDomain<VectorDomain<D>>` for any valid `D`
 #[derive(Clone)]
 pub struct InsertDeleteDistance;
 
@@ -163,7 +161,7 @@ impl<D: Domain> MetricSpace for (VectorDomain<D>, InsertDeleteDistance) {
 /// it is a bounded metric (for bounded DP).
 ///
 /// Since this metric is bounded, the dataset size must be fixed.
-/// Thus we only consider neighboring datasets with the same fixed size: [`crate::domains::SizedDomain`].
+/// Thus we only consider neighboring datasets with the same fixed size: [`crate::domains::VectorDomain::size`].
 ///
 /// # Proof Definition
 ///
@@ -191,7 +189,7 @@ impl<D: Domain> MetricSpace for (VectorDomain<D>, InsertDeleteDistance) {
 ///
 /// # Compatible Domains
 ///
-/// * `SizedDomain<D>` for any valid `D`
+/// * `VectorDomain<D>` for any valid `D`, when `VectorDomain::size.is_some()`.
 #[derive(Clone)]
 pub struct ChangeOneDistance;
 
@@ -228,7 +226,7 @@ impl<D: Domain> MetricSpace for (VectorDomain<D>, ChangeOneDistance) {
 /// it is a bounded metric (for bounded DP).
 ///
 /// Since this metric is bounded, the dataset size must be fixed.
-/// Thus we only consider neighboring datasets with the same fixed size: [`crate::domains::SizedDomain`].
+/// Thus we only consider neighboring datasets with the same fixed size: [`crate::domains::VectorDomain::size`].
 ///
 /// # Proof Definition
 ///
@@ -251,7 +249,7 @@ impl<D: Domain> MetricSpace for (VectorDomain<D>, ChangeOneDistance) {
 ///
 /// # Compatible Domains
 ///
-/// * `SizedDomain<D>` for any valid `D`
+/// * `VectorDomain<D>` for any valid `D`, when `VectorDomain::size.is_some()`.
 #[derive(Clone)]
 pub struct HammingDistance;
 
@@ -300,9 +298,7 @@ impl<D: Domain> MetricSpace for (VectorDomain<D>, HammingDistance) {
 /// # Compatible Domains
 ///
 /// * `VectorDomain<D>` for any valid `D`
-/// * `SizedDomain<VectorDomain<D>>` for any valid `D`
 /// * `MapDomain<D>` for any valid `D`
-/// * `SizedDomain<MapDomain<D>>` for any valid `D`
 pub struct LpDistance<const P: usize, Q>(PhantomData<Q>);
 impl<const P: usize, Q> Default for LpDistance<P, Q> {
     fn default() -> Self {
@@ -422,7 +418,7 @@ impl<T: CheckAtom, Q> MetricSpace for (AtomDomain<T>, AbsoluteDistance<Q>) {
 /// 1 is the expected argument on measurements that use this distance.
 ///
 /// # Compatible Domains
-/// * AtomDomain<T> for any valid `T`.
+/// * `AtomDomain<T>` for any valid `T`.
 #[derive(Clone)]
 pub struct DiscreteDistance;
 

--- a/rust/src/metrics/mod.rs
+++ b/rust/src/metrics/mod.rs
@@ -20,9 +20,10 @@ use std::marker::PhantomData;
 use crate::{
     core::{Domain, Metric, MetricSpace},
     domains::{type_name, AtomDomain, MapDomain, VectorDomain},
-    traits::{CheckAtom, Hashable},
-    transformations::DataFrameDomain,
+    traits::CheckAtom,
 };
+#[cfg(feature = "contrib")]
+use crate::{traits::Hashable, transformations::DataFrameDomain};
 use std::fmt::{Debug, Formatter};
 
 /// The type that represents the distance between datasets.
@@ -90,6 +91,8 @@ impl<D: Domain> MetricSpace for (VectorDomain<D>, SymmetricDistance) {
         true
     }
 }
+
+#[cfg(feature = "contrib")]
 impl<K: Hashable> MetricSpace for (DataFrameDomain<K>, SymmetricDistance) {
     fn check(&self) -> bool {
         true

--- a/rust/src/traits/mod.rs
+++ b/rust/src/traits/mod.rs
@@ -29,9 +29,9 @@ pub mod samplers;
 /// ```
 /// (where d_out and c are of type TO, which implements DistanceConstant)
 ///
-/// - InfCast<TI> is for casting where the distance after the cast is gte the distance before the cast
-/// - InfMul is to multiply with the constant `c` in a way that doesn't round down
-/// - TotalOrd is now only for convenience
+/// - `InfCast<TI>` is for casting where the distance after the cast is gte the distance before the cast
+/// - `InfMul` is to multiply with the constant `c` in a way that doesn't round down
+/// - `TotalOrd` is now only for convenience
 ///
 /// # Example
 /// ```

--- a/rust/src/traits/operations/mod.rs
+++ b/rust/src/traits/operations/mod.rs
@@ -7,6 +7,7 @@ use num::{One, Zero};
 
 use crate::domains::Bounds;
 use crate::error::Fallible;
+#[cfg(feature = "contrib")]
 use crate::interactive::Queryable;
 
 use super::ExactIntCast;
@@ -297,6 +298,7 @@ impl CheckNull for rug::Integer {
         false
     }
 }
+#[cfg(feature = "contrib")]
 impl<Q, A> CheckNull for Queryable<Q, A> {
     #[inline]
     fn is_null(&self) -> bool {

--- a/rust/src/transformations/count/mod.rs
+++ b/rust/src/transformations/count/mod.rs
@@ -58,7 +58,7 @@ where
 /// * [GRS12 Universally Utility-Maximizing Privacy Mechanisms](https://theory.stanford.edu/~tim/papers/priv.pdf)
 ///
 /// # Generics
-/// * `TIA` - Atomic Input Type. Input data is expected to be of the form Vec<TIA>.
+/// * `TIA` - Atomic Input Type. Input data is expected to be of the form `Vec<TIA>`.
 /// * `TO` - Output Type. Must be numeric.
 pub fn make_count_distinct<TIA, TO>() -> Fallible<
     Transformation<

--- a/rust/src/transformations/impute/mod.rs
+++ b/rust/src/transformations/impute/mod.rs
@@ -81,7 +81,7 @@ pub trait ImputeConstantDomain: Domain {
         constant: &'a Self::Imputed,
     ) -> &'a Self::Imputed;
 }
-// how to impute, when null represented as Option<T>
+// how to impute, when null represented as `Option<T>`
 impl<T: CheckAtom> ImputeConstantDomain for OptionDomain<AtomDomain<T>> {
     type Imputed = T;
     fn impute_constant<'a>(
@@ -175,7 +175,7 @@ pub trait DropNullDomain: Domain {
     fn option(value: &Self::Carrier) -> Option<Self::Imputed>;
 }
 
-/// how to standardize into an option, when null represented as Option<T>
+/// how to standardize into an option, when null represented as `Option<T>`
 impl<T: CheckAtom + Clone> DropNullDomain for OptionDomain<AtomDomain<T>> {
     type Imputed = T;
     fn option(value: &Self::Carrier) -> Option<T> {

--- a/tools/publish_tool.py
+++ b/tools/publish_tool.py
@@ -21,14 +21,16 @@ def run_command(description, args, capture_output=True, shell=True):
 
 def rust(args):
     log(f"*** PUBLISHING RUST LIBRARY ***")
-    if args.dry_run:
-        raise NotImplementedError("dry runs aren't supported on workspaces")
     os.environ["CARGO_REGISTRY_TOKEN"] = os.environ["CRATES_IO_API_TOKEN"]
-    run_command("Publishing opendp_tooling crate", f"cargo publish --verbose --manifest-path=rust/opendp_tooling/Cargo.toml")
-    run_command("Letting crates.io index settle", f"sleep {args.settle_time}")
-    run_command("Publishing opendp_derive crate", f"cargo publish --verbose --manifest-path=rust/opendp_derive/Cargo.toml")
-    run_command("Letting crates.io index settle", f"sleep {args.settle_time}")
-    run_command("Publishing opendp crate", f"cargo publish --verbose --manifest-path=rust/Cargo.toml")
+    # We can't do a dry run of everything, because dependencies won't be available for later crates,
+    # but we can at least do any leaf notes (i.e. opendp_tooling).
+    dry_run_arg = " --dry-run" if args.dry_run else ""
+    run_command("Publishing opendp_tooling crate", f"cargo publish{dry_run_arg} --verbose --manifest-path=rust/opendp_tooling/Cargo.toml")
+    if not args.dry_run:
+        run_command("Letting crates.io index settle", f"sleep {args.settle_time}")
+        run_command("Publishing opendp_derive crate", f"cargo publish --verbose --manifest-path=rust/opendp_derive/Cargo.toml")
+        run_command("Letting crates.io index settle", f"sleep {args.settle_time}")
+        run_command("Publishing opendp crate", f"cargo publish --verbose --manifest-path=rust/Cargo.toml")
 
 
 def python(args):

--- a/tools/publish_tool.py
+++ b/tools/publish_tool.py
@@ -25,12 +25,12 @@ def rust(args):
     # We can't do a dry run of everything, because dependencies won't be available for later crates,
     # but we can at least do any leaf notes (i.e. opendp_tooling).
     dry_run_arg = " --dry-run" if args.dry_run else ""
-    run_command("Publishing opendp_tooling crate", f"cargo publish{dry_run_arg} --verbose --manifest-path=rust/opendp_tooling/Cargo.toml")
+    run_command("Publishing opendp_tooling crate", f"cargo publish{dry_run_arg} --verbose --manifest-path=rust/opendp_tooling/Cargo.toml", capture_output=False)
     if not args.dry_run:
         run_command("Letting crates.io index settle", f"sleep {args.settle_time}")
-        run_command("Publishing opendp_derive crate", f"cargo publish --verbose --manifest-path=rust/opendp_derive/Cargo.toml")
+        run_command("Publishing opendp_derive crate", f"cargo publish --verbose --manifest-path=rust/opendp_derive/Cargo.toml", capture_output=False)
         run_command("Letting crates.io index settle", f"sleep {args.settle_time}")
-        run_command("Publishing opendp crate", f"cargo publish --verbose --manifest-path=rust/Cargo.toml")
+        run_command("Publishing opendp crate", f"cargo publish --verbose --manifest-path=rust/Cargo.toml", capture_output=False)
 
 
 def python(args):
@@ -39,7 +39,7 @@ def python(args):
     os.environ["TWINE_USERNAME"] = "__token__"
     os.environ["TWINE_PASSWORD"] = os.environ["PYPI_API_TOKEN"]
     dry_run_arg = " --repository testpypi" if args.dry_run else ""
-    run_command("Publishing opendp package", f"python3 -m twine upload{dry_run_arg} --verbose --skip-existing python/wheelhouse/*")
+    run_command("Publishing opendp package", f"python3 -m twine upload{dry_run_arg} --verbose --skip-existing python/wheelhouse/*", capture_output=False)
 
 
 def meta(args):

--- a/tools/publish_tool.py
+++ b/tools/publish_tool.py
@@ -23,7 +23,7 @@ def rust(args):
     log(f"*** PUBLISHING RUST LIBRARY ***")
     os.environ["CARGO_REGISTRY_TOKEN"] = os.environ["CRATES_IO_API_TOKEN"]
     # We can't do a dry run of everything, because dependencies won't be available for later crates,
-    # but we can at least do any leaf notes (i.e. opendp_tooling).
+    # but we can at least do any leaf nodes (i.e. opendp_tooling).
     dry_run_arg = " --dry-run" if args.dry_run else ""
     run_command("Publishing opendp_tooling crate", f"cargo publish{dry_run_arg} --verbose --manifest-path=rust/opendp_tooling/Cargo.toml", capture_output=False)
     if not args.dry_run:

--- a/tools/release_tool.py
+++ b/tools/release_tool.py
@@ -73,8 +73,8 @@ def get_cached_version():
     return cached_version
 
 
-def get_branch(version):
-    branch = f"release/{version.major}.{version.minor}.x"
+def get_branch(prefix, version):
+    branch = f"{prefix}{version.major}.{version.minor}.x"
     return branch
 
 
@@ -131,7 +131,7 @@ def init(args):
         fetch_repo(args.repo_dir)
     base_version = get_base_version(args.base_version)
     target_version = get_target_version(base_version, args.type)
-    branch = get_branch(target_version)
+    branch = get_branch(args.branch_prefix, target_version)
     tag = get_tag(target_version)
     args.ref = args.ref or "main"
     write_conf(args.type, base_version, target_version, branch, tag, args.ref)
@@ -312,6 +312,7 @@ def _main(argv):
     subparser.add_argument("-nc", "--no-clone", dest="clone", action="store_false")
     subparser.add_argument("-b", "--base-version")
     subparser.add_argument("-t", "--type", choices=["major", "minor", "patch"], required=True)
+    subparser.add_argument("-i", "--branch-prefix", default="release/", help="Release branch prefix")
     subparser.add_argument("-r", "--ref")
     subparser.add_argument("-f", "--force", dest="force", action="store_true", default=False)
     subparser.add_argument("-nf", "--no-force", dest="force", action="store_false")

--- a/tools/release_tool.py
+++ b/tools/release_tool.py
@@ -239,7 +239,8 @@ def create(args):
     # Just in case, clear out any existing tag, so a new one will be created by GitHub.
     run_command("Clearing tag", f"git push origin :refs/tags/{resolved_tag}")
     title = f"OpenDP {cached_version}"
-    notes = f"[Changelog](https://github.com/opendp/opendp/blob/main/CHANGELOG.md#{conf.target_version}---{conf.date})"
+    stripped_target_version = str(conf.target_version).replace(".", "")
+    notes = f"[CHANGELOG](https://github.com/opendp/opendp/blob/main/CHANGELOG.md#{stripped_target_version}---{conf.date})"
     prerelease_arg = " -p" if cached_version.prerelease else ""
     draft_arg = " -d" if args.draft else ""
     run_command("Creating GitHub Release", f"gh release create {resolved_tag} --target {conf.branch} -t '{title}' -n '{notes}'{prerelease_arg}{draft_arg}")

--- a/tools/release_tool.py
+++ b/tools/release_tool.py
@@ -106,6 +106,7 @@ def read_conf(args):
 
 def create_branch(type, branch, ref, force=False):
     create_arg = "-C" if force else "-c"
+    run_command(f"Fetching ref {ref}", f"git fetch origin {ref}:{ref}")
     run_command(f"Creating {type} branch {branch} -> {ref}", f"git switch {create_arg} {branch} {ref}")
 
 
@@ -114,7 +115,7 @@ def switch_branch(type, branch):
 
 
 def commit(what, files, message=None):
-    message = message or f"Updated {what}."
+    message = message or f"Update {what}."
     run_command(f"Committing {what}", f"git add {' '.join(files)} && git commit -m '{message}'")
 
 
@@ -173,7 +174,7 @@ def changelog(args):
     substitution_arg = f"-e 's|{heading_regex}|{replacement}|'"
     inplace_arg = "-i ''" if platform.system() == "Darwin" else "-i"
     run_command("Updating CHANGELOG", f"sed {inplace_arg} {substitution_arg} CHANGELOG.md")
-    commit("CHANGELOG", ["CHANGELOG.md"], f"RELEASE_TOOL: Updated CHANGELOG.md for {conf.target_version}.")
+    commit("CHANGELOG", ["CHANGELOG.md"], f"RELEASE_TOOL: Update CHANGELOG.md for {conf.target_version}.")
 
 
 def version(args):
@@ -271,7 +272,7 @@ def reconcile(args):
     reconciled_files = ["CHANGELOG.md"]
     create_branch("reconciliation", reconciliation_branch, "main", args.force)
     run_command("Copying reconciled files from release branch", f"git restore -s {conf.branch} -- {' '.join(reconciled_files)}")
-    commit("reconciled files", reconciled_files, f"RELEASE_TOOL: Reconciled files from {conf.target_version}.")
+    commit("reconciled files", reconciled_files, f"RELEASE_TOOL: Reconcile files from {conf.target_version}.")
     push("reconciled files", args.force)
     draft_arg = " -d" if args.draft else ""
     run_command("Creating reconciliation PR", f"gh pr create -B main -f{draft_arg}")

--- a/tools/test.py
+++ b/tools/test.py
@@ -2,7 +2,7 @@ from opendp.transformations import *
 from opendp.measurements import *
 from opendp.combinators import *
 
-from opendp.typing import ChangeOneDistance, VectorDomain, AtomDomain
+from opendp.typing import SymmetricDistance, VectorDomain, AtomDomain
 from opendp.mod import enable_features
 enable_features("contrib")
 
@@ -12,7 +12,7 @@ enable_features("contrib")
 def main():
 
     # HELLO WORLD
-    identity = make_identity(D=VectorDomain[AtomDomain[str]], M=ChangeOneDistance)
+    identity = make_identity(D=VectorDomain[AtomDomain[str]], M=SymmetricDistance)
     arg = ["hello, world!"]
     res = identity(arg)
     print(res)


### PR DESCRIPTION
Fixes #709:

* Update CHANGELOG.md
* Fix some problems with default build
* Clean up some nits in rustdoc
* Add option to `release_tool.py` to use a different release branch prefix
* Add ability to run `release.yml` manually on a different branch
* Add ability to run `docs.yml` manually to fill in missing proofs
* Update pre/post-flight test script to use `SymmetricDistance`
* Point dry run at TestPyPI (`twine` has no `--dry-run` option)
* Add `--features untrusted,ffi` to `make doctest-rust` target