### PR TITLE
update sparse histogram api

### DIFF
--- a/rust/src/domains/mod.rs
+++ b/rust/src/domains/mod.rs
@@ -117,6 +117,9 @@ impl<T: CheckAtom> AtomDomain<T> {
         }
         Ok(())
     }
+    pub fn bounds(&self) -> Option<&Bounds<T>> {
+        self.bounds.as_ref()
+    }
 }
 impl<T: CheckAtom + InherentNull> AtomDomain<T> {
     pub fn new_nullable() -> Self {
@@ -234,6 +237,20 @@ impl<T: TotalOrd> Bounds<T> {
         }
         Ok(Bounds { lower, upper })
     }
+    pub fn lower(&self) -> Option<&T> {
+        match &self.lower {
+            Bound::Included(v) => Some(v),
+            Bound::Excluded(v) => Some(v),
+            Bound::Unbounded => None,
+        }
+    }
+    pub fn upper(&self) -> Option<&T> {
+        match &self.upper {
+            Bound::Included(v) => Some(v),
+            Bound::Excluded(v) => Some(v),
+            Bound::Unbounded => None,
+        }
+    }
 }
 impl<T: Clone> Bounds<T> {
     pub fn get_closed(&self) -> Fallible<(T, T)> {
@@ -304,7 +321,7 @@ impl<T: Clone + TotalOrd> Bounds<T> {
 /// assert!(!domain.member(&hashmap)?);
 /// # opendp::error::Fallible::Ok(())
 /// ```
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, Default)]
 pub struct MapDomain<DK: Domain, DV: Domain>
 where
     DK::Carrier: Eq + Hash,

--- a/rust/src/interactive/mod.rs
+++ b/rust/src/interactive/mod.rs
@@ -175,6 +175,19 @@ where
             },
         )
     }
+
+    pub(crate) fn new_raw_external(
+        mut transition: impl FnMut(&Q) -> Fallible<A> + 'static,
+    ) -> Self {
+        Queryable::new_raw(
+            move |_self: &Self, query: Query<Q>| -> Fallible<Answer<A>> {
+                match query {
+                    Query::External(q) => transition(q).map(Answer::External),
+                    Query::Internal(_) => fallible!(FailedFunction, "unrecognized internal query"),
+                }
+            },
+        )
+    }
 }
 
 // manually implemented instead of derived so that Q and A don't have to be Clone

--- a/rust/src/measurements/alp/mod.rs
+++ b/rust/src/measurements/alp/mod.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
 
-use num::{Integer, ToPrimitive};
-use rug::{float::Round, ops::AddAssignRound, ops::DivAssignRound, Float};
+use num::ToPrimitive;
+use rug::{float::Round, ops::AddAssignRound, ops::DivAssignRound, Float as RugFloat};
 
 use crate::core::{Function, Measurement, MetricSpace, PrivacyMap};
 use crate::domains::{AtomDomain, MapDomain};
@@ -12,7 +12,7 @@ use crate::interactive::Queryable;
 use crate::measures::MaxDivergence;
 use crate::metrics::L1Distance;
 use crate::traits::samplers::{fill_bytes, SampleBernoulli};
-use crate::traits::{CheckAtom, DistanceConstant, Float as TFloat, InfCast};
+use crate::traits::{Float, Hashable, InfCast, Integer};
 use std::collections::hash_map::DefaultHasher;
 
 const ALPHA_DEFAULT: u32 = 4;
@@ -30,36 +30,41 @@ type SparseDomain<K, C> = MapDomain<AtomDomain<K>, AtomDomain<C>>;
 
 // Types used to store the DP projection.
 type BitVector = Vec<bool>;
-type HashFunctions<K> = Vec<Rc<dyn Fn(&K) -> usize>>;
+type HashFunction<K> = Rc<dyn Fn(&K) -> usize>;
+
 #[derive(Clone)]
 #[doc(hidden)]
 pub struct AlpState<K, T> {
     alpha: T,
     scale: T,
-    h: HashFunctions<K>,
+    hashers: Vec<HashFunction<K>>,
     z: BitVector,
 }
 
