### PR TITLE
Run doctests with pytest

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           cd ../docs
           python -m pip install -r requirements.txt
-          make doctest-python
+          make html
           linkchecker -f linkchecker.cfg build/html/index.html
 
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -38,15 +38,13 @@ html:
 html-rustdoc:
 	cd ../rust && cargo rustdoc --features untrusted,derive -- --html-in-header katex.html --document-private-items
 
-doctest: doctest-rust doctest-python
+doctest: doctest-rust
 	@echo
+	@echo "TODO: python doctests now run by pytest; Remove this rule?"
 	@echo "Doctest finished. The output is in $(BUILDDIR)/doctest/output.txt."
 
 doctest-rust:
 	cd ../rust && $(CARGO) test --doc --features untrusted,ffi
-
-doctest-python: html
-	$(SPHINXBUILD) $(SPHINXOPTS) -b doctest source $(BUILDDIR)/doctest
 
 versions:
 	# "/en" is the default, but someday we might have translations

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,11 +25,6 @@ Make Sphinx html:
 make html
 ```
 
-Make html and run Python doctests:
-```shell
-make doctest-python
-```
-
 Make rust html:
 ```shell
 make html-rustdoc

--- a/docs/source/user/combinators.rst
+++ b/docs/source/user/combinators.rst
@@ -1,9 +1,3 @@
-.. testsetup::
-
-    from typing import List
-    from opendp.mod import enable_features
-    enable_features('contrib', 'floating-point')
-
 .. _combinator-constructors:
 
 Combinators
@@ -213,6 +207,8 @@ you can make the privacy relation more permissive by wrapping your measurement w
 
     .. doctest::
 
+
+        >>> from opendp.mod import enable_features
         >>> enable_features("honest-but-curious")
 
 

--- a/docs/source/user/programming-framework/supporting-elements.rst
+++ b/docs/source/user/programming-framework/supporting-elements.rst
@@ -182,11 +182,6 @@ Maps are a useful tool to find stability or privacy properties directly.
 
 Putting this to practice, the following example invokes the stability map on a clamp transformation.
 
-.. testsetup::
-
-    from opendp.mod import enable_features
-    enable_features('contrib')
-
 .. doctest::
 
     >>> from opendp.transformations import make_clamp

--- a/docs/source/user/transformations.rst
+++ b/docs/source/user/transformations.rst
@@ -191,13 +191,10 @@ These operations work with `usize` data types: an integer data type representing
 :func:`opendp.transformations.make_find` finds the index of each input datum in a set of categories.
 In other words, it transforms a categorical data vector to a vector of numeric indices.
 
-.. testsetup::
-
-    import opendp.prelude as dp
-    dp.enable_features('contrib')
-
 .. doctest::
 
