### PR TITLE
experimental channel for one-off releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ on:
         description: Target Channel
         type: choice
         options:
-          - experimental
+          - dev
           - nightly
           - beta
           - stable
@@ -42,7 +42,7 @@ jobs:
     uses: ./.github/workflows/credential-check.yml
     with:
       ref: ${{ inputs.channel }}
-      assert_version: ${{ inputs.channel != 'experimental' }}
+      assert_version: ${{ inputs.channel != 'dev' }}
 
   libs-windows:
     needs: credential-check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ on:
           - nightly
           - beta
           - stable
+          - dev-branch
         required: true
         default: nightly
       fake:
@@ -41,6 +42,7 @@ jobs:
     uses: ./.github/workflows/credential-check.yml
     with:
       ref: ${{ inputs.channel }}
+      assert_version: ${{ inputs.channel != 'dev-branch' }}
 
   libs-windows:
     needs: credential-check
@@ -61,7 +63,7 @@ jobs:
         if: ${{ !inputs.fake }}
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.channel }}
+          ref: ${{ inputs.channel == 'dev-branch' && github.ref_name || inputs.channel }}
 
       - name: Cache Rust dependencies
         if: ${{ !inputs.fake }}
@@ -107,7 +109,7 @@ jobs:
         if: ${{ !inputs.fake }}
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.channel }}
+          ref: ${{ inputs.channel == 'dev-branch' && github.ref_name || inputs.channel }}
 
       - name: Cache Rust dependencies
         if: ${{ !inputs.fake }}
@@ -161,7 +163,7 @@ jobs:
         if: ${{ !inputs.fake }}
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.channel }}
+          ref: ${{ inputs.channel == 'dev-branch' && github.ref_name || inputs.channel }}
 
       - name: Cache Rust dependencies
         if: ${{ !inputs.fake }}
@@ -204,7 +206,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.channel }}
+          ref: ${{ inputs.channel == 'dev-branch' && github.ref_name || inputs.channel }}
 
       - name: Cache Rust dependencies
         if: ${{ !inputs.fake }}
@@ -237,7 +239,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.channel }}
+          ref: ${{ inputs.channel == 'dev-branch' && github.ref_name || inputs.channel }}
 
       - name: Set up Python
         uses: actions/setup-python@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         if: ${{ !inputs.fake }}
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.channel == 'dev-branch' && github.ref_name || inputs.channel }}
+          ref: ${{ inputs.channel }}
 
       - name: Cache Rust dependencies
         if: ${{ !inputs.fake }}
@@ -109,7 +109,7 @@ jobs:
         if: ${{ !inputs.fake }}
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.channel == 'dev-branch' && github.ref_name || inputs.channel }}
+          ref: ${{ inputs.channel }}
 
       - name: Cache Rust dependencies
         if: ${{ !inputs.fake }}
@@ -163,7 +163,7 @@ jobs:
         if: ${{ !inputs.fake }}
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.channel == 'dev-branch' && github.ref_name || inputs.channel }}
+          ref: ${{ inputs.channel }}
 
       - name: Cache Rust dependencies
         if: ${{ !inputs.fake }}
@@ -206,7 +206,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.channel == 'dev-branch' && github.ref_name || inputs.channel }}
+          ref: ${{ inputs.channel }}
 
       - name: Cache Rust dependencies
         if: ${{ !inputs.fake }}
@@ -239,7 +239,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.channel == 'dev-branch' && github.ref_name || inputs.channel }}
+          ref: ${{ inputs.channel }}
 
       - name: Set up Python
         uses: actions/setup-python@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,10 @@ on:
         description: Target Channel
         type: choice
         options:
+          - experimental
           - nightly
           - beta
           - stable
-          - dev-branch
         required: true
         default: nightly
       fake:
@@ -42,7 +42,7 @@ jobs:
     uses: ./.github/workflows/credential-check.yml
     with:
       ref: ${{ inputs.channel }}
-      assert_version: ${{ inputs.channel != 'dev-branch' }}
+      assert_version: ${{ inputs.channel != 'experimental' }}
 
   libs-windows:
     needs: credential-check

