### PR TITLE
Remove twitter and discussion from banner

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -122,14 +122,6 @@ html_last_updated_fmt = '%b %d, %Y'
 
 # Custom sidebar templates, maps document names to template names.
 html_theme_options = {
-    "icon_links": [
-        {
-            "name": "GitHub Discussions",
-            "url": "https://github.com/opendp/opendp/discussions",
-            "icon": "far fa-comments",
-        },
-    ],
-    "twitter_url": "https://twitter.com/opendp_org",
     "github_url": "https://github.com/opendp"
 }
 


### PR DESCRIPTION
- Adds to #1055 (Thought this was in there, but must have reverted it by mistake.)
- twitter and github can just be on the resources page: They don't need this real estate. 