### PR TITLE
free supporting elements (fix symbols)

### DIFF
--- a/rust/src/domains/ffi.rs
+++ b/rust/src/domains/ffi.rs
@@ -22,7 +22,7 @@ use super::{Bounds, Null, OptionDomain};
 )]
 /// Internal function. Free the memory associated with `this`.
 #[no_mangle]
-pub extern "C" fn opendp_core___domain_free(this: *mut AnyDomain) -> FfiResult<*mut ()> {
+pub extern "C" fn opendp_domains___domain_free(this: *mut AnyDomain) -> FfiResult<*mut ()> {
     util::into_owned(this).map(|_| ()).into()
 }
 

--- a/rust/src/measures/ffi.rs
+++ b/rust/src/measures/ffi.rs
@@ -20,7 +20,7 @@ use super::SmoothedMaxDivergence;
 )]
 /// Internal function. Free the memory associated with `this`.
 #[no_mangle]
-pub extern "C" fn opendp_core___measure_free(this: *mut AnyMeasure) -> FfiResult<*mut ()> {
+pub extern "C" fn opendp_measures___measure_free(this: *mut AnyMeasure) -> FfiResult<*mut ()> {
     util::into_owned(this).map(|_| ()).into()
 }
 

--- a/rust/src/metrics/ffi.rs
+++ b/rust/src/metrics/ffi.rs
@@ -21,7 +21,7 @@ use super::{
 )]
 /// Internal function. Free the memory associated with `this`.
 #[no_mangle]
-pub extern "C" fn opendp_core___metric_free(this: *mut AnyMetric) -> FfiResult<*mut ()> {
+pub extern "C" fn opendp_metrics___metric_free(this: *mut AnyMetric) -> FfiResult<*mut ()> {
     util::into_owned(this).map(|_| ()).into()
 }
 


### PR DESCRIPTION
Closes #727 

Fixes a bug in #729 that wasn't caught by testing, likely because `__del__` isn't guaranteed to run.