### PR TITLE
user-friendly downcast-ref error message

### DIFF
--- a/rust/src/ffi/util.rs
+++ b/rust/src/ffi/util.rs
@@ -319,7 +319,7 @@ lazy_static! {
             type_vec![SMDCurve, <f32, f64>],
         ].into_iter().flatten().collect();
         let descriptors: HashSet<_> = types.iter().map(|e| &e.descriptor).collect();
-        assert_eq!(descriptors.len(), types.len());
+        assert_eq!(descriptors.len(), types.len(), "detected duplicate TYPES");
         types
     };
 }


### PR DESCRIPTION
Before/after:
* `Failed downcast_ref of AnyBox to polars_lazy::frame::LazyFrame`
* `Expected data of type LazyFrame. Got Vec<AnyObject>`