### PR TITLE
don't use ffiresult in monomorphize functions

### DIFF
--- a/rust/src/core/ffi.rs
+++ b/rust/src/core/ffi.rs
@@ -143,7 +143,7 @@ impl<T: Debug> Debug for FfiResult<*mut T> {
 /// because there's a blanket implementation of From for FfiResult. We can't do this with a method on Result
 /// because it comes from another crate. So we need a separate trait.
 pub trait IntoAnyMeasurementFfiResultExt {
-    fn into_any(self) -> FfiResult<*mut AnyMeasurement>;
+    fn into_any(self) -> Fallible<AnyMeasurement>;
 }
 
 impl<DI: 'static + Domain, TO: 'static, MI: 'static + Metric, MO: 'static + Measure>
@@ -152,8 +152,8 @@ where
     MO::Distance: 'static,
     (DI, MI): MetricSpace,
 {
-    fn into_any(self) -> FfiResult<*mut AnyMeasurement> {
-        self.map(Measurement::into_any).into()
+    fn into_any(self) -> Fallible<AnyMeasurement> {
+        self.map(Measurement::into_any)
     }
 }
 
@@ -161,7 +161,7 @@ where
 /// because there's a blanket implementation of From for FfiResult. We can't do this with a method on Result
 /// because it comes from another crate. So we need a separate trait.
 pub trait IntoAnyTransformationFfiResultExt {
-    fn into_any(self) -> FfiResult<*mut AnyTransformation>;
+    fn into_any(self) -> Fallible<AnyTransformation>;
 }
 
 impl<DI: 'static + Domain, DO: 'static + Domain, MI: 'static + Metric, MO: 'static + Metric>
@@ -172,20 +172,18 @@ where
     (DI, MI): MetricSpace,
     (DO, MO): MetricSpace,
 {
-    fn into_any(self) -> FfiResult<*mut AnyTransformation> {
-        self.map(Transformation::into_any).into()
+    fn into_any(self) -> Fallible<AnyTransformation> {
+        self.map(Transformation::into_any)
     }
 }
 
 pub trait IntoAnyFunctionFfiResultExt {
-    fn into_any(self) -> FfiResult<*mut AnyFunction>;
+    fn into_any(self) -> Fallible<AnyFunction>;
 }
 
-impl<TI: 'static, TO: 'static> IntoAnyFunctionFfiResultExt
-    for Fallible<Function<TI, TO>>
-{
-    fn into_any(self) -> FfiResult<*mut AnyFunction> {
-        self.map(Function::into_any).into()
+impl<TI: 'static, TO: 'static> IntoAnyFunctionFfiResultExt for Fallible<Function<TI, TO>> {
+    fn into_any(self) -> Fallible<AnyFunction> {
+        self.map(Function::into_any)
     }
 }
 

--- a/rust/src/ffi/util.rs
+++ b/rust/src/ffi/util.rs
@@ -367,6 +367,10 @@ pub fn as_ref<'a, T>(p: *const T) -> Option<&'a T> {
     (!p.is_null()).then(|| unsafe { &*p })
 }
 
+pub fn try_as_ref<'a, T>(p: *const T) -> Fallible<&'a T> {
+    as_ref(p).ok_or_else(|| err!(FFI, "attempted to read a null pointer"))
+}
+
 pub fn as_mut_ref<'a, T>(p: *mut T) -> Option<&'a mut T> {
     (!p.is_null()).then(|| unsafe { &mut *p })
 }

--- a/rust/src/ffi/util.rs
+++ b/rust/src/ffi/util.rs
@@ -367,10 +367,6 @@ pub fn as_ref<'a, T>(p: *const T) -> Option<&'a T> {
     (!p.is_null()).then(|| unsafe { &*p })
 }
 
-pub fn try_as_ref<'a, T>(p: *const T) -> Fallible<&'a T> {
-    as_ref(p).ok_or_else(|| err!(FFI, "attempted to read a null pointer"))
-}
-
 pub fn as_mut_ref<'a, T>(p: *mut T) -> Option<&'a mut T> {
     (!p.is_null()).then(|| unsafe { &mut *p })
 }

--- a/rust/src/measurements/gaussian/discrete/ffi.rs
+++ b/rust/src/measurements/gaussian/discrete/ffi.rs
@@ -6,6 +6,7 @@ use rug::{Integer, Rational};
 
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt, MetricSpace};
 use crate::domains::{AtomDomain, VectorDomain};
+use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMeasurement, AnyMetric, Downcast};
 use crate::ffi::util::Type;
 use crate::measurements::{
@@ -28,7 +29,7 @@ pub extern "C" fn opendp_measurements__make_base_discrete_gaussian(
         D: Type,
         MO: Type,
         QI: Type,
-    ) -> FfiResult<*mut AnyMeasurement>
+    ) -> Fallible<AnyMeasurement>
     where
         T: 'static + CheckAtom + Clone,
         Integer: From<T> + SaturatingCast<T>,
@@ -41,7 +42,7 @@ pub extern "C" fn opendp_measurements__make_base_discrete_gaussian(
             input_domain: &AnyDomain,
             input_metric: &AnyMetric,
             scale: MO::Atom,
-        ) -> FfiResult<*mut AnyMeasurement>
+        ) -> Fallible<AnyMeasurement>
         where
             D: 'static + BaseDiscreteGaussianDomain<QI>,
             (D, D::InputMetric): MetricSpace,
@@ -52,8 +53,8 @@ pub extern "C" fn opendp_measurements__make_base_discrete_gaussian(
 
             QI: Number,
         {
-            let input_domain = try_!(input_domain.downcast_ref::<D>()).clone();
-            let input_metric = try_!(input_metric.downcast_ref::<D::InputMetric>()).clone();
+            let input_domain = input_domain.downcast_ref::<D>()?.clone();
+            let input_metric = input_metric.downcast_ref::<D::InputMetric>()?.clone();
             make_base_discrete_gaussian::<D, MO, QI>(input_domain, input_metric, scale).into_any()
         }
         let scale = *try_as_ref!(scale as *const QO);
@@ -77,6 +78,7 @@ pub extern "C" fn opendp_measurements__make_base_discrete_gaussian(
         (QI, @numbers),
         (QO, @floats)
     ], (input_domain, input_metric, scale, D, MO, QI))
+    .into()
 }
 
 #[cfg(test)]

--- a/rust/src/measurements/laplace/continuous/ffi.rs
+++ b/rust/src/measurements/laplace/continuous/ffi.rs
@@ -2,7 +2,9 @@ use std::os::raw::{c_long, c_void};
 
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt, MetricSpace};
 use crate::domains::{AtomDomain, VectorDomain};
+use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMeasurement, AnyMetric, Downcast};
+use crate::ffi::util::try_as_ref;
 use crate::measurements::{make_base_laplace, BaseLaplaceDomain};
 use crate::traits::samplers::SampleDiscreteLaplaceZ2k;
 use crate::traits::{ExactIntCast, Float, FloatBits};
@@ -20,16 +22,16 @@ pub extern "C" fn opendp_measurements__make_base_laplace(
         input_metric: &AnyMetric,
         scale: *const c_void,
         k: i32,
-    ) -> FfiResult<*mut AnyMeasurement>
+    ) -> Fallible<AnyMeasurement>
     where
         D: 'static + BaseLaplaceDomain,
         (D, D::InputMetric): MetricSpace,
         D::Atom: Float + SampleDiscreteLaplaceZ2k,
         i32: ExactIntCast<<D::Atom as FloatBits>::Bits>,
     {
-        let input_domain = try_!(input_domain.downcast_ref::<D>()).clone();
-        let input_metric = try_!(input_metric.downcast_ref::<D::InputMetric>()).clone();
-        let scale = *try_as_ref!(scale as *const D::Atom);
+        let input_domain = input_domain.downcast_ref::<D>()?.clone();
+        let input_metric = input_metric.downcast_ref::<D::InputMetric>()?.clone();
+        let scale = *try_as_ref(scale as *const D::Atom)?;
         make_base_laplace::<D>(input_domain, input_metric, scale, Some(k)).into_any()
     }
     let input_domain = try_as_ref!(input_domain);
@@ -38,7 +40,7 @@ pub extern "C" fn opendp_measurements__make_base_laplace(
     let D = input_domain.type_.clone();
     dispatch!(monomorphize, [
         (D, [AtomDomain<f64>, AtomDomain<f32>, VectorDomain<AtomDomain<f64>>, VectorDomain<AtomDomain<f32>>])
-    ], (input_domain, input_metric, scale, k))
+    ], (input_domain, input_metric, scale, k)).into()
 }
 
 #[cfg(test)]

--- a/rust/src/measurements/laplace/continuous/ffi.rs
+++ b/rust/src/measurements/laplace/continuous/ffi.rs
@@ -4,7 +4,6 @@ use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt, MetricSpace};
 use crate::domains::{AtomDomain, VectorDomain};
 use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMeasurement, AnyMetric, Downcast};
-use crate::ffi::util::try_as_ref;
 use crate::measurements::{make_base_laplace, BaseLaplaceDomain};
 use crate::traits::samplers::SampleDiscreteLaplaceZ2k;
 use crate::traits::{ExactIntCast, Float, FloatBits};
@@ -31,7 +30,7 @@ pub extern "C" fn opendp_measurements__make_base_laplace(
     {
         let input_domain = input_domain.downcast_ref::<D>()?.clone();
         let input_metric = input_metric.downcast_ref::<D::InputMetric>()?.clone();
-        let scale = *try_as_ref(scale as *const D::Atom)?;
+        let scale = *try_as_ref!(scale as *const D::Atom);
         make_base_laplace::<D>(input_domain, input_metric, scale, Some(k)).into_any()
     }
     let input_domain = try_as_ref!(input_domain);

--- a/rust/src/measurements/laplace/discrete/cks20/ffi.rs
+++ b/rust/src/measurements/laplace/discrete/cks20/ffi.rs
@@ -4,10 +4,11 @@ use std::os::raw::{c_char, c_void};
 use az::SaturatingCast;
 
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt, MetricSpace};
+use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMeasurement, AnyMetric, Downcast};
 use crate::{
     domains::{AtomDomain, VectorDomain},
-    ffi::util::Type,
+    ffi::util::{Type, try_as_ref},
     measurements::{make_base_discrete_laplace_cks20, BaseDiscreteLaplaceDomain},
     traits::InfCast,
 };
@@ -25,7 +26,7 @@ pub extern "C" fn opendp_measurements__make_base_discrete_laplace_cks20(
         scale: *const c_void,
         D: Type,
         QO: Type,
-    ) -> FfiResult<*mut AnyMeasurement>
+    ) -> Fallible<AnyMeasurement>
     where
         T: crate::traits::Integer,
         QO: crate::traits::Float + InfCast<T>,
@@ -36,7 +37,7 @@ pub extern "C" fn opendp_measurements__make_base_discrete_laplace_cks20(
             input_domain: &AnyDomain,
             input_metric: &AnyMetric,
             scale: QO,
-        ) -> FfiResult<*mut AnyMeasurement>
+        ) -> Fallible<AnyMeasurement>
         where
             D: 'static + BaseDiscreteLaplaceDomain,
             D::Atom: crate::traits::Integer,
@@ -45,11 +46,11 @@ pub extern "C" fn opendp_measurements__make_base_discrete_laplace_cks20(
             rug::Rational: TryFrom<QO>,
             rug::Integer: From<D::Atom> + SaturatingCast<D::Atom>,
         {
-            let input_domain = try_!(input_domain.downcast_ref::<D>()).clone();
-            let input_metric = try_!(input_metric.downcast_ref::<D::InputMetric>()).clone();
+            let input_domain = input_domain.downcast_ref::<D>()?.clone();
+            let input_metric = input_metric.downcast_ref::<D::InputMetric>()?.clone();
             make_base_discrete_laplace_cks20::<D, QO>(input_domain, input_metric, scale).into_any()
         }
-        let scale = *try_as_ref!(scale as *const QO);
+        let scale = *try_as_ref(scale as *const QO)?;
         dispatch!(monomorphize2, [
             (D, [AtomDomain<T>, VectorDomain<AtomDomain<T>>]),
             (QO, [QO])
@@ -63,7 +64,7 @@ pub extern "C" fn opendp_measurements__make_base_discrete_laplace_cks20(
     dispatch!(monomorphize, [
         (T, @integers),
         (QO, @floats)
-    ], (input_domain, input_metric, scale, D, QO))
+    ], (input_domain, input_metric, scale, D, QO)).into()
 }
 
 #[cfg(test)]

--- a/rust/src/measurements/laplace/discrete/cks20/ffi.rs
+++ b/rust/src/measurements/laplace/discrete/cks20/ffi.rs
@@ -8,7 +8,7 @@ use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMeasurement, AnyMetric, Downcast};
 use crate::{
     domains::{AtomDomain, VectorDomain},
-    ffi::util::{Type, try_as_ref},
+    ffi::util::Type,
     measurements::{make_base_discrete_laplace_cks20, BaseDiscreteLaplaceDomain},
     traits::InfCast,
 };
