### PR TITLE
Make ffi public

### DIFF
--- a/rust/src/ffi/mod.rs
+++ b/rust/src/ffi/mod.rs
@@ -3,6 +3,8 @@
 //! # Overview
 //!
 //! This module contains utilities necessary for the FFI bindings.
+//! It is public so you can write your own lightweight FFI for quick one-off language integrations,
+//! but its use should be rare: More often, you should use the Rust API directly.
 //!
 //! # Generic Functions
 //!

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -167,7 +167,7 @@ macro_rules! enclose {
 
 #[cfg(feature = "ffi")]
 #[macro_use]
-mod ffi;
+pub mod ffi;
 #[cfg(feature = "ffi")]
 #[macro_use]
 extern crate lazy_static;


### PR DESCRIPTION
- Fix #1149
- Note that the FFI docs could use some work: #1148 -- That page was rendered as part of the documentation before, but as part of the public API cleaning it up may be a higher priority.
  - (Michael explains that we are rendering all docs, even for code that is not public, so proofs can be linked.)
- Should anything else change, assuming this is the right direction?