### PR TITLE
Polars `LazyFrameDomain`

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -43,6 +43,7 @@ gmp-mpfr-sys = { version = "1.4.7", default-features = false, features = ["mpfr"
 openssl = { version = "0.10.29", features = ["vendored"], optional = true }
 opendp_tooling = { path = "opendp_tooling", optional = true }
 readonly = "0.2"
+polars = { version = "0.29.0", features = ["lazy", "csv", "dtype-struct", "parquet"] }
 
 lazy_static = { version = "1.4.0", optional = true }
 vega_lite_4 = { version = "0.6.0", optional = true }

--- a/rust/src/domains/mod.rs
+++ b/rust/src/domains/mod.rs
@@ -11,6 +11,9 @@
 #[cfg(feature = "ffi")]
 mod ffi;
 
+mod polars;
+pub use crate::domains::polars::*;
+
 // Once we have things using `Any` that are outside of `contrib`, this should specify `feature="ffi"`.
 #[cfg(feature = "contrib")]
 use std::any::Any;

--- a/rust/src/domains/polars/expr/mod.rs
+++ b/rust/src/domains/polars/expr/mod.rs
@@ -1,0 +1,25 @@
+use polars::lazy::dsl::Expr;
+
+use crate::{core::Domain, error::Fallible};
+
+use super::LazyFrameDomain;
+
+
+#[derive(Clone, PartialEq)]
+struct ExprDomain {
+    lazyframe_domain: LazyFrameDomain
+}
+
+impl Domain for ExprDomain {
+    type Carrier = (Expr, LazyFrameDomain);
+
+    fn member(&self, _val: &Self::Carrier) -> Fallible<bool> {
+        unimplemented!()
+    }
+}
+
+impl std::fmt::Debug for ExprDomain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExprDomain").field("lazyframe_domain", &self.lazyframe_domain).finish()
+    }
+}

