### PR TITLE
997 concrete mean and laplace on query

### DIFF
--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -447,7 +447,6 @@ class Query(object):
         >>> dp_mean = context.query().clamp((0.0, 10.0)).mean().laplace().release()
 
         :param scale: Noise scale parameter for the laplace distribution. `scale` == standard_deviation / sqrt(2).
-        :param k: The noise granularity in terms of 2^k.
         """
         # TODO: When they exist, add this note to docstring:
         # > The `private_mean`, `private_count`, etc. methods apply

--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -463,8 +463,8 @@ class Query(object):
     # some transformations... 
 
 
-    def accuracy(self, alpha):
-        return self.laplacian_scale_to_accuracy(self.param(), alpha)
+    # def accuracy(self, alpha):
+    #     return self.laplacian_scale_to_accuracy(self.param(), alpha)
 
     def new_with(self, *, chain: Chain, wrap_release=None) -> "Query":
         """Convenience constructor that creates a new query with a different chain."""

--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -407,6 +407,50 @@ class Query(object):
 
         return make
 
+    def mean(self):
+        """
+        
+        # Example
+
+        >>> print("A")
+
+        
+        """
+        import opendp.prelude as dp
+        return Query(
+            chain=self._chain >> dp.t.then_mean(),
+            output_measure=self._output_measure,
+            d_in=self._d_in,
+            d_out=self._d_out,
+            context=self._context,
+            _wrap_release=self._wrap_release,
+        )
+
+    def laplace(self, scale=None):
+        """
+        # Example
+
+        >>> query = my_context.query().a().b().laplace()
+        >>> accuracy = query.accuracy(alpha=0.05)
+        """
+        return Query.extend(
+            self,
+            next=dp.t.then_laplace(scale),
+            accuracy_help=dp.laplacian_scale_to_accuracy
+        )
+    
+    # laplace, gaussian
+    # private_mean
+    #  - clamps
+    #  - either splits between a sum and count, then postprocess or just mean, depending on if data size known
+    #  - noise addition- if self.privacy_measure is max divergence then laplace, else gaussian
+    # private_count, private sum, private_variance, private_std, private_histogram, any other private_* things
+    # some transformations... 
+
+
+    def accuracy(self, alpha):
+        return self.laplacian_scale_to_accuracy(self.param(), alpha)
+
     def new_with(self, *, chain: Chain, wrap_release=None) -> "Query":
         """Convenience constructor that creates a new query with a different chain."""
         return Query(

--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -429,7 +429,7 @@ class Query(object):
         import opendp.prelude as dp
         return self.new_with(chain=self._chain >> dp.t.then_mean())
 
-    def laplace(self, scale=None, k=-1074):
+    def laplace(self, scale=None):
         r"""Add Laplacian noise in preparation for a DP release.
 
         :example:

--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -408,7 +408,7 @@ class Query(object):
         return make
 
     def mean(self):
-        r"""Calculates the mean of data with known size and bounds.
+        r"""Calculate the mean of data with known size and bounds.
         TODO: `private_mean` does not have the same constraints, and is preferred.
 
         :example:
@@ -424,30 +424,35 @@ class Query(object):
         ...    split_evenly_over=1
         ... )
         >>> dp_mean = context.query().clamp((0.0, 10.0)).mean().laplace().release()