@@ -50,7 +50,7 @@ pub extern "C" fn opendp_measurements__make_base_discrete_laplace_cks20(
             let input_metric = input_metric.downcast_ref::<D::InputMetric>()?.clone();
             make_base_discrete_laplace_cks20::<D, QO>(input_domain, input_metric, scale).into_any()
         }
-        let scale = *try_as_ref(scale as *const QO)?;
+        let scale = *try_as_ref!(scale as *const QO);
         dispatch!(monomorphize2, [
             (D, [AtomDomain<T>, VectorDomain<AtomDomain<T>>]),
             (QO, [QO])

--- a/rust/src/measurements/laplace/discrete/ffi.rs
+++ b/rust/src/measurements/laplace/discrete/ffi.rs
@@ -5,7 +5,7 @@ use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt, MetricSpace};
 use crate::domains::{AtomDomain, VectorDomain};
 use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMeasurement, AnyMetric, Downcast};
-use crate::ffi::util::{try_as_ref, Type};
+use crate::ffi::util::Type;
 use crate::measurements::{make_base_discrete_laplace, BaseDiscreteLaplaceDomain};
 use crate::traits::samplers::SampleDiscreteLaplaceLinear;
 use crate::traits::{Float, InfCast, Integer};
@@ -49,7 +49,7 @@ pub extern "C" fn opendp_measurements__make_base_discrete_laplace(
             make_base_discrete_laplace::<D, QO>(input_domain, input_metric, scale).into_any()
         }
         let D = input_domain.type_.clone();
-        let scale = *try_as_ref(scale as *const QO)?;
+        let scale = *try_as_ref!(scale as *const QO);
         dispatch!(monomorphize2, [
             (D, [AtomDomain<T>, VectorDomain<AtomDomain<T>>]),
             (QO, [QO])
@@ -82,7 +82,7 @@ pub extern "C" fn opendp_measurements__make_base_discrete_laplace(
             make_base_discrete_laplace::<D, QO>(input_domain, input_metric, scale).into_any()
         }
         let D = input_domain.type_.clone();
-        let scale = *try_as_ref(scale as *const QO)?;
+        let scale = *try_as_ref!(scale as *const QO);
         dispatch!(monomorphize2, [
             (D, [AtomDomain<T>, VectorDomain<AtomDomain<T>>]),
             (QO, [QO])

--- a/rust/src/measurements/laplace/discrete/ffi.rs
+++ b/rust/src/measurements/laplace/discrete/ffi.rs
@@ -3,8 +3,9 @@ use std::os::raw::{c_char, c_void};
 
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt, MetricSpace};
 use crate::domains::{AtomDomain, VectorDomain};
+use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMeasurement, AnyMetric, Downcast};
-use crate::ffi::util::Type;
+use crate::ffi::util::{try_as_ref, Type};
 use crate::measurements::{make_base_discrete_laplace, BaseDiscreteLaplaceDomain};
 use crate::traits::samplers::SampleDiscreteLaplaceLinear;
 use crate::traits::{Float, InfCast, Integer};
@@ -23,7 +24,7 @@ pub extern "C" fn opendp_measurements__make_base_discrete_laplace(
         input_metric: &AnyMetric,
         scale: *const c_void,
         QO: Type,
-    ) -> FfiResult<*mut AnyMeasurement>
+    ) -> Fallible<AnyMeasurement>
     where
         T: Integer + SampleDiscreteLaplaceLinear<QO>,
         QO: Float + InfCast<T> + InfCast<T>,
@@ -34,7 +35,7 @@ pub extern "C" fn opendp_measurements__make_base_discrete_laplace(
             input_domain: &AnyDomain,
             input_metric: &AnyMetric,
             scale: QO,
-        ) -> FfiResult<*mut AnyMeasurement>
+        ) -> Fallible<AnyMeasurement>
         where
             D: 'static + BaseDiscreteLaplaceDomain,
             (D, D::InputMetric): MetricSpace,
@@ -43,12 +44,12 @@ pub extern "C" fn opendp_measurements__make_base_discrete_laplace(
             rug::Rational: TryFrom<QO>,
             rug::Integer: From<D::Atom> + az::SaturatingCast<D::Atom>,
         {
-            let input_domain = try_!(input_domain.downcast_ref::<D>()).clone();
-            let input_metric = try_!(input_metric.downcast_ref::<D::InputMetric>()).clone();
+            let input_domain = input_domain.downcast_ref::<D>()?.clone();
+            let input_metric = input_metric.downcast_ref::<D::InputMetric>()?.clone();
             make_base_discrete_laplace::<D, QO>(input_domain, input_metric, scale).into_any()
         }
         let D = input_domain.type_.clone();
-        let scale = *try_as_ref!(scale as *const QO);
+        let scale = *try_as_ref(scale as *const QO)?;
         dispatch!(monomorphize2, [
             (D, [AtomDomain<T>, VectorDomain<AtomDomain<T>>]),
             (QO, [QO])
@@ -60,7 +61,7 @@ pub extern "C" fn opendp_measurements__make_base_discrete_laplace(
         input_metric: &AnyMetric,
         scale: *const c_void,
         QO: Type,
-    ) -> FfiResult<*mut AnyMeasurement>
+    ) -> Fallible<AnyMeasurement>
     where
         T: Integer + SampleDiscreteLaplaceLinear<QO>,
         QO: Float + InfCast<T>,
@@ -69,19 +70,19 @@ pub extern "C" fn opendp_measurements__make_base_discrete_laplace(
             input_domain: &AnyDomain,
             input_metric: &AnyMetric,
             scale: QO,
-        ) -> FfiResult<*mut AnyMeasurement>
+        ) -> Fallible<AnyMeasurement>
         where
             D: 'static + BaseDiscreteLaplaceDomain,
             (D, D::InputMetric): MetricSpace,
             D::Atom: Integer + SampleDiscreteLaplaceLinear<QO>,
             QO: Float + InfCast<D::Atom>,
         {
-            let input_domain = try_!(input_domain.downcast_ref::<D>()).clone();
-            let input_metric = try_!(input_metric.downcast_ref::<D::InputMetric>()).clone();
+            let input_domain = input_domain.downcast_ref::<D>()?.clone();
+            let input_metric = input_metric.downcast_ref::<D::InputMetric>()?.clone();
             make_base_discrete_laplace::<D, QO>(input_domain, input_metric, scale).into_any()
         }
         let D = input_domain.type_.clone();
-        let scale = *try_as_ref!(scale as *const QO);
+        let scale = *try_as_ref(scale as *const QO)?;
         dispatch!(monomorphize2, [
             (D, [AtomDomain<T>, VectorDomain<AtomDomain<T>>]),
             (QO, [QO])
@@ -95,6 +96,7 @@ pub extern "C" fn opendp_measurements__make_base_discrete_laplace(
         (T, @integers),
         (QO, @floats)
     ], (input_domain, input_metric, scale, QO))
+    .into()
 }
 
 #[cfg(test)]

--- a/rust/src/measurements/laplace/discrete/linear/ffi.rs
+++ b/rust/src/measurements/laplace/discrete/linear/ffi.rs
@@ -7,7 +7,7 @@ use crate::ffi::any::{AnyDomain, AnyMeasurement, AnyMetric, AnyObject, Downcast}
 use crate::{core::IntoAnyMeasurementFfiResultExt, ffi::util};
 use crate::{
     domains::{AtomDomain, VectorDomain},
-    ffi::util::{Type, try_as_ref},
+    ffi::util::Type,
     measurements::{make_base_discrete_laplace_linear, BaseDiscreteLaplaceDomain},
     traits::{samplers::SampleDiscreteLaplaceLinear, Float, InfCast, Integer},
 };
@@ -48,7 +48,7 @@ pub extern "C" fn opendp_measurements__make_base_discrete_laplace_linear(
             make_base_discrete_laplace_linear::<D, QO>(input_domain, input_metric, scale, bounds)
                 .into_any()
         }
-        let scale = *try_as_ref(scale as *const QO)?;
+        let scale = *try_as_ref!(scale as *const QO);
         let bounds = if let Some(bounds) = util::as_ref(bounds) {
             Some(*bounds.downcast_ref::<(T, T)>()?)
         } else {

--- a/rust/src/measurements/laplace/ffi.rs
+++ b/rust/src/measurements/laplace/ffi.rs
@@ -3,8 +3,9 @@ use std::os::raw::{c_char, c_void};
 
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt, MetricSpace};
 use crate::domains::{AtomDomain, VectorDomain};
+use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMeasurement, AnyMetric, Downcast};
-use crate::ffi::util::Type;
+use crate::ffi::util::{Type, try_as_ref};
 use crate::measurements::{make_laplace, BaseLaplaceDomain, MakeLaplace};
 use crate::traits::CheckAtom;
 
@@ -20,7 +21,7 @@ pub extern "C" fn opendp_measurements__make_laplace(
         input_metric: &AnyMetric,
         scale: *const c_void,
         Q: Type,
-    ) -> FfiResult<*mut AnyMeasurement>
+    ) -> Fallible<AnyMeasurement>
     where
         AtomDomain<T>: MakeLaplace<T>,
         VectorDomain<AtomDomain<T>>: MakeLaplace<T>,
@@ -37,12 +38,12 @@ pub extern "C" fn opendp_measurements__make_laplace(
             input_domain: &AnyDomain,
             input_metric: &AnyMetric,
             scale: Q,
-        ) -> FfiResult<*mut AnyMeasurement>
+        ) -> Fallible<AnyMeasurement>
         where
             (D, D::InputMetric): MetricSpace,
         {
-            let input_domain = try_!(input_domain.downcast_ref::<D>()).clone();
-            let input_metric = try_!(input_metric.downcast_ref::<D::InputMetric>()).clone();
+            let input_domain = input_domain.downcast_ref::<D>()?.clone();
+            let input_metric = input_metric.downcast_ref::<D::InputMetric>()?.clone();
             make_laplace::<D, Q>(input_domain, input_metric, scale).into_any()
         }
         let D = input_domain.type_.clone();
@@ -57,7 +58,7 @@ pub extern "C" fn opendp_measurements__make_laplace(
         input_metric: &AnyMetric,
         scale: *const c_void,
         QO: Type,
-    ) -> FfiResult<*mut AnyMeasurement>
+    ) -> Fallible<AnyMeasurement>
     where
         AtomDomain<T>: MakeLaplace<QO>,
         VectorDomain<AtomDomain<T>>: MakeLaplace<QO>,
@@ -74,16 +75,16 @@ pub extern "C" fn opendp_measurements__make_laplace(
             input_domain: &AnyDomain,
             input_metric: &AnyMetric,
             scale: QO,
-        ) -> FfiResult<*mut AnyMeasurement>
+        ) -> Fallible<AnyMeasurement>
         where
             (D, D::InputMetric): MetricSpace,
         {
-            let input_domain = try_!(input_domain.downcast_ref::<D>()).clone();
-            let input_metric = try_!(input_metric.downcast_ref::<D::InputMetric>()).clone();
+            let input_domain = input_domain.downcast_ref::<D>()?.clone();
+            let input_metric = input_metric.downcast_ref::<D::InputMetric>()?.clone();
             make_laplace::<D, QO>(input_domain, input_metric, scale).into_any()
         }
         let D = input_domain.type_.clone();
-        let scale = *try_as_ref!(scale as *const QO);
+        let scale = *try_as_ref(scale as *const QO)?;
         dispatch!(monomorphize2, [
             (D, [AtomDomain<T>, VectorDomain<AtomDomain<T>>]),
             (QO, [QO])
@@ -129,7 +130,7 @@ pub extern "C" fn opendp_measurements__make_laplace(
             (T, @integers),
             (QO, @floats)
         ], (input_domain, input_metric, scale, QO))
-    }
+    }.into()
 }
 
 #[cfg(test)]

--- a/rust/src/measurements/laplace/ffi.rs
+++ b/rust/src/measurements/laplace/ffi.rs
@@ -5,7 +5,7 @@ use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt, MetricSpace};
 use crate::domains::{AtomDomain, VectorDomain};
 use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMeasurement, AnyMetric, Downcast};
-use crate::ffi::util::{Type, try_as_ref};
+use crate::ffi::util::Type;
 use crate::measurements::{make_laplace, BaseLaplaceDomain, MakeLaplace};
 use crate::traits::CheckAtom;
 
@@ -84,7 +84,7 @@ pub extern "C" fn opendp_measurements__make_laplace(
             make_laplace::<D, QO>(input_domain, input_metric, scale).into_any()
         }
         let D = input_domain.type_.clone();
