### PR TITLE
Python and R examples in tabs on quickstart

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -255,9 +255,12 @@ jobs:
           working-directory: R/opendp
           extra-packages: devtools,local::.,RcppTOML
 
-      - name: Test
+      - name: Unit tests
         working-directory: R/opendp/
         run: Rscript -e 'devtools::test(reporter = c("summary", "fail"))'
+
+      - name: Documentation examples
+        run: find docs/source -type f -name '*.R' | xargs Rscript
 
       - name: Document
         run: cd R/opendp/ && Rscript -e 'devtools::document()'

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -260,13 +260,7 @@ jobs:
         run: Rscript -e 'devtools::test(reporter = c("summary", "fail"))'
 
       - name: Documentation examples
-        run: |
-          STATUS=0
-          for R in `find docs/source -type f -name '*.R'`; do
-            echo $R
-            Rscript "$R" || STATUS=1
-          done
-          exit $STATUS
+        run: tools/r_examples.sh
 
       - name: Document
         run: cd R/opendp/ && Rscript -e 'devtools::document()'

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -260,7 +260,13 @@ jobs:
         run: Rscript -e 'devtools::test(reporter = c("summary", "fail"))'
 
       - name: Documentation examples
-        run: find docs/source -type f -name '*.R' | xargs Rscript
+        run: |
+          STATUS=0
+          for R in `find docs/source -type f -name '*.R'`; do
+            echo $R
+            Rscript "$R" || STATUS=1
+          done
+          exit $STATUS
 
       - name: Document
         run: cd R/opendp/ && Rscript -e 'devtools::document()'

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -7,6 +7,7 @@
 
 sphinx
 sphinx-prompt
+sphinx-tabs
 git+https://github.com/samtygier-stfc/sphinx-multiversion.git@prebuild_command
 pydata-sphinx-theme
 nbsphinx

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -44,6 +44,7 @@ docutils==0.19
     #   nbsphinx
     #   pydata-sphinx-theme
     #   sphinx
+    #   sphinx-tabs
 exceptiongroup==1.2.0
     # via ipython
 executing==2.0.1
@@ -136,6 +137,7 @@ pygments==2.17.2
     #   pydata-sphinx-theme
     #   sphinx
     #   sphinx-prompt
+    #   sphinx-tabs
 pypandoc==1.12
     # via -r requirements.in
 pyproject-hooks==1.0.0
@@ -174,6 +176,7 @@ sphinx==5.1.1
     #   pydata-sphinx-theme
     #   sphinx-multiversion
     #   sphinx-prompt
+    #   sphinx-tabs
     #   sphinxcontrib-applehelp
     #   sphinxcontrib-devhelp
     #   sphinxcontrib-htmlhelp
@@ -182,6 +185,8 @@ sphinx==5.1.1
 sphinx-multiversion @ git+https://github.com/samtygier-stfc/sphinx-multiversion.git@prebuild_command
     # via -r requirements.in
 sphinx-prompt==1.5.0
+    # via -r requirements.in
+sphinx-tabs==3.4.5
     # via -r requirements.in
 sphinxcontrib-applehelp==1.0.7
     # via sphinx

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -13,3 +13,11 @@ details summary p { display: inline }
 
 /* fix rendering of pandas dataframe tables in chrome and safari */
 div.rendered_html table { width: 100% }