-// hash function with type: [2^64] -> [2^l]
-// Computes ((a*x + b) mod 2^64) div 2^(64-l)
-// a and b are sampled uniformly at random from [2^64]
-// a must be odd
-// The hash function is 2-approximate universal and uniform
-// See http://hjemmesider.diku.dk/~jyrki/Paper/CP-11.4.1997.pdf
-// "A Reliable Randomized Algorithm for the Closest-Pair Problem"
-fn hash(x: u64, a: u64, b: u64, l: u32) -> usize {
-    (a.wrapping_mul(x).wrapping_add(b) >> (64 - l)) as usize
-}
+/// Hash a key of type K into a u64
 fn pre_hash<K: Hash>(x: K) -> u64 {
     let mut hasher = DefaultHasher::new();
     x.hash(&mut hasher);
     hasher.finish()
 }
 
-fn sample_hash_function<K>(l: u32) -> Fallible<Rc<dyn Fn(&K) -> usize>>
-where
-    K: Clone + Hash,
-{
+/// A hash function with type: [2^64] -> [2^l]
+///
+/// Computes ((a*x + b) mod 2^64) div 2^(64-l)
+/// * where a and b are sampled uniformly at random from [2^64]
+/// * where a must be odd
+/// * where l must be lt 64
+///
+/// The hash function is 2-approximate universal and uniform.
+/// See http://hjemmesider.diku.dk/~jyrki/Paper/CP-11.4.1997.pdf
+/// "A Reliable Randomized Algorithm for the Closest-Pair Problem"
+fn hash(x: u64, a: u64, b: u64, l: u32) -> usize {
+    (a.wrapping_mul(x).wrapping_add(b) >> (64 - l)) as usize
+}
+
+/// Samples a random hash function with type: K -> [2^l]
+/// * where l must be lt 64
+fn sample_hash_function<K: Hash>(l: u32) -> Fallible<Rc<dyn Fn(&K) -> usize>> {
     let mut buf = [0u8; 8];
     fill_bytes(&mut buf)?;
     let a = u64::from_ne_bytes(buf) | 1u64;
@@ -68,7 +73,7 @@ where
     Ok(Rc::new(move |x: &K| hash(pre_hash(x), a, b, l)))
 }
 
-// Returns ceil(log_2(x))
+/// Computes ceil(log_2(x))
 fn exponent_next_power_of_two(x: u64) -> u32 {
     let exp = 63 - x.leading_zeros();
     if x > (1 << exp) {
@@ -79,24 +84,24 @@ fn exponent_next_power_of_two(x: u64) -> u32 {
 }
 
 // Multiplies x with scale/alpha and applies randomized rounding to return an integer
-fn scale_and_round<C, T>(x: C, alpha: T, scale: T) -> Fallible<usize>
+fn scale_and_round<CI, CO>(x: CI, alpha: CO, scale: CO) -> Fallible<usize>
 where
-    C: Integer + ToPrimitive,
-    T: InfCast<Float>,
-    Float: InfCast<T>,
+    CI: Integer + ToPrimitive,
+    CO: InfCast<RugFloat>,
+    RugFloat: InfCast<CO>,
 {
-    let mut scalar = Float::neg_inf_cast(scale)?;
-    scalar.div_assign_round(Float::inf_cast(alpha)?, Round::Down);
+    let mut scale = RugFloat::neg_inf_cast(scale)?;
+    scale.div_assign_round(RugFloat::inf_cast(alpha)?, Round::Down);
     // Truncate bits that represents values below 2^-53
-    scalar.set_prec_round(
-        (f64::MANTISSA_DIGITS as i32 - scalar.get_exp().unwrap()).max(1) as u32,
+    scale.set_prec_round(
+        (f64::MANTISSA_DIGITS as i32 - scale.get_exp().unwrap()).max(1) as u32,
         Round::Down,
     );
 
-    let r = Float::with_val(
+    let r = RugFloat::with_val(
         f64::MANTISSA_DIGITS * 2,
-        x.max(C::zero()).to_u64().unwrap_or_default(),
-    ) * scalar;
+        x.max(CI::zero()).to_u64().unwrap_or_else(|| u64::MAX),
+    ) * scale;
     let floored = f64::inf_cast(r.clone().floor())? as usize;
 
     match bool::sample_bernoulli(f64::inf_cast(r.fract())?, false)? {
@@ -106,46 +111,50 @@ where
 }
 
 // Probability of flipping bits = 1 / (alpha + 2)
-fn compute_prob<T: InfCast<Float>>(alpha: T) -> f64
+fn compute_prob<T: InfCast<RugFloat>>(alpha: T) -> f64
 where
-    Float: InfCast<T>,
+    RugFloat: InfCast<T>,
 {
-    let mut a = Float::neg_inf_cast(alpha).expect("impl is infallible");
-    a.add_assign_round(2, Round::Down);
-    a.recip_round(Round::Up);
+    let mut alpha = RugFloat::neg_inf_cast(alpha).expect("impl is infallible");
+    alpha.add_assign_round(2, Round::Down);
+    alpha.recip_round(Round::Up);
     // Round up to preserve privacy
-    f64::inf_cast(a).expect("impl is infallible")
+    f64::inf_cast(alpha).expect("impl is infallible")
 }
 
-// Due to privacy concerns the current implementation discards bits with significance less than 2^-52 from scale/alpha
-// Concern (Mike): validate that this constant remains correct when T is parameterized by f32
-fn check_parameters<T: InfCast<Float>>(alpha: T, scale: T) -> bool
+/// Reject any choice of `scale` or `alpha` such that `scale / alpha < 2^-52`
+///
+/// Due to privacy concerns the current implementation discards bits with significance less than 2^-52 from scale/alpha
+fn are_parameters_invalid<T: InfCast<RugFloat>>(alpha: T, scale: T) -> bool
 where
-    Float: InfCast<T>,
+    RugFloat: InfCast<T>,
 {
-    let scale = Float::inf_cast(scale).expect("impl is infallible");
-    let alpha = Float::neg_inf_cast(alpha).expect("impl is infallible");
-    scale * Float::with_val(53, 52).exp2() < alpha
+    let scale = RugFloat::inf_cast(scale).expect("impl is infallible");
+    let alpha = RugFloat::neg_inf_cast(alpha).expect("impl is infallible");
+    scale * RugFloat::with_val(53, 52).exp2() < alpha
 }
 
-// Computes the DP projection. This corresponds to Algorithm 4 in the paper
-fn compute_projection<K, C, T>(
-    x: &HashMap<K, C>,
-    h: &HashFunctions<K>,
-    alpha: T,
-    scale: T,
-    s: usize,
+/// Computes the DP projection.
+///
+/// Corresponds to Algorithm 4 in the paper
+fn compute_projection<K, CI, CO>(
+    x: &HashMap<K, CI>,
+    hashers: &Vec<HashFunction<K>>, // h
+    alpha: CO,
+    scale: CO,
+    projection_size: usize, // s
 ) -> Fallible<BitVector>
 where
-    C: Clone + Integer + ToPrimitive,
-    T: Clone + InfCast<Float>,
-    Float: InfCast<T>,
+    CI: Integer + ToPrimitive,
+    CO: Clone + InfCast<RugFloat>,
+    RugFloat: InfCast<CO>,
 {
-    let mut z = vec![false; s];
+    let mut z = vec![false; projection_size];
 
     for (k, v) in x.iter() {
         let round = scale_and_round(v.clone(), alpha.clone(), scale.clone())?;
-        h.iter().take(round).for_each(|f| z[f(k) % s] = true); // ^= true TODO: Hash collisions can be handled using OR or XOR
+        // ^= true TODO: Hash collisions can be handled using OR or XOR
+        (hashers.iter().take(round)).for_each(|h_i| z[h_i(k) % projection_size] = true);
     }
 
     let p = compute_prob(alpha);
@@ -155,11 +164,10 @@ where
         .collect()
 }
 
-// Estimate the value of an entry based on its noisy bitrepresentation. This is Algorithm 3 in the paper
-fn estimate_unary<T>(v: &Vec<bool>) -> T
-where
-    T: num::Float,
-{
+/// Estimate the value of an entry based on its noisy bit representation.
+///
+/// Corresponds to Algorithm 3 in the paper
+fn estimate_unary<T: num::Float>(v: &Vec<bool>) -> T {
     let mut prefix_sum = Vec::with_capacity(v.len() + 1usize);
     prefix_sum.push(0);
 
@@ -178,18 +186,15 @@ where
     T::from(peaks.iter().sum::<usize>()).unwrap() / T::from(peaks.len()).unwrap()
 }
 
-// This is Algorithm 5 in the paper
-fn compute_estimate<K, T>(state: &AlpState<K, T>, key: &K) -> T
-where
-    T: num::Float,
-{
-    let v = state
-        .h
-        .iter()
-        .map(|f| state.z[f(key) % state.z.len()])
+/// Estimates the value of an entry based on its noisy bit representation.
+///
+/// Corresponds to Algorithm 5 in the paper
+fn compute_estimate<K, C: num::Float>(state: &AlpState<K, C>, key: &K) -> C {
+    let v = (state.hashers.iter())
+        .map(|h_i| state.z[h_i(key) % state.z.len()])
         .collect::<Vec<_>>();
 
-    estimate_unary::<T>(&v) * T::from(state.alpha).unwrap() / state.scale
+    estimate_unary::<C>(&v) * C::from(state.alpha).unwrap() / state.scale
 }
 
 /// Measurement to compute a DP projection of bounded sparse data.
@@ -202,35 +207,41 @@ where
 ///   Algorithm 4
 ///
 /// # Arguments
+/// * `scale` - Privacy loss parameter. Equal to epsilon/sensitivity.
 /// * `alpha` - Parameter used for scaling and determining p in randomized response step. The default value is 4.
-/// * `scale` - Privacy loss parameter. This is equal to epsilon/sensitivity.
-/// * `s` - Size of the projection. This should be sufficiently large to limit hash collisions.
-/// * `h` - Hash functions used to project and estimate entries. The hash functions are not allowed to panic on any input.
+/// * `projection_size` - Should be sufficiently large to limit hash collisions.
+/// * `hashers` - Hash functions used to project and estimate entries. The hash functions are not allowed to panic on any input.
 /// The hash functions in `h` should have type K -> \[s\]. To limit collisions the functions should be universal and uniform.
 /// The evaluation time of post-processing is O(h.len()).
-pub fn make_base_alp_with_hashers<K, C, T>(
-    alpha: T,
-    scale: T,
-    s: usize,
-    h: HashFunctions<K>,
-) -> Fallible<Measurement<SparseDomain<K, C>, AlpState<K, T>, L1Distance<C>, MaxDivergence<T>>>
+pub fn make_alp_state_with_hashers<K, CI, CO>(
+    input_domain: SparseDomain<K, CI>,
+    input_metric: L1Distance<CI>,
+    scale: CO,
+    alpha: CO,
+    projection_size: usize,
+    hashers: Vec<HashFunction<K>>,
+) -> Fallible<Measurement<SparseDomain<K, CI>, AlpState<K, CO>, L1Distance<CI>, MaxDivergence<CO>>>
 where
-    K: 'static + Eq + Hash + CheckAtom,
-    C: 'static + Clone + Integer + CheckAtom + DistanceConstant<C> + ToPrimitive,
-    T: 'static + num::Float + DistanceConstant<T> + InfCast<Float> + InfCast<C>,
-    Float: InfCast<T>,
-    (SparseDomain<K, C>, L1Distance<C>): MetricSpace,
+    K: 'static + Hashable,
+    CI: 'static + Integer + ToPrimitive,
+    CO: 'static + Float + InfCast<RugFloat> + InfCast<CI>,
+    RugFloat: InfCast<CO>,
+    (SparseDomain<K, CI>, L1Distance<CI>): MetricSpace,
 {
-    if alpha.is_sign_negative() || alpha.is_zero() {
-        return fallible!(MakeMeasurement, "alpha must be positive");
+    if input_domain.value_domain.nullable() {
+        return fallible!(MakeMeasurement, "value domain must be non-nullable");
     }
+
     if scale.is_sign_negative() || scale.is_zero() {
         return fallible!(MakeMeasurement, "scale must be positive");
     }
-    if s == 0 {
-        return fallible!(MakeMeasurement, "s can not be zero");
+    if alpha.is_sign_negative() || alpha.is_zero() {
+        return fallible!(MakeMeasurement, "alpha must be positive");
     }
-    if check_parameters(alpha, scale) {
+    if projection_size == 0 {
+        return fallible!(MakeMeasurement, "projection_size must be positive");
+    }
+    if are_parameters_invalid(alpha, scale) {
         return fallible!(
             MakeMeasurement,
             "scale divided by alpha must be above 2^-52"
@@ -238,20 +249,17 @@ where
     }
 
     Measurement::new(
-        MapDomain {
-            key_domain: AtomDomain::default(),
-            value_domain: AtomDomain::default(),
-        },
-        Function::new_fallible(move |x: &HashMap<K, C>| {
-            let z = compute_projection(x, &h, alpha, scale, s)?;
+        input_domain,
+        Function::new_fallible(move |x: &HashMap<K, CI>| {
+            let z = compute_projection(x, &hashers, alpha, scale, projection_size)?;
             Ok(AlpState {
                 alpha,
                 scale,
-                h: h.clone(),
+                hashers: hashers.clone(),
                 z,
             })
         }),
-        L1Distance::default(),
+        input_metric,
         MaxDivergence::default(),
         PrivacyMap::new_from_constant(scale),
     )
@@ -259,86 +267,127 @@ where
 
 /// Measurement to compute a DP projection of bounded sparse data.
 ///
-/// The size of the projection is O(total * size_factor * scale / alpha).
-/// The evaluation time of post-processing is O(beta * scale / alpha).
-///
-/// # Citations
-/// * [ALP21 Differentially Private Sparse Vectors with Low Error, Optimal Space, and Fast Access](https://arxiv.org/abs/2106.10068)
-///   Algorithm 4
-///
-/// # Arguments
-/// * `total` - Estimate or true value of the sum of all values in the input.
-/// This should be an upper bound if the true total is private.
-/// * `size_factor` - Optional multiplier for setting the size of the projection. There is a memory/utility trade-off.
-/// The value should be sufficient large to limit hash collisions. The default value is 50.
-/// * `alpha` - Optional parameter used for scaling and determining p in randomized response step. The default value is 4.
-/// * `scale` - Privacy loss parameter. This is equal to epsilon/sensitivity.
-/// * `beta` - Upper bound on values. Entries above beta are clamped.
-pub fn make_base_alp<K, C, T>(
-    total: usize,
+/// See [`make_alp_queryable`] for details.
+pub fn make_alp_state<K, CI, CO>(
+    input_domain: SparseDomain<K, CI>,
+    input_metric: L1Distance<CI>,
+    scale: CO,
+    total_limit: CI,
+    value_limit: Option<CI>,
     size_factor: Option<u32>,
-    alpha: Option<T>,
-    scale: T,
-    beta: C,
-) -> Fallible<Measurement<SparseDomain<K, C>, AlpState<K, T>, L1Distance<C>, MaxDivergence<T>>>
+    alpha: Option<u32>,
+) -> Fallible<Measurement<SparseDomain<K, CI>, AlpState<K, CO>, L1Distance<CI>, MaxDivergence<CO>>>
 where
-    K: 'static + Eq + Hash + Clone + CheckAtom,
-    C: 'static + Clone + Integer + CheckAtom + DistanceConstant<C> + InfCast<T> + ToPrimitive,
-    T: 'static + num::Float + DistanceConstant<T> + InfCast<Float> + InfCast<C>,
-    Float: InfCast<T>,
-    (SparseDomain<K, C>, L1Distance<C>): MetricSpace,
+    K: 'static + Hashable,
+    CI: 'static + Integer + InfCast<CO> + ToPrimitive,
+    CO: 'static + Float + InfCast<RugFloat> + InfCast<CI>,
+    RugFloat: InfCast<CO>,
+    (SparseDomain<K, CI>, L1Distance<CI>): MetricSpace,
 {
-    let factor = size_factor.unwrap_or(SIZE_FACTOR_DEFAULT) as f64;
-    let alpha = alpha.unwrap_or_else(|| T::from(ALPHA_DEFAULT).unwrap());
-
-    let beta: f64 = T::inf_cast(beta)?
+    let value_limit: f64 = value_limit
+        // if value limit is None, read it from the domain
+        .or_else(|| {
+            (input_domain.value_domain.bounds())
+                .and_then(|b| b.upper())
+                .cloned()
+        })
+        // if value limit is still None, return an error
+        .ok_or_else(|| {
+            err!(
+                MakeTransformation,
+                "value_limit is required when data is unbounded"
+            )
+        })?
         .to_f64()
-        .ok_or_else(|| err!(MakeTransformation, "failed to parse beta"))?;
+        .ok_or_else(|| err!(MakeTransformation, "failed to parse value_limit"))?;
+
+    let total_limit: f64 = total_limit
+        .to_f64()
+        .ok_or_else(|| err!(MakeTransformation, "failed to parse total_limit"))?;
+
+    let size_factor = size_factor.unwrap_or(SIZE_FACTOR_DEFAULT) as f64;
+
+    let alpha = CO::inf_cast(alpha.unwrap_or(ALPHA_DEFAULT))?;
+
     let quotient = (scale / alpha)
         .to_f64()
-        .ok_or_else(|| err!(MakeTransformation, "failed to parse scale/alpha"))?;
-    let m = (beta * quotient).ceil() as usize;
+        .ok_or_else(|| err!(MakeTransformation, "failed to parse scale"))?;
+    let m = usize::inf_cast(value_limit * quotient)?;
 
-    let exp = exponent_next_power_of_two((factor * total as f64 * quotient) as u64);
-    let h = (0..m)
+    let exp = exponent_next_power_of_two((size_factor * total_limit * quotient) as u64);
+    let hashers = (0..m)
         .map(|_| sample_hash_function(exp))
-        .collect::<Fallible<HashFunctions<K>>>()?;
+        .collect::<Fallible<Vec<HashFunction<K>>>>()?;
 
-    make_base_alp_with_hashers(alpha, scale, 1 << exp, h)
+    make_alp_state_with_hashers(input_domain, input_metric, scale, alpha, 1 << exp, hashers)
 }
 
-/// Wrap the AlpState in a Queryable object.
+/// Make a postprocessor that wraps the AlpState in a Queryable object.
 ///
 /// The Queryable object works similar to a dictionary.
 /// Note that the access time is O(state.h.len()).
-pub fn post_process<K, T>(state: AlpState<K, T>) -> Fallible<Queryable<K, T>>
+pub fn post_alp_state_to_queryable<K, C>() -> Function<AlpState<K, C>, Queryable<K, C>>
 where
-    T: 'static + TFloat,
-    K: 'static,
+    K: 'static + Clone,
+    C: 'static + Float,
 {
-    Queryable::new_external(move |key: &K| Ok(compute_estimate(&state, key)))
+    Function::new(move |state: &AlpState<K, C>| {
+        let state = state.clone();
+        Queryable::new_raw_external(move |key: &K| Ok(compute_estimate(&state, key)))
+    })
 }
 
-/// Wrapper Measurement. See [`post_process`].
-pub fn make_alp_histogram_post_process<K, C, T>(
-    m: &Measurement<SparseDomain<K, C>, AlpState<K, T>, L1Distance<C>, MaxDivergence<T>>,
-) -> Fallible<Measurement<SparseDomain<K, C>, Queryable<K, T>, L1Distance<C>, MaxDivergence<T>>>
+/// Measurement to release a queryable containing a DP projection of bounded sparse data.
+///
+/// The size of the projection is O(total * size_factor * scale / alpha).
+/// The evaluation time of post-processing is O(beta * scale / alpha).
+///
+/// `size_factor` is an optional multiplier (defaults to 50) for setting the size of the projection.
+/// There is a memory/utility trade-off.
+/// The value should be sufficiently large to limit hash collisions.
+///
+/// # Citations
+/// * [ALP21 Differentially Private Sparse Vectors with Low Error, Optimal Space, and Fast Access](https://arxiv.org/abs/2106.10068) Algorithm 4
+///
+/// # Arguments
+/// * `scale` - Privacy loss parameter. This is equal to epsilon/sensitivity.
+/// * `value_limit` - Upper bound on individual values (referred to as β). Entries above β are clamped.
+/// * `total_limit` - Either the true value or an upper bound estimate of the sum of all values in the input.
+/// * `size_factor` - Optional multiplier (default of 50) for setting the size of the projection.
+/// * `alpha` - Optional parameter (default of 4) for scaling and determining p in randomized response step.
+pub fn make_alp_queryable<K, CI, CO>(
+    input_domain: MapDomain<AtomDomain<K>, AtomDomain<CI>>,
+    input_metric: L1Distance<CI>,
+    scale: CO,
+    total_limit: CI,
+    value_limit: Option<CI>,
+    size_factor: Option<u32>,
+    alpha: Option<u32>,
+) -> Fallible<
+    Measurement<
+        MapDomain<AtomDomain<K>, AtomDomain<CI>>,
+        Queryable<K, CO>,
+        L1Distance<CI>,
+        MaxDivergence<CO>,
+    >,
+>
 where
-    K: 'static + Eq + Hash + CheckAtom,
-    C: 'static + Clone + CheckAtom,
-    T: 'static + TFloat,
-    HashMap<K, C>: Clone,
-    AlpState<K, T>: Clone,
-    (SparseDomain<K, C>, L1Distance<C>): MetricSpace,
+    K: 'static + Hashable,
+    CI: 'static + Integer + InfCast<CO> + ToPrimitive,
+    CO: 'static + Float + InfCast<RugFloat> + InfCast<CI>,
+    RugFloat: InfCast<CO>,
+    (MapDomain<AtomDomain<K>, AtomDomain<CI>>, L1Distance<CI>): MetricSpace,
 {
-    let function = m.function.clone();
-    Measurement::new(
-        m.input_domain.clone(),
-        Function::new_fallible(move |x| function.eval(x).and_then(post_process)),
-        m.input_metric.clone(),
-        m.output_measure.clone(),
-        m.privacy_map.clone(),
-    )
+    // this constructor is a simple wrapper for make_alp_state that adds a postprocessing step
+    make_alp_state(
+        input_domain,
+        input_metric,
+        scale,
+        total_limit,
+        value_limit,
+        size_factor,
+        alpha,
+    )? >> post_alp_state_to_queryable()
 }
 
 #[cfg(test)]
@@ -350,8 +399,8 @@ mod tests {
     }
 
     // Functions that always return its index
-    fn index_identify_functions<T>(n: usize) -> HashFunctions<T> {
-        (0..n).map(|i| idx(i)).collect::<HashFunctions<T>>()
+    fn index_identify_functions<T>(n: usize) -> Vec<HashFunction<T>> {
+        (0..n).map(|i| idx(i)).collect::<Vec<HashFunction<T>>>()
     }
 
     #[test]
@@ -394,9 +443,11 @@ mod tests {
     #[test]
     fn test_alp_construction() -> Fallible<()> {
         let beta = 10;
-        let alp = make_base_alp_with_hashers::<u32, u32, f64>(
-            1.,
+        let alp = make_alp_state_with_hashers::<u32, u32, f64>(
+            MapDomain::default(),
+            L1Distance::default(),
             1.0,
+            1.,
             beta,
             index_identify_functions(beta),
         )?;
@@ -422,7 +473,14 @@ mod tests {
         // Handle silently using modulo
         // Returning an error would violate privacy
         let h = index_identify_functions(20);
-        let alp = make_base_alp_with_hashers::<u32, u32, f64>(1., 1.0, s, h)?;
+        let alp = make_alp_state_with_hashers::<u32, u32, f64>(
+            MapDomain::default(),
+            L1Distance::default(),
+            1.0,
+            1.,
+            s,
+            h,
+        )?;
 
         let mut x = HashMap::new();
         x.insert(42, 3);
@@ -454,7 +512,7 @@ mod tests {
                 &AlpState {
                     alpha: 3.,
                     scale: 1.0,
-                    h: index_identify_functions(8),
+                    hashers: index_identify_functions(8),
                     z: z1
                 },
                 &0
@@ -467,7 +525,7 @@ mod tests {
                 &AlpState {
                     alpha: 1.,
                     scale: 2.0,
-                    h: index_identify_functions(8),
+                    hashers: index_identify_functions(8),
                     z: z2
                 },
                 &0
@@ -480,7 +538,7 @@ mod tests {
                 &AlpState {
                     alpha: 1.,
                     scale: 0.5,
-                    h: index_identify_functions(8),
+                    hashers: index_identify_functions(8),
                     z: z3
                 },
                 &0
@@ -497,16 +555,24 @@ mod tests {
         x.insert(42, 12);
         x.insert(100, 5);
 
-        let alp = make_base_alp::<i32, i32, f64>(24, None, None, 2., 24)?;
+        let alp_meas = make_alp_state::<i32, i32, f64>(
+            MapDomain::default(),
+            L1Distance::default(),
+            2.,
+            24,
+            Some(24),
+            None,
+            None,
+        )?;
+        let alp_state = alp_meas.invoke(&x)?;
 
-        let state = alp.function.eval(&x)?;
+        let postprocessor = post_alp_state_to_queryable();
+        let mut queryable = postprocessor.eval(&alp_state)?;
 
-        let mut query = post_process(state)?;
-
-        query.eval(&0)?;
-        query.eval(&42)?;
-        query.eval(&100)?;
-        query.eval(&1000)?;
+        queryable.eval(&0)?;
+        queryable.eval(&42)?;
+        queryable.eval(&100)?;
+        queryable.eval(&1000)?;
 
         Ok(())
     }
@@ -518,18 +584,26 @@ mod tests {
         x.insert(42, 12);
         x.insert(100, 5);
 
-        let alp = make_base_alp::<i32, i32, f64>(24, None, None, 2., 24)?;
+        let alp_meas = make_alp_queryable::<i32, i32, f64>(
+            MapDomain {
+                key_domain: AtomDomain::default(),
+                value_domain: AtomDomain::default(),
+            },
+            L1Distance::default(),
+            2.,
+            24,
+            Some(24),
+            None,
+            None,
+        )?;
 
-        let wrapped = make_alp_histogram_post_process(&alp)?;
+        assert_eq!(alp_meas.map(&1)?, 2.);
+        let mut queryable = alp_meas.invoke(&x)?;
 
-        assert_eq!(wrapped.map(&1)?, 2.);
-
-        let mut query = wrapped.function.eval(&x)?;
-
-        query.eval(&0)?;
-        query.eval(&42)?;
-        query.eval(&100)?;
-        query.eval(&1000)?;
+        queryable.eval(&0)?;
+        queryable.eval(&42)?;
+        queryable.eval(&100)?;
+        queryable.eval(&1000)?;
 
         Ok(())
     }

--- a/rust/src/traits/cast/mod.rs
+++ b/rust/src/traits/cast/mod.rs
@@ -329,7 +329,7 @@ macro_rules! impl_inf_cast_float_int {
 }
 cartesian!(
     [f32, f64],
-    [u8, u16, u32, u64, u128, i8, i16, i32, i64, i128],
+    [u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128],
     impl_inf_cast_float_int
 );
 

--- a/rust/src/traits/mod.rs
+++ b/rust/src/traits/mod.rs
@@ -221,8 +221,8 @@ impl<T> Number for T where
 ///
 /// test_func(1i8);
 /// ```
-pub trait Integer: Number + Hashable {}
-impl<T> Integer for T where T: Number + Hashable {}
+pub trait Integer: Number + Hashable + Ord {}
+impl<T> Integer for T where T: Number + Hashable + Ord {}
 
 /// Floating-point types.
 ///

--- a/rust/src/transformations/count/ffi.rs
+++ b/rust/src/transformations/count/ffi.rs
@@ -9,7 +9,7 @@ use crate::ffi::any::{AnyDomain, AnyMetric, Downcast};
 use crate::ffi::any::{AnyObject, AnyTransformation};
 use crate::ffi::util::{c_bool, to_bool, Type};
 use crate::metrics::{L1Distance, L2Distance, SymmetricDistance};
-use crate::traits::{Float, Hashable, Number, Primitive};
+use crate::traits::{Hashable, Number, Primitive, Float};
 use crate::transformations::{
     make_count, make_count_by, make_count_by_categories, make_count_distinct,
     CountByCategoriesConstant, CountByConstant,

--- a/rust/src/transformations/count/mod.rs
+++ b/rust/src/transformations/count/mod.rs
@@ -11,7 +11,7 @@ use crate::core::{Function, Metric, MetricSpace, StabilityMap, Transformation};
 use crate::domains::{AtomDomain, MapDomain, VectorDomain};
 use crate::error::*;
 use crate::metrics::{AbsoluteDistance, LpDistance, SymmetricDistance};
-use crate::traits::{CollectionSize, Float, Hashable, Number, Primitive};
+use crate::traits::{CollectionSize, Hashable, Number, Primitive};
 
 #[bootstrap(features("contrib"), generics(TIA(suppress), TO(default = "int")))]
 /// Make a Transformation that computes a count of the number of records in data.
@@ -239,7 +239,7 @@ pub fn make_count_by<MO, TK, TV>(
 >
 where
     MO: CountByConstant<MO::Distance> + Metric,
-    MO::Distance: Float,
+    MO::Distance: Number,
     TK: Hashable,
     TV: Number,
     (VectorDomain<AtomDomain<TK>>, SymmetricDistance): MetricSpace,


### PR DESCRIPTION
Closes #755

The constructors are now named:
* `make_alp_state_with_hashers`
* `make_alp_state`
* `make_alp_queryable`

Just like before, each constructor calls the previous one. The `make_alp_queryable` constructor is the one meant to be used from Python (implemented in #747)

Generics have been renamed:
* `C` -> `CI` for "input count"
* `T` -> `CO` for "output count"

Arguments have been renamed/reordered to be more consistent with other constructors, to highlight the repetition in limit/upper bound arguments, and to make optional arguments trailing. 

These constructors now also follow the (new) library convention of passing the input domain and input metric in as the first two arguments of the constructor, and read what they can from the input.

What should be the only substantive change to the core algorithm is on line 103-- it seems that if the cast of x is overflowing a u64, it should be clamped down to `u64::MAX`, not filled in with the default of zero. Will need to validate that this is the correct behavior.