--- a/.github/workflows/latex-release.yml
+++ b/.github/workflows/latex-release.yml
@@ -30,7 +30,7 @@ jobs:
     uses: ./.github/workflows/credential-check.yml
     with:
       ref: ${{ inputs.channel }}
-      assert_version: ${{ inputs.channel != 'dev-branch' }}
+      assert_version: ${{ inputs.channel != 'experimental' }}
 
   latex:
     needs: credential-check

--- a/.github/workflows/latex-release.yml
+++ b/.github/workflows/latex-release.yml
@@ -30,7 +30,7 @@ jobs:
     uses: ./.github/workflows/credential-check.yml
     with:
       ref: ${{ inputs.channel }}
-      assert_version: ${{ inputs.channel != 'experimental' }}
+      assert_version: ${{ inputs.channel != 'dev' }}
 
   latex:
     needs: credential-check

--- a/.github/workflows/latex-release.yml
+++ b/.github/workflows/latex-release.yml
@@ -30,6 +30,7 @@ jobs:
     uses: ./.github/workflows/credential-check.yml
     with:
       ref: ${{ inputs.channel }}
+      assert_version: ${{ inputs.channel != 'dev-branch' }}
 
   latex:
     needs: credential-check
@@ -38,7 +39,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.channel }}
+          ref: ${{ inputs.channel == 'dev-branch' && github.ref_name || inputs.channel }}
 
       - name: Collect file listing
         id: collect

--- a/.github/workflows/latex-release.yml
+++ b/.github/workflows/latex-release.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.channel == 'dev-branch' && github.ref_name || inputs.channel }}
+          ref: ${{ inputs.channel }}
 
       - name: Collect file listing
         id: collect

--- a/.github/workflows/prepare.yml
+++ b/.github/workflows/prepare.yml
@@ -97,7 +97,7 @@ jobs:
         id: configure
         run: |
           DATE=`python tools/channel_tool.py date -z "$TIME_ZONE"`
-          python tools/channel_tool.py configure -c ${{ inputs.channel }} -d "$DATE"
+          python tools/channel_tool.py configure -c ${{ inputs.channel }} -d "$DATE" -i ${{ inputs.counter }}
           echo "date=$DATE" >> $GITHUB_OUTPUT
 
       - name: Show changes

--- a/.github/workflows/prepare.yml
+++ b/.github/workflows/prepare.yml
@@ -97,7 +97,7 @@ jobs:
         id: configure
         run: |
           DATE=`python tools/channel_tool.py date -z "$TIME_ZONE"`
-          python tools/channel_tool.py configure -c ${{ inputs.channel }} -d "$DATE" -i ${{ inputs.counter }}
+          python tools/channel_tool.py configure -c ${{ inputs.channel }} -d "$DATE"
           echo "date=$DATE" >> $GITHUB_OUTPUT
 
       - name: Show changes

--- a/.github/workflows/prepare.yml
+++ b/.github/workflows/prepare.yml
@@ -39,6 +39,7 @@ on:
           - nightly
           - beta
           - stable
+          - dev-branch
         required: true
         default: nightly
       sync:
@@ -67,7 +68,6 @@ jobs:
       assert_version: false
 
   prepare:
-    if: ${{ inputs.channel != 'dev-branch' }}
     needs: credential-check
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/prepare.yml
+++ b/.github/workflows/prepare.yml
@@ -67,6 +67,7 @@ jobs:
       assert_version: false
 
   prepare:
+    if: ${{ inputs.channel != 'dev-branch' }}
     needs: credential-check
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/prepare.yml
+++ b/.github/workflows/prepare.yml
@@ -36,7 +36,7 @@ on:
         description: Target Channel
         type: choice
         options:
-          - experimental
+          - dev
           - nightly
           - beta
           - stable

--- a/.github/workflows/prepare.yml
+++ b/.github/workflows/prepare.yml
@@ -36,10 +36,10 @@ on:
         description: Target Channel
         type: choice
         options:
+          - experimental
           - nightly
           - beta
           - stable
-          - dev-branch
         required: true
         default: nightly
       sync:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,7 @@ jobs:
           REPOSITORY: ${{ inputs.dry_run && 'testpypi' || 'pypi' }}
         run: |
           pip install -r tools/requirements-publish_tool.txt
