### PR TITLE
Add aarch64-unknown-linux-gnu target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,8 +86,10 @@ jobs:
       - name: Upload .dll
         uses: actions/upload-artifact@v3
         with:
-          name: lib_dll
-          path: rust/target/release/opendp.dll
+          name: lib
+          path: |
+            rust/target/release/opendp.dll
+            rust/INTENTIONALLY_BOGUS
 
 
   python-pre-publish-mac:
@@ -136,8 +138,8 @@ jobs:
       - name: Upload .dylib
         uses: actions/upload-artifact@v3
         with:
-          name: lib_dylib
-          path: rust/target/release/libopendp.dylib
+          name: lib
+          path: '*/target/release/libopendp.dylib'
 
       # need to upload at least one set up updated bindings
       - name: Upload bindings
@@ -180,21 +182,23 @@ jobs:
         if: matrix.architecture == 'x86_64'
 #        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh -i -r -t -g $TARGET -f \"$FEATURES\" && cp rust/target/$TARGET/release/libopendp.so rust/target/release/$ARCH_LIB"
         run: |
-          mkdir -p rust/target/release
-          echo $ARCH_LIB >rust/target/release/$ARCH_LIB
+#          mkdir -p rust/target/release
+#          echo $ARCH_LIB >rust/target/release/$ARCH_LIB
+          echo $ARCH_LIB >rust/target/$TARGET/release/libopendp.so
 
       - name: Create Rust build for linux non-x86_64 (no tests)
         if: matrix.architecture != 'x86_64'
 #        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh -i -r -g $TARGET -f \"$FEATURES\" && cp rust/target/$TARGET/release/libopendp.so rust/target/release/$ARCH_LIB"
         run: |
-          mkdir -p rust/target/release
-          echo $ARCH_LIB >rust/target/release/$ARCH_LIB
+#          mkdir -p rust/target/release
+          echo $ARCH_LIB >rust/target/$TARGET/release/libopendp.so
 
       - name: Upload .so
         uses: actions/upload-artifact@v3
         with:
-          name: lib_so
-          path: rust/target/release/${{ env.ARCH_LIB }}
+          name: lib
+#          path: rust/target/release/${{ env.ARCH_LIB }}
+          path: rust*/target/${{ env.TARGET }}/release/libopendp.so
 
 
   python-publish:
@@ -212,29 +216,35 @@ jobs:
           python-version: 3.8
           cache: pip
 
-      - name: Prepare for libs
-        run: mkdir -p rust/target/release
+#      - name: Prepare for libs
+#        run: mkdir -p rust/target/release
+#
+#      - name: Download windows lib
+#        uses: actions/download-artifact@v3
+#        with:
+#          name: lib_dll
+#          path: rust/target/release
+#
+#      - name: Download macos lib
+#        uses: actions/download-artifact@v3
+#        with:
+#          name: lib_dylib
+#          path: rust/target/release
+#
+#      - name: Download linux lib
+#        uses: actions/download-artifact@v3
+#        with:
+#          name: lib_so
+#          path: rust/target/release
 
-      - name: Download windows lib
+      - name: Download libs
         uses: actions/download-artifact@v3
         with:
-          name: lib_dll
-          path: rust/target/release
-
-      - name: Download macos lib
-        uses: actions/download-artifact@v3
-        with:
-          name: lib_dylib
-          path: rust/target/release
-
-      - name: Download linux lib
-        uses: actions/download-artifact@v3
-        with:
-          name: lib_so
-          path: rust/target/release
+          name: lib
+          path: rust
 
       - name: Dump directory
-        run: ls -lR rust/target/release
+        run: ls -lR rust/target
 
       - name: Download bindings
         uses: actions/download-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,9 +87,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: lib
-          path: |
-            rust/target/release/opendp.dll
-            rust/INTENTIONALLY_BOGUS
+          path: rust/target/release*/opendp.dll
 
 
   python-pre-publish-mac:
@@ -139,7 +137,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: lib
-          path: 'rust/*/release/libopendp.dylib'
+          path: rust/target/release*/libopendp.dylib
 
       # need to upload at least one set up updated bindings
       - name: Upload bindings
@@ -196,8 +194,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: lib
-#          path: rust/target/release/${{ env.ARCH_LIB }}
-          path: rust/target*/${{ env.TARGET }}/release/libopendp.so
+          path: rust/target/${{ env.TARGET }}*/release/libopendp.so
 
 
   python-publish:
