### PR TITLE
Confirm that generated python is in sync

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Test
         run: cargo test --verbose --features untrusted,ffi
 
+      - name: Check that generated python is up to date
+        run: git diff --exit-code
+
       - name: Upload libs
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
- Fix #1154
- Remove the docstrings that shouldn't have been committed in the first place
- ... and comment out the test that checks the docstrings.

The test failure on the second commit below shows what it looks like when there are changes to the generated files.

This seems like it might make things less error-prove... but I've been wrong before. It might also cause merge conflicts with work you already have in progress. We might kill this PR, and apply the idea in a different branch, or just wait until the release is out.

A totally different approach would be to git-ignore all the generated files. That could work, but it feels like a bigger change from what we have now, and we'd also have to keep the ignore list up to date, or distinguish the generated files by name or path.