-          python tools/publish_tool.py python -r $REPOSITORY --counter ${{ inputs.counter }}
+          python tools/publish_tool.py python -r $REPOSITORY
 
   publish-rust:
     needs: publish-python
@@ -140,4 +140,4 @@ jobs:
           DRY_RUN_FLAG: ${{ inputs.dry_run && '--dry_run' || '' }}
         run: |
           pip install -r tools/requirements-publish_tool.txt
-          python tools/publish_tool.py github -d ${{ inputs.date }} $DRY_RUN_FLAG --counter ${{ inputs.counter }}
+          python tools/publish_tool.py github -d ${{ inputs.date }} $DRY_RUN_FLAG

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.channel == 'dev-branch' && github.ref_name || inputs.channel }}
+          ref: ${{ inputs.channel }}
 
       - name: Set up Python
         uses: actions/setup-python@v3
@@ -104,7 +104,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.channel == 'dev-branch' && github.ref_name || inputs.channel }}
+          ref: ${{ inputs.channel }}
 
       - name: Set up Python
         uses: actions/setup-python@v3
@@ -117,7 +117,7 @@ jobs:
           DRY_RUN_FLAG: ${{ inputs.dry_run && '--dry_run' || '' }}
         run: |
           pip install -r tools/requirements-publish_tool.txt
-          python tools/publish_tool.py rust $DRY_RUN_FLAG --counter ${{ inputs.counter }}
+          python tools/publish_tool.py rust $DRY_RUN_FLAG
 
   publish-github:
     needs: publish-rust
@@ -126,7 +126,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.channel == 'dev-branch' && github.ref_name || inputs.channel }}
+          ref: ${{ inputs.channel }}
 
       - name: Set up Python
         uses: actions/setup-python@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,7 @@ on:
           - nightly
           - beta
           - stable
+          - dev-branch
         required: true
         default: nightly
       date:
@@ -60,6 +61,7 @@ jobs:
     uses: ./.github/workflows/credential-check.yml
     with:
       ref: ${{ inputs.channel }}
+      assert_version: ${{ inputs.channel != 'dev-branch' }}
 
   publish-python:
     needs: credential-check
@@ -71,7 +73,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.channel }}
+          ref: ${{ inputs.channel == 'dev-branch' && github.ref_name || inputs.channel }}
 
       - name: Set up Python
         uses: actions/setup-python@v3
@@ -102,7 +104,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.channel }}
+          ref: ${{ inputs.channel == 'dev-branch' && github.ref_name || inputs.channel }}
 
       - name: Set up Python
         uses: actions/setup-python@v3
@@ -124,7 +126,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.channel }}
+          ref: ${{ inputs.channel == 'dev-branch' && github.ref_name || inputs.channel }}
 
       - name: Set up Python
         uses: actions/setup-python@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Publish Python package
         env:
           # twine doesn't support dry-runs, so if that's what we're doing, simulate it by using TestPyPI instead of PyPI
-          REPOSITORY: ${{ inputs.dry_run && 'testpypi' || 'pypi' }}
+          REPOSITORY: ${{ (inputs.dry_run || inputs.channel == 'dev-branch') && 'testpypi' || 'pypi' }}
         run: |
           pip install -r tools/requirements-publish_tool.txt
           python tools/publish_tool.py python -r $REPOSITORY

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,10 +35,10 @@ on:
         description: Target Channel
         type: choice
         options:
+          - experimental
           - nightly
           - beta
           - stable
-          - dev-branch
         required: true
         default: nightly
       date:
@@ -61,7 +61,7 @@ jobs:
     uses: ./.github/workflows/credential-check.yml
     with:
       ref: ${{ inputs.channel }}
-      assert_version: ${{ inputs.channel != 'dev-branch' }}
+      assert_version: ${{ inputs.channel != 'experimental' }}
 
   publish-python:
     needs: credential-check
@@ -90,7 +90,8 @@ jobs:
       - name: Publish Python package
         env:
           # twine doesn't support dry-runs, so if that's what we're doing, simulate it by using TestPyPI instead of PyPI
