### PR TITLE
get rid of `env` that was causing error

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,7 +91,7 @@ jobs:
           REPOSITORY: ${{ inputs.dry_run && 'testpypi' || 'pypi' }}
         run: |
           pip install -r tools/requirements-publish_tool.txt
-          python tools/publish_tool.py python -r $REPOSITORY --counter ${{ inputs.channel }}
+          python tools/publish_tool.py python -r $REPOSITORY --counter ${{ inputs.counter }}
 
   publish-rust:
     needs: publish-python
@@ -115,7 +115,7 @@ jobs:
           DRY_RUN_FLAG: ${{ inputs.dry_run && '--dry_run' || '' }}
         run: |
           pip install -r tools/requirements-publish_tool.txt
-          python tools/publish_tool.py rust $DRY_RUN_FLAG --counter ${{ inputs.channel }}
+          python tools/publish_tool.py rust $DRY_RUN_FLAG --counter ${{ inputs.counter }}
 
   publish-github:
     needs: publish-rust
@@ -138,4 +138,4 @@ jobs:
           DRY_RUN_FLAG: ${{ inputs.dry_run && '--dry_run' || '' }}
         run: |
           pip install -r tools/requirements-publish_tool.txt
-          python tools/publish_tool.py github -d ${{ inputs.date }} $DRY_RUN_FLAG --counter ${{ inputs.channel }}
+          python tools/publish_tool.py github -d ${{ inputs.date }} $DRY_RUN_FLAG --counter ${{ inputs.counter }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,11 +66,6 @@ on:
         required: false
         default: false
 
-env:
-  # env.dry_run should be used instead of inputs.dry_run in each of
-  # the jobs below, to ensure that the fake override always works.
-  dry_run: ${{ inputs.dry_run || inputs.fake }}
-
 jobs:
   prepare:
     uses: ./.github/workflows/prepare.yml
@@ -78,7 +73,7 @@ jobs:
       channel: ${{ inputs.channel }}
       sync: ${{ inputs.sync }}
       counter: ${{ fromJSON(inputs.counter) }}
-      dry_run: ${{ env.dry_run }}
+      dry_run: ${{ inputs.dry_run || inputs.fake }}
 
   build:
     needs: prepare
@@ -101,7 +96,7 @@ jobs:
     with:
       channel: ${{ inputs.channel }}
       date: ${{ needs.prepare.outputs.date }}
-      dry_run: ${{ env.dry_run }}
+      dry_run: ${{ inputs.dry_run || inputs.fake }}
     secrets: inherit
 
   sanity-test-post:
@@ -110,7 +105,7 @@ jobs:
     with:
       channel: ${{ inputs.channel }}
       # dry-runs go to TestPyPI instead of PyPI
-      python_repository: ${{ env.dry_run && 'testpypi' || 'pypi' }}
+      python_repository: ${{ ( inputs.dry_run || inputs.fake ) && ( 'testpypi' || 'pypi' ) }}
       fake: ${{ inputs.fake }}
 
   latex:
@@ -124,4 +119,4 @@ jobs:
     needs: [ sanity-test-post, latex ]
     uses: ./.github/workflows/docs.yml
     with:
-      dry_run: ${{ env.dry_run }}
+      dry_run: ${{ inputs.dry_run || inputs.fake }}

--- a/tools/publish_tool.py
+++ b/tools/publish_tool.py
@@ -11,7 +11,7 @@ def rust(args):
     os.environ["CARGO_REGISTRY_TOKEN"] = os.environ["CRATES_IO_API_TOKEN"]
     # We can't do a dry run of everything, because dependencies won't be available for later crates,
     # but we can at least do any leaf nodes (i.e. opendp_tooling).
-    dry_run_arg = " --dry-run" if args.dry_run else ""
+    dry_run_arg = " --dry_run" if args.dry_run else ""
     run_command("Publishing opendp_tooling crate", f"cargo publish{dry_run_arg} --verbose --manifest-path=rust/opendp_tooling/Cargo.toml")
     if not args.dry_run:
         # As of https://github.com/rust-lang/cargo/pull/11062, cargo publish blocks until the index is propagated,
@@ -88,7 +88,7 @@ def _main(argv):
 
     subparser = subparsers.add_parser("rust", help="Publish Rust crate")
     subparser.set_defaults(func=rust)
-    subparser.add_argument("--dry-run", action="store_true")
+    subparser.add_argument("--dry_run", action="store_true")
     subparser.add_argument("-t", "--index-check-timeout", type=int, default=300, help="How long to keep checking for index update (0 = don't check)")
     subparser.add_argument("-b", "--index-check-backoff", type=float, default=2.0, help="How much to back off between checks for index update")
 

--- a/tools/publish_tool.py
+++ b/tools/publish_tool.py
@@ -11,7 +11,7 @@ def rust(args):
     os.environ["CARGO_REGISTRY_TOKEN"] = os.environ["CRATES_IO_API_TOKEN"]
     # We can't do a dry run of everything, because dependencies won't be available for later crates,
     # but we can at least do any leaf nodes (i.e. opendp_tooling).
-    dry_run_arg = " --dry_run" if args.dry_run else ""
+    dry_run_arg = " --dry-run" if args.dry_run else "" # Keep dash in this arg.
     run_command("Publishing opendp_tooling crate", f"cargo publish{dry_run_arg} --verbose --manifest-path=rust/opendp_tooling/Cargo.toml")
     if not args.dry_run:
         # As of https://github.com/rust-lang/cargo/pull/11062, cargo publish blocks until the index is propagated,

--- a/tools/publish_tool.py
+++ b/tools/publish_tool.py
@@ -87,6 +87,7 @@ def github(args):
 
 def _main(argv):
     parser = argparse.ArgumentParser(description="OpenDP build tool")
+    parser.add_argument("--counter", type=int, default=0, help="Version counter")
     subparsers = parser.add_subparsers(dest="COMMAND", help="Command to run")
     subparsers.required = True
 
@@ -95,16 +96,12 @@ def _main(argv):
     subparser.add_argument("--dry_run", action="store_true")
     subparser.add_argument("-t", "--index-check-timeout", type=int, default=300, help="How long to keep checking for index update (0 = don't check)")
     subparser.add_argument("-b", "--index-check-backoff", type=float, default=2.0, help="How much to back off between checks for index update")
-    # TODO: We do not explicitly specify the version number for Rust, so version counter is not used either.
-    # If this is the correct behavior, add an explanatory note to avoid confusion.
-    subparser.add_argument("--counter", type=int, default=0, help="Version counter")
 
     subparser = subparsers.add_parser("python", help="Publish Python package")
     subparser.set_defaults(func=python)
     subparser.add_argument("-r", "--repository", choices=["pypi", "testpypi"], default="pypi", help="Package repository")
     subparser.add_argument("-t", "--index-check-timeout", type=int, default=300, help="How long to keep checking for index update (0 = don't check)")
     subparser.add_argument("-b", "--index-check-backoff", type=float, default=2.0, help="How much to back off between checks for index update")
-    subparser.add_argument("--counter", type=int, default=0, help="Version counter")
 
     subparser = subparsers.add_parser("sanity", help="Run a sanity test")
     subparser.set_defaults(func=sanity)
@@ -118,7 +115,6 @@ def _main(argv):
     subparser.set_defaults(func=github)
     subparser.add_argument("-d", "--date", type=datetime.date.fromisoformat, help="Release date")
     subparser.add_argument("--draft", action="store_true")
-    subparser.add_argument("--counter", type=int, default=0, help="Version counter")
 
     args = parser.parse_args(argv[1:])
     args.func(args)


### PR DESCRIPTION
- Toward #1130 

It looks like I had run `release.yml` on the branch with the change... but it didn't _really_ run: https://github.com/opendp/opendp/actions/runs/7197498991 -- It just ran `debug` and exited in 10s. Lesson: green checkmark isn't enough -- confirm that it is actually doing the right thing.

Update: The workflow run is still failing on this branch: The new `--counter` flag is not being recognized… Looking up to the top:
```
  publish-python:
    ...
    steps:
      - name: Checkout repository
        uses: actions/checkout@v3
        with:
          ref: ${{ inputs.channel }}
```
So it’s running the workflow from `nightly`, not from this branch.
Normally, `prepare.yml` would have updated nightly with the changes in this PR… but since it’s a dry-run, it doesn’t.

Not sure how best to move this forward: Maybe run it without dry-run on nightly? Or do a close code review, merge, and then try running after that?