### PR TITLE
Upgrade pydata-sphinx-theme; use default search UI

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -31,7 +31,7 @@ html:
 	$(SPHINXAPIDOC) -f -F -e -H "OpenDP" -A "The OpenDP Project" -V $(VERSION) -o source/api/python ../python/src/opendp --templatedir source/_templates
 	# TODO: Figure out how to link locally generated Rust docs into sphinx structure.
 	# 	cd ../rust && $(CARGO) doc --no-deps --target-dir ../docs/source/api/rust
-	$(SPHINXBUILD) $(SPHINXOPTS) -D version=$(VERSION) -D 'html_sidebars.**'=search-field.html,sidebar-nav-bs.html source $(BUILDDIR)/html
+	$(SPHINXBUILD) $(SPHINXOPTS) -D version=$(VERSION) -D 'html_sidebars.**'=sidebar-nav-bs.html source $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 sphinx==5.1.1
 sphinx-prompt==1.5.0
 git+https://github.com/samtygier-stfc/sphinx-multiversion.git@prebuild_command
-pydata-sphinx-theme==0.13.3
+pydata-sphinx-theme==0.14.4
 nbsphinx==0.9.3
 ipython==8.18.1  # for notebook syntax highlighting in docs
 pandoc==2.3

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -165,7 +165,7 @@ html_css_files = [
 # See https://pydata-sphinx-theme.readthedocs.io/en/v0.6.3/user_guide/configuring.html#configure-the-sidebar
 # Note: Overridden in the Makefile for local builds. Be sure to update both places.
 html_sidebars = {
-   '**': ['search-field.html', 'sidebar-nav-bs.html', 'versioning.html'],
+   '**': ['sidebar-nav-bs.html', 'versioning.html'],
 }
 
 # SPHINX-MULTIVERSION STUFF


### PR DESCRIPTION
- Fix #990

After updating dependencies and rebuilding, the search issue is resolved. There are several issues in their repo related to search UI. If I leave the search in the sidebar, we still have the same problem as before, even with the upgrade.

<img width="444" alt="Screenshot 2023-12-12 at 5 59 34 PM" src="https://github.com/opendp/opendp/assets/730388/4740fee2-dd77-4804-b58a-b15d335a9f9b">
