### PR TITLE
In `then_*` docs, point to `make_*`

### DIFF
--- a/python/src/opendp/measurements.py
+++ b/python/src/opendp/measurements.py
@@ -121,8 +121,7 @@ def then_alp_queryable(
     alpha = 4,
     CO: Optional[RuntimeTypeDescriptor] = None
 ):
-    r"""Partial constructructor which uses the preceding output domain and metric
-    as its input domain and metric. See also:
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
 
     :py:func:`opendp.measurements.make_alp_queryable`
     """
@@ -201,6 +200,10 @@ def then_base_discrete_gaussian(
     scale,
     MO: Optional[RuntimeTypeDescriptor] = "ZeroConcentratedDivergence<QO>"
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.measurements.make_base_discrete_gaussian`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_base_discrete_gaussian(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -277,6 +280,10 @@ def then_base_discrete_laplace(
     scale,
     QO: Optional[RuntimeTypeDescriptor] = None
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.measurements.make_base_discrete_laplace`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_base_discrete_laplace(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -351,6 +358,10 @@ def then_base_discrete_laplace_cks20(
     scale,
     QO: Optional[RuntimeTypeDescriptor] = None
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.measurements.make_base_discrete_laplace_cks20`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_base_discrete_laplace_cks20(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -433,6 +444,10 @@ def then_base_discrete_laplace_linear(
     bounds: Optional[Any] = None,
     QO: Optional[RuntimeTypeDescriptor] = None
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.measurements.make_base_discrete_laplace_linear`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_base_discrete_laplace_linear(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -514,6 +529,10 @@ def then_base_gaussian(
     k: Optional[int] = -1074,
     MO: Optional[RuntimeTypeDescriptor] = "ZeroConcentratedDivergence<T>"
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.measurements.make_base_gaussian`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_base_gaussian(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -586,6 +605,10 @@ def then_base_geometric(
     bounds: Optional[Any] = None,
     QO: Optional[RuntimeTypeDescriptor] = None
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.measurements.make_base_geometric`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_base_geometric(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -660,6 +683,10 @@ def then_base_laplace(
     scale,
     k: Optional[int] = -1074
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.measurements.make_base_laplace`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_base_laplace(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -730,6 +757,10 @@ def then_base_laplace_threshold(
     threshold,
     k: Optional[int] = -1074
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.measurements.make_base_laplace_threshold`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_base_laplace_threshold(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -802,6 +833,10 @@ def then_gaussian(
     scale,
     MO: Optional[RuntimeTypeDescriptor] = "ZeroConcentratedDivergence<QO>"
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.measurements.make_gaussian`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_gaussian(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -878,6 +913,10 @@ def then_laplace(
     scale,
     QO: Optional[RuntimeTypeDescriptor] = "float"
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.measurements.make_laplace`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_laplace(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -1057,6 +1096,10 @@ def then_report_noisy_max_gumbel(
     optimize: str,
     QO: Optional[RuntimeTypeDescriptor] = None
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.measurements.make_report_noisy_max_gumbel`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_report_noisy_max_gumbel(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -1129,6 +1172,10 @@ def then_user_measurement(
     privacy_map,
     TO: RuntimeTypeDescriptor
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.measurements.make_user_measurement`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_user_measurement(
         input_domain=input_domain,
         input_metric=input_metric,

--- a/python/src/opendp/measurements.py
+++ b/python/src/opendp/measurements.py
@@ -121,6 +121,11 @@ def then_alp_queryable(
     alpha = 4,
     CO: Optional[RuntimeTypeDescriptor] = None
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric
+    as its input domain and metric. See also:
+
+    :py:func:`opendp.measurements.make_alp_queryable`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_alp_queryable(
         input_domain=input_domain,
         input_metric=input_metric,

--- a/python/src/opendp/transformations.py
+++ b/python/src/opendp/transformations.py
@@ -183,6 +183,10 @@ def then_b_ary_tree(
     leaf_count: int,
     branching_factor: int
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_b_ary_tree`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_b_ary_tree(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -533,6 +537,10 @@ def make_cast(
 def then_cast(
     TOA: RuntimeTypeDescriptor
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_cast`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_cast(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -601,6 +609,10 @@ def make_cast_default(
 def then_cast_default(
     TOA: RuntimeTypeDescriptor
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_cast_default`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_cast_default(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -663,6 +675,10 @@ def make_cast_inherent(
 def then_cast_inherent(
     TOA: RuntimeTypeDescriptor
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_cast_inherent`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_cast_inherent(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -765,6 +781,10 @@ def make_clamp(
 def then_clamp(
     bounds: Tuple[Any, Any]
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_clamp`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_clamp(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -888,6 +908,10 @@ def make_count(
 def then_count(
     TO: Optional[RuntimeTypeDescriptor] = "int"
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_count`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_count(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -957,6 +981,10 @@ def then_count_by(
     MO: SensitivityMetric,
     TV: Optional[RuntimeTypeDescriptor] = "int"
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_count_by`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_count_by(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -1039,6 +1067,10 @@ def then_count_by_categories(
     MO: Optional[SensitivityMetric] = "L1Distance<int>",
     TOA: Optional[RuntimeTypeDescriptor] = "int"
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_count_by_categories`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_count_by_categories(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -1103,6 +1135,10 @@ def make_count_distinct(
 def then_count_distinct(
     TO: Optional[RuntimeTypeDescriptor] = "int"
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_count_distinct`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_count_distinct(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -1226,6 +1262,10 @@ def then_df_cast_default(
     TIA: RuntimeTypeDescriptor,
     TOA: RuntimeTypeDescriptor
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_df_cast_default`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_df_cast_default(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -1297,6 +1337,10 @@ def then_df_is_equal(
     value: Any,
     TIA: Optional[RuntimeTypeDescriptor] = None
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_df_is_equal`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_df_is_equal(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -1356,6 +1400,10 @@ def make_drop_null(
 def then_drop_null(
     
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_drop_null`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_drop_null(
         input_domain=input_domain,
         input_metric=input_metric))
@@ -1416,6 +1464,10 @@ def make_find(
 def then_find(
     categories: Any
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_find`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_find(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -1481,6 +1533,10 @@ def make_find_bin(
 def then_find_bin(
     edges: Any
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_find_bin`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_find_bin(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -1537,6 +1593,10 @@ def make_identity(
 def then_identity(
     
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_identity`
+    """
     return PartialConstructor(lambda domain, metric: make_identity(
         domain=domain,
         metric=metric))
@@ -1599,6 +1659,10 @@ def make_impute_constant(
 def then_impute_constant(
     constant: Any
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_impute_constant`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_impute_constant(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -1656,6 +1720,10 @@ def make_impute_uniform_float(
 def then_impute_uniform_float(
     bounds: Tuple[Any, Any]
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_impute_uniform_float`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_impute_uniform_float(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -1723,6 +1791,10 @@ def then_index(
     null: Any,
     TOA: Optional[RuntimeTypeDescriptor] = None
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_index`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_index(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -1787,6 +1859,10 @@ def make_is_equal(
 def then_is_equal(
     value: Any
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_is_equal`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_is_equal(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -1838,6 +1914,10 @@ def make_is_null(
 def then_is_null(
     
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_is_null`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_is_null(
         input_domain=input_domain,
         input_metric=input_metric))
@@ -1948,6 +2028,10 @@ def make_mean(
 def then_mean(
     
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_mean`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_mean(
         input_domain=input_domain,
         input_metric=input_metric))
@@ -2007,6 +2091,10 @@ def make_metric_bounded(
 def then_metric_bounded(
     
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_metric_bounded`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_metric_bounded(
         input_domain=input_domain,
         input_metric=input_metric))
@@ -2063,6 +2151,10 @@ def make_metric_unbounded(
 def then_metric_unbounded(
     
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_metric_unbounded`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_metric_unbounded(
         input_domain=input_domain,
         input_metric=input_metric))
@@ -2119,6 +2211,10 @@ def make_ordered_random(
 def then_ordered_random(
     
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_ordered_random`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_ordered_random(
         input_domain=input_domain,
         input_metric=input_metric))
@@ -2184,6 +2280,10 @@ def then_quantile_score_candidates(
     candidates: Any,
     alpha: float
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_quantile_score_candidates`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_quantile_score_candidates(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -2309,6 +2409,10 @@ def then_resize(
     constant: Any,
     MO: Optional[RuntimeTypeDescriptor] = "SymmetricDistance"
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_resize`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_resize(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -2947,6 +3051,10 @@ def make_sum(
 def then_sum(
     
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_sum`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_sum(
         input_domain=input_domain,
         input_metric=input_metric))
@@ -3024,6 +3132,10 @@ def make_sum_of_squared_deviations(
 def then_sum_of_squared_deviations(
     S: Optional[RuntimeTypeDescriptor] = "Pairwise<T>"
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_sum_of_squared_deviations`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_sum_of_squared_deviations(
         input_domain=input_domain,
         input_metric=input_metric,
@@ -3081,6 +3193,10 @@ def make_unordered(
 def then_unordered(
     
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_unordered`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_unordered(
         input_domain=input_domain,
         input_metric=input_metric))
@@ -3200,6 +3316,10 @@ def then_variance(
     ddof: Optional[int] = 1,
     S: Optional[RuntimeTypeDescriptor] = "Pairwise<T>"
 ):
+    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:
+
+    :py:func:`opendp.transformations.make_variance`
+    """
     return PartialConstructor(lambda input_domain, input_metric: make_variance(
         input_domain=input_domain,
         input_metric=input_metric,

--- a/python/test/test_docs.py
+++ b/python/test/test_docs.py
@@ -1,0 +1,22 @@
+import pytest
+from opendp import measurements, transformations
+
+@pytest.mark.parametrize(
+    "module,function",
+    [
+        (m, f)
+        for m in [measurements, transformations]
+        for f in [
+            getattr(m, f_name)
+            for f_name in dir(m)
+            if f_name.startswith('then_')
+        ]
+    ])
+def test_thens_are_documented(module, function):
+    m_name = module.__name__
+    then_name = function.__name__
+    make_name = then_name.replace('then_', 'make_')
+
+    assert function.__doc__ is not None, 'missing documentation'
+    assert f':py:func:`{m_name}.{make_name}`' in function.__doc__, f'no link to {make_name}'
+


### PR DESCRIPTION
- Fix #935 

Spent some time trying to get the restructured text syntax right, but decided that that wasn't the most important thing.

Most of the changes here come from a perl one-liner:
```
perl -e 'undef $/; $_ = <>; s/then_(\w+)\([^)]+\):\n/$&    r"""Partial constructructor which uses the preceding output domain and metric as its input domain and metric. See also:\n\n    :py:func:`opendp.transformations.make_$1`\n    """\n/g; print' python/src/opendp/transformations.py > python/src/opendp/transformations.new.py
```

And at the end there's a very parameterized test that checks that the documentation is in place -- Possible that we'll add more `then_*` functions, and we'd want to be sure they got the same documentation.

Happy to take suggestions on the RST syntax, and the content of this string.