-          REPOSITORY: ${{ (inputs.dry_run || inputs.channel == 'dev-branch') && 'testpypi' || 'pypi' }}
+          # always send experimental builds to TestPyPI
+          REPOSITORY: ${{ (inputs.dry_run || inputs.channel == 'experimental') && 'testpypi' || 'pypi' }}
         run: |
           pip install -r tools/requirements-publish_tool.txt
           python tools/publish_tool.py python -r $REPOSITORY

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ on:
         description: Target Channel
         type: choice
         options:
-          - experimental
+          - dev
           - nightly
           - beta
           - stable
@@ -52,7 +52,7 @@ jobs:
     uses: ./.github/workflows/credential-check.yml
     with:
       ref: ${{ inputs.channel }}
-      assert_version: ${{ inputs.channel != 'experimental' }}
+      assert_version: ${{ inputs.channel != 'dev' }}
 
   publish-python:
     needs: credential-check
@@ -81,7 +81,6 @@ jobs:
       - name: Publish Python package
         env:
           # twine doesn't support dry-runs, so if that's what we're doing, simulate it by using TestPyPI instead of PyPI
-          # always send experimental builds to TestPyPI
           REPOSITORY: ${{ inputs.dry_run && 'testpypi' || 'pypi' }}
         run: |
           pip install -r tools/requirements-publish_tool.txt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,10 +18,6 @@ on:
         type: boolean
         required: false
         default: false
-      counter:
-        type: number
-        required: false
-        default: 0
     secrets:
       TEST_PYPI_API_TOKEN:
         required: true
@@ -50,11 +46,6 @@ on:
         type: boolean
         required: false
         default: false
-      counter:
-        description: Version Counter
-        type: number
-        required: false
-        default: 0
 
 jobs:
   credential-check:
@@ -91,7 +82,7 @@ jobs:
         env:
           # twine doesn't support dry-runs, so if that's what we're doing, simulate it by using TestPyPI instead of PyPI
           # always send experimental builds to TestPyPI
-          REPOSITORY: ${{ (inputs.dry_run || inputs.channel == 'experimental') && 'testpypi' || 'pypi' }}
+          REPOSITORY: ${{ inputs.dry_run && 'testpypi' || 'pypi' }}
         run: |
           pip install -r tools/requirements-publish_tool.txt
           python tools/publish_tool.py python -r $REPOSITORY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,10 @@ on:
         description: Target Channel
         type: choice
         options:
+          - experimental
           - nightly
           - beta
           - stable
-          - dev-branch
         required: true
         default: nightly
       sync:
@@ -112,8 +112,8 @@ jobs:
 
   latex:
     needs: prepare
