### PR TITLE
Short summaries of python modules

### DIFF
--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -1,3 +1,7 @@
+'''
+The ``context`` module provides :py:class:`opendp.context.Context` and supporting utilities.
+'''
+
 from typing import Any, Callable, List, Optional, Tuple, Union
 import importlib
 from inspect import signature

--- a/python/src/opendp/extrinsics/__init__.py
+++ b/python/src/opendp/extrinsics/__init__.py
@@ -1,0 +1,4 @@
+'''
+The ``extrinsics`` module is a namespace where non-Rust contributions can live.
+Currently empty.
+'''

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -1,3 +1,11 @@
+'''
+The ``mod`` module provides the classes which implement the
+`OpenDP Programming Framework <../../user/programming-framework/index.html>`_,
+as well as utilities for enabling features and finding parameter values.
+
+The classes here correspond to other top-level modules: For example,
+instances of :py:class:`opendp.mod.Domain` are either inputs or outputs for functions in :py:mod:`opendp.domains`.
+'''
 import ctypes
 from typing import Any, Literal, Type, TypeVar, Union, Tuple, Callable, Optional, overload, TYPE_CHECKING
 
@@ -13,6 +21,11 @@ class Measurement(ctypes.POINTER(AnyMeasurement)): # type: ignore[misc]
     A measurement contains a function and a privacy relation.
     The function releases a differentially-private release.
     The privacy relation maps from an input metric to an output measure.
+
+    See the `Measurement <../../user/programming-framework/core-structures.html#measurement>`_
+    section in the Programming Framework docs for more context.
+
+    Functions for creating measurements are in :py:mod:`opendp.measurements`.
 
     :example:
 
@@ -182,6 +195,11 @@ class Transformation(ctypes.POINTER(AnyTransformation)): # type: ignore[misc]
     A transformation contains a function and a stability relation.
     The function maps from an input domain to an output domain.
     The stability relation maps from an input metric to an output metric.
+
+    See the `Transformation <../../user/programming-framework/core-structures.html#transformation>`_
+    section in the Programming Framework docs for more context.
+
+    Functions for creating transformations are in :py:mod:`opendp.transformations`.
 
     :example:
 
@@ -402,6 +420,10 @@ class Queryable(object):
         
 
 class Function(ctypes.POINTER(AnyFunction)): # type: ignore[misc]
+    '''
+    See the `Function <../../user/programming-framework/supporting-elements.html#function>`_
+    section in the Programming Framework docs for more context.
+    '''
     _type_ = AnyFunction
 
     def __call__(self, arg):
@@ -422,6 +444,12 @@ class Function(ctypes.POINTER(AnyFunction)): # type: ignore[misc]
 
 
 class Domain(ctypes.POINTER(AnyDomain)): # type: ignore[misc]
+    '''
+    See the `Domain <../../user/programming-framework/supporting-elements.html#domain>`_
+    section in the Programming Framework docs for more context.
+
+    Functions for creating domains are in :py:mod:`opendp.domains`.
+    '''
     _type_ = AnyDomain
 
     def member(self, val):
@@ -465,6 +493,12 @@ class Domain(ctypes.POINTER(AnyDomain)): # type: ignore[misc]
 
 
 class Metric(ctypes.POINTER(AnyMetric)): # type: ignore[misc]
+    '''
+    See the `Metric <../../user/programming-framework/supporting-elements.html#metric>`_
+    section in the Programming Framework docs for more context.
+
+    Functions for creating metrics are in :py:mod:`opendp.metrics`.
+    '''
     _type_ = AnyMetric
 
     @property
@@ -499,6 +533,12 @@ class Metric(ctypes.POINTER(AnyMetric)): # type: ignore[misc]
 
 
 class Measure(ctypes.POINTER(AnyMeasure)): # type: ignore[misc]
+    '''
+    See the `Measure <../../user/programming-framework/supporting-elements.html#measure>`_
+    section in the Programming Framework docs for more context.
+
+    Functions for creating measures are in :py:mod:`opendp.measures`.
+    '''
     _type_ = AnyMeasure
 
     @property

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -1,3 +1,10 @@
+'''
+The ``typing`` module provides utilities that bridge between Python and Rust types.
+OpenDP relies on precise descriptions of data types to make its security guarantees:
+These are more natural in Rust with its fine-grained type system,
+but they may feel out of place in Python. These utilities try to fill that gap.
+'''
+
 import sys
 import typing
 from collections.abc import Hashable


### PR DESCRIPTION
- Fix #1129
- and add more docs on `mod`

I would like to add more links in both directions, but there are downsides:
- The relative links won't work if these docs are used by an IDE.
- They will need to be adjusted following doc reorg. (linkchecking will catch problems, it will just be a little chore.)