### PR TITLE
Python convenience constructor for metric spaces

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
           cache: pip
 
       - name: Assert version
@@ -185,7 +185,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
           cache: pip
 
       - name: Prepare for libs
@@ -238,7 +238,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
           cache: pip
 
       - name: Publish Rust crate

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -52,7 +52,7 @@ jobs:
         working-directory: python
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -115,7 +115,7 @@ jobs:
         working-directory: docs
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OpenDP
 [![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Python](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10-blue)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-blue)](https://www.python.org/)
 [![ci tests](https://github.com/opendp/opendp/actions/workflows/smoke-test.yml/badge.svg)](https://github.com/opendp/opendp/actions/workflows/smoke-test.yml?query=branch%3Amain)
 
 The OpenDP Library is a modular collection of statistical algorithms that adhere to the definition of

--- a/docs/source/contributor/development-environment.rst
+++ b/docs/source/contributor/development-environment.rst
@@ -7,7 +7,7 @@ If you are writing code, the first task to tackle is setting up the development 
 Follow the steps below to set up an OpenDP Library development environment, including the ability to run tests in both Rust and Python.
 
 * Install the `Rust toolchain <https://www.rust-lang.org/tools/install>`_.
-* Install `Python version 3.7 or higher <https://www.python.org>`_.
+* Install `Python version 3.8 or higher <https://www.python.org>`_.
 
 
 Clone the OpenDP Repo

--- a/docs/source/user/installation.rst
+++ b/docs/source/user/installation.rst
@@ -12,7 +12,7 @@ Platforms
 
 OpenDP is built for the following platforms:
 
-* Python 3.7-3.10
+* Python 3.8-3.11
 * Linux, x86 64-bit, versions compatible with `manylinux <https://github.com/pypa/manylinux>`_ (others may work)
 * macOS, x86 64-bit, version 10.13 or later
 * Windows, x86 64-bit, version 7 or later

--- a/docs/source/user/programming-framework/supporting-elements.rst
+++ b/docs/source/user/programming-framework/supporting-elements.rst
@@ -69,18 +69,17 @@ Let's look at the Transformation returned from :py:func:`make_bounded_sum(bounds
   >>> enable_features('contrib')
   >>> from opendp.transformations import make_bounded_sum
   >>> bounded_sum = make_bounded_sum(bounds=(0, 1))
-  >>> bounded_sum.input_domain.type
-  'VectorDomain<AtomDomain<i32>>'
+  >>> bounded_sum.input_domain
+  VectorDomain(AtomDomain(bounds=[0, 1], T=i32))
 
-The input domain is ``VectorDomain<AtomDomain<i32>>``, or "the set of all vectors of 32-bit signed integers bounded between 0 and 1."
+We see that the input domain is "the set of all vectors of 32-bit signed integers bounded between 0 and 1."
 
 .. doctest::
 
-  >>> bounded_sum.output_domain.type
-  'AtomDomain<i32>'
+  >>> bounded_sum.output_domain
+  AtomDomain(T=i32)
 
-
-The output domain is simply ``AtomDomain<i32>``, or "the set of all 32-bit signed integers."
+The output domain is "the set of all 32-bit signed integers."
 
 These domains serve two purposes:
 

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -21,7 +21,7 @@ keywords =
 
 [options]
 zip_safe = false
-python_requires = >=3.7
+python_requires = >=3.8
 packages = find:
 package_dir =
     = src

--- a/python/src/opendp/domains.py
+++ b/python/src/opendp/domains.py
@@ -10,6 +10,7 @@ __all__ = [
     "domain_carrier_type",
     "domain_debug",
     "domain_type",
+    "map_domain",
     "member",
     "option_domain",
     "vector_domain"
@@ -161,6 +162,36 @@ def domain_type(
     lib_function.restype = FfiResult
     
     output = c_to_py(unwrap(lib_function(c_this), ctypes.c_char_p))
+    
+    return output
+
+
+@versioned
+def map_domain(
+    key_domain,
+    value_domain
+):
+    """Construct an instance of `MapDomain`.
+    
+    [map_domain in Rust documentation.](https://docs.rs/opendp/latest/opendp/domains/fn.map_domain.html)
+    
+    :param key_domain: domain of keys in the hashmap
+    :param value_domain: domain of values in the hashmap
+    :raises TypeError: if an argument's type differs from the expected type
+    :raises UnknownTypeError: if a type argument fails to parse
+    :raises OpenDPException: packaged error from the core OpenDP library
+    """
+    # No type arguments to standardize.
+    # Convert arguments to c types.
+    c_key_domain = py_to_c(key_domain, c_type=Domain, type_name=AnyDomain)
+    c_value_domain = py_to_c(value_domain, c_type=Domain, type_name=AnyDomain)
+    
+    # Call library function.
+    lib_function = lib.opendp_domains__map_domain
+    lib_function.argtypes = [Domain, Domain]
+    lib_function.restype = FfiResult
+    
+    output = c_to_py(unwrap(lib_function(c_key_domain, c_value_domain), Domain))
     
     return output
 

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -872,7 +872,9 @@ def exponential_bounds_search(
 
 
 def space_of(T, M=None, infer=False) -> Tuple[Domain, Metric]:
-    """A shorthand for building a metric space, consisting of a domain and a metric.
+    """A shorthand for building a metric space.
+     
+    A metric space consists of a domain and a metric.
 
     :example:
 
@@ -881,7 +883,6 @@ def space_of(T, M=None, infer=False) -> Tuple[Domain, Metric]:
     ...
     >>> dp.space_of(List[int])
     (VectorDomain(AtomDomain(T=i32)), SymmetricDistance())
-    ...
     >>> # the verbose form allows greater control:
     >>> (dp.vector_domain(dp.atom_domain(T=dp.i32)), dp.symmetric_distance())
     (VectorDomain(AtomDomain(T=i32)), SymmetricDistance())

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -54,7 +54,7 @@ RuntimeTypeDescriptor = Union[
     tuple,  # shorthand for tuples -- (float, "f64"); (ChangeOneDistance, List[int])
 ]
 
-if sys.version_info >= (3, 7):
+if sys.version_info >= (3, 8):
     from typing import _GenericAlias
     # a Python type hint from the std typing module -- List[int]
     RuntimeTypeDescriptor.__args__ = RuntimeTypeDescriptor.__args__ + (_GenericAlias,)
@@ -157,14 +157,14 @@ class RuntimeType(object):
 
         # parse type hints from the typing module
         hinted_type = None
+        if sys.version_info >= (3, 8):
+            from typing import _GenericAlias
+            if isinstance(type_name, _GenericAlias):
+                hinted_type = typing.get_origin(type_name), typing.get_args(type_name)
         if sys.version_info >= (3, 9):
             from types import GenericAlias
             if isinstance(type_name, GenericAlias):
                 hinted_type = type_name.__origin__, type_name.__args__
-        if sys.version_info >= (3, 7):
-            from typing import _GenericAlias
-            if isinstance(type_name, _GenericAlias):
-                hinted_type = typing.get_origin(type_name), typing.get_args(type_name)
     
         if hinted_type:
             origin, args = hinted_type

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -54,7 +54,7 @@ RuntimeTypeDescriptor = Union[
     tuple,  # shorthand for tuples -- (float, "f64"); (ChangeOneDistance, List[int])
 ]
 
-if sys.version_info >= (3, 8):
+if sys.version_info >= (3, 7):
     from typing import _GenericAlias
     # a Python type hint from the std typing module -- List[int]
     RuntimeTypeDescriptor.__args__ = RuntimeTypeDescriptor.__args__ + (_GenericAlias,)
@@ -161,7 +161,7 @@ class RuntimeType(object):
             from types import GenericAlias
             if isinstance(type_name, GenericAlias):
                 hinted_type = type_name.__origin__, type_name.__args__
-        if sys.version_info >= (3, 8):
+        if sys.version_info >= (3, 7):
             from typing import _GenericAlias
             if isinstance(type_name, _GenericAlias):
                 hinted_type = typing.get_origin(type_name), typing.get_args(type_name)

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -403,22 +403,8 @@ class RuntimeType(object):
         if T in ATOM_MAP:
             return RuntimeType(origin="AtomDomain", args=[T])
 
-        raise TypeError(f"domain_of not implemented for type {T}")
+        raise TypeError(f"domain_type_of is not implemented for type {T}")
     
-    @classmethod
-    def metric_type_of(cls, D, U=None) -> "RuntimeType":
-        """Converts a carrier type to a domain type."""
-        
-        D = RuntimeType.parse(D)
-
-        if D.origin == "VectorDomain":
-            return SymmetricDistance
-        elif D.origin == "AtomDomain":
-            return AbsoluteDistance[U or get_atom(D)]
-        elif D.origin == "Option":
-            U = D.params[0]
-        raise TypeError(f"unable to infer default metric for domain {D}")
-
 
 class GenericType(RuntimeType):
     def __str__(self):
@@ -438,18 +424,10 @@ class UnknownType(RuntimeType):
         raise UnknownTypeException(f"attempted to create a type_name with an unknown type: {self.reason}")
 
 
-class DatasetMetric(RuntimeType):
-    """All dataset metric RuntimeTypes inherit from DatasetMetric.
-    Provides static type checking in user-code for dataset metrics.
-    """
-    pass
-
-
-SymmetricDistance = DatasetMetric('SymmetricDistance')
-InsertDeleteDistance = DatasetMetric('InsertDeleteDistance')
-
-ChangeOneDistance = DatasetMetric('ChangeOneDistance')
-HammingDistance = DatasetMetric('HammingDistance')
+SymmetricDistance = 'SymmetricDistance'
+InsertDeleteDistance = 'InsertDeleteDistance'
+ChangeOneDistance = 'ChangeOneDistance'
+HammingDistance = 'HammingDistance'
 
 
 class SensitivityMetric(RuntimeType):
@@ -463,6 +441,7 @@ class SensitivityMetric(RuntimeType):
 AbsoluteDistance = SensitivityMetric('AbsoluteDistance')
 L1Distance = SensitivityMetric('L1Distance')
 L2Distance = SensitivityMetric('L2Distance')
+DiscreteDistance = SensitivityMetric('DiscreteDistance')
 
 
 class PrivacyMeasure(RuntimeType):

--- a/python/test/test_space_of.py
+++ b/python/test/test_space_of.py
@@ -1,0 +1,17 @@
+import opendp.prelude as dp
+
+
+def test_space_of_infer():
+    space = dp.space_of([1, 3], infer=True)
+    assert space == (dp.vector_domain(dp.atom_domain(T=dp.i32)), dp.symmetric_distance())
+
+
+def test_space_of_typed():
+    space = dp.space_of(list[int])
+    assert space == (dp.vector_domain(dp.atom_domain(T=dp.i32)), dp.symmetric_distance())
+
+    space = dp.space_of(list[int], M=dp.L1Distance)
+    assert space == (dp.vector_domain(dp.atom_domain(T=dp.i32)), dp.l1_distance(T=dp.i32))
+
+    space = dp.space_of(float)
+    assert space == (dp.atom_domain(T=dp.f64), dp.absolute_distance(T=dp.f64))

--- a/python/test/test_space_of.py
+++ b/python/test/test_space_of.py
@@ -1,17 +1,40 @@
 import opendp.prelude as dp
 
+def test_space_of_typed():
+    # metric defaults to symmetric_distance on vector_domain
+    space = dp.space_of(list[int])
+    assert space == (dp.vector_domain(dp.atom_domain(T=dp.i32)), dp.symmetric_distance())
+
+    # can specify metric explicitly. If not fully specified, will infer distance type from domain
+    space = dp.space_of(list[int], M=dp.L1Distance)
+    assert space == (dp.vector_domain(dp.atom_domain(T=dp.i32)), dp.l1_distance(T=dp.i32))
+
+    # when type is scalar, domain defaults to atom_domain and metric defaults to absolute_distance
+    space = dp.space_of(float)
+    assert space == (dp.atom_domain(T=dp.f64), dp.absolute_distance(T=dp.f64))
+
+    space = dp.space_of(int, M=dp.DiscreteDistance)
+    assert space == (dp.atom_domain(T=dp.f64), dp.discrete_distance())
+
+    space = dp.space_of(int, M="DiscreteDistance")
+    assert space == (dp.atom_domain(T=dp.f64), dp.discrete_distance())
+
 
 def test_space_of_infer():
     space = dp.space_of([1, 3], infer=True)
     assert space == (dp.vector_domain(dp.atom_domain(T=dp.i32)), dp.symmetric_distance())
 
-
-def test_space_of_typed():
-    space = dp.space_of(list[int])
-    assert space == (dp.vector_domain(dp.atom_domain(T=dp.i32)), dp.symmetric_distance())
-
-    space = dp.space_of(list[int], M=dp.L1Distance)
+    space = dp.space_of([1, 3], infer=True, M=dp.L1Distance)
     assert space == (dp.vector_domain(dp.atom_domain(T=dp.i32)), dp.l1_distance(T=dp.i32))
 
-    space = dp.space_of(float)
+    space = dp.space_of(1.0, infer=True)
     assert space == (dp.atom_domain(T=dp.f64), dp.absolute_distance(T=dp.f64))
+
+    space = dp.space_of(1, infer=True, M=dp.DiscreteDistance)
+    assert space == (dp.atom_domain(T=dp.f64), dp.discrete_distance())
+
+    space = dp.space_of(1, infer=True, M="DiscreteDistance")
+    assert space == (dp.atom_domain(T=dp.f64), dp.discrete_distance())
+
+    
+test_space_of_typed()

--- a/python/test/test_space_of.py
+++ b/python/test/test_space_of.py
@@ -1,26 +1,31 @@
 import opendp.prelude as dp
+from typing import Dict, List
 
-def test_space_of_typed():
+def test_typed_space_of():
     # metric defaults to symmetric_distance on vector_domain
-    space = dp.space_of(list[int])
+    space = dp.space_of(List[int])  # can also do list[int] if python 3.8+
     assert space == (dp.vector_domain(dp.atom_domain(T=dp.i32)), dp.symmetric_distance())
 
     # can specify metric explicitly. If not fully specified, will infer distance type from domain
-    space = dp.space_of(list[int], M=dp.L1Distance)
+    space = dp.space_of(List[int], dp.L1Distance)
     assert space == (dp.vector_domain(dp.atom_domain(T=dp.i32)), dp.l1_distance(T=dp.i32))
 
     # when type is scalar, domain defaults to atom_domain and metric defaults to absolute_distance
     space = dp.space_of(float)
     assert space == (dp.atom_domain(T=dp.f64), dp.absolute_distance(T=dp.f64))
 
-    space = dp.space_of(int, M=dp.DiscreteDistance)
-    assert space == (dp.atom_domain(T=dp.f64), dp.discrete_distance())
+    # the variable from typing and a string are interchangeable
+    space = dp.space_of(int, "DiscreteDistance")
+    assert space == (dp.atom_domain(T=dp.i32), dp.discrete_distance())
 
-    space = dp.space_of(int, M="DiscreteDistance")
-    assert space == (dp.atom_domain(T=dp.f64), dp.discrete_distance())
+    # can also pass an actual metric
+    space = dp.space_of(int, dp.discrete_distance())
+    assert space == (dp.atom_domain(T=dp.i32), dp.discrete_distance())
 
+    space = dp.space_of(Dict[str, int], dp.L1Distance[int])
+    assert space == (dp.map_domain(dp.atom_domain(T=dp.String), dp.atom_domain(T=dp.i32)), dp.l1_distance(T=dp.i32))
 
-def test_space_of_infer():
+def test_infer_space_of():
     space = dp.space_of([1, 3], infer=True)
     assert space == (dp.vector_domain(dp.atom_domain(T=dp.i32)), dp.symmetric_distance())
 
@@ -31,10 +36,7 @@ def test_space_of_infer():
     assert space == (dp.atom_domain(T=dp.f64), dp.absolute_distance(T=dp.f64))
 
     space = dp.space_of(1, infer=True, M=dp.DiscreteDistance)
-    assert space == (dp.atom_domain(T=dp.f64), dp.discrete_distance())
+    assert space == (dp.atom_domain(T=dp.i32), dp.discrete_distance())
 
     space = dp.space_of(1, infer=True, M="DiscreteDistance")
-    assert space == (dp.atom_domain(T=dp.f64), dp.discrete_distance())
-
-    
-test_space_of_typed()
+    assert space == (dp.atom_domain(T=dp.i32), dp.discrete_distance())

--- a/python/test/test_typing.py
+++ b/python/test/test_typing.py
@@ -22,12 +22,12 @@ def test_numpy_function():
 
 
 def test_typing_hint():
-    # Python < 3.8 should raise a NotImplementedError
+    # Python < 3.8 should raise an exception
     if sys.version_info < (3, 8):
         try:
             assert str(RuntimeType.parse(Tuple[int, float])) == "(i32, f64)"
             raise Exception("typing hints should fail with error below Python 3.8")
-        except NotImplementedError:
+        except:
             # on Python < 3.8 the remaining tests do not apply
             return
 

--- a/python/test/test_typing.py
+++ b/python/test/test_typing.py
@@ -36,7 +36,6 @@ def test_typing_hint():
     assert str(RuntimeType.parse(List[int])) == "Vec<i32>"
     assert str(RuntimeType.parse(List[List[str]])) == "Vec<Vec<String>>"
     assert str(RuntimeType.parse((List[int], (int, bool)))) == '(Vec<i32>, (i32, bool))'
-    assert isinstance(RuntimeType.parse('ChangeOneDistance'), DatasetMetric)
     assert isinstance(RuntimeType.parse('L1Distance<f64>'), SensitivityMetric)
 
     try:

--- a/rust/src/ffi/util.rs
+++ b/rust/src/ffi/util.rs
@@ -16,7 +16,7 @@ use crate::measures::{
 };
 use crate::metrics::{
     AbsoluteDistance, ChangeOneDistance, HammingDistance, InsertDeleteDistance, L1Distance,
-    L2Distance, SymmetricDistance,
+    L2Distance, SymmetricDistance, DiscreteDistance,
 };
 use crate::{err, fallible};
 
@@ -277,6 +277,7 @@ lazy_static! {
 
             // metrics
             type_vec![ChangeOneDistance, SymmetricDistance, InsertDeleteDistance, HammingDistance],
+            type_vec![DiscreteDistance],
             type_vec![AbsoluteDistance, <u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64>],
             type_vec![L1Distance, <u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64>],
             type_vec![L2Distance, <u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64>],


### PR DESCRIPTION
Closes #748

Adds a convenience constructor for building metric spaces in Python.

```python
import opendp.prelude as dp

# current form
(dp.vector_domain(dp.atom_domain(T=dp.i32)), dp.symmetric_distance())

# shortened form
dp.space_of(list[int])

# used like so:
dp.space_of(list[int]) >> dp.t.partial_clamp((0, 10))
```

As a whole, the library is moving towards specifying the input domain and input metric up-front. This helper gives a simpler alternative to learning a set of domain/metric builder APIs.

This PR also addresses some nits:
* FFI for `map_domain` (which we had missed before)
* updates typing code to work with [Python 3.9 type annotations](https://docs.python.org/3.9/whatsnew/3.9.html#type-hinting-generics-in-standard-collections) (like `list[int]`)
* registers DiscreteDomain among the FFI types (which we had missed before)
* increases minimum Python version to 3.8 for `typing.get_origin` (3.7 is EOL in 1 month)