-        >>> assert isinstance(dp_mean, float)
         """
         import opendp.prelude as dp
-        return Query(
-            chain=self._chain >> dp.t.then_mean(),
-            output_measure=self._output_measure,
-            d_in=self._d_in,
-            d_out=self._d_out,
-            context=self._context,
-            _wrap_release=self._wrap_release,
-        )
+        return self.new_with(chain=self._chain >> dp.t.then_mean())
 
-    # def laplace(self, scale=None):
-    #     """
-    #     # Example
+    def laplace(self):
+        r"""Add Laplacian noise in preparation for a DP release.
+        TODO: The `private_mean`, `private_count`, etc. methods apply the appropriate noise automatically,
+        and are preferred.
 
-    #     >>> query = my_context.query().a().b().laplace()
-    #     >>> accuracy = query.accuracy(alpha=0.05)
-    #     """
-    #     return Query.extend(
-    #         self,
-    #         next=dp.t.then_laplace(scale),
-    #         accuracy_help=dp.laplacian_scale_to_accuracy
-    #     )
+        :example:
+
+        >>> import opendp.prelude as dp
+        >>> dp.enable_features('contrib')
+        >>> data = [1.0, 2.0, 3.0]
+        >>> context = dp.Context.compositor(
+        ...    data=data,
+        ...    privacy_unit=dp.unit_of(contributions=1),
+        ...    privacy_loss=dp.loss_of(epsilon=1.0),
+        ...    domain=dp.vector_domain(dp.atom_domain(T=float), size=len(data)),
+        ...    split_evenly_over=1
+        ... )
+        >>> dp_mean = context.query().clamp((0.0, 10.0)).mean().laplace().release()
+        """
+        import opendp.prelude as dp
+
+        # TODO: Use binary search to calculate scale
+        # See https://docs.opendp.org/en/stable/examples/attacks/membership.html?highlight=then_base_laplace#Differential-Privacy
+        scale = 1.0 # TODO: Remove this placeholder
+        return self.new_with(chain=self._chain >> dp.m.then_base_laplace(scale))
     
     # laplace, gaussian
     # private_mean

--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -408,13 +408,23 @@ class Query(object):
         return make
 
     def mean(self):
-        """
-        
-        # Example
+        r"""Calculates the mean of data with known size and bounds.
+        TODO: `private_mean` does not have the same constraints, and is preferred.
 
-        >>> print("A")
+        :example:
 
-        
+        >>> import opendp.prelude as dp
+        >>> dp.enable_features('contrib')
+        >>> data = [1.0, 2.0, 3.0]
+        >>> context = dp.Context.compositor(
+        ...    data=data,
+        ...    privacy_unit=dp.unit_of(contributions=1),
+        ...    privacy_loss=dp.loss_of(epsilon=1.0),
+        ...    domain=dp.vector_domain(dp.atom_domain(T=float), size=len(data)),
+        ...    split_evenly_over=1
+        ... )
+        >>> dp_mean = context.query().clamp((0.0, 10.0)).mean().laplace().release()
+        >>> assert isinstance(dp_mean, float)
         """
         import opendp.prelude as dp
         return Query(
@@ -426,18 +436,18 @@ class Query(object):
             _wrap_release=self._wrap_release,
         )
 
-    def laplace(self, scale=None):
-        """
-        # Example
+    # def laplace(self, scale=None):
+    #     """
+    #     # Example
 
-        >>> query = my_context.query().a().b().laplace()
-        >>> accuracy = query.accuracy(alpha=0.05)
-        """
-        return Query.extend(
-            self,
-            next=dp.t.then_laplace(scale),
-            accuracy_help=dp.laplacian_scale_to_accuracy
-        )
+    #     >>> query = my_context.query().a().b().laplace()
+    #     >>> accuracy = query.accuracy(alpha=0.05)
+    #     """
+    #     return Query.extend(
+    #         self,
+    #         next=dp.t.then_laplace(scale),
+    #         accuracy_help=dp.laplacian_scale_to_accuracy
+    #     )
     
     # laplace, gaussian
     # private_mean


### PR DESCRIPTION
- Towards #997

Rather than making a PR against `main` I've created a new branch, https://github.com/opendp/opendp/tree/997-concrete-query-methods-IN-PROGRESS, with the idea that smaller PRs could be reviewed and merged into it, rather than leaving `main` half-baked. Is this approach ok?

Questions on this bit:

- Since the Context API is designed to be used end-to-end, I'm not sure that there is a good minimal example. Is a long example like this too much clutter?
- Are there other things we do definitely want in the docs? Exceptions?
- In the draft, you had proposed `Query.extend`, which I'm interpreting as a new static method. It looks like `new_with` already does what we need: Ok to just use that?
- Are you imagining that the Laplace helper will do the binary search to determine the scale? If anything, maybe the user would supply a confidence level?
- Am I right in thinking that down-the-road, usage of both of these would be discouraged?