### PR TITLE
Link directly to R function reference

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -9,5 +9,5 @@ If you are looking for long-form, higher-level documentation, then please consul
    :maxdepth: 1
 
    Python API <python/index>
-   R API <https://docs.opendp.org/en/stable/api/r>
+   R API <https://docs.opendp.org/en/stable/api/r/reference/index.html>
    Rust API <https://docs.rs/opendp>


### PR DESCRIPTION
- Fix #1224

I should understand the R docs build process better, but for now, this will save users one click.