@@ -240,10 +237,12 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: lib
-          path: rust
+          path: rust/target/
 
       - name: Dump directory
-        run: ls -lR rust/target
+        run: |
+          ls -l rust/
+          ls -lR rust/target
 
       - name: Download bindings
         uses: actions/download-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,14 +172,11 @@ jobs:
 
       - name: Create Rust build for linux x86_64
         if: matrix.architecture == 'x86_64'
-        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh -i -r -t -g $TARGET -f \"$FEATURES\""
+        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh -i -r -t -g $TARGET -f \"$FEATURES\" && cp rust/target/$TARGET/release/libopendp.so rust/target/release/$ARCH_LIB"
 
       - name: Create Rust build for linux non-x86_64 (no tests)
         if: matrix.architecture != 'x86_64'
-        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh -i -r -g $TARGET -f \"$FEATURES\""
-
-      - name: Retrieve architecture library
-        run: cp rust/target/$TARGET/release/libopendp.so rust/target/release/$ARCH_LIB
+        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh -i -r -g $TARGET -f \"$FEATURES\" && cp rust/target/$TARGET/release/libopendp.so rust/target/release/$ARCH_LIB"
 
       - name: Upload .so
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,14 +182,14 @@ jobs:
         if: matrix.architecture == 'x86_64'
 #        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh -i -r -t -g $TARGET -f \"$FEATURES\" && cp rust/target/$TARGET/release/libopendp.so rust/target/release/$ARCH_LIB"
         run: |
-          mkdir -p rust/target/release
+          mkdir -p rust/target/$TARGET/release
           echo $ARCH_LIB >rust/target/$TARGET/release/libopendp.so
 
       - name: Create Rust build for linux non-x86_64 (no tests)
         if: matrix.architecture != 'x86_64'
 #        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh -i -r -g $TARGET -f \"$FEATURES\" && cp rust/target/$TARGET/release/libopendp.so rust/target/release/$ARCH_LIB"
         run: |
-          mkdir -p rust/target/release
+          mkdir -p rust/target/$TARGET/release
           echo $ARCH_LIB >rust/target/$TARGET/release/libopendp.so
 
       - name: Upload .so

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,15 +182,14 @@ jobs:
         if: matrix.architecture == 'x86_64'
 #        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh -i -r -t -g $TARGET -f \"$FEATURES\" && cp rust/target/$TARGET/release/libopendp.so rust/target/release/$ARCH_LIB"
         run: |
-#          mkdir -p rust/target/release
-#          echo $ARCH_LIB >rust/target/release/$ARCH_LIB
+          mkdir -p rust/target/release
           echo $ARCH_LIB >rust/target/$TARGET/release/libopendp.so
 
       - name: Create Rust build for linux non-x86_64 (no tests)
         if: matrix.architecture != 'x86_64'
 #        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh -i -r -g $TARGET -f \"$FEATURES\" && cp rust/target/$TARGET/release/libopendp.so rust/target/release/$ARCH_LIB"
         run: |
-#          mkdir -p rust/target/release
+          mkdir -p rust/target/release
           echo $ARCH_LIB >rust/target/$TARGET/release/libopendp.so
 
       - name: Upload .so

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,21 +64,24 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Cache Rust dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~\.cargo\bin
-            ~\.cargo\registry\index
-            ~\.cargo\registry\cache
-            ~\.cargo\git\db
-            ~\AppData\Local\gmp-mpfr-sys
-            rust\target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
-          restore-keys: ${{ runner.os }}-cargo-
+#      - name: Cache Rust dependencies
+#        uses: actions/cache@v3
+#        with:
+#          path: |
+#            ~\.cargo\bin
+#            ~\.cargo\registry\index
+#            ~\.cargo\registry\cache
+#            ~\.cargo\git\db
+#            ~\AppData\Local\gmp-mpfr-sys
+#            rust\target
+#          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
+#          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Create Rust build for windows
-        run: bash tools/rust_build.sh -i -r -t -f "$FEATURES"
+#        run: bash tools/rust_build.sh -i -r -t -f "$FEATURES"
+        run: |
+          bash mkdir -p rust/target/release
+          bash echo opendp.dll >rust/target/release/opendp.dll
 
       - name: Upload .dll
         uses: actions/upload-artifact@v3
