### PR TITLE
Use correct repo for sanity-test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,10 +61,12 @@ on:
         required: false
         default: false
       fake:
-        description: Fake Build?
+        description: Fake Build (Implies Dry Run)?
         type: boolean
         required: false
         default: false
+env:
+  DRY_RUN: ${{ inputs.dry_run || inputs.fake }}
 
 jobs:
   prepare:
@@ -95,7 +97,7 @@ jobs:
     with:
       channel: ${{ inputs.channel }}
       date: ${{ needs.prepare.outputs.date }}
-      dry_run: ${{ inputs.dry_run || inputs.fake }}
+      dry_run: ${{ env.DRY_RUN }}
     secrets: inherit
 
   sanity-test-post:
@@ -103,7 +105,8 @@ jobs:
     uses: ./.github/workflows/sanity-test.yml
     with:
       channel: ${{ inputs.channel }}
-      python_repository: testpypi
+      # dry-runs go to TestPyPI instead of PyPI
+      python_repository: ${{ env.DRY_RUN && 'testpypi' || 'pypi' }}
       fake: ${{ inputs.fake }}
 
   latex:
@@ -117,4 +120,4 @@ jobs:
     needs: [ sanity-test-post, latex ]
     uses: ./.github/workflows/docs.yml
     with:
-      dry_run: ${{ inputs.dry_run || inputs.fake }}
+      dry_run: ${{ env.DRY_RUN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,8 +65,6 @@ on:
         type: boolean
         required: false
         default: false
-env:
-  DRY_RUN: ${{ inputs.dry_run || inputs.fake }}
 
 jobs:
   prepare:
@@ -97,7 +95,7 @@ jobs:
     with:
       channel: ${{ inputs.channel }}
       date: ${{ needs.prepare.outputs.date }}
-      dry_run: ${{ env.DRY_RUN }}
+      dry_run: ${{ inputs.dry_run || inputs.fake }}
     secrets: inherit
 
   sanity-test-post:
@@ -106,7 +104,7 @@ jobs:
     with:
       channel: ${{ inputs.channel }}
       # dry-runs go to TestPyPI instead of PyPI
-      python_repository: ${{ env.DRY_RUN && 'testpypi' || 'pypi' }}
+      python_repository: ${{ (inputs.dry_run || inputs.fake) && 'testpypi' || 'pypi' }}
       fake: ${{ inputs.fake }}
 
   latex:
@@ -120,4 +118,4 @@ jobs:
     needs: [ sanity-test-post, latex ]
     uses: ./.github/workflows/docs.yml
     with:
-      dry_run: ${{ env.DRY_RUN }}
+      dry_run: ${{ inputs.dry_run || inputs.fake }}


### PR DESCRIPTION
Fixes #714.

From the nightly run last night, everything worked until the post-release sanity test (failure: https://github.com/opendp/opendp/actions/runs/5676312359/job/15383615116). There was a hard-coded reference to `testpypi` left over from testing. 

I tried to clean up the dry-run logic in `release.yml`, by having a single environment variable, but GH actions don't allow you to reference top-level environment variables in jobs. (See https://github.com/orgs/community/discussions/26529 for discussion and a clunky workaround.) So the `inputs.dry_run || inputs.fake` logic remains inline.