### PR TITLE
UDFs default to ExtrinsicObject and QOL

### DIFF
--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -1,4 +1,5 @@
 from typing import Sequence, Tuple, List, Union, Dict, cast
+from inspect import signature
 
 from opendp._lib import *
 from opendp.mod import UnknownTypeException, OpenDPException, Transformation, Measurement, SMDCurve, Queryable
@@ -486,6 +487,11 @@ TransitionFn = ctypes.CFUNCTYPE(ctypes.c_void_p, AnyObjectPtr, ctypes.c_bool)
 
 def _wrap_py_transition(py_transition, A):
     from opendp._convert import c_to_py, py_to_c
+
+    # the indicator that a query is internal is oftentimes not needed
+    if len(signature(py_transition).parameters) == 1:
+        py_transition_old = py_transition
+        py_transition = lambda q, _=None: py_transition_old(q)
 
     def wrapper_func(c_query, c_is_internal: ctypes.c_bool):
         try:

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -124,8 +124,12 @@ class AnyObjectPtr(ctypes.POINTER(AnyObject)): # type: ignore[misc]
     _type_ = AnyObject
 
     def __del__(self):
-        from opendp._data import object_free
-        object_free(self)
+        try:
+            from opendp._data import object_free
+            object_free(self)
+        except (ImportError, TypeError):
+            # ImportError: sys.meta_path is None, Python is likely shutting down
+            pass
 
 
 class AnyQueryable(ctypes.Structure):