-    # don't build latex if releasing for custom branch
-    if: ${{ inputs.channel != 'dev-branch' }}
+    # don't build latex for experimental builds
+    if: ${{ inputs.channel != 'experimental' }}
     uses: ./.github/workflows/latex-release.yml
     with:
       channel: ${{ inputs.channel }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ on:
           - nightly
           - beta
           - stable
+          - dev-branch
         required: true
         default: nightly
       sync:
@@ -111,6 +112,8 @@ jobs:
 
   latex:
     needs: prepare
+    # don't build latex if releasing for custom branch
+    if: ${{ inputs.channel != 'dev-branch' }}
     uses: ./.github/workflows/latex-release.yml
     with:
       channel: ${{ inputs.channel }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,8 +97,7 @@ jobs:
     with:
       channel: ${{ inputs.channel }}
       date: ${{ needs.prepare.outputs.date }}
-      dry_run: ${{ inputs.dry_run || inputs.fake }}
-      counter: ${{ fromJSON(inputs.counter) }}
+      dry_run: ${{ inputs.dry_run || inputs.fake || inputs.channel == 'experimental' }}
     secrets: inherit
 
   sanity-test-post:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ on:
         description: Target Channel
         type: choice
         options:
-          - experimental
+          - dev
           - nightly
           - beta
           - stable
@@ -97,7 +97,7 @@ jobs:
     with:
       channel: ${{ inputs.channel }}
       date: ${{ needs.prepare.outputs.date }}
-      dry_run: ${{ inputs.dry_run || inputs.fake || inputs.channel == 'experimental' }}
+      dry_run: ${{ inputs.dry_run || inputs.fake }}
     secrets: inherit
 
   sanity-test-post:
@@ -105,14 +105,14 @@ jobs:
     uses: ./.github/workflows/sanity-test.yml
     with:
       channel: ${{ inputs.channel }}
-      # dry-runs go to TestPyPI instead of PyPI
-      python_repository: ${{ ( inputs.dry_run || inputs.fake ) && ( 'testpypi' || 'pypi' ) }}
+      # dry-runs and fake went to TestPyPI instead of PyPI
+      python_repository: ${{ ( inputs.dry_run || inputs.fake ) && 'testpypi' || 'pypi'  }}
       fake: ${{ inputs.fake }}
 
   latex:
     needs: prepare
-    # don't build latex for experimental builds
-    if: ${{ inputs.channel != 'experimental' }}
+    # don't build latex or docs for dev builds
+    if: ${{ inputs.channel != 'dev' }}
     uses: ./.github/workflows/latex-release.yml
     with:
       channel: ${{ inputs.channel }}

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -24,7 +24,7 @@ on:
         description: Target Channel
         type: choice
         options:
-          - experimental
+          - dev
           - nightly
           - beta
           - stable

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.channel == 'dev-branch' && github.ref_name || inputs.channel }}
+          ref: ${{ inputs.channel }}
 
       - name: Download Python wheel
         if: ${{ inputs.python_repository == 'local' }}

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -27,6 +27,7 @@ on:
           - nightly
           - beta
           - stable
+          - dev-branch
         required: true
         default: nightly
       python_repository:
@@ -51,7 +52,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.channel }}
+          ref: ${{ inputs.channel == 'dev-branch' && github.ref_name || inputs.channel }}
 
       - name: Download Python wheel
         if: ${{ inputs.python_repository == 'local' }}

--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -24,10 +24,10 @@ on:
         description: Target Channel
         type: choice
         options:
+          - experimental
           - nightly
           - beta
           - stable
-          - dev-branch
         required: true
         default: nightly
       python_repository:

--- a/tools/channel_tool.py
+++ b/tools/channel_tool.py
@@ -22,7 +22,7 @@ def initialize(args):
     if args.channel not in ("experimental", "nightly", "beta", "stable"):
         raise Exception(f"Unknown channel {args.channel}")
     if args.sync:
-        channel_to_upstream = {"nightly": "main", "beta": "nightly", "stable": "beta"}
+        channel_to_upstream = {"nightly": "main", "beta": "nightly", "stable": "beta", "experimental": get_current_branch()}
         upstream = channel_to_upstream[args.channel] if args.upstream is None else args.upstream
         ensure_branch(upstream)
         log(f"Syncing {args.channel} <= {upstream}")
@@ -125,6 +125,7 @@ def configure(args):
     if args.channel not in ("dev", "experimental", "nightly", "beta", "stable"):
         raise Exception(f"Unknown channel {args.channel}")
     version = get_version()
+
     if args.channel == "dev":
         # dev has a bare tag
         version = version.replace(prerelease="dev", build=None)
@@ -132,11 +133,13 @@ def configure(args):
         # experimental/nightly/beta have a tag with the date and a counter
         date = args.date or datetime.date.today()
         counter = infer_counter(version, date, args)
-        prerelease = f"{args.channel}.{date.strftime('%Y%m%d')}.{counter}"
+        tag = "dev" if args.channel == "experimental" else args.channel
+        prerelease = f"{tag}.{date.strftime('%Y%m%d')}.{counter}"
         version = version.replace(prerelease=prerelease, build=None)
     elif args.channel == "stable":
         # stable has no tag
         version = version.finalize_version()
+
     update_version(version)
 
 

--- a/tools/channel_tool.py
+++ b/tools/channel_tool.py
@@ -230,7 +230,6 @@ def _main(argv):
     subparser.set_defaults(func=configure)
     subparser.add_argument("-c", "--channel", choices=["dev", "nightly", "beta", "stable", "dev-branch"], default="dev", help="Which channel to target")
     subparser.add_argument("-d", "--date", type=datetime.date.fromisoformat, help="Release date")