+
+/* default <pre> blocks in tab looks clunky */
+.sphinx-tabs-panel div.highlight pre {
+    border: unset;
+    background-color: unset;
+    padding: 0;
+    margin: -1em 0;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,6 +25,7 @@ extensions = [
     'sphinx-prompt',
     'sphinx_multiversion',
     'nbsphinx',
+    'sphinx_tabs.tabs',
 ]
 
 # convert markdown to rst when rendering with sphinx

--- a/docs/source/quickstart.R
+++ b/docs/source/quickstart.R
@@ -4,4 +4,4 @@ enable_features("contrib")
 # 2-use
 space <- c(atom_domain(.T = "f64"), absolute_distance(.T = "f64"))
 base_laplace <- space |> then_base_laplace(1.)
-dp_agg <- meas(arg = 23.4)
+dp_agg <- base_laplace(arg = 23.4)

--- a/docs/source/quickstart.R
+++ b/docs/source/quickstart.R
@@ -1,0 +1,7 @@
+# 1-library
+library(opendp)
+enable_features("contrib")
+# 2-use
+space <- c(atom_domain(.T = "f64"), absolute_distance(.T = "f64"))
+base_laplace <- space |> then_base_laplace(1.)
+dp_agg <- meas(arg = 23.4)

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -29,11 +29,23 @@ The vetting process is currently underway for the code in the OpenDP Library.
 Any code that has not completed the vetting process is marked as "contrib" and will not run unless you opt-in.
 Enable ``contrib`` globally with the following snippet:
 
-.. doctest::
+.. tabs::
 
-    >>> from opendp.mod import enable_features
-    >>> enable_features('contrib')
+    .. group-tab:: Python
 
+        .. doctest::
+
+            >>> from opendp.mod import enable_features
+            >>> enable_features('contrib')
+
+    .. group-tab:: R
+
+        .. highlight:: r
+
+        ::
+
+            library(opendp)
+            enable_features("contrib")
 
 Hello, OpenDP!
 --------------

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -1,12 +1,23 @@
 Quickstart
 ==========
 
-The easiest way to get started with OpenDP is from Python.
-Use ``pip`` to install the `opendp <https://pypi.org/project/opendp/>`_ package from PyPI.
+OpenDP is available for Python and R.
 
-.. prompt:: bash
+.. tabs::
 
-    pip install opendp
+    .. group-tab:: Python
+
+        Use ``pip`` to install the `opendp <https://pypi.org/project/opendp/>`_ package from PyPI:
+
+        .. prompt:: bash
+
+            pip install opendp
+
+    .. group-tab:: R
+
+        .. prompt:: bash
+
+            TODO
 
 This will make the OpenDP modules available to your local environment.
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -15,9 +15,13 @@ OpenDP is available for Python and R.
 
     .. group-tab:: R
 
-        .. prompt:: bash
+        Launch R and then use ``install.packages``:
 
-            TODO
+        .. highlight:: r
+        
+        ::
+
+            install.packages('opendp', repos = 'https://opendp-dev.r-universe.dev')
 
 This will make the OpenDP modules available to your local environment.
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -38,10 +38,10 @@ Enable ``contrib`` globally with the following snippet:
 
     .. group-tab:: R
 
-        .. code:: r
-
-            library(opendp)
-            enable_features("contrib")
+        .. literalinclude:: quickstart.R
+            :language: r
+            :start-after: 1-library
+            :end-before: 2-use
 
 Hello, OpenDP!
 --------------
@@ -62,11 +62,9 @@ then invoke it on a scalar aggregate.
 
     .. group-tab:: R
 
-        .. code:: r
-
-            space <- c(atom_domain(.T = "f64"), absolute_distance(.T = "f64"))
-            base_laplace <- space |> then_base_laplace(1.)
-            dp_agg <- meas(arg = 23.4)
+        .. literalinclude:: quickstart.R
+            :language: r
+            :start-after: 2-use
 
 This code snip uses a number of OpenDP concepts:
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -54,17 +54,31 @@ Once you've installed OpenDP, you can write your first program.
 In the example below, we'll construct a Laplace mechanism of type :class:`opendp.mod.Measurement`, 
 then invoke it on a scalar aggregate.
 
-.. doctest::
+.. tabs::
 
-    >>> import opendp.prelude as dp
-    >>> base_laplace = dp.space_of(float) >> dp.m.then_base_laplace(scale=1.)
-    >>> dp_agg = base_laplace(23.4)
+    .. group-tab:: Python
+
+        .. doctest::
+
+            >>> import opendp.prelude as dp
+            >>> base_laplace = dp.space_of(float) >> dp.m.then_base_laplace(scale=1.)
+            >>> dp_agg = base_laplace(23.4)
+
+    .. group-tab:: R
+
+        .. highlight:: r
+
+        ::
+
+            space <- c(atom_domain(.T = "f64"), absolute_distance(.T = "f64"))
+            base_laplace <- space |> then_base_laplace(1.)
+            dp_agg <- meas(arg = 23.4)
 
 This code snip uses a number of OpenDP concepts:
 
-* Defining your metric space up-front with ``space_of``.
-* Chaining operators together with ``>>``.
-* Constructing a ``Measurement`` on your metric space with ``m.then_base_laplace``.
+* Defining your metric space up-front with ``space_of`` in Python.
+* Chaining operators together with ``>>`` in Python, or ``|>`` in R.
+* Constructing a ``Measurement`` on your metric space with ``then_base_laplace``.
 * Invoking the ``base_laplace`` measurement on a value to get a DP release.
 
 If you would like to skip directly to a more complete example, see :ref:`putting-together`.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -17,9 +17,7 @@ OpenDP is available for Python and R.
 
         Launch R and then use ``install.packages``:
 
-        .. highlight:: r
-        
-        ::
+        .. code:: r
 
             install.packages('opendp', repos = 'https://opendp-dev.r-universe.dev')
 
@@ -40,9 +38,7 @@ Enable ``contrib`` globally with the following snippet:
 
     .. group-tab:: R
 
-        .. highlight:: r
-
-        ::
+        .. code:: r
 
             library(opendp)
             enable_features("contrib")
@@ -66,9 +62,7 @@ then invoke it on a scalar aggregate.
 
     .. group-tab:: R
 
-        .. highlight:: r
-
-        ::
+        .. code:: r
 
             space <- c(atom_domain(.T = "f64"), absolute_distance(.T = "f64"))
             base_laplace <- space |> then_base_laplace(1.)

--- a/tools/r_examples.sh
+++ b/tools/r_examples.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+FAILS=0
+RUNS=0
+for R in `find docs/source -type f -name '*.R'`; do
+    ((RUNS++))
+    echo "$RUNS: $R"
+    Rscript "$R" || ((FAILS++))
+done
+if [[ "$RUNS" -eq 0 ]]; then
+    echo "FAIL: no examples found"
+    exit 1
+fi
+if [[ "$FAILS" -ne 0 ]]; then
+    echo "FAIL: $FAILS tests failed"
+    exit 1
+fi
+echo "PASS"


### PR DESCRIPTION
- Fix #1232

I think this much is probably useful on its own, but it wouldn't be unreasonable to ask that we figure out something like doctests for R examples before this goes in. Your call.

<img width="271" alt="Screenshot 2024-02-08 at 7 31 45 PM" src="https://github.com/opendp/opendp/assets/730388/a8474db3-cd26-4090-8822-0064fcc12be8">