-        let scale = *try_as_ref(scale as *const QO)?;
+        let scale = *try_as_ref!(scale as *const QO);
         dispatch!(monomorphize2, [
             (D, [AtomDomain<T>, VectorDomain<AtomDomain<T>>]),
             (QO, [QO])

--- a/rust/src/measurements/laplace_threshold/ffi.rs
+++ b/rust/src/measurements/laplace_threshold/ffi.rs
@@ -5,7 +5,7 @@ use crate::domains::{AtomDomain, MapDomain};
 use crate::err;
 use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMeasurement, AnyMetric, Downcast};
-use crate::ffi::util::{try_as_ref, Type, TypeContents};
+use crate::ffi::util::{Type, TypeContents};
 use crate::measurements::make_base_laplace_threshold;
 use crate::metrics::L1Distance;
 use crate::traits::samplers::SampleDiscreteLaplaceZ2k;
@@ -35,8 +35,8 @@ pub extern "C" fn opendp_measurements__make_base_laplace_threshold(
             .downcast_ref::<MapDomain<AtomDomain<TK>, AtomDomain<TV>>>()?
             .clone();
         let input_metric = input_metric.downcast_ref::<L1Distance<TV>>()?.clone();
-        let scale = *try_as_ref(scale as *const TV)?;
-        let threshold = *try_as_ref(threshold as *const TV)?;
+        let scale = *try_as_ref!(scale as *const TV);
+        let threshold = *try_as_ref!(threshold as *const TV);
         make_base_laplace_threshold::<TK, TV>(input_domain, input_metric, scale, threshold, Some(k))
             .into_any()
     }

--- a/rust/src/measurements/laplace_threshold/ffi.rs
+++ b/rust/src/measurements/laplace_threshold/ffi.rs
@@ -3,8 +3,9 @@ use std::os::raw::{c_long, c_void};
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::domains::{AtomDomain, MapDomain};
 use crate::err;
+use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMeasurement, AnyMetric, Downcast};
-use crate::ffi::util::{Type, TypeContents};
+use crate::ffi::util::{try_as_ref, Type, TypeContents};
 use crate::measurements::make_base_laplace_threshold;
 use crate::metrics::L1Distance;
 use crate::traits::samplers::SampleDiscreteLaplaceZ2k;
@@ -24,17 +25,18 @@ pub extern "C" fn opendp_measurements__make_base_laplace_threshold(
         scale: *const c_void,
         threshold: *const c_void,
         k: i32,
-    ) -> FfiResult<*mut AnyMeasurement>
+    ) -> Fallible<AnyMeasurement>
     where
         TK: Hashable,
         TV: Float + SampleDiscreteLaplaceZ2k,
         i32: ExactIntCast<TV::Bits>,
     {
-        let input_domain =
-            try_!(input_domain.downcast_ref::<MapDomain<AtomDomain<TK>, AtomDomain<TV>>>()).clone();
-        let input_metric = try_!(input_metric.downcast_ref::<L1Distance<TV>>()).clone();
-        let scale = *try_as_ref!(scale as *const TV);
-        let threshold = *try_as_ref!(threshold as *const TV);
+        let input_domain = input_domain
+            .downcast_ref::<MapDomain<AtomDomain<TK>, AtomDomain<TV>>>()?
+            .clone();
+        let input_metric = input_metric.downcast_ref::<L1Distance<TV>>()?.clone();
+        let scale = *try_as_ref(scale as *const TV)?;
+        let threshold = *try_as_ref(threshold as *const TV)?;
         make_base_laplace_threshold::<TK, TV>(input_domain, input_metric, scale, threshold, Some(k))
             .into_any()
     }
@@ -59,5 +61,5 @@ pub extern "C" fn opendp_measurements__make_base_laplace_threshold(
     dispatch!(monomorphize, [
         (TK, @hashable),
         (TV, @floats)
-    ], (input_domain, input_metric, scale, threshold, k))
+    ], (input_domain, input_metric, scale, threshold, k)).into()
 }

--- a/rust/src/measurements/randomized_response/ffi.rs
+++ b/rust/src/measurements/randomized_response/ffi.rs
@@ -6,7 +6,7 @@ use std::os::raw::{c_char, c_void};
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
 use crate::error::Fallible;
 use crate::ffi::any::{AnyMeasurement, AnyObject, Downcast};
-use crate::ffi::util::{c_bool, to_bool, try_as_ref, Type};
+use crate::ffi::util::{c_bool, to_bool, Type};
 use crate::measurements::{make_randomized_response, make_randomized_response_bool};
 use crate::traits::samplers::SampleBernoulli;
 use crate::traits::{Float, Hashable};
@@ -22,7 +22,7 @@ pub extern "C" fn opendp_measurements__make_randomized_response_bool(
         bool: SampleBernoulli<QO>,
         QO: Float,
     {
-        let prob = *try_as_ref(prob as *const QO)?;
+        let prob = *try_as_ref!(prob as *const QO);
         make_randomized_response_bool::<QO>(prob, constant_time).into_any()
     }
     let QO = try_!(Type::try_from(QO));
@@ -51,8 +51,8 @@ pub extern "C" fn opendp_measurements__make_randomized_response(
         bool: SampleBernoulli<QO>,
         QO: Float,
     {
-        let categories = try_as_ref(categories)?.downcast_ref::<Vec<T>>()?.clone();
-        let prob = *try_as_ref(prob as *const QO)?;
+        let categories = try_as_ref!(categories).downcast_ref::<Vec<T>>()?.clone();
+        let prob = *try_as_ref!(prob as *const QO);
         make_randomized_response::<T, QO>(
             HashSet::from_iter(categories.into_iter()),
             prob,

--- a/rust/src/measurements/randomized_response/ffi.rs
+++ b/rust/src/measurements/randomized_response/ffi.rs
@@ -4,9 +4,9 @@ use std::iter::FromIterator;
 use std::os::raw::{c_char, c_void};
 
 use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt};
-use crate::err;
+use crate::error::Fallible;
 use crate::ffi::any::{AnyMeasurement, AnyObject, Downcast};
-use crate::ffi::util::{c_bool, to_bool, Type};
+use crate::ffi::util::{c_bool, to_bool, try_as_ref, Type};
 use crate::measurements::{make_randomized_response, make_randomized_response_bool};
 use crate::traits::samplers::SampleBernoulli;
 use crate::traits::{Float, Hashable};
@@ -17,12 +17,12 @@ pub extern "C" fn opendp_measurements__make_randomized_response_bool(
     constant_time: c_bool,
     QO: *const c_char,
 ) -> FfiResult<*mut AnyMeasurement> {
-    fn monomorphize<QO>(prob: *const c_void, constant_time: bool) -> FfiResult<*mut AnyMeasurement>
+    fn monomorphize<QO>(prob: *const c_void, constant_time: bool) -> Fallible<AnyMeasurement>
     where
         bool: SampleBernoulli<QO>,
         QO: Float,
     {
-        let prob = *try_as_ref!(prob as *const QO);
+        let prob = *try_as_ref(prob as *const QO)?;
         make_randomized_response_bool::<QO>(prob, constant_time).into_any()
     }
     let QO = try_!(Type::try_from(QO));
@@ -30,6 +30,7 @@ pub extern "C" fn opendp_measurements__make_randomized_response_bool(
     dispatch!(monomorphize, [
         (QO, @floats)
     ], (prob, constant_time))
+    .into()
 }
 
 #[no_mangle]
@@ -44,14 +45,14 @@ pub extern "C" fn opendp_measurements__make_randomized_response(
         categories: *const AnyObject,
         prob: *const c_void,
         constant_time: bool,
-    ) -> FfiResult<*mut AnyMeasurement>
+    ) -> Fallible<AnyMeasurement>
     where
         T: Hashable,
         bool: SampleBernoulli<QO>,
         QO: Float,
     {
-        let categories = try_!(try_as_ref!(categories).downcast_ref::<Vec<T>>()).clone();
-        let prob = *try_as_ref!(prob as *const QO);
+        let categories = try_as_ref(categories)?.downcast_ref::<Vec<T>>()?.clone();
+        let prob = *try_as_ref(prob as *const QO)?;
         make_randomized_response::<T, QO>(
             HashSet::from_iter(categories.into_iter()),
             prob,
@@ -66,4 +67,5 @@ pub extern "C" fn opendp_measurements__make_randomized_response(
         (T, @hashable),
         (QO, @floats)
     ], (categories, prob, constant_time))
+    .into()
 }

--- a/rust/src/transformations/b_ary_tree/consistency_postprocessor/ffi.rs
+++ b/rust/src/transformations/b_ary_tree/consistency_postprocessor/ffi.rs
@@ -7,7 +7,7 @@ use crate::{
     core::{FfiResult, IntoAnyFunctionFfiResultExt},
     ffi::{any::AnyFunction, util::Type},
     traits::{CheckAtom, Float, RoundCast},
-    transformations::make_consistent_b_ary_tree,
+    transformations::make_consistent_b_ary_tree, error::Fallible,
 };
 
 #[no_mangle]
@@ -16,7 +16,7 @@ pub extern "C" fn opendp_transformations__make_consistent_b_ary_tree(
     TIA: *const c_char,
     TOA: *const c_char,
 ) -> FfiResult<*mut AnyFunction> {
-    fn monomorphize<TIA, TOA>(branching_factor: usize) -> FfiResult<*mut AnyFunction>
+    fn monomorphize<TIA, TOA>(branching_factor: usize) -> Fallible<AnyFunction>
     where
         TIA: 'static + CheckAtom + Clone,
         TOA: Float + RoundCast<TIA>,
@@ -30,5 +30,5 @@ pub extern "C" fn opendp_transformations__make_consistent_b_ary_tree(
     dispatch!(monomorphize, [
         (TIA, @integers),
         (TOA, @floats)
-    ], (branching_factor))
+    ], (branching_factor)).into()
 }

--- a/rust/src/transformations/b_ary_tree/ffi.rs
+++ b/rust/src/transformations/b_ary_tree/ffi.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     metrics::{L1Distance, L2Distance},
     traits::{Integer, Number},
-    transformations::{make_b_ary_tree, BAryTreeMetric},
+    transformations::{make_b_ary_tree, BAryTreeMetric}, error::Fallible,
 };
 
 use super::choose_branching_factor;
@@ -28,7 +28,7 @@ pub extern "C" fn opendp_transformations__make_b_ary_tree(
         branching_factor: usize,
         M: Type,
         TA: Type,
-    ) -> FfiResult<*mut AnyTransformation>
+    ) -> Fallible<AnyTransformation>
     where
         Q: Number,
     {
@@ -37,7 +37,7 @@ pub extern "C" fn opendp_transformations__make_b_ary_tree(
             input_metric: &AnyMetric,
             leaf_count: usize,
             branching_factor: usize,
-        ) -> FfiResult<*mut AnyTransformation>
+        ) -> Fallible<AnyTransformation>
         where
             TA: Integer,
             (VectorDomain<AtomDomain<TA>>, M): MetricSpace,
@@ -45,8 +45,8 @@ pub extern "C" fn opendp_transformations__make_b_ary_tree(
             M::Distance: Number,
         {
             let input_domain =
-                try_!(input_domain.downcast_ref::<VectorDomain<AtomDomain<TA>>>()).clone();
-            let input_metric = try_!(input_metric.downcast_ref::<M>()).clone();
+                input_domain.downcast_ref::<VectorDomain<AtomDomain<TA>>>()?.clone();
+            let input_metric = input_metric.downcast_ref::<M>()?.clone();
             make_b_ary_tree::<M, TA>(input_domain, input_metric, leaf_count, branching_factor)
                 .into_any()
         }
@@ -66,7 +66,7 @@ pub extern "C" fn opendp_transformations__make_b_ary_tree(
     let Q = try_!(M.get_atom());
     dispatch!(monomorphize, [
         (Q, @integers)
-    ], (input_domain, input_metric, leaf_count, branching_factor, M, TA))
+    ], (input_domain, input_metric, leaf_count, branching_factor, M, TA)).into()
 }
 
 #[no_mangle]

--- a/rust/src/transformations/cast/ffi.rs
+++ b/rust/src/transformations/cast/ffi.rs
@@ -4,6 +4,7 @@ use std::os::raw::c_char;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt, MetricSpace};
 use crate::domains::{AtomDomain, OptionDomain, VectorDomain};
 use crate::err;
+use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMetric, AnyTransformation, Downcast};
 use crate::ffi::util::Type;
 use crate::metrics::IntDistance;
@@ -25,7 +26,7 @@ pub extern "C" fn opendp_transformations__make_cast(
     fn monomorphize<M, TIA, TOA>(
         input_domain: &AnyDomain,
         input_metric: &AnyMetric,
-    ) -> FfiResult<*mut AnyTransformation>
+    ) -> Fallible<AnyTransformation>
     where
         M: 'static + DatasetMetric<Distance = IntDistance>,
         TIA: 'static + Clone + CheckAtom,
@@ -34,15 +35,15 @@ pub extern "C" fn opendp_transformations__make_cast(
         (VectorDomain<OptionDomain<AtomDomain<TOA>>>, M): MetricSpace,
     {
         let input_domain =
-            try_!(input_domain.downcast_ref::<VectorDomain<AtomDomain<TIA>>>()).clone();
-        let input_metric = try_!(input_metric.downcast_ref::<M>()).clone();
+            input_domain.downcast_ref::<VectorDomain<AtomDomain<TIA>>>()?.clone();
+        let input_metric = input_metric.downcast_ref::<M>()?.clone();
         make_cast::<M, TIA, TOA>(input_domain, input_metric).into_any()
     }
     dispatch!(monomorphize, [
         (M, @dataset_metrics),
         (TIA, @primitives), 
         (TOA, @primitives)
-    ], (input_domain, input_metric))
+    ], (input_domain, input_metric)).into()
 }
 
 #[no_mangle]