-    subparser.add_argument("-i", "--counter", type=int, default=0, help="Intra-date version counter")
 
     subparser = subparsers.add_parser("changelog", help="Update the CHANGELOG file")
     subparser.set_defaults(func=changelog)

--- a/tools/channel_tool.py
+++ b/tools/channel_tool.py
@@ -19,7 +19,7 @@ def ensure_branch(branch):
 
 def initialize(args):
     log(f"*** INITIALIZING CHANNEL FROM UPSTREAM ***")
-    if args.channel not in ("nightly", "beta", "stable", "dev-branch"):
+    if args.channel not in ("experimental", "nightly", "beta", "stable"):
         raise Exception(f"Unknown channel {args.channel}")
     if args.sync:
         channel_to_upstream = {"nightly": "main", "beta": "nightly", "stable": "beta"}
@@ -122,14 +122,14 @@ def update_version(version):
 
 def configure(args):
     log(f"*** CONFIGURING CHANNEL ***")
-    if args.channel not in ("dev", "nightly", "beta", "stable", "dev-branch"):
+    if args.channel not in ("dev", "experimental", "nightly", "beta", "stable"):
         raise Exception(f"Unknown channel {args.channel}")
     version = get_version()
     if args.channel == "dev":
         # dev has a bare tag
         version = version.replace(prerelease="dev", build=None)
-    elif args.channel in ("nightly", "beta", "dev-branch"):
-        # nightly/beta/dev-branch have a tag with the date and a counter
+    elif args.channel in ("experimental", "nightly", "beta"):
+        # experimental/nightly/beta have a tag with the date and a counter
         date = args.date or datetime.date.today()
         counter = infer_counter(version, date, args)
         prerelease = f"{args.channel}.{date.strftime('%Y%m%d')}.{counter}"
@@ -217,7 +217,7 @@ def _main(argv):
 
     subparser = subparsers.add_parser("initialize", help="Initialize the channel")
     subparser.set_defaults(func=initialize)
-    subparser.add_argument("-c", "--channel", choices=["nightly", "beta", "stable", "dev-branch"], default="nightly", help="Which channel to target")
+    subparser.add_argument("-c", "--channel", choices=["experimental", "nightly", "beta", "stable"], default="nightly", help="Which channel to target")
     subparser.add_argument("--sync", action="store_true", help="Sync the channel from upstream")
     subparser.add_argument("-u", "--upstream", help="Upstream ref")
     subparser.add_argument("-p", "--preserve", dest="preserve", action="store_true")
@@ -228,7 +228,7 @@ def _main(argv):
 
     subparser = subparsers.add_parser("configure", help="Configure the channel")
     subparser.set_defaults(func=configure)
-    subparser.add_argument("-c", "--channel", choices=["dev", "nightly", "beta", "stable", "dev-branch"], default="dev", help="Which channel to target")
+    subparser.add_argument("-c", "--channel", choices=["dev", "experimental", "nightly", "beta", "stable"], default="dev", help="Which channel to target")
     subparser.add_argument("-d", "--date", type=datetime.date.fromisoformat, help="Release date")
     subparser.add_argument("-i", "--counter", type=int, default=0, help="Intra-date version counter")
 

--- a/tools/channel_tool.py
+++ b/tools/channel_tool.py
@@ -129,7 +129,7 @@ def configure(args):
         # dev has a bare tag
         version = version.replace(prerelease="dev", build=None)
     elif args.channel in ("nightly", "beta", "dev-branch"):
-        # nightly/beta have a tag with the date and a counter
+        # nightly/beta/dev-branch have a tag with the date and a counter
         date = args.date or datetime.date.today()
         counter = infer_counter(version, date, args)
         prerelease = f"{args.channel}.{date.strftime('%Y%m%d')}.{counter}"
@@ -217,7 +217,7 @@ def _main(argv):
 
     subparser = subparsers.add_parser("initialize", help="Initialize the channel")
     subparser.set_defaults(func=initialize)
