### PR TITLE
Fix 0.8 release issues

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,3 +1,4 @@
 # For https://mybinder.org
 # Pin to matching version
 opendp==0.8.0.dev0
+-r ../docs/requirements_notebooks.txt

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -185,10 +185,10 @@ rst_prolog = """
 # we have to resolve the link ref here, at runtime, because sphinx-multiversion mediates the reading of this config
 nbsphinx_prolog = fr"""
 {{% set docname = 'docs/source/' + env.doc2path(env.docname, base=None) %}}
-{{% if env.config.version.endswith('-dev') %}}
+{{% if env.config.release.endswith('-dev') %}}
     {{% set frag = 'main' %}}
-{{% elif '-' in env.config.version %}}
-    {{% set frag = env.config.version.split('-', 1)[1].split('.', 1)[0] %}}
+{{% elif '-' in env.config.release %}}
+    {{% set frag = env.config.release.split('-', 1)[1].split('.', 1)[0] %}}
 {{% else %}}
     {{% set frag = 'v' ~ env.config.version %}}
 {{% endif %}}

--- a/tools/channel_tool.py
+++ b/tools/channel_tool.py
@@ -92,6 +92,7 @@ def update_version(version):
     def munge_cargo_root(toml):
         toml["workspace"]["package"]["version"] = str(version)
         toml["dependencies"]["opendp_derive"]["version"] = str(stripped_version)
+        toml["dependencies"]["opendp_tooling"]["version"] = str(stripped_version)
         toml["build-dependencies"]["opendp_tooling"]["version"] = str(stripped_version)
         return toml
     update_file("rust/Cargo.toml", tomlkit.load, munge_cargo_root, tomlkit.dump)


### PR DESCRIPTION
Fixes #909.

* Make `channel_tool.py` update version dependencies version for `opendp_tooling`
* Have `nbsphinx_prolog` Jinja magic use `env.config.release` for constructing binder links
* Add `requirements_notebooks.txt` to binder requirements