### PR TITLE
pass dry_run to prepare.yml

### DIFF
--- a/.github/workflows/prepare.yml
+++ b/.github/workflows/prepare.yml
@@ -23,6 +23,10 @@ on:
         type: number
         required: false
         default: 0
+      dry_run:
+        type: boolean
+        required: false
+        default: false
     outputs:
       date:
         value: ${{ jobs.prepare.outputs.date }}
@@ -47,6 +51,11 @@ on:
         type: number
         required: false
         default: 0
+      dry_run:
+        description: Dry Run?
+        type: boolean
+        required: false
+        default: false
 env:
   # Standardize dates to Eastern time
   TIME_ZONE: "America/New_York"
@@ -94,6 +103,7 @@ jobs:
         run: git diff
 
       - name: Push changes
+        if: ${{ !inputs.dry_run }}
         run: |
           git commit -a -m "Initialize and configure channel"
           git push --force origin ${{ inputs.channel }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,7 @@ jobs:
       channel: ${{ inputs.channel }}
       sync: ${{ inputs.sync }}
       counter: ${{ fromJSON(inputs.counter) }}
+      dry_run: ${{ inputs.dry_run || inputs.fake }}
 
   build:
     needs: prepare


### PR DESCRIPTION
- Fix #1089

In release.yaml, `dry_run` is never referenced alone. I'll make a branch from this and see if I can make a top-level variable to capture `inputs.dry_run || inputs.fake`, rather than repeating it across the file.