### PR TITLE
Expand test matrix: test with Python 3.12

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -52,7 +52,7 @@ jobs:
         working-directory: python
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.8, 3.12]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -118,7 +118,7 @@ jobs:
         working-directory: docs
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.8, 3.12]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/docs/linkchecker.cfg
+++ b/docs/linkchecker.cfg
@@ -18,6 +18,9 @@ ignore=
   # JS sniffing is involved? Easiest just to leave this ignore in place.
   https://crates.io/crates/opendp
 
+  # Binder has returned intermittant 500s, but we can trust that in general it is available.
+  https://mybinder.org
+
   # Internal:
   # - Rust function docs:
   measurements/fn


### PR DESCRIPTION
- Fix #1036

Unless there's a reason we've chosen not to test 3.12? Testing for 3.9, 3.10, and 3.11 feels like it would add a lot to CI, without corresponding benefits... but maybe it would be something to check before release?

- See also #1022:
  - It would be cleaner if the version matrix didn't need to be maintained in two places
  - We only need to run the doctests under different versions -- I don't think we care so much about running the doc build itself under different versions -- but maybe not worth refactoring. 