@@ -94,38 +97,41 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Cache Rust dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
-            ~/Library/Caches/gmp-mpfr-sys
-            rust/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
-          restore-keys: ${{ runner.os }}-cargo-
+#      - name: Cache Rust dependencies
+#        uses: actions/cache@v3
+#        with:
+#          path: |
+#            ~/.cargo/bin
+#            ~/.cargo/registry/index
+#            ~/.cargo/registry/cache
+#            ~/.cargo/git/db
+#            ~/Library/Caches/gmp-mpfr-sys
+#            rust/target
+#          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
+#          restore-keys: ${{ runner.os }}-cargo-
 
-      - name: Create Rust build for macos x86_64
-        run: bash tools/rust_build.sh -i -r -t -g x86_64-apple-darwin -f "$FEATURES"
-        env:
-          CC: clang -target x86_64-apple-darwin
+#      - name: Create Rust build for macos x86_64
+#        run: bash tools/rust_build.sh -i -r -t -g x86_64-apple-darwin -f "$FEATURES"
+#        env:
+#          CC: clang -target x86_64-apple-darwin
 
-      - name: Create Rust build for macos aarch64 (no tests)
-        # include python bindings generation to get updated links in python codegen
-        run: bash tools/rust_build.sh -i -r -g aarch64-apple-darwin -f "$FEATURES,bindings-python"
-        env:
-          CC: clang -target aarch64-apple-darwin
+#      - name: Create Rust build for macos aarch64 (no tests)
+#        # include python bindings generation to get updated links in python codegen
+#        run: bash tools/rust_build.sh -i -r -g aarch64-apple-darwin -f "$FEATURES,bindings-python"
+#        env:
+#          CC: clang -target aarch64-apple-darwin
 
       - name: Create universal binary of Rust build for macos
         # https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary#Update-the-Architecture-List-of-Custom-Makefiles
+#        run: |
+#          mkdir -p rust/target/release
+#          lipo \
+#              rust/target/x86_64-apple-darwin/release/libopendp.dylib \
+#              rust/target/aarch64-apple-darwin/release/libopendp.dylib \
+#              -output rust/target/release/libopendp.dylib -create
         run: |
           mkdir -p rust/target/release
-          lipo \
-              rust/target/x86_64-apple-darwin/release/libopendp.dylib \
-              rust/target/aarch64-apple-darwin/release/libopendp.dylib \
-              -output rust/target/release/libopendp.dylib -create
+          echo libopendp.dylib >rust/target/release/libopendp.dylib
 
       - name: Upload .dylib
         uses: actions/upload-artifact@v3
@@ -157,26 +163,32 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Cache Rust dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
-            ~/.cache/gmp-mpfr-sys
-            rust/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
-          restore-keys: ${{ runner.os }}-cargo-
+#      - name: Cache Rust dependencies
+#        uses: actions/cache@v3
+#        with:
+#          path: |
+#            ~/.cargo/bin
+#            ~/.cargo/registry/index
+#            ~/.cargo/registry/cache
+#            ~/.cargo/git/db
+#            ~/.cache/gmp-mpfr-sys
+#            rust/target
+#          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
+#          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Create Rust build for linux x86_64
         if: matrix.architecture == 'x86_64'
-        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh -i -r -t -g $TARGET -f \"$FEATURES\" && cp rust/target/$TARGET/release/libopendp.so rust/target/release/$ARCH_LIB"
+#        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh -i -r -t -g $TARGET -f \"$FEATURES\" && cp rust/target/$TARGET/release/libopendp.so rust/target/release/$ARCH_LIB"
+        run: |
+          mkdir -p rust/target/release
+          echo $ARCH_LIB >rust/target/release/$ARCH_LIB
 
       - name: Create Rust build for linux non-x86_64 (no tests)
         if: matrix.architecture != 'x86_64'
-        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh -i -r -g $TARGET -f \"$FEATURES\" && cp rust/target/$TARGET/release/libopendp.so rust/target/release/$ARCH_LIB"
+#        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh -i -r -g $TARGET -f \"$FEATURES\" && cp rust/target/$TARGET/release/libopendp.so rust/target/release/$ARCH_LIB"
+        run: |
+          bash mkdir -p rust/target/release
+          echo $ARCH_LIB >rust/target/release/$ARCH_LIB
 
       - name: Upload .so
         uses: actions/upload-artifact@v3