-    subparser.add_argument("-c", "--channel", choices=["nightly", "beta", "stable"], default="nightly", help="Which channel to target")
+    subparser.add_argument("-c", "--channel", choices=["nightly", "beta", "stable", "dev-branch"], default="nightly", help="Which channel to target")
     subparser.add_argument("--sync", action="store_true", help="Sync the channel from upstream")
     subparser.add_argument("-u", "--upstream", help="Upstream ref")
     subparser.add_argument("-p", "--preserve", dest="preserve", action="store_true")
@@ -230,6 +230,7 @@ def _main(argv):
     subparser.set_defaults(func=configure)
     subparser.add_argument("-c", "--channel", choices=["dev", "nightly", "beta", "stable", "dev-branch"], default="dev", help="Which channel to target")
     subparser.add_argument("-d", "--date", type=datetime.date.fromisoformat, help="Release date")
+    subparser.add_argument("-i", "--counter", type=int, default=0, help="Intra-date version counter")
 
     subparser = subparsers.add_parser("changelog", help="Update the CHANGELOG file")
     subparser.set_defaults(func=changelog)

--- a/tools/channel_tool.py
+++ b/tools/channel_tool.py
@@ -19,7 +19,7 @@ def ensure_branch(branch):
 
 def initialize(args):
     log(f"*** INITIALIZING CHANNEL FROM UPSTREAM ***")
-    if args.channel not in ("nightly", "beta", "stable"):
+    if args.channel not in ("nightly", "beta", "stable", "dev-branch"):
         raise Exception(f"Unknown channel {args.channel}")
     if args.sync:
         channel_to_upstream = {"nightly": "main", "beta": "nightly", "stable": "beta"}
@@ -122,13 +122,13 @@ def update_version(version):
 
 def configure(args):
     log(f"*** CONFIGURING CHANNEL ***")
-    if args.channel not in ("dev", "nightly", "beta", "stable"):
+    if args.channel not in ("dev", "nightly", "beta", "stable", "dev-branch"):
         raise Exception(f"Unknown channel {args.channel}")
     version = get_version()
     if args.channel == "dev":
         # dev has a bare tag
         version = version.replace(prerelease="dev", build=None)
-    elif args.channel in ("nightly", "beta"):
+    elif args.channel in ("nightly", "beta", "dev-branch"):
         # nightly/beta have a tag with the date and a counter
         date = args.date or datetime.date.today()
         counter = infer_counter(version, date, args)
@@ -228,7 +228,7 @@ def _main(argv):
 
     subparser = subparsers.add_parser("configure", help="Configure the channel")
     subparser.set_defaults(func=configure)
-    subparser.add_argument("-c", "--channel", choices=["dev", "nightly", "beta", "stable"], default="dev", help="Which channel to target")
+    subparser.add_argument("-c", "--channel", choices=["dev", "nightly", "beta", "stable", "dev-branch"], default="dev", help="Which channel to target")
     subparser.add_argument("-d", "--date", type=datetime.date.fromisoformat, help="Release date")
     subparser.add_argument("-i", "--counter", type=int, default=0, help="Intra-date version counter")
 

--- a/tools/publish_tool.py
+++ b/tools/publish_tool.py
@@ -29,9 +29,9 @@ def python(args):
     config.read("python/setup.cfg")
     version = config["metadata"]["version"]
 
-    # Note, version naming should comply with:
-    # https://packaging.python.org/specifications/core-metadata for more
-    # 
+    # Note, version naming will comply with:
+    # https://packaging.python.org/en/latest/specifications/version-specifiers/
+    # (but don't enforce it here, enforce it in )
     wheel = f"opendp-{version}-py3-none-any.whl"
     run_command("Publishing opendp package", f"python -m twine upload -r {args.repository} --verbose python/wheelhouse/{wheel}")
     # Unfortunately, twine doesn't have an option to block until the index is propagated. Polling the index is unreliable,

--- a/tools/publish_tool.py
+++ b/tools/publish_tool.py
@@ -28,6 +28,10 @@ def python(args):
     config = configparser.RawConfigParser()
     config.read("python/setup.cfg")
     version = config["metadata"]["version"]
