### PR TITLE
Add mypy and check python type annotations

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -88,6 +88,10 @@ jobs:
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
+      - name: Type check with mypy
+        run: |
+          mypy .
+
       - name: Download libs
         uses: actions/download-artifact@v3
         with:

--- a/python/.mypy.ini
+++ b/python/.mypy.ini
@@ -1,16 +1,33 @@
 [mypy]
 
-disable_error_code = 
+# To generate list:
+# mypy . | grep error: | perl -pne 's/.*\[(\S+)\]/$1/' | sort | uniq -c | perl -pne 'chomp;s/\s+(\d+)\s+(\D+)/  # $1\n  $2,\n/'
+disable_error_code =
+  # 208
   arg-type,
+  # 15
   assignment,
+  # 9
   attr-defined,
+  # 1
   call-arg,
+  # 4
   import-not-found,
+  # 1
   import-untyped,
+  # 3
   index,
+  # 11
   misc,
+  # 6
   operator,
+  # 1
+  overload-overlap,
+  # 2
   return,
+  # 3
   return-value,
+  # 4
   union-attr,
-  var-annotated
+  # 1
+  var-annotated,

--- a/python/.mypy.ini
+++ b/python/.mypy.ini
@@ -1,0 +1,16 @@
+[mypy]
+
+disable_error_code = 
+  arg-type,
+  assignment,
+  attr-defined,
+  call-arg,
+  import-not-found,
+  import-untyped,
+  index,
+  misc,
+  operator,
+  return,
+  return-value,
+  union-attr,
+  var-annotated

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -2,3 +2,4 @@ flake8 ~= 6.1
 pytest ~= 7.4
 wheel ~= 0.41
 coverage ~= 7.3
+mypy ~= 1.7


### PR DESCRIPTION
- Fix #1023
- Builds on #1029

Even with the 13 error codes we ignore here, this is protecting us against a number of other possible errors: I think there are 47 mypy error codes total:
```
wget https://raw.githubusercontent.com/python/mypy/master/docs/source/error_code_list.rst
grep '.. _code-' error_code_list.rst | perl -pne 's/.*_code-//; s/://' | sort | wc -l
      47
```

If this much is good, can file a follow-up issue to address the errors in the ignore list: They might be the result of misusing the tool and not real errors at all, for all I know.