@@ -60,7 +61,7 @@ pub extern "C" fn opendp_transformations__make_cast_default(
     fn monomorphize<M, TIA, TOA>(
         input_domain: &AnyDomain,
         input_metric: &AnyMetric,
-    ) -> FfiResult<*mut AnyTransformation>
+    ) -> Fallible<AnyTransformation>
     where
         M: 'static + DatasetMetric,
         TIA: 'static + Clone + CheckAtom,
@@ -69,15 +70,15 @@ pub extern "C" fn opendp_transformations__make_cast_default(
         (VectorDomain<AtomDomain<TOA>>, M): MetricSpace,
     {
         let input_domain =
-            try_!(input_domain.downcast_ref::<VectorDomain<AtomDomain<TIA>>>()).clone();
-        let input_metric = try_!(input_metric.downcast_ref::<M>()).clone();
+            input_domain.downcast_ref::<VectorDomain<AtomDomain<TIA>>>()?.clone();
+        let input_metric = input_metric.downcast_ref::<M>()?.clone();
         make_cast_default::<M, TIA, TOA>(input_domain, input_metric).into_any()
     }
     dispatch!(monomorphize, [
         (M, @dataset_metrics),
         (TIA, @primitives), 
         (TOA, @primitives)
-    ], (input_domain, input_metric))
+    ], (input_domain, input_metric)).into()
 }
 
 #[no_mangle]
@@ -95,7 +96,7 @@ pub extern "C" fn opendp_transformations__make_cast_inherent(
     fn monomorphize<M, TIA, TOA>(
         input_domain: &AnyDomain,
         input_metric: &AnyMetric,
-    ) -> FfiResult<*mut AnyTransformation>
+    ) -> Fallible<AnyTransformation>
     where
         M: 'static + DatasetMetric,
         TIA: 'static + Clone + CheckAtom,
@@ -104,15 +105,15 @@ pub extern "C" fn opendp_transformations__make_cast_inherent(
         (VectorDomain<AtomDomain<TOA>>, M): MetricSpace,
     {
         let input_domain =
-            try_!(input_domain.downcast_ref::<VectorDomain<AtomDomain<TIA>>>()).clone();
-        let input_metric = try_!(input_metric.downcast_ref::<M>()).clone();
+            input_domain.downcast_ref::<VectorDomain<AtomDomain<TIA>>>()?.clone();
+        let input_metric = input_metric.downcast_ref::<M>()?.clone();
         make_cast_inherent::<M, TIA, TOA>(input_domain, input_metric).into_any()
     }
     dispatch!(monomorphize, [
         (M, @dataset_metrics),
         (TIA, @primitives), 
         (TOA, @floats)
-    ], (input_domain, input_metric))
+    ], (input_domain, input_metric)).into()
 }
 
 #[cfg(test)]

--- a/rust/src/transformations/count/ffi.rs
+++ b/rust/src/transformations/count/ffi.rs
@@ -8,7 +8,7 @@ use crate::err;
 use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMetric, Downcast};
 use crate::ffi::any::{AnyObject, AnyTransformation};
-use crate::ffi::util::{c_bool, to_bool, Type, try_as_ref};
+use crate::ffi::util::{c_bool, to_bool, Type};
 use crate::metrics::{L1Distance, L2Distance, SymmetricDistance};
 use crate::traits::{Hashable, Number, Primitive};
 use crate::transformations::{
@@ -111,7 +111,7 @@ pub extern "C" fn opendp_transformations__make_count_by_categories(
             let input_domain =
                 input_domain.downcast_ref::<VectorDomain<AtomDomain<TI>>>()?.clone();
             let input_metric = input_metric.downcast_ref::<SymmetricDistance>()?.clone();
-            let categories = try_as_ref(categories)?.downcast_ref::<Vec<TI>>()?.clone();
+            let categories = try_as_ref!(categories).downcast_ref::<Vec<TI>>()?.clone();
             make_count_by_categories::<MO, TI, TO>(
                 input_domain,
                 input_metric,

--- a/rust/src/transformations/count_cdf/ffi.rs
+++ b/rust/src/transformations/count_cdf/ffi.rs
@@ -4,7 +4,7 @@ use crate::{
     core::{FfiResult, IntoAnyFunctionFfiResultExt},
     ffi::{
         any::{AnyFunction, AnyObject, Downcast},
-        util::{to_str, Type, try_as_ref},
+        util::{to_str, Type},
     },
     traits::{Float, Number, RoundCast},
     transformations::{make_cdf, make_quantiles_from_counts, Interpolation}, error::Fallible,
@@ -40,8 +40,8 @@ pub extern "C" fn opendp_transformations__make_quantiles_from_counts(
         TA: Number + RoundCast<F>,
         F: Float + RoundCast<TA>,
     {
-        let bin_edges = try_as_ref(bin_edges)?.downcast_ref::<Vec<TA>>()?;
-        let alphas = try_as_ref(alphas)?.downcast_ref::<Vec<F>>()?;
+        let bin_edges = try_as_ref!(bin_edges).downcast_ref::<Vec<TA>>()?;
+        let alphas = try_as_ref!(alphas).downcast_ref::<Vec<F>>()?;
         make_quantiles_from_counts::<TA, F>(bin_edges.clone(), alphas.clone(), interpolation)
             .into_any()
     }

--- a/rust/src/transformations/covariance/ffi.rs
+++ b/rust/src/transformations/covariance/ffi.rs
@@ -7,7 +7,7 @@ use crate::{
     core::{FfiResult, IntoAnyTransformationFfiResultExt},
     ffi::{
         any::{AnyObject, AnyTransformation, Downcast},
-        util::{Type, try_as_ref},
+        util::Type,
     },
     traits::{CheckAtom, Float},
     transformations::{make_sized_bounded_covariance, Pairwise, Sequential, UncheckedSum}, error::Fallible,
@@ -46,8 +46,8 @@ pub extern "C" fn opendp_transformations__make_sized_bounded_covariance(
         {
             make_sized_bounded_covariance::<S>(size, bounds_0, bounds_1, ddof).into_any()
         }
-        let bounds_0 = *try_as_ref(bounds_0)?.downcast_ref::<(T, T)>()?;
-        let bounds_1 = *try_as_ref(bounds_1)?.downcast_ref::<(T, T)>()?;
+        let bounds_0 = *try_as_ref!(bounds_0).downcast_ref::<(T, T)>()?;
+        let bounds_1 = *try_as_ref!(bounds_1).downcast_ref::<(T, T)>()?;
         dispatch!(monomorphize2, [
             (S, [Sequential<T>, Pairwise<T>])
         ], (size, bounds_0, bounds_1, ddof))

--- a/rust/src/transformations/covariance/ffi.rs
+++ b/rust/src/transformations/covariance/ffi.rs
@@ -7,10 +7,10 @@ use crate::{
     core::{FfiResult, IntoAnyTransformationFfiResultExt},
     ffi::{
         any::{AnyObject, AnyTransformation, Downcast},
-        util::Type,
+        util::{Type, try_as_ref},
     },
     traits::{CheckAtom, Float},
-    transformations::{make_sized_bounded_covariance, Pairwise, Sequential, UncheckedSum},
+    transformations::{make_sized_bounded_covariance, Pairwise, Sequential, UncheckedSum}, error::Fallible,
 };
 
 // no entry in bootstrap.json because there's no way to get data into it
@@ -28,7 +28,7 @@ pub extern "C" fn opendp_transformations__make_sized_bounded_covariance(
         bounds_1: *const AnyObject,
         ddof: usize,
         S: Type,
-    ) -> FfiResult<*mut AnyTransformation>
+    ) -> Fallible<AnyTransformation>
     where
         T: 'static + Float,
         (T, T): CheckAtom,
@@ -38,7 +38,7 @@ pub extern "C" fn opendp_transformations__make_sized_bounded_covariance(
             bounds_0: (S::Item, S::Item),
             bounds_1: (S::Item, S::Item),
             ddof: usize,
-        ) -> FfiResult<*mut AnyTransformation>
+        ) -> Fallible<AnyTransformation>
         where
             S: UncheckedSum,
             S::Item: 'static + Float,
@@ -46,8 +46,8 @@ pub extern "C" fn opendp_transformations__make_sized_bounded_covariance(
         {
             make_sized_bounded_covariance::<S>(size, bounds_0, bounds_1, ddof).into_any()
         }
-        let bounds_0 = *try_!(try_as_ref!(bounds_0).downcast_ref::<(T, T)>());
-        let bounds_1 = *try_!(try_as_ref!(bounds_1).downcast_ref::<(T, T)>());
+        let bounds_0 = *try_as_ref(bounds_0)?.downcast_ref::<(T, T)>()?;
+        let bounds_1 = *try_as_ref(bounds_1)?.downcast_ref::<(T, T)>()?;
         dispatch!(monomorphize2, [
             (S, [Sequential<T>, Pairwise<T>])
         ], (size, bounds_0, bounds_1, ddof))
@@ -58,5 +58,5 @@ pub extern "C" fn opendp_transformations__make_sized_bounded_covariance(
     let T = try_!(S.get_atom());
     dispatch!(monomorphize, [
         (T, @floats)
-    ], (size, bounds_0, bounds_1, ddof, S))
+    ], (size, bounds_0, bounds_1, ddof, S)).into()
 }

--- a/rust/src/transformations/dataframe/apply/ffi.rs
+++ b/rust/src/transformations/dataframe/apply/ffi.rs
@@ -3,13 +3,14 @@ use std::os::raw::c_char;
 
 use crate::domains::{AtomDomain, VectorDomain};
 use crate::err;
+use crate::error::Fallible;
 use crate::transformations::{
     make_df_cast_default, make_df_is_equal, DataFrameDomain, DatasetMetric,
 };
 
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt, MetricSpace};
 use crate::ffi::any::{AnyDomain, AnyMetric, AnyObject, AnyTransformation, Downcast};
-use crate::ffi::util::Type;
+use crate::ffi::util::{Type, try_as_ref};
 use crate::traits::{Hashable, Primitive, RoundCast};
 
 #[no_mangle]
@@ -24,7 +25,7 @@ pub extern "C" fn opendp_transformations__make_df_cast_default(
         input_domain: &AnyDomain,
         input_metric: &AnyMetric,
         column_name: *const AnyObject,
-    ) -> FfiResult<*mut AnyTransformation>
+    ) -> Fallible<AnyTransformation>
     where
         TK: Hashable,
         TIA: Primitive,
@@ -34,9 +35,9 @@ pub extern "C" fn opendp_transformations__make_df_cast_default(
         (VectorDomain<AtomDomain<TIA>>, M): MetricSpace,
         (VectorDomain<AtomDomain<TOA>>, M): MetricSpace,
     {
-        let input_domain = try_!(input_domain.downcast_ref::<DataFrameDomain<TK>>()).clone();
-        let input_metric = try_!(input_metric.downcast_ref::<M>()).clone();
-        let column_name: TK = try_!(try_as_ref!(column_name).downcast_ref::<TK>()).clone();
+        let input_domain = input_domain.downcast_ref::<DataFrameDomain<TK>>()?.clone();
+        let input_metric = input_metric.downcast_ref::<M>()?.clone();
+        let column_name: TK = try_as_ref(column_name)?.downcast_ref::<TK>()?.clone();
         make_df_cast_default::<TK, TIA, TOA, M>(input_domain, input_metric, column_name).into_any()
     }
 
@@ -52,7 +53,7 @@ pub extern "C" fn opendp_transformations__make_df_cast_default(
         (TIA, @primitives),
         (TOA, @primitives),
         (M, @dataset_metrics)
-    ], (input_domain, input_metric, column_name))
+    ], (input_domain, input_metric, column_name)).into()
 }
 
 #[no_mangle]
@@ -73,7 +74,7 @@ pub extern "C" fn opendp_transformations__make_df_is_equal(
         input_metric: &AnyMetric,
         column_name: &AnyObject,
         value: &AnyObject,
-    ) -> FfiResult<*mut AnyTransformation>
+    ) -> Fallible<AnyTransformation>
     where
         TK: Hashable,
         TIA: Primitive,
@@ -82,10 +83,10 @@ pub extern "C" fn opendp_transformations__make_df_is_equal(
         (VectorDomain<AtomDomain<TIA>>, M): MetricSpace,
         (VectorDomain<AtomDomain<bool>>, M): MetricSpace,
     {
-        let input_domain = try_!(input_domain.downcast_ref::<DataFrameDomain<TK>>()).clone();
-        let input_metric = try_!(input_metric.downcast_ref::<M>()).clone();
-        let column_name: TK = try_!(column_name.downcast_ref::<TK>()).clone();
-        let value: TIA = try_!(value.downcast_ref::<TIA>()).clone();
+        let input_domain = input_domain.downcast_ref::<DataFrameDomain<TK>>()?.clone();
+        let input_metric = input_metric.downcast_ref::<M>()?.clone();
+        let column_name: TK = column_name.downcast_ref::<TK>()?.clone();
+        let value: TIA = value.downcast_ref::<TIA>()?.clone();
         make_df_is_equal::<TK, TIA, M>(input_domain, input_metric, column_name, value).into_any()
     }
     let TK = try_!(input_domain.type_.get_atom());
@@ -96,7 +97,7 @@ pub extern "C" fn opendp_transformations__make_df_is_equal(
         (TK, @hashable),
         (TIA, @primitives),
         (M, @dataset_metrics)
-    ], (input_domain, input_metric, column_name, value))
+    ], (input_domain, input_metric, column_name, value)).into()
 }
 
 #[cfg(test)]

