### PR TITLE
remove floating-point flag from RNM Gumbel

### DIFF
--- a/R/opendp/R/measurements.R
+++ b/R/opendp/R/measurements.R
@@ -1225,7 +1225,7 @@ make_report_noisy_max_gumbel <- function(
     optimize,
     .QO = NULL
 ) {
-    assert_features("contrib", "floating-point")
+    assert_features("contrib")
 
     # Standardize type arguments.
     .QO <- parse_or_infer(type_name = .QO, public_example = scale)

--- a/python/src/opendp/measurements.py
+++ b/python/src/opendp/measurements.py
@@ -1139,7 +1139,7 @@ def make_report_noisy_max_gumbel(
     :raises UnknownTypeException: if a type argument fails to parse
     :raises OpenDPException: packaged error from the core OpenDP library
     """
-    assert_features("contrib", "floating-point")
+    assert_features("contrib")
 
     # Standardize type arguments.
     QO = RuntimeType.parse_or_infer(type_name=QO, public_example=scale)

--- a/rust/src/measurements/gumbel_max/mod.rs
+++ b/rust/src/measurements/gumbel_max/mod.rs
@@ -25,7 +25,7 @@ pub enum Optimize {
 }
 
 #[bootstrap(
-    features("contrib", "floating-point"),
+    features("contrib"),
     arguments(optimize(c_type = "char *", rust_type = "String")),
     generics(TIA(suppress))
 )]


### PR DESCRIPTION
This flag never needed to be set. The implementation has always been floating-point-safe.