### PR TITLE
fix typos and run flake8 on pseudocode

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,7 +4,6 @@
 
 [flake8]
 exclude =
-	*/pseudocode/*
     .venv # python/
     venv # docs/
 

--- a/rust/src/measurements/gumbel_max/pseudocode/make_report_noisy_max_gumbel.py
+++ b/rust/src/measurements/gumbel_max/pseudocode/make_report_noisy_max_gumbel.py
@@ -1,7 +1,7 @@
 # type: ignore
 def make_report_noisy_max_gumbel(
     input_domain: VectorDomain[AtomDomain[TIA]],
-    input_metric: RangeDistance[TIA]
+    input_metric: RangeDistance[TIA],
     scale: QO, 
     optimize: Union[Literal["max"], Literal["min"]]
 ) -> Measurement:

--- a/rust/src/traits/samplers/uniform/pseudocode/sample_uniform_int_below_native.py
+++ b/rust/src/traits/samplers/uniform/pseudocode/sample_uniform_int_below_native.py
@@ -2,6 +2,6 @@
 # returns a single bit with some probability of success
 def sample_uniform_int_below(upper, T) -> int:
     while True:
-        sample = T.sample_uniform_int():
+        sample = T.sample_uniform_int()
         if sample < T.MAX - T.MAX % upper:
             return sample % upper

--- a/rust/src/transformations/quantile_score_candidates/pseudocode/compute_score.py
+++ b/rust/src/transformations/quantile_score_candidates/pseudocode/compute_score.py
@@ -3,7 +3,7 @@ def compute_score(
     x: List[TIA], 
     candidates: List[TIA], 
     alpha_numer: usize,
-    alpha_denom: usize
+    alpha_denom: usize,
     size_limit: usize
 ) -> List[usize]:
 

--- a/rust/src/transformations/quantile_score_candidates/pseudocode/compute_score.py
+++ b/rust/src/transformations/quantile_score_candidates/pseudocode/compute_score.py
@@ -2,8 +2,8 @@
 def compute_score(
     x: List[TIA], 
     candidates: List[TIA], 
-    alpha_numer: usize,
-    alpha_denom: usize,
+    alpha_num: usize,
+    alpha_den: usize,
     size_limit: usize
 ) -> List[usize]:
 


### PR DESCRIPTION
- Fix #1197

There are actually only a couple of errors for our current flake8 config, and they all seem like typos we would like to catch.

Looking at this, I am also reminded that many of the flake8 checks are still turned off, including ones that we would like to run on pseudo code:

```
def compute_score(
    x: List[TIA], 
    candidates: List[TIA], 
    alpha_numer: usize,
    alpha_denom: usize,
    size_limit: usize
) -> List[usize]:
    ...
            alpha_den * min(lt, size_limit),
            alpha_num * min(len(x) - eq, size_limit))
```

Note `alpha_numer` vs `alpha_num` -- This is something we'd like to catch in the production code too! I think that removing this from the ignore list would surface these problems:

```
    # F821: undefined name '...'
    F821,
```
- See #1069