--- a/rust/src/transformations/dataframe/apply/ffi.rs
+++ b/rust/src/transformations/dataframe/apply/ffi.rs
@@ -10,7 +10,7 @@ use crate::transformations::{
 
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt, MetricSpace};
 use crate::ffi::any::{AnyDomain, AnyMetric, AnyObject, AnyTransformation, Downcast};
-use crate::ffi::util::{Type, try_as_ref};
+use crate::ffi::util::Type;
 use crate::traits::{Hashable, Primitive, RoundCast};
 
 #[no_mangle]
@@ -37,7 +37,7 @@ pub extern "C" fn opendp_transformations__make_df_cast_default(
     {
         let input_domain = input_domain.downcast_ref::<DataFrameDomain<TK>>()?.clone();
         let input_metric = input_metric.downcast_ref::<M>()?.clone();
-        let column_name: TK = try_as_ref(column_name)?.downcast_ref::<TK>()?.clone();
+        let column_name: TK = try_as_ref!(column_name).downcast_ref::<TK>()?.clone();
         make_df_cast_default::<TK, TIA, TOA, M>(input_domain, input_metric, column_name).into_any()
     }
 

--- a/rust/src/transformations/dataframe/create/ffi.rs
+++ b/rust/src/transformations/dataframe/create/ffi.rs
@@ -4,17 +4,17 @@ use crate::{
     core::{FfiResult, IntoAnyTransformationFfiResultExt},
     ffi::{
         any::{AnyObject, AnyTransformation, Downcast},
-        util::{self, Type},
+        util::{self, Type, try_as_ref},
     },
     traits::Hashable,
-    transformations::{make_create_dataframe, make_split_dataframe},
+    transformations::{make_create_dataframe, make_split_dataframe}, error::Fallible,
 };
 
 use super::{make_split_lines, make_split_records};
 
 #[no_mangle]
 pub extern "C" fn opendp_transformations__make_split_lines() -> FfiResult<*mut AnyTransformation> {
-    make_split_lines().into_any()
+    make_split_lines().into_any().into()
 }
 
 #[no_mangle]
@@ -22,7 +22,7 @@ pub extern "C" fn opendp_transformations__make_split_records(
     separator: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
     let separator = try_!(util::to_option_str(separator));
-    make_split_records(separator).into_any()
+    make_split_records(separator).into_any().into()
 }
 
 #[no_mangle]
@@ -30,15 +30,15 @@ pub extern "C" fn opendp_transformations__make_create_dataframe(
     col_names: *const AnyObject,
     K: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<K>(col_names: *const AnyObject) -> FfiResult<*mut AnyTransformation>
+    fn monomorphize<K>(col_names: *const AnyObject) -> Fallible<AnyTransformation>
     where
         K: Hashable,
     {
-        let col_names = try_!(try_as_ref!(col_names).downcast_ref::<Vec<K>>()).clone();
+        let col_names = try_as_ref(col_names)?.downcast_ref::<Vec<K>>()?.clone();
         make_create_dataframe::<K>(col_names).into_any()
     }
     let K = try_!(Type::try_from(K));
-    dispatch!(monomorphize, [(K, @hashable)], (col_names))
+    dispatch!(monomorphize, [(K, @hashable)], (col_names)).into()
 }
 
 #[no_mangle]
@@ -50,17 +50,17 @@ pub extern "C" fn opendp_transformations__make_split_dataframe(
     fn monomorphize<K>(
         separator: Option<&str>,
         col_names: *const AnyObject,
-    ) -> FfiResult<*mut AnyTransformation>
+    ) -> Fallible<AnyTransformation>
     where
         K: Hashable,
     {
-        let col_names = try_!(try_as_ref!(col_names).downcast_ref::<Vec<K>>()).clone();
+        let col_names = try_as_ref(col_names)?.downcast_ref::<Vec<K>>()?.clone();
         make_split_dataframe::<K>(separator, col_names).into_any()
     }
     let K = try_!(Type::try_from(K));
     let separator = try_!(util::to_option_str(separator));
 
-    dispatch!(monomorphize, [(K, @hashable)], (separator, col_names))
+    dispatch!(monomorphize, [(K, @hashable)], (separator, col_names)).into()
 }
 
 #[cfg(test)]

--- a/rust/src/transformations/dataframe/create/ffi.rs
+++ b/rust/src/transformations/dataframe/create/ffi.rs
@@ -4,7 +4,7 @@ use crate::{
     core::{FfiResult, IntoAnyTransformationFfiResultExt},
     ffi::{
         any::{AnyObject, AnyTransformation, Downcast},
-        util::{self, Type, try_as_ref},
+        util::{self, Type},
     },
     traits::Hashable,
     transformations::{make_create_dataframe, make_split_dataframe}, error::Fallible,
@@ -34,7 +34,7 @@ pub extern "C" fn opendp_transformations__make_create_dataframe(
     where
         K: Hashable,
     {
-        let col_names = try_as_ref(col_names)?.downcast_ref::<Vec<K>>()?.clone();
+        let col_names = try_as_ref!(col_names).downcast_ref::<Vec<K>>()?.clone();
         make_create_dataframe::<K>(col_names).into_any()
     }
     let K = try_!(Type::try_from(K));
@@ -54,7 +54,7 @@ pub extern "C" fn opendp_transformations__make_split_dataframe(
     where
         K: Hashable,
     {
-        let col_names = try_as_ref(col_names)?.downcast_ref::<Vec<K>>()?.clone();
+        let col_names = try_as_ref!(col_names).downcast_ref::<Vec<K>>()?.clone();
         make_split_dataframe::<K>(separator, col_names).into_any()
     }
     let K = try_!(Type::try_from(K));

--- a/rust/src/transformations/dataframe/select/ffi.rs
+++ b/rust/src/transformations/dataframe/select/ffi.rs
@@ -6,7 +6,7 @@ use crate::transformations::make_select_column;
 
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
-use crate::ffi::util::{Type, try_as_ref};
+use crate::ffi::util::Type;
 use crate::traits::{Hashable, Primitive};
 
 #[no_mangle]
@@ -20,7 +20,7 @@ pub extern "C" fn opendp_transformations__make_select_column(
         K: Hashable,
         TOA: Primitive,
     {
-        let key: K = try_as_ref(key)?.downcast_ref::<K>()?.clone();
+        let key: K = try_as_ref!(key).downcast_ref::<K>()?.clone();
         make_select_column::<K, TOA>(key).into_any()
     }
     let K = try_!(Type::try_from(K));

--- a/rust/src/transformations/dataframe/select/ffi.rs
+++ b/rust/src/transformations/dataframe/select/ffi.rs
@@ -1,12 +1,12 @@
 use std::convert::TryFrom;
 use std::os::raw::c_char;
 
-use crate::err;
+use crate::error::Fallible;
 use crate::transformations::make_select_column;
 
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
-use crate::ffi::util::Type;
+use crate::ffi::util::{Type, try_as_ref};
 use crate::traits::{Hashable, Primitive};
 
 #[no_mangle]
@@ -15,12 +15,12 @@ pub extern "C" fn opendp_transformations__make_select_column(
     K: *const c_char,
     TOA: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<K, TOA>(key: *const AnyObject) -> FfiResult<*mut AnyTransformation>
+    fn monomorphize<K, TOA>(key: *const AnyObject) -> Fallible<AnyTransformation>
     where
         K: Hashable,
         TOA: Primitive,
     {
-        let key: K = try_!(try_as_ref!(key).downcast_ref::<K>()).clone();
+        let key: K = try_as_ref(key)?.downcast_ref::<K>()?.clone();
         make_select_column::<K, TOA>(key).into_any()
     }
     let K = try_!(Type::try_from(K));
@@ -29,5 +29,5 @@ pub extern "C" fn opendp_transformations__make_select_column(
     dispatch!(monomorphize, [
         (K, @hashable),
         (TOA, @primitives)
-    ], (key))
+    ], (key)).into()
 }

--- a/rust/src/transformations/dataframe/subset/ffi.rs
+++ b/rust/src/transformations/dataframe/subset/ffi.rs
@@ -6,7 +6,7 @@ use crate::transformations::make_subset_by;
 
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
-use crate::ffi::util::{try_as_ref, Type};
+use crate::ffi::util::Type;
 use crate::traits::Hashable;
 
 #[no_mangle]
@@ -22,8 +22,8 @@ pub extern "C" fn opendp_transformations__make_subset_by(
     where
         TK: Hashable,
     {
-        let indicator_column: TK = try_as_ref(indicator_column)?.downcast_ref::<TK>()?.clone();
-        let keep_columns: Vec<TK> = try_as_ref(keep_columns)?.downcast_ref::<Vec<TK>>()?.clone();
+        let indicator_column: TK = try_as_ref!(indicator_column).downcast_ref::<TK>()?.clone();
+        let keep_columns: Vec<TK> = try_as_ref!(keep_columns).downcast_ref::<Vec<TK>>()?.clone();
         make_subset_by::<TK>(indicator_column, keep_columns).into_any()
     }
     let TK = try_!(Type::try_from(TK));

--- a/rust/src/transformations/dataframe/subset/ffi.rs
+++ b/rust/src/transformations/dataframe/subset/ffi.rs
@@ -1,12 +1,12 @@
 use std::convert::TryFrom;
 use std::os::raw::c_char;
 
-use crate::err;
+use crate::error::Fallible;
 use crate::transformations::make_subset_by;
 
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
-use crate::ffi::util::Type;
+use crate::ffi::util::{try_as_ref, Type};
 use crate::traits::Hashable;
 
 #[no_mangle]
@@ -18,21 +18,19 @@ pub extern "C" fn opendp_transformations__make_subset_by(
     fn monomorphize<TK>(
         indicator_column: *const AnyObject,
         keep_columns: *const AnyObject,
-    ) -> FfiResult<*mut AnyTransformation>
+    ) -> Fallible<AnyTransformation>
     where
         TK: Hashable,
     {
-        let indicator_column: TK =
-            try_!(try_as_ref!(indicator_column).downcast_ref::<TK>()).clone();
-        let keep_columns: Vec<TK> =
-            try_!(try_as_ref!(keep_columns).downcast_ref::<Vec<TK>>()).clone();
+        let indicator_column: TK = try_as_ref(indicator_column)?.downcast_ref::<TK>()?.clone();
+        let keep_columns: Vec<TK> = try_as_ref(keep_columns)?.downcast_ref::<Vec<TK>>()?.clone();
         make_subset_by::<TK>(indicator_column, keep_columns).into_any()
     }
     let TK = try_!(Type::try_from(TK));
 
     dispatch!(monomorphize, [
         (TK, @hashable)
-    ], (indicator_column, keep_columns))
+    ], (indicator_column, keep_columns)).into()
 }
 
 #[cfg(test)]

--- a/rust/src/transformations/impute/ffi.rs
+++ b/rust/src/transformations/impute/ffi.rs
@@ -3,7 +3,7 @@ use crate::domains::{AtomDomain, OptionDomain, VectorDomain};
 use crate::err;
 use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMetric, AnyObject, AnyTransformation, Downcast};
-use crate::ffi::util::{try_as_ref, Type, TypeContents};
+use crate::ffi::util::{Type, TypeContents};
 use crate::traits::samplers::SampleUniform;
 use crate::traits::{CheckAtom, Float, InherentNull};
 use crate::transformations::{
@@ -37,7 +37,7 @@ pub extern "C" fn opendp_transformations__make_impute_uniform_float(
             .downcast_ref::<VectorDomain<AtomDomain<TA>>>()?
             .clone();
         let input_metric = input_metric.downcast_ref::<M>()?.clone();
-        let bounds = *try_as_ref(bounds)?.downcast_ref::<(TA, TA)>()?;
+        let bounds = *try_as_ref!(bounds).downcast_ref::<(TA, TA)>()?;
         make_impute_uniform_float(input_domain, input_metric, bounds).into_any()
     }
     dispatch!(monomorphize, [(M, @dataset_metrics), (TA, @floats)], (input_domain, input_metric, bounds)).into()

--- a/rust/src/transformations/index/ffi.rs
+++ b/rust/src/transformations/index/ffi.rs
@@ -4,9 +4,10 @@ use std::os::raw::c_char;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt, MetricSpace};
 use crate::domains::{AtomDomain, OptionDomain, VectorDomain};
 use crate::err;
+use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMetric, Downcast};
 use crate::ffi::any::{AnyObject, AnyTransformation};
-use crate::ffi::util::Type;
+use crate::ffi::util::{Type, try_as_ref};
 use crate::traits::{Hashable, Number, Primitive};
 use crate::transformations::{make_find, make_find_bin, make_index, DatasetMetric};
 
