### PR TITLE
Add more flake8 checks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,64 @@
+# We could configure flake8 in python/setup.cfg,
+# but there is also python code outside the python directory,
+# so this config belongs at the top level.
+
+[flake8]
+exclude =
+	*/pseudocode/*
+    # Agree on name for venv: In https://github.com/opendp/opendp/pull/1013
+    # I propose `.venv`, but it could be anything else, but `opendp` may be confusing.
+    .venv
+
+extend-ignore =
+    # E125: continuation line with same indent as next logical line
+    E125,
+    # E128: continuation line under-indented for visual indent
+    E128,
+    # E251: unexpected spaces around keyword / parameter equals
+    E251,
+    # E261: at least two spaces before inline comment
+    E261,
+    # E265: block comment should start with '# '
+    E265,
+    # E302: expected 2 blank lines, found ...
+    E302,
+    # E303: too many blank lines (...)
+    E303,
+    # E305: expected 2 blank lines after class or function definition, found ...
+    E305,
+    # E306: expected 1 blank line before a nested definition, found ...
+    E306,
+    # E402: module level import not at top of file
+    E402,
+    # E501: line too long (... > 79 characters)
+    E501,
+    # E721: do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
+    E721,
+    # E722: do not use bare 'except'
+    E722,
+    # E731: do not assign a lambda expression, use a def
+    E731,
+    # E741: ambiguous variable name '...'
+    E741,
+    # F401: '...' imported but unused
+    F401,
+    # F403: 'from ... import *' used; unable to detect undefined names
+    F403,
+    # F405: '...' may be undefined, or defined from star imports: ...
+    F405,
+    # F541: f-string is missing placeholders
+    F541,
+    # F811: redefinition of unused 're' from line 4
+    F811,
+    # F821: undefined name '...'
+    F821,
+    # F841: local variable '...' is assigned to but never used
+    F841,
+    # W291: trailing whitespace
+    W291,
+    # W292: no newline at end of file
+    W292,
+    # W293: blank line contains whitespace
+    W293,
+    # W391: blank line at end of file
+    W391

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           # Stop the build if there are new linting errors.
           # There is a long ignore list in .flake8.
-          flake8 . --count --show-source --statistics
+          flake8 .. --count --show-source --statistics
 
       - name: Download libs
         uses: actions/download-artifact@v3

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -83,10 +83,9 @@ jobs:
 
       - name: Lint with flake8
         run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          # Stop the build if there are new linting errors.
+          # There is a long ignore list in .flake8.
+          flake8 . --count --show-source --statistics
 
       - name: Download libs
         uses: actions/download-artifact@v3

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -38,3 +38,11 @@ opendp =
 testpaths = 
 	test
 
+[flake8]
+exclude = 
+	rust/*
+extend-ignore =
+    E501, # line too long
+	F405, # ... may be undefined, or defined from star imports
+	E306, # expected 1 blank line before a nested definition
+

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -38,11 +38,3 @@ opendp =
 testpaths = 
 	test
 
-[flake8]
-exclude = 
-	rust/*
-extend-ignore =
-    E501, # line too long
-	F405, # ... may be undefined, or defined from star imports
-	E306, # expected 1 blank line before a nested definition
-


### PR DESCRIPTION
- Towards #256
- Suggest first resolving #1013 

Instead of using `select` to pick a few checks to run, use `extend-ignore` on a longer list: All the warnings our code currently produces. Could work on shortening the list of ignores over time... Some are good things to check, others are a bit arbitrary, but it would take more stylistic questions out of the code-review process.

This PR also runs flake8 on the whole checkout and not just the `python` directory.