### PR TITLE
Nightly Build Phase 1: Migrate to new version scheme

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,3 +1,3 @@
 # For https://mybinder.org
-# No specific version. We'll mostly link to the "stable" branch.
-opendp
+# Pin to matching version
+opendp==0.8.0.dev0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,7 +296,7 @@ The format of this file is based on [Keep a Changelog](https://keepachangelog.co
 scripts when generating a release, so please maintain the existing format.
 
 Whenever you're preparing a significant commit, add a bullet list entry summarizing the change under the
-[Upcoming Release](#upcoming-release---tbd) heading at the top. Entries should be grouped in sections based on the kind of change.
+X.Y.Z-dev heading at the top. Entries should be grouped in sections based on the kind of change.
 Please use the following sections, maintaining the same ordering. If the appropriate section isn't present yet,
 just add it by copying from those below.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,8 @@
 This file documents the version history of OpenDP. The links on each version number will take you to a comparison
 showing the source changes from the previous version.
 
-Please keep this up to date, following the [instructions](#instructions) below.
 
-
-## [Unreleased](https://github.com/opendp/opendp/compare/stable...HEAD)
+## [0.8.0-dev](https://github.com/opendp/opendp/compare/v0.7.0...HEAD) - TBD
 
 
 ## [0.7.0] - 2023-05-18
@@ -298,7 +296,7 @@ The format of this file is based on [Keep a Changelog](https://keepachangelog.co
 scripts when generating a release, so please maintain the existing format.
 
 Whenever you're preparing a significant commit, add a bullet list entry summarizing the change under the
-[Unreleased](#unreleased) heading at the top. Entries should be grouped in sections based on the kind of change.
+[Upcoming Release](#upcoming-release---tbd) heading at the top. Entries should be grouped in sections based on the kind of change.
 Please use the following sections, maintaining the same ordering. If the appropriate section isn't present yet,
 just add it by copying from those below.
 

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-0.0.0+development
+0.8.0-dev

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,30 +1,30 @@
 [metadata]
 name = opendp
-version = 0.0.0+development
+version = 0.8.0.dev0
 url = https://opendp.org
-project_urls =
-    Source = https://github.com/opendp/opendp
-    Issues = https://github.com/opendp/opendp/issues
-    Documentation = https://docs.opendp.org/
+project_urls = 
+	Source = https://github.com/opendp/opendp
+	Issues = https://github.com/opendp/opendp/issues
+	Documentation = https://docs.opendp.org/
 author = The OpenDP Project
 author_email = info@opendp.org
-classifiers =
-    Programming Language :: Python :: 3
-    License :: OSI Approved :: MIT License
-    Operating System :: OS Independent
+classifiers = 
+	Programming Language :: Python :: 3
+	License :: OSI Approved :: MIT License
+	Operating System :: OS Independent
 license_files = ../LICENSE
 description = Python bindings for the OpenDP Library
 long_description = file: README.md
 long_description_content_type = text/markdown
-keywords =
-    differential privacy
+keywords = 
+	differential privacy
 
 [options]
 zip_safe = false
 python_requires = >=3.8
 packages = find:
-package_dir =
-    = src
+package_dir = 
+	= src
 
 [options.packages.find]
 where = src
@@ -33,5 +33,6 @@ where = src
 opendp = lib/*
 
 [tool:pytest]
-testpaths =
-    test
+testpaths = 
+	test
+

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -199,15 +199,18 @@ def versioned(function):
     This is shown in the help(*) and Sphinx documentation (like docs.opendp.org)."""
 
     version = get_opendp_version()
+    channel = get_channel(version)
 
-    if version != "0.0.0+development":
+    if channel != "dev":
+        # docs.rs keeps all releases, so we can use the full version.
         function.__doc__ = function.__doc__.replace(
             "https://docs.rs/opendp/latest/", f"https://docs.rs/opendp/{version}/"
         )
 
+        docs_ref = get_docs_ref(version)
         function.__doc__ = function.__doc__.replace(
             "https://docs.opendp.org/en/latest/",
-            f"https://docs.opendp.org/en/v{version}/",
+            f"https://docs.opendp.org/en/{docs_ref}/",
         )
 
     return function
@@ -273,9 +276,9 @@ def make_proof_link(
 
         # find the version
         version = get_opendp_version()
-        version_segment = "latest" if version == "0.0.0+development" else "v" + version
+        docs_ref = get_docs_ref(version)
 
-        proof_uri = f"{docs_uri}/en/{version_segment}"
+        proof_uri = f"{docs_uri}/en/{docs_ref}"
 
     return f"{proof_uri}/proofs/{repo_path}/{relative_path}"
 
@@ -299,13 +302,23 @@ def get_opendp_version():
             return get_opendp_version_from_file()
 
 
-def unmangle_py_version(version):
-    # Python mangles pre-release versions like "X.Y.Z-rc.N" into "X.Y.ZrcN", but the docs use the correct format,
-    # so we need to unmangle so the links will work.
-    match = re.match(r"^(\d+\.\d+\.\d+)rc(\d+)$", version)
+def unmangle_py_version(py_version):
+    # Python mangles pre-release versions like "X.Y.Z-nightly.NNN.M" into "X.Y.ZaNNN00M", but the docs use
+    # the original format, so we need to unmangle for links to work.
+    # There are more variations possible, but we only need to handle X.Y.Z-dev0, X.Y.Z-aNNN00M, X.Y.Z-bNNN00M, X.Y.Z
+    if py_version.endswith(".dev0"):
+        return f"{py_version[:-5]}-dev"
+    match = re.match(r"^(\d+\.\d+\.\d+)(?:([ab])(\d{8})(\d{3}))?$", py_version)
     if match:
-        version = f"{match.group(1)}-rc.{match.group(2)}"
-    return version
+        base = match.group(1)
+        py_tag = match.group(2)
+        if not py_tag:
+            return base
+        channel = "nightly" if py_tag == "a" else "beta"
+        date = match.group(3)
+        counter = int(match.group(4))
+        return f"{base}-{channel}.{date}.{counter}"
+    return py_version
 
 
 def get_opendp_version_from_file():
@@ -313,3 +326,21 @@ def get_opendp_version_from_file():
     # so fall back to the version file.
     version_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), *['..'] * 3, 'VERSION')
     return open(version_file, 'r').read().strip()
+
+
+def get_docs_ref(version):
+    channel = get_channel(version)
+    if channel == "stable":
+        return f"v{version}"  # For stable, we have tags.
+    elif channel == "dev":
+        return "latest"  # Will be replaced by the @versioned decorator.
+    else:
+        return channel  # For beta & nightly, we don't have tags, just a single branch.
+
+
+def get_channel(version):
+    match = re.match(r"^(\d+\.\d+\.\d+)(?:-(dev|nightly|beta)(?:\.(.+))?)?$", version)
+    if match:
+        channel = match.group(2)
+        return channel or "stable"
+    return "unknown"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.0.0+development"
+version = "0.8.0-dev"
 license-file = "../LICENSE"
 readme = "../README.md"
 homepage = "https://opendp.org/"
@@ -32,7 +32,7 @@ rust-version.workspace = true
 exclude = ["windows/*"]
 
 [dependencies]
-opendp_derive = { path = "opendp_derive" }
+opendp_derive = { path = "opendp_derive", version = "0.8.0-dev" }
 rand = "0.7.3"
 num = "0.3.1"
 thiserror = "1.0.24"
@@ -41,14 +41,14 @@ rug = { version = "1.14.0", default-features = false, features = ["integer", "fl
 az = { version = "1.2.0", optional = true }
 gmp-mpfr-sys = { version = "1.4.7", default-features = false, features = ["mpfr", "force-cross"], optional = true }
 openssl = { version = "0.10.29", features = ["vendored"], optional = true }
-opendp_tooling = { path = "opendp_tooling", optional = true }
+opendp_tooling = { path = "opendp_tooling", optional = true, version = "0.8.0-dev" }
 readonly = "0.2"
 
 lazy_static = { version = "1.4.0", optional = true }
 vega_lite_4 = { version = "0.6.0", optional = true }
 
 [build-dependencies]
-opendp_tooling = { path = "opendp_tooling", optional = true }
+opendp_tooling = { path = "opendp_tooling", optional = true, version= "0.8.0-dev" }
 syn = { workspace = true, optional = true }
 proc-macro2 = { workspace = true, optional = true }
 

--- a/rust/opendp_derive/Cargo.toml
+++ b/rust/opendp_derive/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 [dependencies]
 syn = { workspace = true, optional = true }
 quote = { workspace = true, optional = true }
-opendp_tooling = { path = "../opendp_tooling", optional = true }
+opendp_tooling = { path = "../opendp_tooling", optional = true, version = "0.8.0-dev" }
 
 [features]
 full = ["syn", "quote", "opendp_tooling"]

--- a/rust/opendp_tooling/Cargo.toml
+++ b/rust/opendp_tooling/Cargo.toml
@@ -16,3 +16,4 @@ serde_json = { version = "1.0" }
 syn = { workspace = true }
 quote = { workspace = true }
 proc-macro2 = { workspace = true }
+regex = { version = "1.9.1" }

--- a/rust/opendp_tooling/src/bootstrap/docstring.rs
+++ b/rust/opendp_tooling/src/bootstrap/docstring.rs
@@ -375,7 +375,7 @@ pub fn make_rustdoc_link(module: &str, name: &str) -> Result<String> {
 
         // find the version
         let mut version = env!("CARGO_PKG_VERSION");
-        if version == "0.0.0+development" {
+        if version.ends_with("-dev") {
             version = "latest";
         };
 

--- a/rust/src/ffi/dispatch.rs
+++ b/rust/src/ffi/dispatch.rs
@@ -144,7 +144,7 @@ pub trait FailedDispatch {
 impl<T> FailedDispatch for Fallible<T> {
     fn failed_dispatch(type_: &str) -> Self {
         let debug_message = if cfg!(debug_assertions) {
-            "You've got a debug binary! Debug binaries support fewer types. Consult https://docs.opendp.org/en/latest/contributor/development-environment.html#build-opendp"
+            "You've got a debug binary! Debug binaries support fewer types. Consult https://docs.opendp.org/en/stable/contributor/development-environment.html#build-opendp"
         } else {
             "See https://github.com/opendp/opendp/discussions/451."
         };

--- a/rust/src/lib.sty
+++ b/rust/src/lib.sty
@@ -76,7 +76,7 @@
 \ifnum\pdf@shellescape=1
   % latex macro expansion has a separate phase for \input evaluation
   %     immediately evaluate a command to write a temp file to ./out containing the base path
-  \immediate\write18{[ ! -f out/rustdoc.txt ] && mkdir -p out && ([ -z `kpsewhich --var-value OPENDP_RUSTDOC_PORT` ] && echo "https://docs.rs/opendp/`head -n 1 \@backslashchar`git rev-parse --show-toplevel\@backslashchar`/VERSION | sed 's|0.0.0+development|latest|g'`" || echo "http://localhost:`kpsewhich --var-value OPENDP_RUSTDOC_PORT`") > out/rustdoc.txt}
+  \immediate\write18{[ ! -f out/rustdoc.txt ] && mkdir -p out && ([ -z `kpsewhich --var-value OPENDP_RUSTDOC_PORT` ] && echo "https://docs.rs/opendp/`head -n 1 \@backslashchar`git rev-parse --show-toplevel\@backslashchar`/VERSION | sed 's|.*-dev.*|latest|g'`" || echo "http://localhost:`kpsewhich --var-value OPENDP_RUSTDOC_PORT`") > out/rustdoc.txt}
   %     ...and then retrieve the base path by loading the temp file
   \CatchFileDef\OpenDPRustdocBase{out/rustdoc.txt}{\endlinechar=-1}
 \else

--- a/tools/assert_version.py
+++ b/tools/assert_version.py
@@ -1,20 +1,38 @@
 import configparser
-import toml
+import tomlkit
+
+from utils import *
 
 # all version numbers should be:
-version = open("VERSION", 'r').read().strip()
-assert version != "0.0.0+development", "Please update the repository with the current version."
-print("Checking if all version numbers are synchronized at", version)
+version = get_version()
+python_version = get_python_version(version)
 
-# check that Python version is set properly
-config = configparser.RawConfigParser()
-config.read('python/setup.cfg')
-assert config['metadata']['version'] == version, \
-    "python/setup.cfg package version is incorrect"
+assert "dev" not in version.prerelease, "Please configure the channel with a non-dev version."
+print("Checking if all version numbers are synchronized at", version, python_version)
 
 # check that opendp crate version is set properly
-opendp_toml = toml.load('rust/Cargo.toml')
+# cargo doesn't like build metadata in dependency references, so we strip that for those.
+stripped_version = version.replace(build=None)
+opendp_toml = tomlkit.load(open('rust/Cargo.toml'))
 assert opendp_toml['workspace']['package']['version'] == version, \
-    "rust/Cargo.toml crate version is incorrect"
+    "rust/Cargo.toml workspace version is incorrect"
+assert opendp_toml['dependencies']['opendp_derive']['version'] == version, \
+    "rust/Cargo.toml dependency opendp_derive version is incorrect"
+assert opendp_toml['build-dependencies']['opendp_tooling']['version'] == version, \
+    "rust/Cargo.toml build-dependency opendp_tooling version is incorrect"
+opendp_derive_toml = tomlkit.load(open('rust/opendp_derive/Cargo.toml'))
+assert opendp_derive_toml['dependencies']['opendp_tooling']['version'] == version, \
+    "rust/Cargo.toml dependency opendp_derive version is incorrect"
+
+config = configparser.RawConfigParser()
+config.read('python/setup.cfg')
+assert config['metadata']['version'] == str(python_version), \
+    "python/setup.cfg package version is incorrect"
+
+binder_requirements = open('.binder/requirements.txt').readlines()
+for line in binder_requirements:
+    if line.startswith("opendp=="):
+        assert line == f"opendp=={python_version}\n", \
+            ".binder/requirements.txt opendp dependency is incorrect"
 
 print("All version numbers are synchronized")

--- a/tools/requirements-assert_version.txt
+++ b/tools/requirements-assert_version.txt
@@ -1,1 +1,2 @@
-toml
+semver==3.0
+tomlkit==0.11.8

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -1,0 +1,108 @@
+import subprocess
+import sys
+import time
+
+import semver
+
+
+def log(message, command=False):
+    prefix = "$" if command else "#"
+    print(f"{prefix} {message}", file=sys.stderr)
+
+
+def run_command(description, cmd, capture_output=False, shell=True):
+    if description:
+        log(description)
+    printed_cmd = " ".join(cmd) if type(cmd) == list else cmd
+    log(printed_cmd, command=True)
+    stdout = subprocess.PIPE if capture_output else None
+    completed_process = subprocess.run(cmd, stdout=stdout, shell=shell, check=True, encoding="utf-8")
+    return completed_process.stdout.rstrip() if capture_output else None
+
+
+def run_command_with_retries(description, args, timeout, backoff, capture_output=False, shell=True):
+    start = time.time()
+    wait = 1.0
+    while True:
+        try:
+            return run_command(description, args, capture_output=capture_output, shell=shell)
+        except Exception as e:
+            elapsed = time.time() - start
+            if elapsed >= timeout:
+                raise e
+        w = min(wait, timeout - elapsed)
+        log(f"Retrying in {w:.1f} seconds")
+        time.sleep(w)
+        wait *= backoff
+
+
+def get_version(version_str=None):
+    if not version_str:
+        with open("VERSION") as f:
+            version_str = f.read().strip()
+    return semver.Version.parse(version_str)
+
+
+def get_python_version(version):
+    # Python (PEP 440) has several annoying quirks that make it not quite compatible with semantic versioning:
+    # 1. Python doesn't allow arbitrary tags, only (a|b|rc|post|dev). (You can use (alpha|beta|c|pre|preview|rev|r),
+    #    but they'll be mapped to (a|b|rc|rc|rc|post|post) respectively.)
+    #    So "1.2.3-nightly.456" will fail, and "1.2.3-alpha.456" gets mapped to "1.2.3a456" (see #2).
+    # 2. Python doesn't allow separators between the main version and the tag, nor within the tag.
+    #    So "1.2.3-a.456" gets mapped to "1.2.3a456"
+    # 3. HOWEVER, Python treats tags "post" and "dev" differently, and in these cases uses a "." separator between
+    #    the main version and the tag (but still doesn't allow separators within the tag).
+    #    So "1.2.3-dev.456" gets mapped to "1.2.3.dev456".
+    # 4. Python requires that all tags have a numeric suffix, and will assume 0 if none is present.
+    #    So "1.2.3-dev" gets mapped to "1.2.3.dev0" (by #3 & #4).
+    # We don't use all these variations, only (dev|nightly|beta), but if that ever changes, hopefully we won't
+    # have to look at this whole mess again.
+    tag_to_py_tag = {
+        "nightly": "a",
+        "beta": "b",
+        "c": "rc",
+        "pre": "rc",
+        "preview": "rc",
+        "rev": "post",
+        "r": "post",
+    }
+    if version.prerelease is not None:
+        split = version.prerelease.split(".", 2)
+        tag = split[0]
+        py_tag = tag_to_py_tag.get(tag, tag)
+        date = split[1] if len(split) >= 2 else None
+        counter = split[2] if len(split) >= 3 else None
+        py_n = f"{date}{counter:>03}" if date and counter else (date if date else "0")
+        py_separator = "." if py_tag in ("post", "dev") else ""
+    else:
+        py_tag = None
+        py_n = None
+        py_separator = None
+    # semver can't represent the rendered Python version, so we generate a string.
+    if py_tag is not None:
+        return f"{version.major}.{version.minor}.{version.patch}{py_separator}{py_tag}{py_n}"
+    else:
+        return str(version)
+
+
+def infer_channel(version):
+    if version.prerelease is None:
+        return "stable"
+    channel = version.prerelease.split(".", 1)[0]
+    if channel not in ("dev", "nightly", "beta"):
+        raise Exception(f"Unable to infer channel from version {version}")
+    return channel
+
+
+def get_current_branch():
+    return run_command(f"Determining current branch", "git branch --show-current", capture_output=True)
+
+
+def main():
+    version = get_version()
+    python_version = get_python_version(version)
+    print(f"{version} ({python_version})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Overview
Phase 1 of nightly builds. This part is limited to updating the version references in various files to match the new scheme, plus tweaking the codegen that consumes them.

# Details
* Adopt 3 release channels, with corresponding branches (takes full effect in #878)
  * `nightly` pulls from `main` every night (if there are changes)
  * `beta` pulls from `nightly` every 3 months, ~1 week before release
  * `stable` pulls from `beta` every 3 months
* switch from null version `0.0.0+development` to correct version on each channel
  * `main`: `X.Y.Z-dev`
  * `nightly`: `X.Y.Z-nightly.YYYYMMDD.N`
  * `beta`: `X.Y.Z-beta.YYYYMMDD.N`
  * `stable`: `X.Y.Z`
 
# Changes
* The various `Cargo.toml` files were updated so that internal dependencies have good versions (which get updated by `channel_tool.py` as necessary).
* `python/setup.cfg` was reformatted so that it round-trips cleanly through configparser (tabs, ugh)
* A bunch of stuff in the codegen docstrings was tweaked to match the new versioning scheme.
* `nightly` and `beta` versions have a counter after the date, which isn't necessary for regular operation, but is extremely useful for testing multiple versions in a single day.
* If we decide to commit the generated Python bindings (could do this in `build.yml`), then I think we could get rid of the `@versioned` decorator, as all building and doc generation happens on a channel with the versions updated.