@@ -20,7 +21,7 @@ pub extern "C" fn opendp_transformations__make_find(
         input_domain: &AnyDomain,
         input_metric: &AnyMetric,
         categories: &AnyObject,
-    ) -> FfiResult<*mut AnyTransformation>
+    ) -> Fallible<AnyTransformation>
     where
         M: 'static + DatasetMetric,
         TIA: 'static + Hashable,
@@ -28,9 +29,9 @@ pub extern "C" fn opendp_transformations__make_find(
         (VectorDomain<OptionDomain<AtomDomain<usize>>>, M): MetricSpace,
     {
         let input_domain =
-            try_!(input_domain.downcast_ref::<VectorDomain<AtomDomain<TIA>>>()).clone();
-        let input_metric = try_!(input_metric.downcast_ref::<M>()).clone();
-        let categories = try_!(categories.downcast_ref::<Vec<TIA>>()).clone();
+            input_domain.downcast_ref::<VectorDomain<AtomDomain<TIA>>>()?.clone();
+        let input_metric = input_metric.downcast_ref::<M>()?.clone();
+        let categories = categories.downcast_ref::<Vec<TIA>>()?.clone();
         make_find(input_domain, input_metric, categories).into_any()
     }
     let input_domain = try_as_ref!(input_domain);
@@ -41,7 +42,7 @@ pub extern "C" fn opendp_transformations__make_find(
     dispatch!(monomorphize, [
         (M, @dataset_metrics),
         (TIA, @hashable)
-    ], (input_domain, input_metric, categories))
+    ], (input_domain, input_metric, categories)).into()
 }
 
 #[no_mangle]
@@ -54,7 +55,7 @@ pub extern "C" fn opendp_transformations__make_find_bin(
         input_domain: &AnyDomain,
         input_metric: &AnyMetric,
         edges: &AnyObject,
-    ) -> FfiResult<*mut AnyTransformation>
+    ) -> Fallible<AnyTransformation>
     where
         TIA: 'static + Number,
         M: 'static + DatasetMetric,
@@ -62,9 +63,9 @@ pub extern "C" fn opendp_transformations__make_find_bin(
         (VectorDomain<AtomDomain<usize>>, M): MetricSpace,
     {
         let input_domain =
-            try_!(input_domain.downcast_ref::<VectorDomain<AtomDomain<TIA>>>()).clone();
-        let input_metric = try_!(input_metric.downcast_ref::<M>()).clone();
-        let edges = try_!(try_as_ref!(edges).downcast_ref::<Vec<TIA>>()).clone();
+            input_domain.downcast_ref::<VectorDomain<AtomDomain<TIA>>>()?.clone();
+        let input_metric = input_metric.downcast_ref::<M>()?.clone();
+        let edges = try_as_ref(edges)?.downcast_ref::<Vec<TIA>>()?.clone();
         make_find_bin(input_domain, input_metric, edges).into_any()
     }
     let input_domain = try_as_ref!(input_domain);
@@ -75,7 +76,7 @@ pub extern "C" fn opendp_transformations__make_find_bin(
     dispatch!(monomorphize, [
         (M, @dataset_metrics),
         (TIA, @numbers)
-    ], (input_domain, input_metric, edges))
+    ], (input_domain, input_metric, edges)).into()
 }
 
 #[no_mangle]
@@ -91,7 +92,7 @@ pub extern "C" fn opendp_transformations__make_index(
         input_metric: &AnyMetric,
         edges: &AnyObject,
         null: &AnyObject,
-    ) -> FfiResult<*mut AnyTransformation>
+    ) -> Fallible<AnyTransformation>
     where
         TOA: Primitive,
         M: 'static + DatasetMetric,
@@ -99,10 +100,10 @@ pub extern "C" fn opendp_transformations__make_index(
         (VectorDomain<AtomDomain<TOA>>, M): MetricSpace,
     {
         let input_domain =
-            try_!(input_domain.downcast_ref::<VectorDomain<AtomDomain<usize>>>()).clone();
-        let input_metric = try_!(input_metric.downcast_ref::<M>()).clone();
-        let edges = try_!(try_as_ref!(edges).downcast_ref::<Vec<TOA>>()).clone();
-        let null = try_!(try_as_ref!(null).downcast_ref::<TOA>()).clone();
+            input_domain.downcast_ref::<VectorDomain<AtomDomain<usize>>>()?.clone();
+        let input_metric = input_metric.downcast_ref::<M>()?.clone();
+        let edges = try_as_ref(edges)?.downcast_ref::<Vec<TOA>>()?.clone();
+        let null = try_as_ref(null)?.downcast_ref::<TOA>()?.clone();
         make_index(input_domain, input_metric, edges, null).into_any()
     }
     let input_domain = try_as_ref!(input_domain);
@@ -114,5 +115,5 @@ pub extern "C" fn opendp_transformations__make_index(
     dispatch!(monomorphize, [
         (M, @dataset_metrics),
         (TOA, @primitives)
-    ], (input_domain, input_metric, categories, null))
+    ], (input_domain, input_metric, categories, null)).into()
 }

--- a/rust/src/transformations/index/ffi.rs
+++ b/rust/src/transformations/index/ffi.rs
@@ -7,7 +7,7 @@ use crate::err;
 use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMetric, Downcast};
 use crate::ffi::any::{AnyObject, AnyTransformation};
-use crate::ffi::util::{Type, try_as_ref};
+use crate::ffi::util::Type;
 use crate::traits::{Hashable, Number, Primitive};
 use crate::transformations::{make_find, make_find_bin, make_index, DatasetMetric};
 
@@ -65,7 +65,7 @@ pub extern "C" fn opendp_transformations__make_find_bin(
         let input_domain =
             input_domain.downcast_ref::<VectorDomain<AtomDomain<TIA>>>()?.clone();
         let input_metric = input_metric.downcast_ref::<M>()?.clone();
-        let edges = try_as_ref(edges)?.downcast_ref::<Vec<TIA>>()?.clone();
+        let edges = try_as_ref!(edges).downcast_ref::<Vec<TIA>>()?.clone();
         make_find_bin(input_domain, input_metric, edges).into_any()
     }
     let input_domain = try_as_ref!(input_domain);
@@ -102,8 +102,8 @@ pub extern "C" fn opendp_transformations__make_index(
         let input_domain =
             input_domain.downcast_ref::<VectorDomain<AtomDomain<usize>>>()?.clone();
         let input_metric = input_metric.downcast_ref::<M>()?.clone();
-        let edges = try_as_ref(edges)?.downcast_ref::<Vec<TOA>>()?.clone();
-        let null = try_as_ref(null)?.downcast_ref::<TOA>()?.clone();
+        let edges = try_as_ref!(edges).downcast_ref::<Vec<TOA>>()?.clone();
+        let null = try_as_ref!(null).downcast_ref::<TOA>()?.clone();
         make_index(input_domain, input_metric, edges, null).into_any()
     }
     let input_domain = try_as_ref!(input_domain);

--- a/rust/src/transformations/lipschitz_mul/ffi.rs
+++ b/rust/src/transformations/lipschitz_mul/ffi.rs
@@ -10,7 +10,7 @@ use crate::{
     metrics::AbsoluteDistance,
     traits::Float,
     traits::SaturatingMul,
-    transformations::{make_lipschitz_float_mul, LipschitzMulFloatDomain, LipschitzMulFloatMetric},
+    transformations::{make_lipschitz_float_mul, LipschitzMulFloatDomain, LipschitzMulFloatMetric}, error::Fallible,
 };
 
 #[no_mangle]
@@ -25,14 +25,14 @@ pub extern "C" fn opendp_transformations__make_lipschitz_float_mul(
         bounds: *const AnyObject,
         D: Type,
         M: Type,
-    ) -> FfiResult<*mut AnyTransformation>
+    ) -> Fallible<AnyTransformation>
     where
         T: 'static + Float + SaturatingMul,
     {
         fn monomorphize2<D, M>(
             constant: D::Atom,
             bounds: (D::Atom, D::Atom),
-        ) -> FfiResult<*mut AnyTransformation>
+        ) -> Fallible<AnyTransformation>
         where
             D: 'static + LipschitzMulFloatDomain,
             D::Atom: Float + SaturatingMul,
@@ -55,5 +55,5 @@ pub extern "C" fn opendp_transformations__make_lipschitz_float_mul(
     let T = try_!(D.get_atom());
     dispatch!(monomorphize, [
         (T, @floats)
-    ], (constant, bounds, D, M))
+    ], (constant, bounds, D, M)).into()
 }

--- a/rust/src/transformations/manipulation/ffi.rs
+++ b/rust/src/transformations/manipulation/ffi.rs
@@ -2,8 +2,9 @@ use crate::core::MetricSpace;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::domains::{AtomDomain, OptionDomain, VectorDomain};
 use crate::err;
+use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMetric, AnyObject, AnyTransformation, Downcast};
-use crate::ffi::util::{Type, TypeContents};
+use crate::ffi::util::{Type, TypeContents, try_as_ref};
 use crate::traits::{CheckAtom, InherentNull, Primitive};
 use crate::transformations::{make_is_equal, make_is_null, DatasetMetric};
 
@@ -35,24 +36,25 @@ pub extern "C" fn opendp_transformations__make_is_equal(
         input_domain: &AnyDomain,
         input_metric: &AnyMetric,
         value: &AnyObject,
-    ) -> FfiResult<*mut AnyTransformation>
+    ) -> Fallible<AnyTransformation>
     where
         TIA: Primitive,
         M: 'static + DatasetMetric,
         (VectorDomain<AtomDomain<TIA>>, M): MetricSpace,
         (VectorDomain<AtomDomain<bool>>, M): MetricSpace,
     {
-        let input_domain =
-            try_!(try_as_ref!(input_domain).downcast_ref::<VectorDomain<AtomDomain<TIA>>>())
-                .clone();
-        let input_metric = try_!(try_as_ref!(input_metric).downcast_ref::<M>()).clone();
-        let value = try_!(try_as_ref!(value).downcast_ref::<TIA>()).clone();
+        let input_domain = try_as_ref(input_domain)?
+            .downcast_ref::<VectorDomain<AtomDomain<TIA>>>()?
+            .clone();
+        let input_metric = try_as_ref(input_metric)?.downcast_ref::<M>()?.clone();
+        let value = try_as_ref(value)?.downcast_ref::<TIA>()?.clone();
         make_is_equal::<TIA, M>(input_domain, input_metric, value).into_any()
     }
     dispatch!(monomorphize, [
         (TIA, @primitives),
         (M, @dataset_metrics)
     ], (input_domain, input_metric, value))
+    .into()
 }
 
 #[no_mangle]
@@ -83,39 +85,39 @@ pub extern "C" fn opendp_transformations__make_is_null(
             fn monomorphize<M, TIA>(
                 input_domain: &AnyDomain,
                 input_metric: &AnyMetric,
-            ) -> FfiResult<*mut AnyTransformation>
+            ) -> Fallible<AnyTransformation>
             where
                 TIA: 'static + CheckAtom,
                 M: 'static + DatasetMetric,
                 (VectorDomain<OptionDomain<AtomDomain<TIA>>>, M): MetricSpace,
                 (VectorDomain<AtomDomain<bool>>, M): MetricSpace,
             {
-                let input_domain = try_!(
-                    input_domain.downcast_ref::<VectorDomain<OptionDomain<AtomDomain<TIA>>>>()
-                )
-                .clone();
+                let input_domain = input_domain
+                    .downcast_ref::<VectorDomain<OptionDomain<AtomDomain<TIA>>>>()?
+                    .clone();
                 let input_metric = try_!(input_metric.downcast_ref::<M>()).clone();
                 make_is_null(input_domain, input_metric).into_any()
             }
-            dispatch!(monomorphize, [(M, @dataset_metrics), (TIA, @primitives)], (input_domain, input_metric))
+            dispatch!(monomorphize, [(M, @dataset_metrics), (TIA, @primitives)], (input_domain, input_metric)).into()
         }
         TypeContents::GENERIC { name, .. } if name == &"AtomDomain" => {
             fn monomorphize<M, TIA>(
                 input_domain: &AnyDomain,
                 input_metric: &AnyMetric,
-            ) -> FfiResult<*mut AnyTransformation>
+            ) -> Fallible<AnyTransformation>
             where
                 TIA: 'static + CheckAtom + InherentNull,
                 M: 'static + DatasetMetric,
                 (VectorDomain<AtomDomain<TIA>>, M): MetricSpace,
                 (VectorDomain<AtomDomain<bool>>, M): MetricSpace,
             {
-                let input_domain =
-                    try_!(input_domain.downcast_ref::<VectorDomain<AtomDomain<TIA>>>()).clone();
-                let input_metric = try_!(input_metric.downcast_ref::<M>()).clone();
+                let input_domain = input_domain
+                    .downcast_ref::<VectorDomain<AtomDomain<TIA>>>()?
+                    .clone();
+                let input_metric = input_metric.downcast_ref::<M>()?.clone();
                 make_is_null(input_domain, input_metric).into_any()
             }
