### PR TITLE
Use longer param names for flags

### DIFF
--- a/.github/workflows/prepare.yml
+++ b/.github/workflows/prepare.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Initialize channel
         env:
-          SYNC_FLAG: ${{ inputs.sync && '-s' || '' }}
+          SYNC_FLAG: ${{ inputs.sync && '--sync' || '' }}
         run: python tools/channel_tool.py initialize -c ${{ inputs.channel }} $SYNC_FLAG
 
       - name: Configure channel

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Publish Rust crate
         env:
-          DRY_RUN_FLAG: ${{ inputs.dry_run && '-n' || '' }}
+          DRY_RUN_FLAG: ${{ inputs.dry_run && '--dry_run' || '' }}
         run: |
           pip install -r tools/requirements-publish_tool.txt
           python tools/publish_tool.py rust $DRY_RUN_FLAG
@@ -126,7 +126,7 @@ jobs:
       - name: Publish GitHub Release
         if: ${{ inputs.channel == 'stable' }}
         env:
-          DRAFT_FLAG: ${{ inputs.dry_run && '-n' || '' }}
+          DRAFT_FLAG: ${{ inputs.dry_run && '--dry_run' || '' }}
         run: |
           pip install -r tools/requirements-publish_tool.txt
           python tools/publish_tool.py github -d ${{ inputs.date }} $DRAFT_FLAG

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -71,5 +71,5 @@ jobs:
 
       - name: Run sanity test
         env:
-          FAKE_FLAG: ${{ inputs.fake && '-f' || '' }}
+          FAKE_FLAG: ${{ inputs.fake && '--fake' || '' }}
         run: python tools/publish_tool.py sanity -r ${{ inputs.python_repository }} -t 300 $FAKE_FLAG

--- a/docs/linkchecker.cfg
+++ b/docs/linkchecker.cfg
@@ -18,6 +18,9 @@ ignore=
   # JS sniffing is involved? Easiest just to leave this ignore in place.
   https://crates.io/crates/opendp
 
+  # Binder is returning 500s.
+  https://mybinder.org/
+
   # Internal:
   # - Rust function docs:
   measurements/fn

--- a/tools/build_tool.py
+++ b/tools/build_tool.py
@@ -85,8 +85,8 @@ def _main(argv):
     subparser.set_defaults(func=rust)
     subparser.add_argument("-p", "--platform", choices=["mac", "windows", "linux"])
     subparser.add_argument("-c", "--toolchain", default="stable")
-    subparser.add_argument("-r", "--release-mode", dest="release_mode", action="store_true")
-    subparser.add_argument("-t", "--run-tests", dest="run_tests", action="store_true")
+    subparser.add_argument("--release_mode", action="store_true")
+    subparser.add_argument("--run_tests", action="store_true")
     subparser.add_argument("-f", "--features", default="untrusted,ffi")
 
     subparser = subparsers.add_parser("python", help="Build Python library")

--- a/tools/channel_tool.py
+++ b/tools/channel_tool.py
@@ -218,7 +218,7 @@ def _main(argv):
     subparser = subparsers.add_parser("initialize", help="Initialize the channel")
     subparser.set_defaults(func=initialize)
     subparser.add_argument("-c", "--channel", choices=["nightly", "beta", "stable"], default="nightly", help="Which channel to target")
-    subparser.add_argument("-s", "--sync", dest="sync", action="store_true", help="Sync the channel from upstream")
+    subparser.add_argument("--sync", action="store_true", help="Sync the channel from upstream")
     subparser.add_argument("-u", "--upstream", help="Upstream ref")
     subparser.add_argument("-p", "--preserve", dest="preserve", action="store_true")
 
@@ -235,7 +235,7 @@ def _main(argv):
     subparser = subparsers.add_parser("changelog", help="Update the CHANGELOG file")
     subparser.set_defaults(func=changelog)
     subparser.add_argument("-d", "--date", type=datetime.date.fromisoformat, help="Release date")
-    subparser.add_argument("-p", "--prepend", dest="prepend", action="store_true", help="Prepend new empty heading (for dev only)")
+    subparser.add_argument("--prepend", action="store_true", help="Prepend new empty heading (for dev only)")
 
     subparser = subparsers.add_parser("bump_version", help="Bump the version number (assumes dev channel)")
     subparser.set_defaults(func=bump_version)

--- a/tools/publish_tool.py
+++ b/tools/publish_tool.py
@@ -88,7 +88,7 @@ def _main(argv):
 
     subparser = subparsers.add_parser("rust", help="Publish Rust crate")
     subparser.set_defaults(func=rust)
-    subparser.add_argument("-n", "--dry-run", dest="dry_run", action="store_true")
+    subparser.add_argument("--dry-run", action="store_true")
     subparser.add_argument("-t", "--index-check-timeout", type=int, default=300, help="How long to keep checking for index update (0 = don't check)")
     subparser.add_argument("-b", "--index-check-backoff", type=float, default=2.0, help="How much to back off between checks for index update")
 
@@ -104,12 +104,12 @@ def _main(argv):
     subparser.add_argument("-r", "--python-repository", choices=["pypi", "testpypi", "local"], default="pypi", help="Python package repository")
     subparser.add_argument("-t", "--package-timeout", type=int, default=0, help="How long to retry package installation attempts (0 = no retries)")
     subparser.add_argument("-b", "--package-backoff", type=float, default=2.0, help="How much to back off between package installation attempts")
-    subparser.add_argument("-f", "--fake", dest="fake", action="store_true")
+    subparser.add_argument("--fake", action="store_true")
 
     subparser = subparsers.add_parser("github", help="Publish GitHub release")
     subparser.set_defaults(func=github)
     subparser.add_argument("-d", "--date", type=datetime.date.fromisoformat, help="Release date")
-    subparser.add_argument("-n", "--draft", dest="draft", action="store_true")
+    subparser.add_argument("--draft", action="store_true")
 
     args = parser.parse_args(argv[1:])
     args.func(args)


### PR DESCRIPTION
- Builds on #1105
- More transparent
- Less fragile
- Less code, when we let the `dest` be implicit.