--- a/rust/src/domains/polars/lazyframe/mod.rs
+++ b/rust/src/domains/polars/lazyframe/mod.rs
@@ -1,0 +1,414 @@
+use std::collections::{BTreeSet, HashMap};
+use std::fmt::Debug;
+
+use crate::core::{Domain, MetricSpace};
+use crate::domains::{AtomDomain, OptionDomain};
+use crate::error::Fallible;
+
+use polars::lazy::dsl::{col, cols, count};
+use polars::prelude::*;
+
+use super::{DatasetMetric, SeriesDomain};
+
+
+// gradations of public info:
+//                | public keys | private keys
+// public counts  | Some(df+id) | x
+// partial counts | Some(df)    | x
+
+#[derive(Clone, PartialEq)]
+pub struct LazyFrameDomain {
+    pub series_domains: Vec<SeriesDomain>,
+    pub margins: HashMap<BTreeSet<usize>, Margin>,
+    pub user_id: Option<usize>,
+}
+
+impl<D: DatasetMetric> MetricSpace for (LazyFrameDomain, D) {
+    fn check(&self) -> bool {
+        true
+    }
+}
+
+impl LazyFrameDomain {
+    pub fn new(series_domains: Vec<SeriesDomain>) -> Fallible<Self> {
+        if BTreeSet::from_iter(series_domains.iter().map(|s| s.field.name.clone())).len()
+            != series_domains.len()
+        {
+            return fallible!(MakeDomain, "column names must be distinct");
+        }
+        Ok(LazyFrameDomain {
+            series_domains,
+            margins: HashMap::new(),
+            user_id: None,
+        })
+    }
+
+    pub fn new_from_schema(schema: Schema) -> Fallible<Self> {
+        let series_domains = (schema.iter_fields())
+            .map(|field| {
+                macro_rules! new_series_domain {
+                    ($ty:ty, $func:ident) => {
+                        SeriesDomain::new(
+                            field.name.as_str(),
+                            OptionDomain::new(AtomDomain::<$ty>::$func()),
+                        )
+                    };
+                }
+
+                Ok(match field.data_type() {
+                    DataType::Boolean => new_series_domain!(bool, default),
+                    DataType::UInt8 => new_series_domain!(u8, default),
+                    DataType::UInt16 => new_series_domain!(u16, default),
+                    DataType::UInt32 => new_series_domain!(u32, default),
+                    DataType::UInt64 => new_series_domain!(u64, default),
+                    DataType::Int8 => new_series_domain!(i8, default),
+                    DataType::Int16 => new_series_domain!(i16, default),
+                    DataType::Int32 => new_series_domain!(i32, default),
+                    DataType::Int64 => new_series_domain!(i64, default),
+                    DataType::Float32 => new_series_domain!(f64, new_nullable),
+                    DataType::Float64 => new_series_domain!(f64, new_nullable),
+                    DataType::Utf8 => new_series_domain!(String, default),
+                    dtype => return fallible!(MakeDomain, "unsupported type {}", dtype),
+                })
+            })
+            .collect::<Fallible<_>>()?;
+        LazyFrameDomain::new(series_domains)
+    }
+
+    // add categories to the domain
+    #[must_use]
+    pub fn with_categories(self, categories: Series) -> Fallible<Self> {
+        let count_col_name = categories.name();
+        // make sure the dtype matches
+        self.check_dtype_matches(count_col_name, categories.dtype())?;
+
+        let margin_id = BTreeSet::from_iter([count_col_name.try_column_index(&self)?]);
+        let margin = Margin::new_from_categories(categories)?;
+        self.with_margin(margin_id, margin)
+    }
+
+    #[must_use]
+    pub fn with_counts(self, counts: LazyFrame) -> Fallible<Self> {
+        let counts_schema = counts.schema()?;
+
+        // determine which column is the counts column (the one not in the data)
+        let counts_col_index = (counts_schema.iter_names())
+            .position(|name| self.column(name).is_none())
+            .ok_or_else(|| err!(MakeDomain, "could not find counts column"))?;
+
+        let margin = Margin::new_from_counts(counts, counts_col_index)?;
+
+        // check that all dtypes in id columns match
+        let id_names = margin.get_join_column_names()?;
+        for id_name in id_names.iter() {
+            self.check_dtype_matches(id_name, &counts_schema.get_field(&id_name).unwrap().dtype)?;
+        }
+
+        let margin_id: BTreeSet<_> = (id_names.into_iter())
+            .map(|id| id.as_str().try_column_index(&self))
+            .collect::<Fallible<_>>()?;
+        self.with_margin(margin_id, margin)
+    }
+
+    #[must_use]
+    fn with_margin(mut self, margin_id: BTreeSet<usize>, margin: Margin) -> Fallible<Self> {
+        if self.margins.contains_key(&margin_id) {
+            return fallible!(MakeDomain, "margin already exists");
+        }
+        self.margins.insert(margin_id, margin);
+        Ok(self)
+    }
+
+    #[must_use]
+    pub fn with_user_id<I: IntoColumnIndex>(mut self, user_id_column: I) -> Fallible<Self> {
+        self.user_id = Some(user_id_column.try_column_index(&self)?);
+        Ok(self)
+    }
+
+    pub fn column<I: AsRef<str>>(&self, name: I) -> Option<&SeriesDomain> {
+        Some(&self.series_domains[name.as_ref().column_index(self)?])
+    }
+    pub fn try_column<I: AsRef<str>>(&self, name: I) -> Fallible<&SeriesDomain> {
+        self.column(&name)
+            .ok_or_else(|| err!(FailedFunction, "{} is not in dataframe", name.as_ref()))
+    }
+
+    fn check_dtype_matches<I: AsRef<str>>(&self, name: I, dtype: &DataType) -> Fallible<()> {
+        let domain_dtype = &self.try_column(&name)?.field.dtype;
+        if domain_dtype != dtype {
+            return fallible!(
+                MakeDomain,
+                "{} data type mismatch: expected {}, got {}",
+                name.as_ref(),
+                domain_dtype,
+                dtype
+            );
+        }
+        Ok(())
+    }
+}
+
+impl Debug for LazyFrameDomain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "LazyFrameDomain({})",
+            self.series_domains
+                .iter()
+                .map(|s| format!("{}: {}", s.field.name, s.field.dtype))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+}
+
+impl Domain for LazyFrameDomain {
+    type Carrier = LazyFrame;
+    fn member(&self, val: &Self::Carrier) -> Fallible<bool> {
+        let val_df = val.clone().collect()?;
+
+        if val_df.schema().len() != self.series_domains.len() {
+            return Ok(false);
+        }
+
+        for (s, dom) in val_df.get_columns().iter().zip(self.series_domains.iter()) {
+            if !dom.member(s)? {
+                return Ok(false);
+            }
+        }
+
+        for margin in self.margins.values() {
+            if !margin.member(val)? {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+}
+
+/// A restriction on the unique values in the margin, as well as possibly their counts,
+/// over a set of columns in a LazyFrame.
+///
+/// If `counts_index` is not set, then `data` is the unique values in a column.
+/// Otherwise, counts are stored in the `counts_index` column of the `data`.
+#[derive(Clone)]
+pub struct Margin {
+    data: LazyFrame,
+    counts_index: Option<usize>,
+}
+
+impl Margin {
+    pub fn new_from_categories(series: Series) -> Fallible<Self> {
+        if series.n_unique()? != series.len() {
+            return fallible!(MakeDomain, "categories must be unique");
+        }
+        Ok(Self {
+            data: DataFrame::new(vec![series])?.lazy(),
+            counts_index: None,
+        })
+    }
+    pub fn new_from_counts(data: LazyFrame, counts_index: usize) -> Fallible<Self> {
+        let mut margin = Self {
+            data,
+            counts_index: Some(counts_index),
+        };
+
+        // set the data type on the counts column
+        let count_col_name = margin.get_count_column_name()?;
+        margin.data = margin
+            .data
+            .with_column(col(count_col_name.as_str()).cast(DataType::UInt32));
+
+        Ok(margin)
+    }
+
+    fn get_count_column_name(&self) -> Fallible<String> {
+        let count_index = self
+            .counts_index
+            .ok_or_else(|| err!(FailedFunction, "counts do not exist"))?;
+        Ok((self.data.schema()?.get_at_index(count_index).unwrap().0).to_string())
+    }
+
+    fn get_join_column_names(&self) -> Fallible<Vec<String>> {
+        Ok((self.data.schema()?.iter_names().enumerate())
+            .filter(|(i, _)| Some(*i) != self.counts_index)
+            .map(|v| v.1.to_string())
+            .collect())
+    }
+
+    fn member(&self, value: &LazyFrame) -> Fallible<bool> {
+        let col_names = self.get_join_column_names()?;
+
+        // retrieves the first row/first column from $tgt as type $ty
+        macro_rules! item {
+            ($tgt:expr, $ty:ident) => {
+                ($tgt.collect()?.get_columns()[0].$ty()?.get(0))
+                    .ok_or_else(|| err!(FailedFunction))?
+            };
+        }
+
+        // 1. count number of unique combinations of col_names in actual data
+        let actual_n_unique = item!(
+            (value.clone())
+                // .drop_nulls(Some(vec![cols(&col_names)])) // commented because counts for null values are permitted
+                .select([as_struct(&[cols(&col_names)]).n_unique()]),
+            u32
+        );
+        // println!("actual n unique, {}", actual_n_unique);
+
+        // 2. count number of unique combinations after an outer join with metadata
+        let on_expr: Vec<_> = col_names.iter().map(|v| col(v.as_str())).collect();
+
+        let actual_margins = (value.clone().groupby([cols(&col_names)])).agg([count()]);
+        let joined =
+            (self.data.clone()).join(actual_margins, on_expr.clone(), on_expr, JoinType::Left);
+
+        // println!("joined {}", joined.clone().collect()?);
+
+        // 3. to check that categories match, ensure that 1 and 2 are same length
+        let joined_n_unique = item!(joined.clone().select([count()]), u32);
+
+        // if the join reduced the number of records,
+        // then the actual data has values not in the category set
+        if actual_n_unique != joined_n_unique {
+            return Ok(false);
+        }
+
+        // 4. check that counts match
+        if self.counts_index.is_some() {
+            let count_colname = self.get_count_column_name()?;
+            let count_colname_right = format!("{count_colname}_right");
+
+            let eq_expr = col(count_colname.as_str())
+                .eq(col(count_colname_right.as_str()))
+                .all();
+
+            if !item!(joined.clone().select([eq_expr]), bool) {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+}
+
+impl PartialEq for Margin {
+    fn eq(&self, other: &Self) -> bool {
+        if self.counts_index != other.counts_index {
+            return false;
+        }
+
+        let Ok(self_margins) = self.data.clone().collect() else {return false};
+        let Ok(other_margins) = self.data.clone().collect() else {return false};
+        if self_margins != other_margins {
+            return false;
+        }
+        true
+    }
+}
+
+/// Convert from either a usize (index) or &str (name) to a column index.
+///
+/// The return is always either an error, or a valid index wrt `domain`.
+pub trait IntoColumnIndex {
+    fn column_index(&self, domain: &LazyFrameDomain) -> Option<usize>;
+    fn try_column_index(&self, domain: &LazyFrameDomain) -> Fallible<usize> {
+        self.column_index(domain)
+            .ok_or_else(|| err!(FailedFunction, "column id not in domain"))
+    }
+}
+
+impl IntoColumnIndex for usize {
+    fn column_index(&self, domain: &LazyFrameDomain) -> Option<usize> {
+        // reject indices greater than the column length
+        if *self >= domain.series_domains.len() {
+            return None;
+        }
+        Some(*self)
+    }
+}
+impl IntoColumnIndex for &str {
+    fn column_index(&self, domain: &LazyFrameDomain) -> Option<usize> {
+        // reject names that don't correspond to a known column
+        (domain.series_domains.iter()).position(|s| s.field.name == *self)
+    }
+}
+
+#[cfg(test)]
+mod test_lazyframe {
+    use crate::domains::{AtomDomain, OptionDomain};
+
+    use super::*;
+
+    #[test]
+    fn test_frame_new() -> Fallible<()> {
+        let frame_domain = LazyFrameDomain::new(vec![
+            SeriesDomain::new("A", AtomDomain::<i32>::default()),
+            SeriesDomain::new("B", AtomDomain::<f64>::default()),
+        ])?;
+
+        let frame = df!(
+            "A" => &[3, 4, 5],
+            "B" => &[1., 3., 7.]
+        )?
+        .lazy();
+
+        assert!(frame_domain.member(&frame)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_frame_categories_bool() -> Fallible<()> {
+        let categories = Series::new("A", vec![true]);
+        let series_domain =
+            SeriesDomain::new("A", OptionDomain::new(AtomDomain::<bool>::default()));
+        let frame_domain =
+            LazyFrameDomain::new(vec![series_domain])?.with_categories(categories.clone())?;
+
+        // not a member because None is not in the category set
+        let example = df!["A" => [Some(true), None]]?.lazy();
+        assert!(!frame_domain.member(&example)?);
+
+        let example = df!["A" => [Some(true), Some(false)]]?.lazy();
+        assert!(!frame_domain.member(&example)?);
+
+        let example = df!["A" => [Some(true)]]?.lazy();
+        assert!(frame_domain.member(&example)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_frame_categories_float() -> Fallible<()> {
+        let categories = Series::new("A", vec![1.]);
+        let series_domain = SeriesDomain::new("A", OptionDomain::new(AtomDomain::<f64>::default()));
+        let frame_domain =
+            LazyFrameDomain::new(vec![series_domain])?.with_categories(categories.clone())?;
+
+        let example = df!["A" => [Some(1.), None]]?.lazy();
+        assert!(!frame_domain.member(&example)?);
+        let example = df!["A" => [1., 2.]]?.lazy();
+        assert!(!frame_domain.member(&example)?);
+        let example = df!["A" => [1.]]?.lazy();
+        assert!(frame_domain.member(&example)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_frame_counts() -> Fallible<()> {
+        let frame_domain = LazyFrameDomain::new(vec![
+            SeriesDomain::new("A", AtomDomain::<i32>::default()),
+            SeriesDomain::new("B", AtomDomain::<String>::default()),
+        ])?
+        .with_counts(df!["A" => [1, 2], "count" => [1, 2]]?.lazy())?
+        .with_counts(df!["B" => ["1", "2"], "count" => [2, 1]]?.lazy())?;
+
+        let frame = df!("A" => [1, 2, 2], "B" => ["1", "1", "2"])?.lazy();
+        assert!(frame_domain.member(&frame)?);
+
+        Ok(())
+    }
+}

--- a/rust/src/domains/polars/mod.rs
+++ b/rust/src/domains/polars/mod.rs
@@ -1,0 +1,8 @@
+mod lazyframe;
+pub use lazyframe::*;
+
+mod series;
+pub use series::*;
+
+mod scan;
+pub use scan::*;

--- a/rust/src/domains/polars/mod.rs
+++ b/rust/src/domains/polars/mod.rs
@@ -1,3 +1,7 @@
+mod expr;
+pub use expr::*;
+
+
 mod lazyframe;
 pub use lazyframe::*;
 

--- a/rust/src/domains/polars/scan/mod.rs
+++ b/rust/src/domains/polars/scan/mod.rs
@@ -1,0 +1,115 @@
+use std::path::PathBuf;
+
+use polars::prelude::*;
+
+use crate::{
+    core::{Domain, Metric, MetricSpace},
+    error::Fallible,
+    metrics::{
+        ChangeOneDistance, HammingDistance, InsertDeleteDistance, IntDistance, SymmetricDistance,
+    },
+};
+
+use super::LazyFrameDomain;
+
+pub trait DatasetMetric: Metric<Distance = IntDistance> {}
+impl DatasetMetric for SymmetricDistance {}
+impl DatasetMetric for InsertDeleteDistance {}
+impl DatasetMetric for ChangeOneDistance {}
+impl DatasetMetric for HammingDistance {}
+
+pub struct CsvDomain {
+    pub lazy_frame_domain: LazyFrameDomain,
+    pub reader: LazyCsvReader<'static>,
+}
+
+impl CsvDomain {
+    pub fn new(lazy_frame_domain: LazyFrameDomain, reader: LazyCsvReader<'static>) -> Self {
+        CsvDomain {
+            lazy_frame_domain,
+            reader,
+        }
+    }
+}
+
+impl Domain for CsvDomain {
+    type Carrier = String;
+
+    fn member(&self, val: &Self::Carrier) -> Fallible<bool> {
+        self.lazy_frame_domain.member(
+            &(self.reader.clone())
+                .with_path(PathBuf::from(val).clone())
+                .finish()?,
+        )
+    }
+}
+
+impl PartialEq for CsvDomain {
+    fn eq(&self, other: &Self) -> bool {
+        self.lazy_frame_domain == other.lazy_frame_domain
+    }
+}
+
+impl std::fmt::Debug for CsvDomain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CsvDomain({:?})", self.lazy_frame_domain)
+    }
+}
+
+impl Clone for CsvDomain {
+    fn clone(&self) -> Self {
+        Self {
+            lazy_frame_domain: self.lazy_frame_domain.clone(),
+            reader: self.reader.clone(),
+        }
+    }
+}
+
+impl<D: DatasetMetric> MetricSpace for (CsvDomain, D) {
+    fn check(&self) -> bool {
+        true
+    }
+}
+
+pub struct ParquetDomain {
+    pub lazy_frame_domain: LazyFrameDomain,
+    pub scan_args_parquet: ScanArgsParquet,
+}
+
+impl Domain for ParquetDomain {
+    type Carrier = String;
+
+    fn member(&self, val: &Self::Carrier) -> Fallible<bool> {
+        self.lazy_frame_domain.member(&LazyFrame::scan_parquet(
+            PathBuf::from(val),
+            self.scan_args_parquet.clone(),
+        )?)
+    }
+}
+
+impl PartialEq for ParquetDomain {
+    fn eq(&self, other: &Self) -> bool {
+        self.lazy_frame_domain == other.lazy_frame_domain
+    }
+}
+
+impl std::fmt::Debug for ParquetDomain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ParquetDomain({:?})", self.lazy_frame_domain)
+    }
+}
+
+impl Clone for ParquetDomain {
+    fn clone(&self) -> Self {
+        Self {
+            lazy_frame_domain: self.lazy_frame_domain.clone(),
+            scan_args_parquet: self.scan_args_parquet.clone(),
+        }
+    }
+}
+
+impl<D: DatasetMetric> MetricSpace for (ParquetDomain, D) {
+    fn check(&self) -> bool {
+        true
+    }
+}

--- a/rust/src/domains/polars/series/mod.rs
+++ b/rust/src/domains/polars/series/mod.rs
@@ -9,9 +9,6 @@ use polars::prelude::*;
 
 use crate::domains::{AtomDomain, OptionDomain};
 
-#[cfg(feature = "ffi")]
-mod ffi;
-
 #[derive(Clone)]
 pub struct SeriesDomain {
     pub field: Field,

--- a/rust/src/domains/polars/series/mod.rs
+++ b/rust/src/domains/polars/series/mod.rs
@@ -1,0 +1,238 @@
+use std::any::Any;
+use std::fmt::Debug;
+use std::rc::Rc;
+
+use crate::error::Fallible;
+use crate::{core::Domain, traits::CheckAtom};
+
+use polars::prelude::*;
+
+use crate::domains::{AtomDomain, OptionDomain};
+
+#[cfg(feature = "ffi")]
+mod ffi;
+
+#[derive(Clone)]
+pub struct SeriesDomain {
+    pub field: Field,
+    pub element_domain: Rc<dyn DynSeriesAtomDomain>,
+    pub nullable: bool,
+}
+
+impl core::cmp::PartialEq for SeriesDomain {
+    fn eq(&self, other: &Self) -> bool {
+        self.field.eq(&other.field) && self.element_domain.eq(&self.element_domain)
+    }
+}
+
+impl Domain for SeriesDomain {
+    type Carrier = Series;
+    fn member(&self, value: &Self::Carrier) -> Fallible<bool> {
+        if &self.field != &*value.field() {
+            return Ok(false);
+        }
+
+        macro_rules! atom_member {
+            ($ty:ty, $polars_ty:ty) => {{
+                let atom_domain = self
+                    .element_domain
+                    .as_any()
+                    .downcast_ref::<AtomDomain<<$ty as ToOwned>::Owned>>()
+                    .ok_or_else(|| err!(FailedCast, "domain downcast failed"))?;
+
+                let chunked = value.0.unpack::<$polars_ty>()?;
+                if !self.nullable && chunked.null_count() > 0 {
+                    return Ok(false);
+                }
+
+                for arr in chunked.downcast_iter() {
+                    for v in arr.values_iter() {
+                        if !atom_domain.member(&v.to_owned())? {
+                            return Ok(false);
+                        }
+                    }
+                }
+                Ok(true)
+            }};
+        }
+
+        match self.field.dtype {
+            DataType::UInt8 => atom_member!(u8, UInt8Type),
+            DataType::UInt16 => atom_member!(u16, UInt16Type),
+            DataType::UInt32 => atom_member!(u32, UInt32Type),
+            DataType::UInt64 => atom_member!(u64, UInt64Type),
+            DataType::Int8 => atom_member!(i8, Int8Type),
+            DataType::Int16 => atom_member!(i16, Int16Type),
+            DataType::Int32 => atom_member!(i32, Int32Type),
+            DataType::Int64 => atom_member!(i64, Int64Type),
+            DataType::Float32 => atom_member!(f32, Float32Type),
+            DataType::Float64 => atom_member!(f64, Float64Type),
+            DataType::Boolean => atom_member!(bool, BooleanType),
+            DataType::Utf8 => atom_member!(str, Utf8Type),
+            _ => return fallible!(NotImplemented, "unsupported dtype: {:?}", self.field.dtype),
+        }
+    }
+}
+
+impl SeriesDomain {
+    pub fn new<DA: 'static + SeriesAtomDomain>(name: &str, element_domain: DA) -> Self {
+        SeriesDomain {
+            field: Field::new(name, DA::Atom::dtype()),
+            element_domain: Rc::new(element_domain.atom_domain()),
+            nullable: DA::NULLABLE,
+        }
+    }
+}
+
+impl Debug for SeriesDomain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "SeriesDomain(\"{}\", {})",
+            self.field.name, self.field.dtype
+        )
+    }
+}
+
+// BEGIN UTILITY TRAITS
+
+/// Common trait for domains that can be used to describe the space of typed elements within a series.
+pub trait SeriesAtomDomain: Domain {
+    type Atom: CheckAtom + DataTypeFrom;
+    fn atom_domain(self) -> AtomDomain<Self::Atom>;
+    const NULLABLE: bool;
+}
+impl<T: CheckAtom + DataTypeFrom> SeriesAtomDomain for AtomDomain<T> {
+    type Atom = T;
+
+    fn atom_domain(self) -> AtomDomain<Self::Atom> {
+        self
+    }
+
+    const NULLABLE: bool = false;
+}
+impl<T: CheckAtom + DataTypeFrom> SeriesAtomDomain for OptionDomain<AtomDomain<T>> {
+    type Atom = T;
+
+    fn atom_domain(self) -> AtomDomain<Self::Atom> {
+        self.element_domain
+    }
+
+    const NULLABLE: bool = true;
+}
+
+/// Object-safe version of SeriesAtomDomain.
+pub trait DynSeriesAtomDomain {
+    fn as_any(&self) -> &dyn Any;
+    fn dyn_partial_eq(&self, other: &dyn DynSeriesAtomDomain) -> bool;
+}
+impl<D: 'static + SeriesAtomDomain> DynSeriesAtomDomain for D {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn dyn_partial_eq(&self, other: &dyn DynSeriesAtomDomain) -> bool {
+        (other.as_any().downcast_ref::<D>()).map_or(false, |a| self == a)
+    }
+}
+
+impl PartialEq for dyn DynSeriesAtomDomain + '_ {
+    fn eq(&self, other: &Self) -> bool {
+        self.dyn_partial_eq(other)
+    }
+}
+
+/// Utility trait to construct the Polars runtime data-type indicator from an atomic type.
+pub trait DataTypeFrom {
+    fn dtype() -> DataType;
+}
+
+macro_rules! impl_dtype_from {
+    ($ty:ty, $dt:expr) => {
+        impl DataTypeFrom for $ty {
+            fn dtype() -> DataType {
+                $dt
+            }
+        }
+    };
+}
+impl_dtype_from!(u8, DataType::UInt8);
+impl_dtype_from!(u16, DataType::UInt16);
+impl_dtype_from!(u32, DataType::UInt32);
+impl_dtype_from!(u64, DataType::UInt64);
+impl_dtype_from!(i8, DataType::Int8);
+impl_dtype_from!(i16, DataType::Int16);
+impl_dtype_from!(i32, DataType::Int32);
+impl_dtype_from!(i64, DataType::Int64);
+impl_dtype_from!(f32, DataType::Float32);
+impl_dtype_from!(f64, DataType::Float64);
+impl_dtype_from!(bool, DataType::Boolean);
+impl_dtype_from!(String, DataType::Utf8);
+
+#[cfg(test)]
+mod test_series {
+    use crate::domains::OptionDomain;
+
+    use super::*;
+
+    #[test]
+    fn test_series_new() -> Fallible<()> {
+        let series_domain = SeriesDomain::new("A", AtomDomain::<bool>::default());
+
+        let series = Series::new("A", vec![true; 50]);
+        assert!(series_domain.member(&series)?);
+        assert!(series_domain == series_domain);
+        Ok(())
+    }
+
+    #[test]
+    fn test_series_bounded() -> Fallible<()> {
+        let series_domain = SeriesDomain::new("A", AtomDomain::new_closed((1, 3))?);
+
+        let series = Series::new("A", vec![1; 50]);
+        assert!(series_domain.member(&series)?);
+
+        let series = Series::new("A", vec![4; 50]);
+        assert!(!series_domain.member(&series)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_series_nullable() -> Fallible<()> {
+        // option domain with non-nullable type
+        let series_domain =
+            SeriesDomain::new("A", OptionDomain::new(AtomDomain::<bool>::default()));
+        {
+            let series = Series::new("A", vec![Some(true), Some(false), None]);
+            assert!(series_domain.member(&series)?);
+        }
+
+        // nullable type without options
+        let series_domain = SeriesDomain::new("A", AtomDomain::<f64>::new_nullable());
+        {
+            // None is not ok, but NaN is ok
+            let series = Series::new("A", vec![Some(1.), Some(f64::NAN), None]);
+            assert!(!series_domain.member(&series)?);
+            // series made with Option::Some are ok
+            let series = Series::new("A", vec![Some(1.), Some(f64::NAN)]);
+            assert!(series_domain.member(&series)?);
+            // series made without options are ok
+            let series = Series::new("A", vec![1., f64::NAN]);
+            assert!(series_domain.member(&series)?);
+        }
+
+        // permit both kinds of nullity
+        let series_domain =
+            SeriesDomain::new("A", OptionDomain::new(AtomDomain::<f64>::new_nullable()));
+        {
+            // None and NaN are both ok
+            let series = Series::new("A", vec![Some(1.), Some(f64::NAN), None]);
+            assert!(series_domain.member(&series)?);
+            // doesn't have to have NaN
+            let series = Series::new("A", vec![1., 2.]);
+            assert!(series_domain.member(&series)?);
+        }
+
+        Ok(())
+    }
+}

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -5,6 +5,8 @@ use std::fmt::Debug;
 
 use std::backtrace::Backtrace as _Backtrace;
 
+use polars::prelude::PolarsError;
+
 /// Create an instance of [`Fallible`]
 #[macro_export]
 macro_rules! fallible {

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -123,6 +123,16 @@ impl<T> From<Error> for Result<T, Error> {
     }
 }
 
+impl From<PolarsError> for Error {
+    fn from(error: PolarsError) -> Self {
+        Self {
+            variant: ErrorVariant::FailedFunction,
+            message: Some(format!("{:?}", error)),
+            backtrace: std::backtrace::Backtrace::capture(),
+        }
+    }
+}
+
 pub type Fallible<T> = Result<T, Error>;
 
 /// A trait for calling unwrap with an explanation. Makes calls to unwrap() discoverable.


### PR DESCRIPTION
Closes #695

## Changes
* new domains:
	* `LazyFrameDomain`, `SeriesDomain`, `CsvDomain`, `ParquetDomain`
	* FFI for constructing `LazyFrameDomain` and `SeriesDomain` from Python
* new constructors:
	* `make_scan_csv` for loading a LazyFrame from a csv file
	* `make_scan_parquet` for loading a LazyFrame from a parquet file
	* `make_sink_csv` for writing a LazyFrame to a csv file


## TODO
* include margins in `LazyFrameDomain`'s FFI constructor
* FFI data loaders for LazyFrames

See `python/tests/test_polars.py` for example usage. 