-            dispatch!(monomorphize, [(M, @dataset_metrics), (TIA, [f64, f32])], (input_domain, input_metric))
+            dispatch!(monomorphize, [(M, @dataset_metrics), (TIA, [f64, f32])], (input_domain, input_metric)).into()
         }
         _ => err!(
             TypeParse,

--- a/rust/src/transformations/manipulation/ffi.rs
+++ b/rust/src/transformations/manipulation/ffi.rs
@@ -4,7 +4,7 @@ use crate::domains::{AtomDomain, OptionDomain, VectorDomain};
 use crate::err;
 use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMetric, AnyObject, AnyTransformation, Downcast};
-use crate::ffi::util::{Type, TypeContents, try_as_ref};
+use crate::ffi::util::{Type, TypeContents};
 use crate::traits::{CheckAtom, InherentNull, Primitive};
 use crate::transformations::{make_is_equal, make_is_null, DatasetMetric};
 
@@ -43,11 +43,11 @@ pub extern "C" fn opendp_transformations__make_is_equal(
         (VectorDomain<AtomDomain<TIA>>, M): MetricSpace,
         (VectorDomain<AtomDomain<bool>>, M): MetricSpace,
     {
-        let input_domain = try_as_ref(input_domain)?
+        let input_domain = try_as_ref!(input_domain)
             .downcast_ref::<VectorDomain<AtomDomain<TIA>>>()?
             .clone();
-        let input_metric = try_as_ref(input_metric)?.downcast_ref::<M>()?.clone();
-        let value = try_as_ref(value)?.downcast_ref::<TIA>()?.clone();
+        let input_metric = try_as_ref!(input_metric).downcast_ref::<M>()?.clone();
+        let value = try_as_ref!(value).downcast_ref::<TIA>()?.clone();
         make_is_equal::<TIA, M>(input_domain, input_metric, value).into_any()
     }
     dispatch!(monomorphize, [

--- a/rust/src/transformations/resize/ffi.rs
+++ b/rust/src/transformations/resize/ffi.rs
@@ -4,6 +4,7 @@ use std::os::raw::{c_char, c_uint};
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt, MetricSpace};
 use crate::domains::{AtomDomain, VectorDomain};
 use crate::err;
+use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyObject, AnyTransformation};
 use crate::ffi::any::{AnyMetric, Downcast};
 use crate::ffi::util::Type;
@@ -32,7 +33,7 @@ pub extern "C" fn opendp_transformations__make_resize(
         input_metric: &AnyMetric,
         size: usize,
         constant: &AnyObject,
-    ) -> FfiResult<*mut AnyTransformation>
+    ) -> Fallible<AnyTransformation>
     where
         MI: 'static + IsMetricOrdered<Distance = IntDistance>,
         MO: 'static + IsMetricOrdered<Distance = IntDistance>,
@@ -40,9 +41,9 @@ pub extern "C" fn opendp_transformations__make_resize(
         (VectorDomain<AtomDomain<TA>>, MO): MetricSpace,
     {
         let input_domain =
-            try_!(input_domain.downcast_ref::<VectorDomain<AtomDomain<TA>>>()).clone();
-        let input_metric = try_!(input_metric.downcast_ref::<MI>()).clone();
-        let constant = try_!(constant.downcast_ref::<TA>()).clone();
+            input_domain.downcast_ref::<VectorDomain<AtomDomain<TA>>>()?.clone();
+        let input_metric = input_metric.downcast_ref::<MI>()?.clone();
+        let constant = constant.downcast_ref::<TA>()?.clone();
         super::make_resize::<_, MI, MO>(input_domain, input_metric, size, constant).into_any()
     }
 
@@ -50,7 +51,7 @@ pub extern "C" fn opendp_transformations__make_resize(
         (MI, [SymmetricDistance, InsertDeleteDistance]),
         (MO, [SymmetricDistance, InsertDeleteDistance]),
         (T, @primitives)
-    ], (input_domain, input_metric, size, constant))
+    ], (input_domain, input_metric, size, constant)).into()
 }
 
 #[cfg(test)]

--- a/rust/src/transformations/sum/float/checked/ffi.rs
+++ b/rust/src/transformations/sum/float/checked/ffi.rs
@@ -6,7 +6,7 @@ use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::err;
 use crate::error::Fallible;
 use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
-use crate::ffi::util::{Type, try_as_ref};
+use crate::ffi::util::Type;
 use crate::traits::Float;
 use crate::transformations::{
     make_bounded_float_checked_sum, make_sized_bounded_float_checked_sum, CanFloatSumOverflow,
@@ -39,7 +39,7 @@ pub extern "C" fn opendp_transformations__make_bounded_float_checked_sum(
         {
             make_bounded_float_checked_sum::<S>(size_limit, bounds).into_any()
         }
-        let bounds = *try_as_ref(bounds)?.downcast_ref::<(T, T)>()?;
+        let bounds = *try_as_ref!(bounds).downcast_ref::<(T, T)>()?;
         dispatch!(monomorphize2, [(S, [Sequential<T>, Pairwise<T>])], (size_limit, bounds))
     }
     let size_limit = size_limit as usize;

--- a/rust/src/transformations/sum/float/checked/ffi.rs
+++ b/rust/src/transformations/sum/float/checked/ffi.rs
@@ -4,8 +4,9 @@ use std::os::raw::{c_char, c_uint};
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 
 use crate::err;
+use crate::error::Fallible;
 use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
-use crate::ffi::util::Type;
+use crate::ffi::util::{Type, try_as_ref};
 use crate::traits::Float;
 use crate::transformations::{
     make_bounded_float_checked_sum, make_sized_bounded_float_checked_sum, CanFloatSumOverflow,
@@ -22,7 +23,7 @@ pub extern "C" fn opendp_transformations__make_bounded_float_checked_sum(
         S: Type,
         size_limit: usize,
         bounds: *const AnyObject,
-    ) -> FfiResult<*mut AnyTransformation>
+    ) -> Fallible<AnyTransformation>
     where
         T: 'static + Float,
         Sequential<T>: CanFloatSumOverflow<Item = T>,
@@ -31,20 +32,20 @@ pub extern "C" fn opendp_transformations__make_bounded_float_checked_sum(
         fn monomorphize2<S>(
             size_limit: usize,
             bounds: (S::Item, S::Item),
-        ) -> FfiResult<*mut AnyTransformation>
+        ) -> Fallible<AnyTransformation>
         where
             S: UncheckedSum,
             S::Item: 'static + Float,
         {
             make_bounded_float_checked_sum::<S>(size_limit, bounds).into_any()
         }
-        let bounds = *try_!(try_as_ref!(bounds).downcast_ref::<(T, T)>());
+        let bounds = *try_as_ref(bounds)?.downcast_ref::<(T, T)>()?;
         dispatch!(monomorphize2, [(S, [Sequential<T>, Pairwise<T>])], (size_limit, bounds))
     }
     let size_limit = size_limit as usize;
     let S = try_!(Type::try_from(S));
     let T = try_!(S.get_atom());
-    dispatch!(monomorphize, [(T, @floats)], (S, size_limit, bounds))
+    dispatch!(monomorphize, [(T, @floats)], (S, size_limit, bounds)).into()
 }
 
 #[no_mangle]
@@ -57,14 +58,14 @@ pub extern "C" fn opendp_transformations__make_sized_bounded_float_checked_sum(
         S: Type,
         size: usize,
         bounds: *const AnyObject,
-    ) -> FfiResult<*mut AnyTransformation>
+    ) -> Fallible<AnyTransformation>
     where
         T: 'static + Float,
     {
         fn monomorphize2<S>(
             size: usize,
             bounds: (S::Item, S::Item),
-        ) -> FfiResult<*mut AnyTransformation>
+        ) -> Fallible<AnyTransformation>
         where
             S: UncheckedSum,
             S::Item: 'static + Float,
@@ -77,7 +78,7 @@ pub extern "C" fn opendp_transformations__make_sized_bounded_float_checked_sum(
     let size = size as usize;
     let S = try_!(Type::try_from(S));
     let T = try_!(S.get_atom());
-    dispatch!(monomorphize, [(T, @floats)], (S, size, bounds))
+    dispatch!(monomorphize, [(T, @floats)], (S, size, bounds)).into()
 }
 
 #[cfg(test)]

--- a/rust/src/transformations/sum/float/ordered/ffi.rs
+++ b/rust/src/transformations/sum/float/ordered/ffi.rs
@@ -6,7 +6,7 @@ use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::err;
 use crate::error::Fallible;
 use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
