### PR TITLE
pull out linting and typing as separate jobs

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -49,17 +49,14 @@ jobs:
     defaults:
       run:
         working-directory: python
-    strategy:
-      matrix:
-        python-version: [3.9] # Do not expand: running under one python version is sufficient.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.9
 
       - name: Install dependencies
         run: |
@@ -75,17 +72,14 @@ jobs:
     defaults:
       run:
         working-directory: python
-    strategy:
-      matrix:
-        python-version: [3.9] # Do not expand: running under one python version is sufficient.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.9
 
       - name: Install dependencies
         run: |
@@ -150,9 +144,6 @@ jobs:
     defaults:
       run:
         working-directory: docs
-    strategy:
-      matrix:
-        python-version: [3.9] # Do not expand: running under one python version is sufficient.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -175,17 +166,14 @@ jobs:
     defaults:
       run:
         working-directory: docs
-    strategy:
-      matrix:
-        python-version: [3.9] # Do not expand: running under one python version is sufficient.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.9
 
       - name: Get pip cache dir
         id: pip-cache

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -51,7 +51,7 @@ jobs:
         working-directory: python
     strategy:
       matrix:
-        python-version: [3.9] # Do not expand: linting under one python version is sufficient.
+        python-version: [3.9] # Do not expand: running under one python version is sufficient.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -77,7 +77,7 @@ jobs:
         working-directory: python
     strategy:
       matrix:
-        python-version: [3.9] # Do not expand: typing under one python version is sufficient.
+        python-version: [3.9] # Do not expand: running under one python version is sufficient.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -145,15 +145,18 @@ jobs:
         run: coverage report
 
   docs-links:
-    needs: rust-build-and-test
+    needs: rust-build-and-test # TODO: Is this needed?
     runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: docs
     strategy:
       matrix:
-        python-version: [3.9] # Do not expand: typing under one python version is sufficient.
+        python-version: [3.9] # Do not expand: running under one python version is sufficient.
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Install Pandoc
         run: sudo apt-get install -y pandoc
 
@@ -174,7 +177,7 @@ jobs:
         working-directory: docs
     strategy:
       matrix:
-        python-version: [3.9] # Do not expand: typing under one python version is sufficient.
+        python-version: [3.9] # Do not expand: running under one python version is sufficient.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -103,7 +103,7 @@ jobs:
         working-directory: python
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.8, 3.12]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -112,9 +112,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Install Pandoc
-        run: sudo apt-get install -y pandoc
 
       - name: Get pip cache dir
         id: pip-cache
@@ -147,15 +144,7 @@ jobs:
       - name: Test coverage
         run: coverage report
 
-      - name: Test docs
-        run: |
-          cd ../docs
-          python -m pip install -r requirements.txt
-          make html
-          linkchecker -f linkchecker.cfg build/html/index.html
-
-
-  python-test-notebooks:
+  docs-links:
     needs: rust-build-and-test
     runs-on: ubuntu-22.04
     defaults:
@@ -163,7 +152,29 @@ jobs:
         working-directory: docs
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9] # Do not expand: typing under one python version is sufficient.
+    steps:
+      - name: Install Pandoc
+        run: sudo apt-get install -y pandoc
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Build docs
+        run: make html
+
+      - name: Check links
+        run: linkchecker -f linkchecker.cfg build/html/index.html
+
+  python-notebooks:
+    needs: rust-build-and-test
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: docs
+    strategy:
+      matrix:
+        python-version: [3.9] # Do not expand: typing under one python version is sufficient.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -44,6 +44,57 @@ jobs:
           name: libs
           path: rust/target/debug/libopendp.so
 
+  python-lint:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: python
+    strategy:
+      matrix:
+        python-version: [3.9] # Do not expand: linting under one python version is sufficient.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -r requirements-dev.txt
+
+      - name: Lint with flake8
+        run: |
+          # There is a long ignore list in .flake8.
+          flake8 .. --count --show-source --statistics
+
+  python-type:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: python
+    strategy:
+      matrix:
+        python-version: [3.9] # Do not expand: typing under one python version is sufficient.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -r requirements-dev.txt
+
+      - name: Type check with mypy
+        run: |
+          mypy .
+
   python-test:
     needs: rust-build-and-test
     runs-on: ubuntu-22.04
@@ -80,16 +131,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements-dev.txt
-
-      - name: Lint with flake8
-        run: |
-          # Stop the build if there are new linting errors.
-          # There is a long ignore list in .flake8.
-          flake8 .. --count --show-source --statistics
-
-      - name: Type check with mypy
-        run: |
-          mypy .
 
       - name: Download libs
         uses: actions/download-artifact@v3

--- a/docs/linkchecker.cfg
+++ b/docs/linkchecker.cfg
@@ -18,6 +18,9 @@ ignore=
   # JS sniffing is involved? Easiest just to leave this ignore in place.
   https://crates.io/crates/opendp
 
+  # Binder has returned intermittant 500s.
+  https://mybinder.org
+
   # Internal:
   # - Rust function docs:
   measurements/fn


### PR DESCRIPTION
- Builds on #1095

With more tooling in place, we probably want to pull some of it into separate jobs. Not because we're expecting to save any CI time from parallelizing -- these checks run fast -- but to save developer time: It's annoying to fix an issue in linting ... and then CI tells you there's a problem with typing ... and then there's a problem with tests.

It does add a lot of lines to the YAML.
- Making more artifacts seems like overkill
- Most of the steps could be reduced to a single line, at some cost to readability
- use YAML shortcuts to minimize copy and paste.

Filing as draft for now.