@@ -220,7 +232,10 @@ jobs:
         with:
           name: lib_so
           path: rust/target/release
-      
+
+      - name: Dump directory
+        run: ls -lR rust/target/release
+
       - name: Download bindings
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,7 @@ jobs:
       - name: Create Rust build for linux
         env:
           # Only run tests for native compile
-          FLAGS: ${{ matrix.architecture == 'x86_64 && '-i -r -t' || '-i -r' }}
+          FLAGS: ${{ matrix.architecture == 'x86_64' && '-i -r -t' || '-i -r' }}
         run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh $FLAGS -g $TARGET -f \"$FEATURES\""
 
       - name: Upload .so

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,9 +179,7 @@ jobs:
         run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh -i -r -g $TARGET -f \"$FEATURES\""
 
       - name: Retrieve architecture library
-        run: |
-          mkdir -p rust/target/release
-          mv rust/target/$TARGET/release/libopendp.so rust/target/release/$ARCH_LIB
+        run: cp rust/target/$TARGET/release/libopendp.so rust/target/release/$ARCH_LIB
 
       - name: Upload .so
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,8 +80,8 @@ jobs:
       - name: Create Rust build for windows
 #        run: bash tools/rust_build.sh -i -r -t -f "$FEATURES"
         run: |
-          bash mkdir -p rust/target/release
-          bash echo opendp.dll >rust/target/release/opendp.dll
+          mkdir -p rust/target/release
+          echo opendp.dll >rust/target/release/opendp.dll
 
       - name: Upload .dll
         uses: actions/upload-artifact@v3
@@ -187,7 +187,7 @@ jobs:
         if: matrix.architecture != 'x86_64'
 #        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh -i -r -g $TARGET -f \"$FEATURES\" && cp rust/target/$TARGET/release/libopendp.so rust/target/release/$ARCH_LIB"
         run: |
-          bash mkdir -p rust/target/release
+          mkdir -p rust/target/release
           echo $ARCH_LIB >rust/target/release/$ARCH_LIB
 
       - name: Upload .so

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: lib
-          path: '*/target/release/libopendp.dylib'
+          path: 'rust/*/release/libopendp.dylib'
 
       # need to upload at least one set up updated bindings
       - name: Upload bindings
@@ -197,7 +197,7 @@ jobs:
         with:
           name: lib
 #          path: rust/target/release/${{ env.ARCH_LIB }}
-          path: rust*/target/${{ env.TARGET }}/release/libopendp.so
+          path: rust/target*/${{ env.TARGET }}/release/libopendp.so
 
 
   python-publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,7 +216,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: libs
-          path: rust/target/
+          path: rust/
 
       - name: Dump directory
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,8 +170,13 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-
 
-      - name: Create Rust build for linux
+      - name: Create Rust build for linux x86_64
+        if: matrix.architecture == 'x86_64'
         run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh -i -r -t -g $TARGET -f \"$FEATURES\""
+
+      - name: Create Rust build for linux non-x86_64 (no tests)
+        if: matrix.architecture != 'x86_64'
+        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh -i -r -g $TARGET -f \"$FEATURES\""
 
       - name: Retrieve architecture library
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,79 +64,75 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-#      - name: Cache Rust dependencies
-#        uses: actions/cache@v3
-#        with:
-#          path: |
-#            ~\.cargo\bin
-#            ~\.cargo\registry\index
-#            ~\.cargo\registry\cache
-#            ~\.cargo\git\db
-#            ~\AppData\Local\gmp-mpfr-sys
-#            rust\target
-#          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
-#          restore-keys: ${{ runner.os }}-cargo-
+      - name: Cache Rust dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~\.cargo\bin
+            ~\.cargo\registry\index
+            ~\.cargo\registry\cache
+            ~\.cargo\git\db
+            ~\AppData\Local\gmp-mpfr-sys
+            rust\target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Create Rust build for windows
-#        run: bash tools/rust_build.sh -i -r -t -f "$FEATURES"
-        run: |
-          mkdir -p rust/target/release
-          echo opendp.dll >rust/target/release/opendp.dll
+        run: bash tools/rust_build.sh -i -r -t -f "$FEATURES"
 
       - name: Upload .dll
         uses: actions/upload-artifact@v3
         with:
           name: libs
+          # Unnecessary '*' in path will cause artifact to include parent directories starting at that element.
           path: rust/target*/release/opendp.dll
 
 
-  python-pre-publish-mac:
+  python-pre-publish-macos:
     runs-on: macos-11
     needs: credential-check
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-#      - name: Cache Rust dependencies
-#        uses: actions/cache@v3
-#        with:
-#          path: |
-#            ~/.cargo/bin
-#            ~/.cargo/registry/index
-#            ~/.cargo/registry/cache
-#            ~/.cargo/git/db
-#            ~/Library/Caches/gmp-mpfr-sys
-#            rust/target
-#          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
-#          restore-keys: ${{ runner.os }}-cargo-
+      - name: Cache Rust dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            ~/Library/Caches/gmp-mpfr-sys
+            rust/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
-#      - name: Create Rust build for macos x86_64
-#        run: bash tools/rust_build.sh -i -r -t -g x86_64-apple-darwin -f "$FEATURES"
-#        env:
-#          CC: clang -target x86_64-apple-darwin
+      - name: Create Rust build for macos x86_64
+        run: bash tools/rust_build.sh -i -r -t -g x86_64-apple-darwin -f "$FEATURES"
+        env:
+          CC: clang -target x86_64-apple-darwin
 
-#      - name: Create Rust build for macos aarch64 (no tests)
-#        # include python bindings generation to get updated links in python codegen
-#        run: bash tools/rust_build.sh -i -r -g aarch64-apple-darwin -f "$FEATURES,bindings-python"
-#        env:
-#          CC: clang -target aarch64-apple-darwin
+      - name: Create Rust build for macos aarch64 (no tests)
+        # include python bindings generation to get updated links in python codegen
+        run: bash tools/rust_build.sh -i -r -g aarch64-apple-darwin -f "$FEATURES,bindings-python"
+        env:
+          CC: clang -target aarch64-apple-darwin
 
       - name: Create universal binary of Rust build for macos
         # https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary#Update-the-Architecture-List-of-Custom-Makefiles
-#        run: |
-#          mkdir -p rust/target/release
-#          lipo \
-#              rust/target/x86_64-apple-darwin/release/libopendp.dylib \
-#              rust/target/aarch64-apple-darwin/release/libopendp.dylib \
-#              -output rust/target/release/libopendp.dylib -create
         run: |
           mkdir -p rust/target/release
-          echo libopendp.dylib >rust/target/release/libopendp.dylib
+          lipo \
+              rust/target/x86_64-apple-darwin/release/libopendp.dylib \
+              rust/target/aarch64-apple-darwin/release/libopendp.dylib \
+              -output rust/target/release/libopendp.dylib -create
 
       - name: Upload .dylib
         uses: actions/upload-artifact@v3
         with:
           name: libs
+          # Unnecessary '*' in path will cause artifact to include parent directories starting at that element.
           path: rust/target*/release/libopendp.dylib
 
       # need to upload at least one set up updated bindings
@@ -163,43 +159,36 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-#      - name: Cache Rust dependencies
-#        uses: actions/cache@v3
-#        with:
-#          path: |
-#            ~/.cargo/bin
-#            ~/.cargo/registry/index
-#            ~/.cargo/registry/cache
-#            ~/.cargo/git/db
-#            ~/.cache/gmp-mpfr-sys
-#            rust/target
-#          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
-#          restore-keys: ${{ runner.os }}-cargo-
+      - name: Cache Rust dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            ~/.cache/gmp-mpfr-sys
+            rust/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
-      - name: Create Rust build for linux x86_64
-        if: matrix.architecture == 'x86_64'
-#        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh -i -r -t -g $TARGET -f \"$FEATURES\" && cp rust/target/$TARGET/release/libopendp.so rust/target/release/$ARCH_LIB"
-        run: |
-          mkdir -p rust/target/$TARGET/release
-          echo $ARCH_LIB >rust/target/$TARGET/release/libopendp.so
-
-      - name: Create Rust build for linux non-x86_64 (no tests)
-        if: matrix.architecture != 'x86_64'
-#        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh -i -r -g $TARGET -f \"$FEATURES\" && cp rust/target/$TARGET/release/libopendp.so rust/target/release/$ARCH_LIB"
-        run: |
-          mkdir -p rust/target/$TARGET/release
-          echo $ARCH_LIB >rust/target/$TARGET/release/libopendp.so
+      - name: Create Rust build for linux
+        env:
+          # Only run tests for native compile
+          FLAGS: ${{ matrix.architecture == 'x86_64 && '-i -r -t' || '-i -r' }}
+        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh $FLAGS -g $TARGET -f \"$FEATURES\""
 
       - name: Upload .so
         uses: actions/upload-artifact@v3
         with:
           name: libs
+          # Unnecessary '*' in path will cause artifact to include parent directories starting at that element.
           path: rust/target*/${{ env.TARGET }}/release/libopendp.so
 
 
   python-publish:
     runs-on: ubuntu-20.04
-    needs: [ python-pre-publish-windows, python-pre-publish-mac, python-pre-publish-linux ]
+    needs: [ python-pre-publish-windows, python-pre-publish-macos, python-pre-publish-linux ]
     env:
       PYPI_API_TOKEN: ${{ inputs.dry_run && secrets.TEST_PYPI_API_TOKEN || secrets.PYPI_API_TOKEN }}
     steps:
@@ -216,6 +205,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: libs
+          # Artifact contains all libs with leading paths starting at target
           path: rust/
 
       - name: Dump directory
@@ -236,7 +226,7 @@ jobs:
           DRY_RUN_FLAG: ${{ inputs.dry_run && '-n' || '-nn' }}
         run: |
           pip install -r tools/requirements-publish_tool.txt
-#          python tools/publish_tool.py python $DRY_RUN_FLAG
+          python tools/publish_tool.py python $DRY_RUN_FLAG
 
 
   rust-publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: lib_so
-          path: rust/target/release/$ARCH_LIB
+          path: rust/target/release/${{ env.ARCH_LIB }}
 
 
   python-publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,8 +86,8 @@ jobs:
       - name: Upload .dll
         uses: actions/upload-artifact@v3
         with:
-          name: lib
-          path: rust/target/release*/opendp.dll
+          name: libs
+          path: rust/target*/release/opendp.dll
 
 
   python-pre-publish-mac:
@@ -136,8 +136,8 @@ jobs:
       - name: Upload .dylib
         uses: actions/upload-artifact@v3
         with:
-          name: lib
-          path: rust/target/release*/libopendp.dylib
+          name: libs
+          path: rust/target*/release/libopendp.dylib
 
       # need to upload at least one set up updated bindings
       - name: Upload bindings
@@ -193,8 +193,8 @@ jobs:
       - name: Upload .so
         uses: actions/upload-artifact@v3
         with:
-          name: lib
-          path: rust/target/${{ env.TARGET }}*/release/libopendp.so
+          name: libs
+          path: rust/target*/${{ env.TARGET }}/release/libopendp.so
 
 
   python-publish:
@@ -212,37 +212,15 @@ jobs:
           python-version: 3.8
           cache: pip
 
-#      - name: Prepare for libs
-#        run: mkdir -p rust/target/release
-#
-#      - name: Download windows lib
-#        uses: actions/download-artifact@v3
-#        with:
-#          name: lib_dll
-#          path: rust/target/release
-#
-#      - name: Download macos lib
-#        uses: actions/download-artifact@v3
-#        with:
-#          name: lib_dylib
-#          path: rust/target/release
-#
-#      - name: Download linux lib
-#        uses: actions/download-artifact@v3
-#        with:
-#          name: lib_so
-#          path: rust/target/release
-
       - name: Download libs
         uses: actions/download-artifact@v3
         with:
-          name: lib
+          name: libs
           path: rust/target/
 
       - name: Dump directory
         run: |
-          ls -l rust/
-          ls -lR rust/target
+          ls -lR rust/target/
 
       - name: Download bindings
         uses: actions/download-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,10 @@ jobs:
         run: if [[ $BRANCH_DRY_RUN_OK == true ]]; then echo OK; else echo 'Disabled dry run on non-release branch!'; exit 1; fi
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.8
           cache: pip
@@ -62,10 +62,10 @@ jobs:
           install: m4
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~\.cargo\bin
@@ -92,10 +92,10 @@ jobs:
     needs: credential-check
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin
@@ -144,14 +144,21 @@ jobs:
   python-pre-publish-linux:
     runs-on: ubuntu-20.04
     needs: credential-check
+    strategy:
+      matrix:
+        architecture: [x86_64, aarch64]
     env:
-      DOCKER_IMAGE: quay.io/pypa/manylinux2014_x86_64
+      # This image is important. The default manylinux2014 images are problematic to configure for cross-compilation
+      # in a way that will satisfy the gmp configure script.
+      DOCKER_IMAGE: messense/manylinux2014-cross:${{ matrix.architecture }}
+      TARGET: ${{ matrix.architecture }}-unknown-linux-gnu
+      ARCH_LIB: libopendp-${{ matrix.architecture }}.so
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin
@@ -164,13 +171,18 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Create Rust build for linux
-        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh -i -r -t -f \"$FEATURES\""
+        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh -i -r -t -g $TARGET -f \"$FEATURES\""
+
+      - name: Retrieve architecture library
+        run: |
+          mkdir -p rust/target/release
+          mv rust/target/$TARGET/release/libopendp.so rust/target/release/$ARCH_LIB
 
       - name: Upload .so
         uses: actions/upload-artifact@v3
         with:
           name: lib_so
-          path: rust/target/release/libopendp.so
+          path: rust/target/release/$ARCH_LIB
 
 
   python-publish:
@@ -180,10 +192,10 @@ jobs:
       PYPI_API_TOKEN: ${{ inputs.dry_run && secrets.TEST_PYPI_API_TOKEN || secrets.PYPI_API_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.8
           cache: pip
@@ -223,20 +235,20 @@ jobs:
           DRY_RUN_FLAG: ${{ inputs.dry_run && '-n' || '-nn' }}
         run: |
           pip install -r tools/requirements-publish_tool.txt
-          python tools/publish_tool.py python $DRY_RUN_FLAG
+#          python tools/publish_tool.py python $DRY_RUN_FLAG
 
 
   rust-publish:
     runs-on: ubuntu-20.04
-    needs: credential-check
+    needs: python-publish
     env:
       CRATES_IO_API_TOKEN: ${{ secrets.CRATES_IO_API_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.8
           cache: pip

--- a/tools/python_build.sh
+++ b/tools/python_build.sh
@@ -47,6 +47,11 @@ function build() {
   for LIB in release/opendp.dll release/libopendp.dylib release/libopendp.so; do
     [[ -f rust/target/$LIB ]] && run cp rust/target/$LIB python/src/opendp/lib
   done
+  for ARCH in x86_64 aarch64; do
+    [[ -f rust/target/$ARCH-pc-windows-gnu/release/opendp.dll ]] && run cp rust/target/$ARCH-pc-windows-gnu/release/opendp.dll python/src/opendp/lib/opendp-$ARCH.dll
+    [[ -f rust/target/$ARCH-apple-darwin/release/libopendp.dylib ]] && run cp rust/target/$ARCH-apple-darwin/release/libopendp.dylib python/src/opendp/lib/libopendp-$ARCH.dylib
+    [[ -f rust/target/$ARCH-unknown-linux-gnu/release/libopendp.so ]] && run cp rust/target/$ARCH-unknown-linux-gnu/release/libopendp.so python/src/opendp/lib/libopendp-$ARCH.so
+  done
 
   log "Copy README.md"
   run cp README.md python/README.md

--- a/tools/rust_build.sh
+++ b/tools/rust_build.sh
@@ -89,8 +89,9 @@ function init_linux() {
     run curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal
     source ~/.cargo/env
   fi
-  log "Install Perl IPC-CMD"
-  run yum -y install perl-IPC-Cmd
+  # We need m4 for gmp, but messense/manylinux2014-cross doesn't include it.
+  log "Install m4"
+  run apt-get -y install m4
 }
 
 function run_cargo() {


### PR DESCRIPTION
Fixes #817.

* Refactor `release.yml` to include target `aarch64-unknown-linux-gnu`
  * The main grief was getting `gmp` to cross compile to aarch64 from x86_64.
    The configure script just wouldn't work with the toolchain in the standard `manylinux_2014` images,
    but `messense/manylinux2014-cross` seems to have a better setup.
  * Because linux doesn't have fat binaries, we need to have separate `libopendp-XXX.so` files with tagged names
  * Also did some cleanup of action versions
* Tweak rust_build.sh and python_build.sh
* Add logic to _lib.py to load arch-specific libraries