### PR TITLE
Add a new feature that controls whether rust stack traces are shown

### DIFF
--- a/docs/source/user/combinators.rst
+++ b/docs/source/user/combinators.rst
@@ -79,13 +79,14 @@ but the chaining fails because the sum emits floats and the discrete Laplace mec
     ...     dp.vector_domain(dp.atom_domain(bounds=(0., 1.))), 
     ...     dp.symmetric_distance()
     ... )
-    >>> try:
-    ...     sum_trans >> lap_meas
-    ... except OpenDPException as err:
-    ...     print(err.message[:-1])
-    Intermediate domains don't match. See https://github.com/opendp/opendp/discussions/297
+    >>> sum_trans >> lap_meas
+    Traceback (most recent call last):
+    ...
+    opendp.mod.OpenDPException: 
+      DomainMismatch("Intermediate domains don't match. See https://github.com/opendp/opendp/discussions/297
         output_domain: AtomDomain(T=f64)
         input_domain:  AtomDomain(T=i32)
+    ")
 
 Note that ``noisy_sum_trans``'s input domain and input metric come from ``sum_trans``'s input domain and input metric.
 This is intended to enable further chaining with preprocessors like :py:func:`make_cast <opendp.transformations.make_cast>`, :py:func:`make_impute_constant <opendp.transformations.make_impute_constant>`, :py:func:`make_clamp <opendp.transformations.make_clamp>` and :py:func:`make_resize <opendp.transformations.make_resize>`.

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -583,7 +583,7 @@ class OpenDPException(Exception):
 
     def __str__(self) -> str: # pragma: no cover
         response = ''
-        if self.raw_traceback:
+        if self.raw_traceback and 'rust-stack-trace' in GLOBAL_FEATURES:
             # join and split by newlines because frames may be multi-line
             lines = "\n".join(self.frames()[::-1]).split('\n')
             response += "Continued Rust stack trace:\n" + '\n'.join('    ' + line for line in lines)


### PR DESCRIPTION
- Prompted by #1001
- and [Evaluating the Usability of Differential Privacy Tools with Data Practitioners](https://arxiv.org/abs/2309.13506)

Proposal: New users have trouble getting OpenDP to work for them. One issue is the leakage of Rust details into the Python environment: A rust stack trace isn't something a python enduser can do anything with. I'd propose that we hide the rust details by default, and developers can turn them on, if that's needed.