### PR TITLE
Only show binder link above 0.7.0

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,3 +1,5 @@
 # For https://mybinder.org
 # Pin to matching version
 opendp==0.8.0.dev0
+
+-r docs/requirements_notebooks.txt

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,5 +1,3 @@
 # For https://mybinder.org
 # Pin to matching version
 opendp==0.8.0.dev0
-
--r docs/requirements_notebooks.txt

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ The steps below assume the use of [Homebrew] on a Mac.
 [Homebrew]: https://brew.sh
 
 ```shell
+cd docs
 brew install pandoc
 python3 -m venv venv
 source venv/bin/activate

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -181,6 +181,11 @@ rst_prolog = """
 .. |toctitle| replace:: Contents:
 """
 
+binder_link = '' if semver_version <= semver.Version.parse('0.7.0') else '''
+  Interactive online version:
+  <span style="white-space: nowrap;"><a href="https://mybinder.org/v2/gh/opendp/opendp/{{ frag|e }}?filepath={{ docname|e }}" target="_blank"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg" style="vertical-align:text-bottom"></a>.</span>
+'''
+
 # insert this header on nbsphinx pages to link to binder and github:
 # we have to resolve the link ref here, at runtime, because sphinx-multiversion mediates the reading of this config
 nbsphinx_prolog = fr"""
@@ -197,7 +202,6 @@ nbsphinx_prolog = fr"""
     <div class="admonition note">
       This page was generated from
       <a class="reference external" href="https://github.com/opendp/opendp/tree/{{{{ frag|e }}}}/{{{{ docname|e }}}}" target="_blank">{{{{ docname|e }}}}</a>.
-      Interactive online version:
-      <span style="white-space: nowrap;"><a href="https://mybinder.org/v2/gh/opendp/opendp/{{{{ frag|e }}}}?filepath={{{{ docname|e }}}}" target="_blank"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg" style="vertical-align:text-bottom"></a>.</span>
+      {binder_link}
     </div>
 """


### PR DESCRIPTION
Possible fix for the remaining part of:
- #903

I've run `make html`, but I'm getting an error with `make versions` locally, though I don't think it's related to these particular changes.

I'm ambivalent about this PR:
- It adds complexity, for a pretty minor change in behavior.
- I'm not confident that 0.7.0 is the right bound: would less-than 0.8.0 be better?
- Even if this is the right direction, maybe it's better to do the conditional inside the template?