### PR TITLE
Add a docstring to prelude module

### DIFF
--- a/python/src/opendp/prelude.py
+++ b/python/src/opendp/prelude.py
@@ -1,3 +1,40 @@
+'''
+The ``prelude`` module provides shortcuts that reduce the number of ``import`` statements needed to get started.
+In most of our notebooks we begin with:
+
+.. doctest::
+
+    >>> import opendp.prelude as dp
+    >>> dp.enable_features("contrib")
+
+After that we can refer to members of 
+:py:mod:`mod <opendp.mod>`,
+:py:mod:`domains <opendp.domains>`,
+:py:mod:`metrics <opendp.metrics>`,
+:py:mod:`measures <opendp.measures>`,
+:py:mod:`typing <opendp.typing>`,
+:py:mod:`accuracy <opendp.accuracy>`, and
+:py:mod:`context <opendp.context>`
+using the shortcut.
+Above, ``dp.enable_features`` is an example:
+Its full path is :py:func:`opendp.mod.enable_features`.
+
+In addition, three modules are distinctive and have shortcut submodules:
+:py:mod:`transformations <opendp.transformations>` as ``t``,
+:py:mod:`measurements <opendp.measurements>` as ``m``, and
+:py:mod:`combinators <opendp.combinators>` as ``c``.
+For example:
+
+.. doctest::
+
+    >>> type(dp.t.then_sum)
+    <class 'function'>
+    >>> type(dp.m.then_laplace)
+    <class 'function'>
+    >>> type(dp.c.make_basic_composition)
+    <class 'function'>
+'''
+
 from opendp.mod import *
 import opendp.transformations as t
 import opendp.measurements as m


### PR DESCRIPTION
- Fix #942

Could also add a section to the narrative docs, but I think it's enough to just have examples there, and if people are wondering what `prelude` is, the API docs are now more informative. (I've confirmed locally that `docs/build/html/api/python/opendp.prelude.html` looks good.)

I wonder if we could get rid of the `__ALL__`? We don't have any example where we `from opendp.prelude import *`... and if anyone did do that, I think the risk of confusion is not worth saving three characters.