-use crate::ffi::util::{Type, try_as_ref};
+use crate::ffi::util::Type;
 use crate::traits::Float;
 use crate::transformations::{
     make_bounded_float_ordered_sum, make_sized_bounded_float_ordered_sum, Pairwise, SaturatingSum,
@@ -72,7 +72,7 @@ pub extern "C" fn opendp_transformations__make_sized_bounded_float_ordered_sum(
         {
             make_sized_bounded_float_ordered_sum::<S>(size, bounds).into_any()
         }
-        let bounds = *try_as_ref(bounds)?.downcast_ref::<(T, T)>()?;
+        let bounds = *try_as_ref!(bounds).downcast_ref::<(T, T)>()?;
         dispatch!(monomorphize2, [(S, [Sequential<T>, Pairwise<T>])], (size, bounds))
     }
     let size = size as usize;

--- a/rust/src/transformations/sum/int/checked/ffi.rs
+++ b/rust/src/transformations/sum/int/checked/ffi.rs
@@ -4,9 +4,9 @@ use std::os::raw::{c_char, c_uint};
 
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 
-use crate::err;
+use crate::error::Fallible;
 use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
-use crate::ffi::util::Type;
+use crate::ffi::util::{Type, try_as_ref};
 use crate::traits::Number;
 use crate::transformations::make_sized_bounded_int_checked_sum;
 use crate::transformations::sum::int::AddIsExact;
@@ -17,17 +17,17 @@ pub extern "C" fn opendp_transformations__make_sized_bounded_int_checked_sum(
     bounds: *const AnyObject,
     T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<T>(size: usize, bounds: *const AnyObject) -> FfiResult<*mut AnyTransformation>
+    fn monomorphize<T>(size: usize, bounds: *const AnyObject) -> Fallible<AnyTransformation>
     where
         T: 'static + Number + AddIsExact,
         for<'a> T: Sum<&'a T>,
     {
-        let bounds = try_!(try_as_ref!(bounds).downcast_ref::<(T, T)>()).clone();
+        let bounds = try_as_ref(bounds)?.downcast_ref::<(T, T)>()?.clone();
         make_sized_bounded_int_checked_sum::<T>(size, bounds).into_any()
     }
     let size = size as usize;
     let T = try_!(Type::try_from(T));
-    dispatch!(monomorphize, [(T, @integers)], (size, bounds))
+    dispatch!(monomorphize, [(T, @integers)], (size, bounds)).into()
 }
 
 #[cfg(test)]

--- a/rust/src/transformations/sum/int/checked/ffi.rs
+++ b/rust/src/transformations/sum/int/checked/ffi.rs
@@ -6,7 +6,7 @@ use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 
 use crate::error::Fallible;
 use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
-use crate::ffi::util::{Type, try_as_ref};
+use crate::ffi::util::Type;
 use crate::traits::Number;
 use crate::transformations::make_sized_bounded_int_checked_sum;
 use crate::transformations::sum::int::AddIsExact;
@@ -22,7 +22,7 @@ pub extern "C" fn opendp_transformations__make_sized_bounded_int_checked_sum(
         T: 'static + Number + AddIsExact,
         for<'a> T: Sum<&'a T>,
     {
-        let bounds = try_as_ref(bounds)?.downcast_ref::<(T, T)>()?.clone();
+        let bounds = try_as_ref!(bounds).downcast_ref::<(T, T)>()?.clone();
         make_sized_bounded_int_checked_sum::<T>(size, bounds).into_any()
     }
     let size = size as usize;

--- a/rust/src/transformations/sum/int/monotonic/ffi.rs
+++ b/rust/src/transformations/sum/int/monotonic/ffi.rs
@@ -5,7 +5,7 @@ use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 
 use crate::error::Fallible;
 use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
-use crate::ffi::util::{Type, try_as_ref};
+use crate::ffi::util::Type;
 use crate::traits::Number;
 use crate::transformations::{
     make_bounded_int_monotonic_sum, make_sized_bounded_int_monotonic_sum, AddIsExact, IsMonotonic,
@@ -20,7 +20,7 @@ pub extern "C" fn opendp_transformations__make_bounded_int_monotonic_sum(
     where
         T: Number + AddIsExact + IsMonotonic,
     {
-        let bounds = try_as_ref(bounds)?.downcast_ref::<(T, T)>()?.clone();
+        let bounds = try_as_ref!(bounds).downcast_ref::<(T, T)>()?.clone();
         make_bounded_int_monotonic_sum::<T>(bounds).into_any()
     }
     let T = try_!(Type::try_from(T));
@@ -39,7 +39,7 @@ pub extern "C" fn opendp_transformations__make_sized_bounded_int_monotonic_sum(
     where
         T: Number + AddIsExact + IsMonotonic,
     {
-        let bounds = try_as_ref(bounds)?.downcast_ref::<(T, T)>()?.clone();
+        let bounds = try_as_ref!(bounds).downcast_ref::<(T, T)>()?.clone();
         make_sized_bounded_int_monotonic_sum::<T>(size, bounds).into_any()
     }
     let size = size as usize;

--- a/rust/src/transformations/sum/int/monotonic/ffi.rs
+++ b/rust/src/transformations/sum/int/monotonic/ffi.rs
@@ -3,9 +3,9 @@ use std::os::raw::{c_char, c_uint};
 
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 
-use crate::err;
+use crate::error::Fallible;
 use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
-use crate::ffi::util::Type;
+use crate::ffi::util::{Type, try_as_ref};
 use crate::traits::Number;
 use crate::transformations::{
     make_bounded_int_monotonic_sum, make_sized_bounded_int_monotonic_sum, AddIsExact, IsMonotonic,
@@ -16,17 +16,17 @@ pub extern "C" fn opendp_transformations__make_bounded_int_monotonic_sum(
     bounds: *const AnyObject,
     T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<T>(bounds: *const AnyObject) -> FfiResult<*mut AnyTransformation>
+    fn monomorphize<T>(bounds: *const AnyObject) -> Fallible<AnyTransformation>
     where
         T: Number + AddIsExact + IsMonotonic,
     {
-        let bounds = try_!(try_as_ref!(bounds).downcast_ref::<(T, T)>()).clone();
+        let bounds = try_as_ref(bounds)?.downcast_ref::<(T, T)>()?.clone();
         make_bounded_int_monotonic_sum::<T>(bounds).into_any()
     }
     let T = try_!(Type::try_from(T));
     dispatch!(monomorphize, [
         (T, @integers)
-    ], (bounds))
+    ], (bounds)).into()
 }
 
 #[no_mangle]
@@ -35,16 +35,16 @@ pub extern "C" fn opendp_transformations__make_sized_bounded_int_monotonic_sum(
     bounds: *const AnyObject,
     T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<T>(size: usize, bounds: *const AnyObject) -> FfiResult<*mut AnyTransformation>
+    fn monomorphize<T>(size: usize, bounds: *const AnyObject) -> Fallible<AnyTransformation>
     where
         T: Number + AddIsExact + IsMonotonic,
     {
-        let bounds = try_!(try_as_ref!(bounds).downcast_ref::<(T, T)>()).clone();
+        let bounds = try_as_ref(bounds)?.downcast_ref::<(T, T)>()?.clone();
         make_sized_bounded_int_monotonic_sum::<T>(size, bounds).into_any()
     }
     let size = size as usize;
     let T = try_!(Type::try_from(T));
-    dispatch!(monomorphize, [(T, @integers)], (size, bounds))
+    dispatch!(monomorphize, [(T, @integers)], (size, bounds)).into()
 }
 
 #[cfg(test)]

--- a/rust/src/transformations/sum/int/ordered/ffi.rs
+++ b/rust/src/transformations/sum/int/ordered/ffi.rs
@@ -3,9 +3,10 @@ use std::os::raw::{c_char, c_uint};
 
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 
-use crate::err;
+
+use crate::error::Fallible;
 use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
-use crate::ffi::util::Type;
+use crate::ffi::util::{Type, try_as_ref};
 use crate::traits::Number;
 use crate::transformations::{
     make_bounded_int_ordered_sum, make_sized_bounded_int_ordered_sum, AddIsExact,
@@ -16,17 +17,17 @@ pub extern "C" fn opendp_transformations__make_bounded_int_ordered_sum(
     bounds: *const AnyObject,
     T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<T>(bounds: *const AnyObject) -> FfiResult<*mut AnyTransformation>
+    fn monomorphize<T>(bounds: *const AnyObject) -> Fallible<AnyTransformation>
     where
         T: Number + AddIsExact,
     {
-        let bounds = try_!(try_as_ref!(bounds).downcast_ref::<(T, T)>()).clone();
+        let bounds = try_as_ref(bounds)?.downcast_ref::<(T, T)>()?.clone();
         make_bounded_int_ordered_sum::<T>(bounds).into_any()
     }
     let T = try_!(Type::try_from(T));
     dispatch!(monomorphize, [
         (T, @integers)
-    ], (bounds))
+    ], (bounds)).into()
 }
 
 #[no_mangle]
@@ -35,16 +36,16 @@ pub extern "C" fn opendp_transformations__make_sized_bounded_int_ordered_sum(
     bounds: *const AnyObject,
     T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<T>(size: usize, bounds: *const AnyObject) -> FfiResult<*mut AnyTransformation>
+    fn monomorphize<T>(size: usize, bounds: *const AnyObject) -> Fallible<AnyTransformation>
     where
         T: Number + AddIsExact,
     {
-        let bounds = try_!(try_as_ref!(bounds).downcast_ref::<(T, T)>()).clone();
+        let bounds = try_as_ref(bounds)?.downcast_ref::<(T, T)>()?.clone();
         make_sized_bounded_int_ordered_sum::<T>(size, bounds).into_any()
     }
     let size = size as usize;
     let T = try_!(Type::try_from(T));
-    dispatch!(monomorphize, [(T, @integers)], (size, bounds))
+    dispatch!(monomorphize, [(T, @integers)], (size, bounds)).into()
 }
 
 #[cfg(test)]

--- a/rust/src/transformations/sum/int/ordered/ffi.rs
+++ b/rust/src/transformations/sum/int/ordered/ffi.rs
@@ -6,7 +6,7 @@ use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 
 use crate::error::Fallible;
 use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
-use crate::ffi::util::{Type, try_as_ref};
+use crate::ffi::util::Type;
 use crate::traits::Number;
 use crate::transformations::{
     make_bounded_int_ordered_sum, make_sized_bounded_int_ordered_sum, AddIsExact,
@@ -21,7 +21,7 @@ pub extern "C" fn opendp_transformations__make_bounded_int_ordered_sum(
     where
         T: Number + AddIsExact,
     {
-        let bounds = try_as_ref(bounds)?.downcast_ref::<(T, T)>()?.clone();
+        let bounds = try_as_ref!(bounds).downcast_ref::<(T, T)>()?.clone();
         make_bounded_int_ordered_sum::<T>(bounds).into_any()
     }
     let T = try_!(Type::try_from(T));
@@ -40,7 +40,7 @@ pub extern "C" fn opendp_transformations__make_sized_bounded_int_ordered_sum(
     where
         T: Number + AddIsExact,
     {
-        let bounds = try_as_ref(bounds)?.downcast_ref::<(T, T)>()?.clone();
+        let bounds = try_as_ref!(bounds).downcast_ref::<(T, T)>()?.clone();
         make_sized_bounded_int_ordered_sum::<T>(size, bounds).into_any()
     }
     let size = size as usize;

--- a/rust/src/transformations/sum/int/split/ffi.rs
+++ b/rust/src/transformations/sum/int/split/ffi.rs
@@ -3,9 +3,9 @@ use std::os::raw::{c_char, c_uint};
 
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 
-use crate::err;
+use crate::error::Fallible;
 use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
-use crate::ffi::util::Type;
+use crate::ffi::util::{Type, try_as_ref};
 use crate::traits::Number;
 use crate::transformations::{
     make_bounded_int_split_sum, make_sized_bounded_int_split_sum, AddIsExact, SplitSatSum,
@@ -16,17 +16,17 @@ pub extern "C" fn opendp_transformations__make_bounded_int_split_sum(
     bounds: *const AnyObject,
     T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<T>(bounds: *const AnyObject) -> FfiResult<*mut AnyTransformation>
+    fn monomorphize<T>(bounds: *const AnyObject) -> Fallible<AnyTransformation>
     where
         T: Number + SplitSatSum + AddIsExact,
     {
-        let bounds = try_!(try_as_ref!(bounds).downcast_ref::<(T, T)>()).clone();
+        let bounds = try_as_ref(bounds)?.downcast_ref::<(T, T)>()?.clone();
         make_bounded_int_split_sum::<T>(bounds).into_any()
     }
     let T = try_!(Type::try_from(T));
     dispatch!(monomorphize, [
         (T, @integers)
-    ], (bounds))
+    ], (bounds)).into()
 }
 
 #[no_mangle]
@@ -35,16 +35,16 @@ pub extern "C" fn opendp_transformations__make_sized_bounded_int_split_sum(
     bounds: *const AnyObject,
     T: *const c_char,
 ) -> FfiResult<*mut AnyTransformation> {
-    fn monomorphize<T>(size: usize, bounds: *const AnyObject) -> FfiResult<*mut AnyTransformation>
+    fn monomorphize<T>(size: usize, bounds: *const AnyObject) -> Fallible<AnyTransformation>
     where
         T: Number + SplitSatSum + AddIsExact,
     {
-        let bounds = try_!(try_as_ref!(bounds).downcast_ref::<(T, T)>()).clone();
+        let bounds = try_as_ref(bounds)?.downcast_ref::<(T, T)>()?.clone();
         make_sized_bounded_int_split_sum::<T>(size, bounds).into_any()
     }
     let size = size as usize;
     let T = try_!(Type::try_from(T));
-    dispatch!(monomorphize, [(T, @integers)], (size, bounds))
+    dispatch!(monomorphize, [(T, @integers)], (size, bounds)).into()
 }
 
 #[cfg(test)]

--- a/rust/src/transformations/sum/int/split/ffi.rs
+++ b/rust/src/transformations/sum/int/split/ffi.rs
@@ -5,7 +5,7 @@ use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 
 use crate::error::Fallible;
 use crate::ffi::any::{AnyObject, AnyTransformation, Downcast};
-use crate::ffi::util::{Type, try_as_ref};
+use crate::ffi::util::Type;
 use crate::traits::Number;
 use crate::transformations::{
     make_bounded_int_split_sum, make_sized_bounded_int_split_sum, AddIsExact, SplitSatSum,
@@ -20,7 +20,7 @@ pub extern "C" fn opendp_transformations__make_bounded_int_split_sum(
     where
         T: Number + SplitSatSum + AddIsExact,
     {
-        let bounds = try_as_ref(bounds)?.downcast_ref::<(T, T)>()?.clone();
+        let bounds = try_as_ref!(bounds).downcast_ref::<(T, T)>()?.clone();
         make_bounded_int_split_sum::<T>(bounds).into_any()
     }
     let T = try_!(Type::try_from(T));
@@ -39,7 +39,7 @@ pub extern "C" fn opendp_transformations__make_sized_bounded_int_split_sum(
     where
         T: Number + SplitSatSum + AddIsExact,
     {
-        let bounds = try_as_ref(bounds)?.downcast_ref::<(T, T)>()?.clone();
+        let bounds = try_as_ref!(bounds).downcast_ref::<(T, T)>()?.clone();
         make_sized_bounded_int_split_sum::<T>(size, bounds).into_any()
     }
     let size = size as usize;

--- a/rust/src/transformations/sum_of_squared_deviations/ffi.rs
+++ b/rust/src/transformations/sum_of_squared_deviations/ffi.rs
@@ -4,6 +4,7 @@ use std::os::raw::c_char;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::domains::{AtomDomain, VectorDomain};
 use crate::err;
+use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMetric, AnyTransformation, Downcast};
 use crate::ffi::util::Type;
 use crate::metrics::SymmetricDistance;
@@ -20,21 +21,21 @@ pub extern "C" fn opendp_transformations__make_sum_of_squared_deviations(
         input_domain: &AnyDomain,
         input_metric: &AnyMetric,
         S: Type,
-    ) -> FfiResult<*mut AnyTransformation>
+    ) -> Fallible<AnyTransformation>
     where
         T: 'static + Float,
     {
         fn monomorphize2<S>(
             input_domain: &AnyDomain,
             input_metric: &AnyMetric,
-        ) -> FfiResult<*mut AnyTransformation>
+        ) -> Fallible<AnyTransformation>
         where
             S: UncheckedSum,
             S::Item: 'static + Float,
         {
             let input_domain =
-                try_!(input_domain.downcast_ref::<VectorDomain<AtomDomain<S::Item>>>()).clone();
-            let input_metric = try_!(input_metric.downcast_ref::<SymmetricDistance>()).clone();
+                input_domain.downcast_ref::<VectorDomain<AtomDomain<S::Item>>>()?.clone();
+            let input_metric = input_metric.downcast_ref::<SymmetricDistance>()?.clone();
             make_sum_of_squared_deviations::<S>(input_domain, input_metric).into_any()
         }
         dispatch!(monomorphize2, [(S, [Sequential<T>, Pairwise<T>])], (input_domain, input_metric))
@@ -45,5 +46,5 @@ pub extern "C" fn opendp_transformations__make_sum_of_squared_deviations(
     let T = try_!(S.get_atom());
     dispatch!(monomorphize, [
         (T, @floats)
-    ], (input_domain, input_metric, S))
+    ], (input_domain, input_metric, S)).into()
 }


### PR DESCRIPTION
Through the process of writing this, I've become more unsure about switching these. On one hand, it's nice to be able to try, but on the other hand, 
* the error handling is now inconsistent with the root code
* the macro-based error handling is easier to use with proc-macro-generated dispatch, should we change our dispatch to it

Alternatively, it may not matter-- as the proc macro could simply enclose the dispatch in a closure.