+
+    # Note, version naming should comply with:
+    # https://packaging.python.org/specifications/core-metadata for more
+    # 
     wheel = f"opendp-{version}-py3-none-any.whl"
     run_command("Publishing opendp package", f"python -m twine upload -r {args.repository} --verbose python/wheelhouse/{wheel}")
     # Unfortunately, twine doesn't have an option to block until the index is propagated. Polling the index is unreliable,

--- a/tools/publish_tool.py
+++ b/tools/publish_tool.py
@@ -87,7 +87,6 @@ def github(args):
 
 def _main(argv):
     parser = argparse.ArgumentParser(description="OpenDP build tool")
-    parser.add_argument("--counter", type=int, default=0, help="Version counter")
     subparsers = parser.add_subparsers(dest="COMMAND", help="Command to run")
     subparsers.required = True
 
@@ -102,6 +101,7 @@ def _main(argv):
     subparser.add_argument("-r", "--repository", choices=["pypi", "testpypi"], default="pypi", help="Package repository")
     subparser.add_argument("-t", "--index-check-timeout", type=int, default=300, help="How long to keep checking for index update (0 = don't check)")
     subparser.add_argument("-b", "--index-check-backoff", type=float, default=2.0, help="How much to back off between checks for index update")
+    subparser.add_argument("--counter", type=int, default=0, help="Version counter")
 
     subparser = subparsers.add_parser("sanity", help="Run a sanity test")
     subparser.set_defaults(func=sanity)
@@ -115,6 +115,7 @@ def _main(argv):
     subparser.set_defaults(func=github)
     subparser.add_argument("-d", "--date", type=datetime.date.fromisoformat, help="Release date")
     subparser.add_argument("--draft", action="store_true")
+    subparser.add_argument("--counter", type=int, default=0, help="Version counter")
 
     args = parser.parse_args(argv[1:])
     args.func(args)

--- a/tools/publish_tool.py
+++ b/tools/publish_tool.py
@@ -28,8 +28,6 @@ def python(args):
     config = configparser.RawConfigParser()
     config.read("python/setup.cfg")
     version = config["metadata"]["version"]
-    if args.counter:
-        version += f'-{args.counter}'
     wheel = f"opendp-{version}-py3-none-any.whl"
     run_command("Publishing opendp package", f"python -m twine upload -r {args.repository} --verbose python/wheelhouse/{wheel}")
     # Unfortunately, twine doesn't have an option to block until the index is propagated. Polling the index is unreliable,
@@ -69,8 +67,6 @@ def github(args):
     if branch != channel:
         raise Exception(f"Version {version} implies channel {channel}, but current branch is {branch}")
     tag = f"v{version}"
-    if args.counter:
-        tag += f'-{args.counter}'
     # Just in case, clear out any existing tag, so a new one will be created by GitHub.
     run_command("Clearing tag", f"git push origin :refs/tags/{tag}")
     title = f"OpenDP {version}"
@@ -101,7 +97,6 @@ def _main(argv):
     subparser.add_argument("-r", "--repository", choices=["pypi", "testpypi"], default="pypi", help="Package repository")
     subparser.add_argument("-t", "--index-check-timeout", type=int, default=300, help="How long to keep checking for index update (0 = don't check)")
     subparser.add_argument("-b", "--index-check-backoff", type=float, default=2.0, help="How much to back off between checks for index update")
-    subparser.add_argument("--counter", type=int, default=0, help="Version counter")
 
     subparser = subparsers.add_parser("sanity", help="Run a sanity test")
     subparser.set_defaults(func=sanity)
@@ -115,7 +110,6 @@ def _main(argv):
     subparser.set_defaults(func=github)
     subparser.add_argument("-d", "--date", type=datetime.date.fromisoformat, help="Release date")
     subparser.add_argument("--draft", action="store_true")
-    subparser.add_argument("--counter", type=int, default=0, help="Version counter")
 
     args = parser.parse_args(argv[1:])
     args.func(args)


### PR DESCRIPTION
Adds a new channel `experimental` that can be used to cut one-off releases to test-pypi from arbitrary branches.


Closes #1142