--- a/python/src/opendp/core.py
+++ b/python/src/opendp/core.py
@@ -24,7 +24,7 @@ __all__ = [
     "measurement_output_distance_type",
     "measurement_output_measure",
     "new_function",
-    "new_user_queryable",
+    "new_queryable",
     "queryable_eval",
     "queryable_query_type",
     "transformation_check",
@@ -535,14 +535,14 @@ def new_function(
 
 
 @versioned
-def new_user_queryable(
+def new_queryable(
     transition,
-    Q: RuntimeTypeDescriptor,
-    A: RuntimeTypeDescriptor
+    Q: Optional[RuntimeTypeDescriptor] = "ExtrinsicObject",
+    A: Optional[RuntimeTypeDescriptor] = "ExtrinsicObject"
 ) -> Any:
     r"""Construct a queryable from a user-defined transition function.
     
-    [new_user_queryable in Rust documentation.](https://docs.rs/opendp/latest/opendp/core/fn.new_user_queryable.html)
+    [new_queryable in Rust documentation.](https://docs.rs/opendp/latest/opendp/core/fn.new_queryable.html)
     
     :param transition: A transition function taking a reference to self, a query, and an internal/external indicator
     :param Q: Query Type
@@ -566,7 +566,7 @@ def new_user_queryable(
     c_A = py_to_c(A, c_type=ctypes.c_char_p)
     
     # Call library function.
-    lib_function = lib.opendp_core__new_user_queryable
+    lib_function = lib.opendp_core__new_queryable
     lib_function.argtypes = [TransitionFn, ctypes.c_char_p, ctypes.c_char_p]
     lib_function.restype = FfiResult
     

--- a/python/src/opendp/measurements.py
+++ b/python/src/opendp/measurements.py
@@ -1193,7 +1193,7 @@ def make_user_measurement(
     output_measure: Measure,
     function,
     privacy_map,
-    TO: RuntimeTypeDescriptor
+    TO: Optional[RuntimeTypeDescriptor] = "ExtrinsicObject"
 ) -> Measurement:
     r"""Construct a Measurement from user-defined callbacks.
     
@@ -1247,7 +1247,7 @@ def then_user_measurement(
     output_measure: Measure,
     function,
     privacy_map,
-    TO: RuntimeTypeDescriptor
+    TO: Optional[RuntimeTypeDescriptor] = "ExtrinsicObject"
 ):  
     r"""partial constructor of make_user_measurement
 

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -112,6 +112,10 @@ class Measurement(ctypes.POINTER(AnyMeasurement)): # type: ignore[misc]
         if isinstance(other, Transformation):
             other = other.function
 
+        if not isinstance(other, Function):
+            from opendp.core import new_function
+            other = new_function(other, TO="ExtrinsicObject")
+
         if isinstance(other, Function):
             from opendp.combinators import make_chain_pm
             return make_chain_pm(other, self)

--- a/python/src/opendp/prelude.py
+++ b/python/src/opendp/prelude.py
@@ -44,7 +44,7 @@ from opendp.metrics import *
 from opendp.measures import *
 from opendp.typing import *
 from opendp.accuracy import *
-from opendp.core import new_function, new_user_queryable
+from opendp.core import new_function, new_queryable
 from opendp.context import *
 
 __all__ = ["t", "m", "c"]

--- a/python/test/test_interactive.py
+++ b/python/test/test_interactive.py
@@ -75,10 +75,10 @@ def test_sequential_composition_approxdp():
 
 
 def test_udf_queryable_int():
-    def transition(query, _is_internal):
+    def transition(query):
         assert query == 2
         return query + 1
-    qbl = dp.new_user_queryable(transition, int, int)
+    qbl = dp.new_queryable(transition, int, int)
     assert qbl(2) == 3
 
 
@@ -86,14 +86,14 @@ def test_udf_queryable_list():
     def transition(query, _is_internal):
         assert query == [2, 3]
         return query[-1]
-    qbl = dp.new_user_queryable(transition, "Vec<i32>", int)
+    qbl = dp.new_queryable(transition, "Vec<i32>", int)
     assert qbl([2, 3]) == 3
 
 
 def test_udf_queryable_error():
     def transition(_query, _is_internal):
         raise ValueError("test clean stack trace")
-    qbl = dp.new_user_queryable(transition, "Vec<i32>", int)
+    qbl = dp.new_queryable(transition, "Vec<i32>", int)
 
     with pytest.raises(dp.OpenDPException):
         qbl([2, 3])

--- a/python/test/test_user_transform.py
+++ b/python/test/test_user_transform.py
@@ -102,6 +102,4 @@ def test_user_constructors():
     print(meas(2))
     print(meas.map(1))
 
-    post = dp.new_function(lambda x: x[0], dp.i32)
-
-    print((meas >> post)(2))
+    print((meas >> (lambda x: x[0]))(2))

--- a/python/test/test_user_transform.py
+++ b/python/test/test_user_transform.py
@@ -88,8 +88,8 @@ def test_user_constructors():
         lambda x: [x] * 10,
         lambda d_in: d_in * 10
     )
-    print(trans(2))
-    print(trans.map(1))
+    assert trans(2) == [2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+    assert trans.map(1) == 10
 
     meas = dp.m.make_user_measurement(
         dp.atom_domain((2, 10)),
@@ -99,7 +99,8 @@ def test_user_constructors():
         lambda d_in: float(d_in * 10),
         TO=dp.Vec[int],
     )
-    print(meas(2))
-    print(meas.map(1))
 
-    print((meas >> (lambda x: x[0]))(2))
+    assert meas(2) == [2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+    assert meas.map(1) == 10
+
+    assert (meas >> (lambda x: x[0]))(2) == 2

--- a/rust/src/core/ffi.rs
+++ b/rust/src/core/ffi.rs
@@ -813,9 +813,10 @@ fn wrap_transition(
 }
 
 #[bootstrap(
-    name = "new_user_queryable",
+    name = "new_queryable",
     features("contrib"),
     arguments(transition(rust_type = "$pass_through(A)")),
+    generics(Q(default = "ExtrinsicObject"), A(default = "ExtrinsicObject")),
     dependencies("c_transition")
 )]
 /// Construct a queryable from a user-defined transition function.
@@ -827,13 +828,13 @@ fn wrap_transition(
 /// * `Q` - Query Type
 /// * `A` - Output Type
 #[allow(dead_code)]
-fn new_user_queryable<Q, A>(transition: TransitionFn) -> Fallible<AnyObject> {
+fn new_queryable<Q, A>(transition: TransitionFn) -> Fallible<AnyObject> {
     let _ = transition;
     panic!("this signature only exists for code generation")
 }
 
 #[no_mangle]
-pub extern "C" fn opendp_core__new_user_queryable(
+pub extern "C" fn opendp_core__new_queryable(
     transition: TransitionFn,
     Q: *const c_char,
     A: *const c_char,

--- a/rust/src/measurements/make_user_measurement/mod.rs
+++ b/rust/src/measurements/make_user_measurement/mod.rs
@@ -20,6 +20,7 @@ use crate::{
         function(rust_type = "$pass_through(TO)"),
         privacy_map(rust_type = "$measure_distance_type(output_measure)"),
     ),
+    generics(TO(default = "ExtrinsicObject")),
     dependencies(
         "input_domain",
         "input_metric",


### PR DESCRIPTION
Closes #1146

* the second argument on queryable transition functions (generally unused internal query indicator) is now optional
* rename `new_user_queryable` -> `new_queryable` for consistency with `new_function`. It's not a privacy structure
* try/catch object_free, as it failed to call during interpreter shutdown like the other free functions do
* specify default parameters of "ExtrinsicObject" for measurement's TO, and queryables' Q and A
* raw functions can now be chained as postprocessors onto measurements, without wrapping in `new_function`