+    >>> import opendp.prelude as dp
+    >>> dp.enable_features('contrib')
     >>> finder = (
     ...     # define the input space
     ...     (dp.vector_domain(dp.atom_domain(T=str)), dp.symmetric_distance()) >>

--- a/docs/source/user/utilities/parameter-search.rst
+++ b/docs/source/user/utilities/parameter-search.rst
@@ -28,15 +28,15 @@ OpenDP comes with some utility functions to make these binary searches easier to
 
 This is extremely powerful!
 
-.. testsetup::
+.. doctest::
 
-    from opendp.measurements import *
-    from opendp.transformations import *
-    from opendp.domains import atom_domain, vector_domain
-    from opendp.metrics import absolute_distance, symmetric_distance
-    from opendp.mod import *
-    from opendp.mod import enable_features
-    enable_features('contrib', 'floating-point')
+    >>> from opendp.measurements import *
+    >>> from opendp.transformations import *
+    >>> from opendp.domains import atom_domain, vector_domain
+    >>> from opendp.metrics import absolute_distance, symmetric_distance
+    >>> from opendp.mod import *
+    >>> from opendp.mod import enable_features
+    >>> enable_features('contrib', 'floating-point')
 
 * | If you have a bound on ``d_in`` and a budget ``d_out``, you can solve for the smallest noise scale that is still differentially private.
   | This is useful when you want to determine how accurate you can make a query with a given budget.

--- a/python/.mypy.ini
+++ b/python/.mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 
-# check_untyped_defs = True
+check_untyped_defs = True
 
 [mypy-opendp._data]
 disable_error_code =

--- a/python/.mypy.ini
+++ b/python/.mypy.ini
@@ -1,46 +1,40 @@
 [mypy]
 
-check_untyped_defs = True
+# check_untyped_defs = True
 
-# These occur in multiple files:
+[mypy-opendp._data]
 disable_error_code =
-  # 208
   arg-type,
-  # 15
+
+[mypy-opendp.accuracy]
+disable_error_code =
+  arg-type,
+
+[mypy-opendp.combinators]
+disable_error_code =
+  arg-type,
+
+[mypy-opendp.core]
+disable_error_code =
+  arg-type,
+
+[mypy-opendp.domains]
+disable_error_code =
+  arg-type,
+
+[mypy-opendp.measurements]
+disable_error_code =
+  arg-type,
+
+[mypy-opendp.measures]
+disable_error_code =
+  arg-type,
+
+[mypy-opendp.metrics]
+disable_error_code =
+  arg-type,
+
+[mypy-opendp.transformations]
+disable_error_code =
+  arg-type,
   assignment,
-  # 9
-  attr-defined,
-
-# ... and the rest occur in just one or two files, so we can narrow the filter.
-# In tests and notebooks there are some inline "type: ignore" flags,
-# but better to keep most of the ignores in one place as a TODO list.
-[mypy-opendp.context]
-disable_error_code =
-  index,
-  misc,
-  operator,
-  return-value,
-  union-attr
-
-[mypy-opendp.mod]
-disable_error_code =
-  call-arg,
-  misc,
-  name-defined,
-
-[mypy-opendp.typing]
-disable_error_code =
-  import-not-found,
-  index,
-  union-attr,
-
-[mypy-opendp._convert]
-disable_error_code =
-  import-not-found,
-  index,
-  operator,
-  union-attr,
-
-[mypy-opendp._lib]
-disable_error_code =
-  misc,

--- a/python/.pytest.ini
+++ b/python/.pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
 testpaths = 
 	test
+	../docs
+
+addopts = --doctest-glob docs/source/*/*.rst

--- a/python/.pytest.ini
+++ b/python/.pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = 
+	test

--- a/python/.pytest.ini
+++ b/python/.pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 testpaths = 
 	test
+	src
 	../docs
 
-addopts = --doctest-glob docs/source/*/*.rst
+addopts = --doctest-glob *.rst --doctest-modules --ignore=../docs/source/conf.py

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -3,9 +3,3 @@ pytest ~= 7.4
 wheel ~= 0.41
 coverage ~= 7.3
 mypy ~= 1.7
-
-# For notebook tests:
-nbmake==1.4.6
-pandas==2.1.3
-numpy
-seaborn==0.13.0

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -3,3 +3,9 @@ pytest ~= 7.4
 wheel ~= 0.41
 coverage ~= 7.3
 mypy ~= 1.7
+
+# For notebook tests:
+nbmake==1.4.6
+pandas==2.1.3
+numpy
+seaborn==0.13.0

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -33,8 +33,3 @@ where = src
 opendp = 
     lib/* 
     py.typed
-
-[tool:pytest]
-testpaths = 
-	test
-

--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -5,7 +5,7 @@ from opendp.mod import UnknownTypeException, OpenDPException, Transformation, Me
 from opendp.typing import RuntimeType, RuntimeTypeDescriptor, Vec
 
 try:
-    import numpy as np
+    import numpy as np # type: ignore[import-not-found]
 except ImportError: # pragma: no cover
     np = None
 
@@ -60,7 +60,7 @@ def check_c_int_cast(v, type_name):
         raise ValueError(f"value is not representable by {type_name}")
 
 
-def py_to_c(value: Any, c_type, type_name: RuntimeTypeDescriptor = None) -> Any:
+def py_to_c(value: Any, c_type, type_name: RuntimeTypeDescriptor = None) -> Any: # type: ignore[assignment]
     """Map from Python `value` to ctypes `c_type`.
 
     :param value: value to convert to c_type
@@ -151,7 +151,7 @@ def c_to_py(value: Any) -> Any:
 
     if isinstance(value, ctypes.c_char_p):
         from opendp._data import str_free
-        value_contents = value.value.decode() # type: ignore[reportOptionalMemberAccess]
+        value_contents = value.value.decode() # type: ignore[reportOptionalMemberAccess,union-attr]
         str_free(value)
         return value_contents
 
@@ -249,7 +249,7 @@ def _scalar_to_slice(val, type_name: str) -> FfiSlicePtr:
 
 
 def _slice_to_scalar(raw: FfiSlicePtr, type_name: str):
-    return ctypes.cast(raw.contents.ptr, ctypes.POINTER(ATOM_MAP[type_name])).contents.value
+    return ctypes.cast(raw.contents.ptr, ctypes.POINTER(ATOM_MAP[type_name])).contents.value # type: ignore[attr-defined]
 
 
 def _refcounter(ptr, increment):
@@ -277,7 +277,7 @@ def _string_to_slice(val: str) -> FfiSlicePtr:
 
 
 def _slice_to_string(raw: FfiSlicePtr) -> str:
-    return ctypes.cast(raw.contents.ptr, ctypes.c_char_p).value.decode() # type: ignore[reportOptionalMemberAccess]
+    return ctypes.cast(raw.contents.ptr, ctypes.c_char_p).value.decode() # type: ignore[reportOptionalMemberAccess,union-attr]
 
 
 def _vector_to_slice(val: Sequence[Any], type_name: RuntimeType) -> FfiSlicePtr:
@@ -297,7 +297,7 @@ def _vector_to_slice(val: Sequence[Any], type_name: RuntimeType) -> FfiSlicePtr:
 
     if isinstance(inner_type_name, RuntimeType):
         c_repr = [py_to_c(v, c_type=AnyObjectPtr, type_name=inner_type_name) for v in val]
-        array = (AnyObjectPtr * len(val))(*c_repr)
+        array = (AnyObjectPtr * len(val))(*c_repr) # type: ignore[operator] # type: ignore[operator]
         ffislice = _wrap_in_slice(array, len(val))
         ffislice.depends_on(*c_repr)
         return ffislice
@@ -321,7 +321,7 @@ def _vector_to_slice(val: Sequence[Any], type_name: RuntimeType) -> FfiSlicePtr:
     if inner_type_name not in ATOM_MAP:
         raise TypeError(f"Members must be one of {tuple(ATOM_MAP.keys())}. Found {inner_type_name}.")
 
-    array = (ATOM_MAP[inner_type_name] * len(val))(*val)
+    array = (ATOM_MAP[inner_type_name] * len(val))(*val) # type: ignore[operator] # type: ignore[operator]
     return _wrap_in_slice(array, len(val))
 
 
@@ -407,7 +407,7 @@ def _hashmap_to_slice(val: Dict[Any, Any], type_name: RuntimeType) -> FfiSlicePt
     
     keys: AnyObjectPtr = py_to_c(list(val.keys()), type_name=Vec[key_type], c_type=AnyObjectPtr)
     vals: AnyObjectPtr = py_to_c(list(val.values()), type_name=Vec[val_type], c_type=AnyObjectPtr)
-    ffislice = _wrap_in_slice(ctypes.pointer((AnyObjectPtr * 2)(keys, vals)), 2)
+    ffislice = _wrap_in_slice(ctypes.pointer((AnyObjectPtr * 2)(keys, vals)), 2) # type: ignore[operator] # type: ignore[operator]
 
     # The __del__ destructor on `keys` and `vals` is called and memory freed when their refcounts go to zero.
     # ffislice needs keys and vals to have a lifetime at least as long as itself,
@@ -425,8 +425,8 @@ def _slice_to_hashmap(raw: FfiSlicePtr) -> Dict[Any, Any]:
     # AnyObjectPtr.__del__ would free the memory behind keys and vals when this stack frame is popped.
     # But that memory has a lifetime at least as long as raw, so it cannot be freed yet.
     # Adjust the class to avoid calling AnyObjectPtr.__del__, which would free the backing memory.
-    keys.__class__ = ctypes.POINTER(AnyObject)
-    vals.__class__ = ctypes.POINTER(AnyObject)
+    keys.__class__ = ctypes.POINTER(AnyObject) # type: ignore[assignment]
+    vals.__class__ = ctypes.POINTER(AnyObject) # type: ignore[assignment]
     return result
 
 

--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -44,7 +44,7 @@ def check_similar_scalar(expected, value):
     inferred = RuntimeType.infer(value)
     
     if inferred in ATOM_EQUIVALENCE_CLASSES:
-        if expected not in ATOM_EQUIVALENCE_CLASSES[inferred]:
+        if expected not in ATOM_EQUIVALENCE_CLASSES[inferred]: # type: ignore[index]
             raise TypeError(f"inferred type is {inferred}, expected {expected}. See {_ERROR_URL_298}")
     else:
         if expected != inferred:

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -116,11 +116,11 @@ class AnyFunction(ctypes.Structure):
     pass  # Opaque struct
 
 
-class BoolPtr(ctypes.POINTER(ctypes.c_bool)):
+class BoolPtr(ctypes.POINTER(ctypes.c_bool)): # type: ignore[misc]
     _type_ = ctypes.c_bool
 
 
-class AnyObjectPtr(ctypes.POINTER(AnyObject)):
+class AnyObjectPtr(ctypes.POINTER(AnyObject)): # type: ignore[misc]
     _type_ = AnyObject
 
     def __del__(self):
@@ -132,7 +132,7 @@ class AnyQueryable(ctypes.Structure):
     pass  # Opaque struct
 
 
-class FfiSlicePtr(ctypes.POINTER(FfiSlice)):
+class FfiSlicePtr(ctypes.POINTER(FfiSlice)): # type: ignore[misc]
     _type_ = FfiSlice
     _dependencies: Dict[Any, Any] = {}  # TODO: Tighten this
 

--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -83,16 +83,16 @@ def space_of(T, M=None, infer=False) -> Tuple[Domain, Metric]:
 
     # choose a metric type if not set
     if M is None:
-        if D.origin == "VectorDomain":
+        if D.origin == "VectorDomain": # type: ignore[union-attr]
             M = ty.SymmetricDistance
-        elif D.origin == "AtomDomain" and ty.get_atom(D) in ty.NUMERIC_TYPES:
+        elif D.origin == "AtomDomain" and ty.get_atom(D) in ty.NUMERIC_TYPES: # type: ignore[union-attr]
             M = ty.AbsoluteDistance
         else:
             raise TypeError(f"no default metric for domain {D}. Please set `M`")
 
     # choose a distance type if not set
     if isinstance(M, ty.RuntimeType) and not M.args:
-        M = M[ty.get_atom(D)]
+        M = M[ty.get_atom(D)] # type: ignore[index]
 
     return domain, metric_of(M)
 
@@ -179,7 +179,7 @@ def loss_of(*, epsilon=None, delta=None, rho=None, U=None) -> Tuple[Measure, flo
         return max_divergence(T=U), epsilon
     else:
         U = RuntimeType.parse_or_infer(U, epsilon)
-        return fixed_smoothed_max_divergence(T=U), (epsilon, delta)
+        return fixed_smoothed_max_divergence(T=U), (epsilon, delta) # type: ignore[return-value]
 
 
 def unit_of(
@@ -314,9 +314,9 @@ class Context(object):
             d_query = self.d_mids[0]
         elif kwargs: # pragma: no cover
             measure, d_query = loss_of(**kwargs)
-            if measure != self.output_measure:
+            if measure != self.output_measure: # type: ignore[attr-defined]
                 raise ValueError(
-                    f"Expected output measure {self.output_measure} but got {measure}"
+                    f"Expected output measure {self.output_measure} but got {measure}" # type: ignore[attr-defined]
                 )
 
         return Query(
@@ -347,10 +347,10 @@ class Query(object):
     def __init__(
         self,
         chain: Chain,
-        output_measure: Measure = None,
+        output_measure: Measure = None, # type: ignore[assignment]
         d_in=None,
         d_out=None,
-        context: "Context" = None,
+        context: "Context" = None, # type: ignore[assignment]
         _wrap_release=None,
     ) -> None:
         """Initializes the query with the given chain and output measure.
@@ -415,7 +415,7 @@ class Query(object):
             output_measure=self._output_measure,
             d_in=self._d_in,
             d_out=self._d_out,
-            context=self._context,
+            context=self._context, # type: ignore[arg-type]
             _wrap_release=wrap_release or self._wrap_release,
         )
 
@@ -440,7 +440,7 @@ class Query(object):
     def release(self) -> Any:
         """Release the query. The query must be part of a context."""
         # TODO: consider adding an optional `data` parameter for when _context is None
-        answer = self._context(self.resolve())
+        answer = self._context(self.resolve()) # type: ignore[misc]
         if self._wrap_release:
             answer = self._wrap_release(answer)
         return answer

--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -421,7 +421,7 @@ class Query(object):
 
     def __dir__(self):
         """Returns the list of available constructors. Used by Python's error suggestion mechanism."""
-        return super().__dir__() + list(constructors.keys()) # pragma: no cover
+        return super().__dir__() + list(constructors.keys())  # type: ignore[operator] # pragma: no cover
 
     def resolve(self, allow_transformations=False):
         """Resolve the query into a measurement."

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from opendp.typing import RuntimeType # pragma: no cover
 
 
-class Measurement(ctypes.POINTER(AnyMeasurement)):
+class Measurement(ctypes.POINTER(AnyMeasurement)): # type: ignore[misc]
     """A differentially private unit of computation.
     A measurement contains a function and a privacy relation.
     The function releases a differentially-private release.
@@ -177,7 +177,7 @@ class Measurement(ctypes.POINTER(AnyMeasurement)):
         return f"Measurement(\n    input_domain   = {self.input_domain}, \n    input_metric   = {self.input_metric}, \n    output_measure = {self.output_measure}\n)" # pragma: no cover
 
 
-class Transformation(ctypes.POINTER(AnyTransformation)):
+class Transformation(ctypes.POINTER(AnyTransformation)): # type: ignore[misc]
     """A non-differentially private unit of computation.
     A transformation contains a function and a stability relation.
     The function maps from an input domain to an output domain.
@@ -270,7 +270,7 @@ class Transformation(ctypes.POINTER(AnyTransformation)):
     def __rshift__(self, other: "PartialConstructor") -> "PartialConstructor":
         ...
 
-    def __rshift__(self, other: Union["Measurement", "Transformation", "PartialConstructor"]) -> Union["Measurement", "Transformation", "PartialConstructor", "PartialChain"]:  # noqa F821
+    def __rshift__(self, other: Union["Measurement", "Transformation", "PartialConstructor"]) -> Union["Measurement", "Transformation", "PartialConstructor", "PartialChain"]:  # type: ignore[name-defined] # noqa F821
         if isinstance(other, Measurement):
             from opendp.combinators import make_chain_mt
             return make_chain_mt(other, self)
@@ -280,7 +280,7 @@ class Transformation(ctypes.POINTER(AnyTransformation)):
             return make_chain_tt(other, self)
         
         if isinstance(other, PartialConstructor):
-            return self >> other(self.output_domain, self.output_metric)
+            return self >> other(self.output_domain, self.output_metric) # type: ignore[call-arg]
 
         from opendp.context import PartialChain
         if isinstance(other, PartialChain):
@@ -373,7 +373,7 @@ class Transformation(ctypes.POINTER(AnyTransformation)):
         return f"Transformation(\n    input_domain   = {self.input_domain},\n    output_domain  = {self.output_domain},\n    input_metric   = {self.input_metric},\n    output_metric  = {self.output_metric}\n)"
 
 from typing import cast
-Transformation = cast(Type[Transformation], Transformation)
+Transformation = cast(Type[Transformation], Transformation) # type: ignore[misc]
 
 class Queryable(object):
     def __init__(self, value):
@@ -401,7 +401,7 @@ class Queryable(object):
         setattr(self, "_dependencies", args)
         
 
-class Function(ctypes.POINTER(AnyFunction)):
+class Function(ctypes.POINTER(AnyFunction)): # type: ignore[misc]
     _type_ = AnyFunction
 
     def __call__(self, arg):
@@ -421,7 +421,7 @@ class Function(ctypes.POINTER(AnyFunction)):
             pass
 
 
-class Domain(ctypes.POINTER(AnyDomain)):
+class Domain(ctypes.POINTER(AnyDomain)): # type: ignore[misc]
     _type_ = AnyDomain
 
     def member(self, val):
@@ -464,7 +464,7 @@ class Domain(ctypes.POINTER(AnyDomain)):
         setattr(self, "_dependencies", args)
 
 
-class Metric(ctypes.POINTER(AnyMetric)):
+class Metric(ctypes.POINTER(AnyMetric)): # type: ignore[misc]
     _type_ = AnyMetric
 
     @property
@@ -498,7 +498,7 @@ class Metric(ctypes.POINTER(AnyMetric)):
         return str(self) == str(other)
 
 
-class Measure(ctypes.POINTER(AnyMeasure)):
+class Measure(ctypes.POINTER(AnyMeasure)): # type: ignore[misc]
     _type_ = AnyMeasure
 
     @property
@@ -747,7 +747,7 @@ def binary_search_param(
     return binary_search(lambda param: make_chain(param).check(d_in, d_out), bounds, T)
 
 @overload
-def binary_search(
+def binary_search( # type: ignore[overload-overlap]
         predicate: Callable[[T], bool],
         bounds: Optional[Tuple[T, T]] = None,
         T: Optional[Type[T]] = None,

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -793,11 +793,6 @@ def binary_search(
     Find epsilon usage of the gaussian(scale=1.) mechanism applied on a dp mean.
     Assume neighboring datasets differ by up to three additions/removals, and fix delta to 1e-8.
 
-    .. testsetup:: *
-
-        import opendp.prelude as dp
-        dp.enable_features("contrib", "floating-point")
-
     >>> # build a histogram that emits float counts
     >>> input_space = dp.vector_domain(dp.atom_domain(bounds=(0., 100.)), 1000), dp.symmetric_distance()
     >>> dp_mean = dp.c.make_fix_delta(dp.c.make_zCDP_to_approxDP(

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -794,6 +794,7 @@ def binary_search(
     Assume neighboring datasets differ by up to three additions/removals, and fix delta to 1e-8.
 
     >>> # build a histogram that emits float counts
+    >>> import opendp.prelude as dp
     >>> input_space = dp.vector_domain(dp.atom_domain(bounds=(0., 100.)), 1000), dp.symmetric_distance()
     >>> dp_mean = dp.c.make_fix_delta(dp.c.make_zCDP_to_approxDP(
     ...     input_space >> dp.t.then_mean() >> dp.m.then_gaussian(1.)), 

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -16,7 +16,7 @@ ELEMENTARY_TYPES: Dict[Any, str] = {
     Transformation: 'AnyTransformationPtr'
 }
 try:
-    import numpy as np
+    import numpy as np # type: ignore[import-not-found]
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#sized-aliases
     ELEMENTARY_TYPES.update({  # pragma: no cover
         # np.bytes_: '&[u8]',  # np.string_ # not used in OpenDP
@@ -56,14 +56,14 @@ RuntimeTypeDescriptor = Union[
 ]
 
 if sys.version_info >= (3, 8):
-    from typing import _GenericAlias
+    from typing import _GenericAlias # type: ignore[attr-defined]
     # a Python type hint from the std typing module -- List[int]
-    RuntimeTypeDescriptor.__args__ = RuntimeTypeDescriptor.__args__ + (_GenericAlias,)
+    RuntimeTypeDescriptor.__args__ = RuntimeTypeDescriptor.__args__ + (_GenericAlias,) # type: ignore[attr-defined]
 
 if sys.version_info >= (3, 9):  # pragma: no cover
     from types import GenericAlias
     # a Python type hint from the std types module -- list[int]
-    RuntimeTypeDescriptor.__args__ = RuntimeTypeDescriptor.__args__ + (GenericAlias,)
+    RuntimeTypeDescriptor.__args__ = RuntimeTypeDescriptor.__args__ + (GenericAlias,) # type: ignore[attr-defined]
 
 
 def set_default_int_type(T: RuntimeTypeDescriptor) -> None:
@@ -80,8 +80,8 @@ def set_default_int_type(T: RuntimeTypeDescriptor) -> None:
     T = RuntimeType.parse(T)
     assert T in equivalence_class, f"T must be one of {equivalence_class}"
 
-    ATOM_EQUIVALENCE_CLASSES[T] = ATOM_EQUIVALENCE_CLASSES.pop(ELEMENTARY_TYPES[int])
-    ELEMENTARY_TYPES[int] = T
+    ATOM_EQUIVALENCE_CLASSES[T] = ATOM_EQUIVALENCE_CLASSES.pop(ELEMENTARY_TYPES[int]) # type: ignore[index]
+    ELEMENTARY_TYPES[int] = T # type: ignore[assignment]
 
 
 def set_default_float_type(T: RuntimeTypeDescriptor) -> None: # pragma: no cover
@@ -99,8 +99,8 @@ def set_default_float_type(T: RuntimeTypeDescriptor) -> None: # pragma: no cover
     T = RuntimeType.parse(T)
     assert T in equivalence_class, f"T must be a float type in {equivalence_class}"
 
-    ATOM_EQUIVALENCE_CLASSES[T] = ATOM_EQUIVALENCE_CLASSES.pop(ELEMENTARY_TYPES[float])
-    ELEMENTARY_TYPES[float] = T
+    ATOM_EQUIVALENCE_CLASSES[T] = ATOM_EQUIVALENCE_CLASSES.pop(ELEMENTARY_TYPES[float]) # type: ignore[index]
+    ELEMENTARY_TYPES[float] = T # type: ignore[assignment]
 
 
 class RuntimeType(object):
@@ -166,17 +166,17 @@ class RuntimeType(object):
         # parse type hints from the typing module
         hinted_type = None
         if sys.version_info >= (3, 8):
-            from typing import _GenericAlias
+            from typing import _GenericAlias # type: ignore[attr-defined]
             if isinstance(type_name, _GenericAlias):
                 hinted_type = typing.get_origin(type_name), typing.get_args(type_name)
         if sys.version_info >= (3, 9):  # pragma: no cover
             from types import GenericAlias
-            if isinstance(type_name, GenericAlias):
-                hinted_type = type_name.__origin__, type_name.__args__ # pragma: no cover
+            if isinstance(type_name, GenericAlias): # type: ignore[attr-defined]
+                hinted_type = type_name.__origin__, type_name.__args__ # type: ignore[attr-defined] # pragma: no cover
     
         if hinted_type:
             origin, args = hinted_type
-            args = [RuntimeType.parse(v, generics=generics) for v in args] or None
+            args = [RuntimeType.parse(v, generics=generics) for v in args] or None # type: ignore[assignment]
             if origin == tuple:
                 origin = 'Tuple'
             elif origin == list:
@@ -207,7 +207,7 @@ class RuntimeType(object):
 
             # attempt to upgrade strings to the metric/measure instance
             origin = type_name[:start] if 0 < start else type_name
-            closeness: RuntimeType = {
+            closeness: RuntimeType = { # type: ignore[assignment]
                 'ChangeOneDistance': ChangeOneDistance,
                 'SymmetricDistance': SymmetricDistance,
                 'AbsoluteDistance': AbsoluteDistance,
@@ -330,7 +330,7 @@ class RuntimeType(object):
     @classmethod
     def parse_or_infer(
             cls,
-            type_name: RuntimeTypeDescriptor = None,
+            type_name: RuntimeTypeDescriptor = None, # type: ignore[assignment]
             public_example: Any = None,
             generics: Optional[List[str]] = None
     ) -> Union["RuntimeType", str]:
@@ -368,8 +368,8 @@ class UnknownType(RuntimeType):
     """Indicator for a type that cannot be inferred. Typically the atomic type of an empty list.
     RuntimeTypes containing UnknownType cannot be used in FFI
     """
-    origin: None
-    args: None
+    origin: None # type: ignore[assignment]
+    args: None # type: ignore[assignment]
 
     def __init__(self, reason): # pragma: no cover
         self.origin = None

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -494,7 +494,7 @@ def get_type(value):
     return value.type
 
 def get_value_type(type_name):
-    return RuntimeType.parse(type_name).args[1]
+    return RuntimeType.parse(type_name).args[1] # type: ignore[union-attr]
 
 def get_distance_type(value: Union[Metric, Measure]) -> Union[RuntimeType, str]:
     return value.distance_type

--- a/python/test/context/test_context.py
+++ b/python/test/context/test_context.py
@@ -62,12 +62,12 @@ def test_sc_query():
     )
 
     # build a child sequential compositor, and then use it to release a laplace sum
-    sub_context = context.query().compositor(split_evenly_over=3).release()
+    sub_context = context.query().compositor(split_evenly_over=3).release() # type: ignore[attr-defined]
     dp_sum = sub_context.query().clamp((1, 10)).sum().laplace()
     print("laplace dp_sum", dp_sum.release())
 
     # build a child sequential compositor in zCDP, and then use it to release some gaussian queries
-    sub_context = context.query().compositor(
+    sub_context = context.query().compositor(  # type: ignore[attr-defined]
         split_evenly_over=2, 
         output_measure=dp.zero_concentrated_divergence(T=float)
     ).release()

--- a/python/test/test_convert.py
+++ b/python/test/test_convert.py
@@ -52,7 +52,7 @@ def test_data_object_tuple():
 def test_roundtrip_int():
     in_ = 23
     ptr = ctypes.POINTER(ctypes.c_int32)(ctypes.c_int32(in_))
-    ptr = ctypes.byref(ctypes.c_int32(in_))
+    ptr = ctypes.byref(ctypes.c_int32(in_))  # type: ignore[assignment]
 
     int_void = ctypes.cast(ptr, ctypes.c_void_p)
     out = ctypes.cast(int_void, ctypes.POINTER(ctypes.c_int32)).contents.value

--- a/python/test/test_core.py
+++ b/python/test/test_core.py
@@ -204,7 +204,7 @@ def test_user_domain():
     map_domain = dp.map_domain(dp.atom_domain(T=str), domain)
     assert map_domain.member({"A": datetime.now(), "B": datetime.now()})
     trans = dp.t.make_identity(map_domain, dp.symmetric_distance())
-    misc_data = {"A": datetime.now(), "C": 1j + 2}
+    misc_data = {"A": datetime.now(), "C": 1j + 2}  # type: ignore[assignment]
     assert trans(misc_data) == misc_data
     assert not map_domain.member(misc_data)
 

--- a/python/test/test_tests.py
+++ b/python/test/test_tests.py
@@ -1,3 +1,3 @@
 def test_number_of_tests_found(request):
     tests_found = len(request.session.items)
-    assert tests_found >= 208
+    assert tests_found >= 216

--- a/python/test/test_tests.py
+++ b/python/test/test_tests.py
@@ -1,0 +1,3 @@
+def test_number_of_tests_found(request):
+    tests_found = len(request.session.items)
+    assert tests_found >= 208

--- a/python/test/test_tests.py
+++ b/python/test/test_tests.py
@@ -1,3 +1,3 @@
 def test_number_of_tests_found(request):
     tests_found = len(request.session.items)
-    assert tests_found >= 216
+    assert tests_found >= 227

--- a/python/test/test_typing.py
+++ b/python/test/test_typing.py
@@ -31,8 +31,8 @@ def test_typing_hint():
             # on Python < 3.8 the remaining tests do not apply
             return
 
-    assert str(RuntimeType.parse(Tuple[int, float])) == "(i32, f64)"
-    assert str(RuntimeType.parse(Tuple[int, Tuple[str]])) == "(i32, (String))"
+    assert str(RuntimeType.parse(Tuple[int, float])) == "(i32, f64)" # type: ignore[arg-type]
+    assert str(RuntimeType.parse(Tuple[int, Tuple[str]])) == "(i32, (String))" # type: ignore[arg-type]
     assert str(RuntimeType.parse(List[int])) == "Vec<i32>"
     assert str(RuntimeType.parse(List[List[str]])) == "Vec<Vec<String>>"
     assert str(RuntimeType.parse((List[int], (int, bool)))) == '(Vec<i32>, (i32, bool))'


### PR DESCRIPTION
- Fix #1022, or at least enough to close the issue.
 
@Shoeboxam notes that it makes sense to keep nbmake separate to keep tests fast. Besides that, it seems that turning on nbmake turns off the other tests -- I couldn't find a setting that ran notebooks _and_ other tests. (If we wanted to go farther with this, there are other libraries we could look at: [pytest-notebook](http://pytest-notebook.readthedocs.io/) seems to be more like doctest, where it checks that the outputs are the same not just that the notebook run. In some ways the stricter check is nice, but we would need a lot of configuration to help it play well with our non-deterministic behavior, on top of the hassle of just using a different library.)

With this PR, `pytest` now does three things:
- unit tests
- doctests on the doc source code
- doctests on the python source code

Removed the post-sphinx-build doctest to avoid confusion about how to run doctests

Motivations:
- We want to run tests under different python version, but we're running into dependency conflicts on ipython with python 3.12. With this change, pytest is covering everything except the notebooks, so we can run pytest on different versions without worrying about the notebook dependencies on different versions.
- Towards #739 -- Most of the python testing is now covered by just running `pytest`.
- Protection against regressions: I've added `test_tests.py` -- since the tests are now being pulled from different locations, a reorganization might cause us to lose tests, and we wouldn't notice. Now there's a check on the number of tests found, and if that drops suddenly, we'll notice.

Realizing I didn't start this from a clean branch. D'oh. Will rebase to clean that up...