### PR TITLE
CI fails if python code is untested, unless explicitly ignored

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -98,7 +98,10 @@ jobs:
         run: python -m pip install -e .
 
       - name: Test
-        run: pytest -v
+        run: coverage run -m pytest -v
+
+      - name: Test coverage
+        run: coverage report
 
       - name: Test docs
         run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install flake8 pytest
+          python -m pip install -r requirements-dev.txt
 
       - name: Lint with flake8
         run: |

--- a/docs/source/contributor/development-environment.rst
+++ b/docs/source/contributor/development-environment.rst
@@ -146,7 +146,7 @@ Change to the ``python`` directory, install dependencies, and then install the P
 
     cd python
 
-    pip install flake8 pytest wheel
+    pip install -r requirements-dev.txt
     pip install -e .
 
 The `-e` flag is significant! 

--- a/python/.coveragerc
+++ b/python/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+fail_under = 100
+show_missing = True

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,4 +1,4 @@
-flake8
-pytest
-wheel
-coverage
+flake8 ~= 6.1
+pytest ~= 7.4
+wheel ~= 0.41
+coverage ~= 7.3

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,0 +1,4 @@
+flake8
+pytest
+wheel
+coverage


### PR DESCRIPTION
- Fix #1028
- Since this adds another dev dependency, formalize it with a `requirements-dev.txt`, and loosely pin dependencies.
- Intersects with #1022 -- That may expand our test coverage.
  - If that's resolved first, confirm that all of the ignores here are still needed.
  - If this is resolved first, then add a note there to confirm that all ignores are needed before merging.

Filing as draft.