### PR TITLE
Subheadings in R docs

### DIFF
--- a/R/opendp/R/accuracy.R
+++ b/R/opendp/R/accuracy.R
@@ -12,6 +12,7 @@ NULL
 #'
 #' [(Proof Document)](https://docs.opendp.org/en/nightly/proofs/rust/src/accuracy/accuracy_to_discrete_gaussian_scale.pdf)
 #'
+#' @concept accuracy
 #' @param accuracy Desired accuracy. A tolerance for how far values may diverge from the input to the mechanism.
 #' @param alpha Statistical significance, level-`alpha`, or (1. - `alpha`)100% confidence. Must be within (0, 1].
 #' @param .T Data type of `accuracy` and `alpha`
@@ -51,6 +52,7 @@ accuracy_to_discrete_gaussian_scale <- function(
 #'
 #' [(Proof Document)](https://docs.opendp.org/en/nightly/proofs/rust/src/accuracy/accuracy_to_discrete_laplacian_scale.pdf)
 #'
+#' @concept accuracy
 #' @param accuracy Desired accuracy. A tolerance for how far values may diverge from the input to the mechanism.
 #' @param alpha Statistical significance, level-`alpha`, or (1. - `alpha`)100% confidence. Must be within (0, 1].
 #' @param .T Data type of `accuracy` and `alpha`
@@ -86,6 +88,7 @@ accuracy_to_discrete_laplacian_scale <- function(
 #'
 #' [accuracy_to_gaussian_scale in Rust documentation.](https://docs.rs/opendp/latest/opendp/accuracy/fn.accuracy_to_gaussian_scale.html)
 #'
+#' @concept accuracy
 #' @param accuracy Desired accuracy. A tolerance for how far values may diverge from the input to the mechanism.
 #' @param alpha Statistical significance, level-`alpha`, or (1. - `alpha`)100% confidence. Must be within (0, 1].
 #' @param .T Data type of `accuracy` and `alpha`
@@ -121,6 +124,7 @@ accuracy_to_gaussian_scale <- function(
 #'
 #' [accuracy_to_laplacian_scale in Rust documentation.](https://docs.rs/opendp/latest/opendp/accuracy/fn.accuracy_to_laplacian_scale.html)
 #'
+#' @concept accuracy
 #' @param accuracy Desired accuracy. A tolerance for how far values may diverge from the input to the mechanism.
 #' @param alpha Statistical significance, level-`alpha`, or (1. - `alpha`)100% confidence. Must be within (0, 1].
 #' @param .T Data type of `accuracy` and `alpha`
@@ -160,6 +164,7 @@ accuracy_to_laplacian_scale <- function(
 #'
 #' [(Proof Document)](https://docs.opendp.org/en/nightly/proofs/rust/src/accuracy/discrete_gaussian_scale_to_accuracy.pdf)
 #'
+#' @concept accuracy
 #' @param scale Gaussian noise scale.
 #' @param alpha Statistical significance, level-`alpha`, or (1. - `alpha`)100% confidence. Must be within (0, 1].
 #' @param .T Data type of `scale` and `alpha`
@@ -205,6 +210,7 @@ discrete_gaussian_scale_to_accuracy <- function(
 #'
 #' [(Proof Document)](https://docs.opendp.org/en/nightly/proofs/rust/src/accuracy/discrete_laplacian_scale_to_accuracy.pdf)
 #'
+#' @concept accuracy
 #' @param scale Discrete Laplacian noise scale.
 #' @param alpha Statistical significance, level-`alpha`, or (1. - `alpha`)100% confidence. Must be within (0, 1].
 #' @param .T Data type of `scale` and `alpha`
@@ -240,6 +246,7 @@ discrete_laplacian_scale_to_accuracy <- function(
 #'
 #' [gaussian_scale_to_accuracy in Rust documentation.](https://docs.rs/opendp/latest/opendp/accuracy/fn.gaussian_scale_to_accuracy.html)
 #'
+#' @concept accuracy
 #' @param scale Gaussian noise scale.
 #' @param alpha Statistical significance, level-`alpha`, or (1. - `alpha`)100% confidence. Must be within (0, 1].
 #' @param .T Data type of `scale` and `alpha`
@@ -275,6 +282,7 @@ gaussian_scale_to_accuracy <- function(
 #'
 #' [laplacian_scale_to_accuracy in Rust documentation.](https://docs.rs/opendp/latest/opendp/accuracy/fn.laplacian_scale_to_accuracy.html)
 #'
+#' @concept accuracy
 #' @param scale Laplacian noise scale.
 #' @param alpha Statistical significance, level-`alpha`, or (1. - `alpha`)100% confidence. Must be within (0, 1].
 #' @param .T Data type of `scale` and `alpha`

--- a/R/opendp/R/combinators.R
+++ b/R/opendp/R/combinators.R
@@ -20,6 +20,7 @@ NULL
 #'
 #' [make_basic_composition in Rust documentation.](https://docs.rs/opendp/latest/opendp/combinators/fn.make_basic_composition.html)
 #'
+#' @concept combinators
 #' @param measurements A vector of Measurements to compose.
 #' @return Measurement
 #' @export
@@ -80,6 +81,7 @@ then_basic_composition <- function(
 #'
 #' [make_chain_mt in Rust documentation.](https://docs.rs/opendp/latest/opendp/combinators/fn.make_chain_mt.html)
 #'
+#' @concept combinators
 #' @param measurement1 outer mechanism
 #' @param transformation0 inner transformation
 #' @return Measurement
@@ -141,6 +143,7 @@ then_chain_mt <- function(
 #'
 #' [make_chain_pm in Rust documentation.](https://docs.rs/opendp/latest/opendp/combinators/fn.make_chain_pm.html)
 #'
+#' @concept combinators
 #' @param postprocess1 outer postprocessor
 #' @param measurement0 inner measurement/mechanism
 #' @return Measurement
@@ -201,6 +204,7 @@ then_chain_pm <- function(
 #'
 #' [make_chain_tt in Rust documentation.](https://docs.rs/opendp/latest/opendp/combinators/fn.make_chain_tt.html)
 #'
+#' @concept combinators
 #' @param transformation1 outer transformation
 #' @param transformation0 inner transformation
 #' @return Transformation
@@ -260,6 +264,7 @@ then_chain_tt <- function(
 #'
 #' [make_fix_delta in Rust documentation.](https://docs.rs/opendp/latest/opendp/combinators/fn.make_fix_delta.html)
 #'
+#' @concept combinators
 #' @param measurement a measurement with a privacy curve to be fixed
 #' @param delta parameter to fix the privacy curve with
 #' @return Measurement
@@ -331,6 +336,7 @@ then_fix_delta <- function(
 #'
 #' [make_population_amplification in Rust documentation.](https://docs.rs/opendp/latest/opendp/combinators/fn.make_population_amplification.html)
 #'
+#' @concept combinators
 #' @param measurement the computation to amplify
 #' @param population_size the size of the population from which the input dataset is a simple sample
 #' @return Measurement
@@ -395,6 +401,7 @@ then_population_amplification <- function(
 #'
 #' [make_pureDP_to_fixed_approxDP in Rust documentation.](https://docs.rs/opendp/latest/opendp/combinators/fn.make_pureDP_to_fixed_approxDP.html)
 #'
+#' @concept combinators
 #' @param measurement a measurement with a privacy measure to be casted
 #' @return Measurement
 #' @export
@@ -457,6 +464,7 @@ then_pureDP_to_fixed_approxDP <- function(
 #'
 #' - [BS16 Concentrated Differential Privacy: Simplifications, Extensions, and Lower Bounds](https://arxiv.org/pdf/1605.02065.pdf#subsection.3.1)
 #'
+#' @concept combinators
 #' @param measurement a measurement with a privacy measure to be casted
 #' @return Measurement
 #' @export
@@ -533,6 +541,7 @@ then_pureDP_to_zCDP <- function(
 #' * Input Metric:   `MI`
 #' * Output Measure: `MO`
 #'
+#' @concept combinators
 #' @param input_domain indicates the space of valid input datasets
 #' @param input_metric how distances are measured between members of the input domain
 #' @param output_measure how privacy is measured
@@ -612,6 +621,7 @@ then_sequential_composition <- function(
 #'
 #' [make_zCDP_to_approxDP in Rust documentation.](https://docs.rs/opendp/latest/opendp/combinators/fn.make_zCDP_to_approxDP.html)
 #'
+#' @concept combinators
 #' @param measurement a measurement with a privacy measure to be casted
 #' @return Measurement
 #' @export

--- a/R/opendp/R/core.R
+++ b/R/opendp/R/core.R
@@ -6,6 +6,7 @@ NULL
 
 #' Eval the `function` with `arg`.
 #'
+#' @concept core
 #' @param this Function to invoke.
 #' @param arg Input data to supply to the measurement. A member of the measurement's input domain.
 #' @param TI Input Type.
@@ -38,6 +39,7 @@ function_eval <- function(
 
 #' Check the privacy relation of the `measurement` at the given `d_in`, `d_out`
 #'
+#' @concept core
 #' @param measurement Measurement to check the privacy relation of.
 #' @param distance_in undocumented
 #' @param distance_out undocumented
@@ -72,6 +74,7 @@ measurement_check <- function(
 
 #' Get the function from a measurement.
 #'
+#' @concept core
 #' @param this The measurement to retrieve the value from.
 #' @return Function
 #' @export
@@ -95,6 +98,7 @@ measurement_function <- function(
 
 #' Get the input (carrier) data type of `this`.
 #'
+#' @concept core
 #' @param this The measurement to retrieve the type from.
 #' @return str
 #' @export
@@ -118,6 +122,7 @@ measurement_input_carrier_type <- function(
 
 #' Get the input distance type of `measurement`.
 #'
+#' @concept core
 #' @param this The measurement to retrieve the type from.
 #' @return str
 #' @export
@@ -141,6 +146,7 @@ measurement_input_distance_type <- function(
 
 #' Get the input domain from a `measurement`.
 #'
+#' @concept core
 #' @param this The measurement to retrieve the value from.
 #' @return Domain
 #' @export
@@ -164,6 +170,7 @@ measurement_input_domain <- function(
 
 #' Get the input domain from a `measurement`.
 #'
+#' @concept core
 #' @param this The measurement to retrieve the value from.
 #' @return Metric
 #' @export
@@ -187,6 +194,7 @@ measurement_input_metric <- function(
 
 #' Invoke the `measurement` with `arg`. Returns a differentially private release.
 #'
+#' @concept core
 #' @param this Measurement to invoke.
 #' @param arg Input data to supply to the measurement. A member of the measurement's input domain.
 #' @return Any
@@ -217,6 +225,7 @@ measurement_invoke <- function(
 
 #' Use the `measurement` to map a given `d_in` to `d_out`.
 #'
+#' @concept core
 #' @param measurement Measurement to check the map distances with.
 #' @param distance_in Distance in terms of the input metric.
 #' @return Any
@@ -247,6 +256,7 @@ measurement_map <- function(
 
 #' Get the output distance type of `measurement`.
 #'
+#' @concept core
 #' @param this The measurement to retrieve the type from.
 #' @return str
 #' @export
@@ -270,6 +280,7 @@ measurement_output_distance_type <- function(
 
 #' Get the output domain from a `measurement`.
 #'
+#' @concept core
 #' @param this The measurement to retrieve the value from.
 #' @return Measure
 #' @export
@@ -293,6 +304,7 @@ measurement_output_measure <- function(
 
 #' Invoke the `queryable` with `query`. Returns a differentially private release.
 #'
+#' @concept core
 #' @param queryable Queryable to eval.
 #' @param query Input data to supply to the measurement. A member of the measurement's input domain.
 #' @return Any
@@ -323,6 +335,7 @@ queryable_eval <- function(
 
 #' Get the query type of `queryable`.
 #'
+#' @concept core
 #' @param this The queryable to retrieve the query type from.
 #' @return str
 #' @export
@@ -346,6 +359,7 @@ queryable_query_type <- function(
 
 #' Check the privacy relation of the `measurement` at the given `d_in`, `d_out`
 #'
+#' @concept core
 #' @param transformation undocumented
 #' @param distance_in undocumented
 #' @param distance_out undocumented
@@ -380,6 +394,7 @@ transformation_check <- function(
 
 #' Get the function from a transformation.
 #'
+#' @concept core
 #' @param this The transformation to retrieve the value from.
 #' @return Function
 #' @export
@@ -403,6 +418,7 @@ transformation_function <- function(
 
 #' Get the input (carrier) data type of `this`.
 #'
+#' @concept core
 #' @param this The transformation to retrieve the type from.
 #' @return str
 #' @export
@@ -426,6 +442,7 @@ transformation_input_carrier_type <- function(
 
 #' Get the input distance type of `transformation`.
 #'
+#' @concept core
 #' @param this The transformation to retrieve the type from.
 #' @return str
 #' @export
@@ -449,6 +466,7 @@ transformation_input_distance_type <- function(
 
 #' Get the input domain from a `transformation`.
 #'
+#' @concept core
 #' @param this The transformation to retrieve the value from.
 #' @return Domain
 #' @export
@@ -472,6 +490,7 @@ transformation_input_domain <- function(
 
 #' Get the input domain from a `transformation`.
 #'
+#' @concept core
 #' @param this The transformation to retrieve the value from.
 #' @return Metric
 #' @export
@@ -495,6 +514,7 @@ transformation_input_metric <- function(
 
 #' Invoke the `transformation` with `arg`. Returns a differentially private release.
 #'
+#' @concept core
 #' @param this Transformation to invoke.
 #' @param arg Input data to supply to the transformation. A member of the transformation's input domain.
 #' @return Any
@@ -525,6 +545,7 @@ transformation_invoke <- function(
 
 #' Use the `transformation` to map a given `d_in` to `d_out`.
 #'
+#' @concept core
 #' @param transformation Transformation to check the map distances with.
 #' @param distance_in Distance in terms of the input metric.
 #' @return Any
@@ -555,6 +576,7 @@ transformation_map <- function(
 
 #' Get the output distance type of `transformation`.
 #'
+#' @concept core
 #' @param this The transformation to retrieve the type from.
 #' @return str
 #' @export
@@ -578,6 +600,7 @@ transformation_output_distance_type <- function(
 
 #' Get the output domain from a `transformation`.
 #'
+#' @concept core
 #' @param this The transformation to retrieve the value from.
 #' @return Domain
 #' @export
@@ -601,6 +624,7 @@ transformation_output_domain <- function(
 
 #' Get the output domain from a `transformation`.
 #'
+#' @concept core
 #' @param this The transformation to retrieve the value from.
 #' @return Metric
 #' @export

--- a/R/opendp/R/data.R
+++ b/R/opendp/R/data.R
@@ -6,6 +6,7 @@ NULL
 
 #' Internal function. Retrieve the type descriptor string of an AnyObject.
 #'
+#' @concept data
 #' @param this A pointer to the AnyObject.
 #' @return str
 object_type <- function(
@@ -28,6 +29,7 @@ object_type <- function(
 
 #' Internal function. Use an SMDCurve to find epsilon at a given `delta`.
 #'
+#' @concept data
 #' @param curve The SMDCurve.
 #' @param delta What to fix delta to compute epsilon.
 #' @return Epsilon at a given `delta`.
@@ -57,6 +59,7 @@ smd_curve_epsilon <- function(
 
 #' Internal function. Convert the AnyObject to a string representation.
 #'
+#' @concept data
 #' @param this The AnyObject to convert to a string representation.
 #' @return str
 to_string <- function(

--- a/R/opendp/R/domains.R
+++ b/R/opendp/R/domains.R
@@ -8,6 +8,7 @@ NULL
 #'
 #' [atom_domain in Rust documentation.](https://docs.rs/opendp/latest/opendp/domains/fn.atom_domain.html)
 #'
+#' @concept domains
 #' @param bounds undocumented
 #' @param nullable undocumented
 #' @param .T The type of the atom.
@@ -42,6 +43,7 @@ atom_domain <- function(
 
 #' Get the carrier type of a `domain`.
 #'
+#' @concept domains
 #' @param this The domain to retrieve the carrier type from.
 #' @return str
 #' @export
@@ -65,6 +67,7 @@ domain_carrier_type <- function(
 
 #' Debug a `domain`.
 #'
+#' @concept domains
 #' @param this The domain to debug (stringify).
 #' @return str
 #' @export
@@ -88,6 +91,7 @@ domain_debug <- function(
 
 #' Get the type of a `domain`.
 #'
+#' @concept domains
 #' @param this The domain to retrieve the type from.
 #' @return str
 #' @export
@@ -111,6 +115,7 @@ domain_type <- function(
 
 #' Construct an instance of `MapDomain`.
 #'
+#' @concept domains
 #' @param key_domain domain of keys in the hashmap
 #' @param value_domain domain of values in the hashmap
 #' @return Domain
@@ -140,6 +145,7 @@ map_domain <- function(
 
 #' Check membership in a `domain`.
 #'
+#' @concept domains
 #' @param this The domain to check membership in.
 #' @param val A potential element of the domain.
 #' @export
@@ -172,6 +178,7 @@ member <- function(
 #'
 #' [option_domain in Rust documentation.](https://docs.rs/opendp/latest/opendp/domains/fn.option_domain.html)
 #'
+#' @concept domains
 #' @param element_domain undocumented
 #' @param .D The type of the inner domain.
 #' @return Domain
@@ -202,6 +209,7 @@ option_domain <- function(
 
 #' Construct an instance of `VectorDomain`.
 #'
+#' @concept domains
 #' @param atom_domain The inner domain.
 #' @param size undocumented
 #' @return Domain

--- a/R/opendp/R/measurements.R
+++ b/R/opendp/R/measurements.R
@@ -28,6 +28,7 @@ NULL
 #' * Input Metric:   `L1Distance<CI>`
 #' * Output Measure: `MaxDivergence<CO>`
 #'
+#' @concept measurements
 #' @param input_domain undocumented
 #' @param input_metric undocumented
 #' @param scale Privacy loss parameter. This is equal to epsilon/sensitivity.
@@ -140,6 +141,7 @@ then_alp_queryable <- function(
 #' * Input Metric:   `D::InputMetric`
 #' * Output Measure: `MO`
 #'
+#' @concept measurements
 #' @param input_domain Domain of the data type to be privatized.
 #' @param input_metric Metric of the data type to be privatized.
 #' @param scale Noise scale parameter for the gaussian distribution. `scale` == standard_deviation.
@@ -233,6 +235,7 @@ then_base_discrete_gaussian <- function(
 #' * Input Metric:   `D::InputMetric`
 #' * Output Measure: `MaxDivergence<QO>`
 #'
+#' @concept measurements
 #' @param input_domain Domain of the data type to be privatized.
 #' @param input_metric Metric of the data type to be privatized.
 #' @param scale Noise scale parameter for the laplace distribution. `scale` == standard_deviation / sqrt(2).
@@ -322,6 +325,7 @@ then_base_discrete_laplace <- function(
 #' * Input Metric:   `D::InputMetric`
 #' * Output Measure: `MaxDivergence<QO>`
 #'
+#' @concept measurements
 #' @param input_domain undocumented
 #' @param input_metric undocumented
 #' @param scale Noise scale parameter for the laplace distribution. `scale` == standard_deviation / sqrt(2).
@@ -412,6 +416,7 @@ then_base_discrete_laplace_cks20 <- function(
 #' * Input Metric:   `D::InputMetric`
 #' * Output Measure: `MaxDivergence<QO>`
 #'
+#' @concept measurements
 #' @param input_domain Domain of the data type to be privatized.
 #' @param input_metric Metric of the data type to be privatized.
 #' @param scale Noise scale parameter for the distribution. `scale` == standard_deviation / sqrt(2).
@@ -508,6 +513,7 @@ then_base_discrete_laplace_linear <- function(
 #' * Input Metric:   `D::InputMetric`
 #' * Output Measure: `MO`
 #'
+#' @concept measurements
 #' @param input_domain Domain of the data type to be privatized. Valid values are `VectorDomain<AtomDomain<T>>` or `AtomDomain<T>`.
 #' @param input_metric Metric of the data type to be privatized. Valid values are `AbsoluteDistance<T>` or `L2Distance<T>`.
 #' @param scale Noise scale parameter for the gaussian distribution. `scale` == standard_deviation.
@@ -595,6 +601,7 @@ then_base_gaussian <- function(
 #' * Input Metric:   `D::InputMetric`
 #' * Output Measure: `MaxDivergence<QO>`
 #'
+#' @concept measurements
 #' @param input_domain undocumented
 #' @param input_metric undocumented
 #' @param scale undocumented
@@ -691,6 +698,7 @@ then_base_geometric <- function(
 #' * Input Metric:   `D::InputMetric`
 #' * Output Measure: `MaxDivergence<D::Atom>`
 #'
+#' @concept measurements
 #' @param input_domain Domain of the data type to be privatized.
 #' @param input_metric Metric of the data type to be privatized.
 #' @param scale Noise scale parameter for the laplace distribution. `scale` == standard_deviation / sqrt(2).
@@ -773,6 +781,7 @@ then_base_laplace <- function(
 #' * Input Metric:   `L1Distance<TV>`
 #' * Output Measure: `FixedSmoothedMaxDivergence<TV>`
 #'
+#' @concept measurements
 #' @param input_domain Domain of the input.
 #' @param input_metric Metric for the input domain.
 #' @param scale Noise scale parameter for the laplace distribution. `scale` == standard_deviation / sqrt(2).
@@ -864,6 +873,7 @@ then_base_laplace_threshold <- function(
 #' * Input Metric:   `D::InputMetric`
 #' * Output Measure: `MO`
 #'
+#' @concept measurements
 #' @param input_domain Domain of the data type to be privatized.
 #' @param input_metric Metric of the data type to be privatized.
 #' @param scale Noise scale parameter for the gaussian distribution. `scale` == standard_deviation.
@@ -958,6 +968,7 @@ then_gaussian <- function(
 #' * Input Metric:   `D::InputMetric`
 #' * Output Measure: `MaxDivergence<QO>`
 #'
+#' @concept measurements
 #' @param input_domain Domain of the data type to be privatized.
 #' @param input_metric Metric of the data type to be privatized.
 #' @param scale Noise scale parameter for the laplace distribution. `scale` == standard_deviation / sqrt(2).
@@ -1036,6 +1047,7 @@ then_laplace <- function(
 #' * Input Metric:   `DiscreteDistance`
 #' * Output Measure: `MaxDivergence<QO>`
 #'
+#' @concept measurements
 #' @param categories Set of valid outcomes
 #' @param prob Probability of returning the correct answer. Must be in `[1/num_categories, 1)`
 #' @param constant_time Set to true to enable constant time. Slower.
@@ -1130,6 +1142,7 @@ then_randomized_response <- function(
 #'
 #' [(Proof Document)](https://docs.opendp.org/en/nightly/proofs/rust/src/measurements/randomized_response/make_randomized_response_bool.pdf)
 #'
+#' @concept measurements
 #' @param prob Probability of returning the correct answer. Must be in `[0.5, 1)`
 #' @param constant_time Set to true to enable constant time. Slower.
 #' @param .QO Data type of probability and output distance.
@@ -1211,6 +1224,7 @@ then_randomized_response_bool <- function(
 #'
 #' [(Proof Document)](https://docs.opendp.org/en/nightly/proofs/rust/src/measurements/gumbel_max/make_report_noisy_max_gumbel.pdf)
 #'
+#' @concept measurements
 #' @param input_domain Domain of the input vector. Must be a non-nullable VectorDomain.
 #' @param input_metric Metric on the input domain. Must be LInfDistance
 #' @param scale Higher scales are more private.

--- a/R/opendp/R/measures.R
+++ b/R/opendp/R/measures.R
@@ -8,6 +8,7 @@ NULL
 #'
 #' [fixed_smoothed_max_divergence in Rust documentation.](https://docs.rs/opendp/latest/opendp/measures/fn.fixed_smoothed_max_divergence.html)
 #'
+#' @concept measures
 #' @param .T undocumented
 #' @return Measure
 #' @export
@@ -35,6 +36,7 @@ fixed_smoothed_max_divergence <- function(
 #'
 #' [max_divergence in Rust documentation.](https://docs.rs/opendp/latest/opendp/measures/fn.max_divergence.html)
 #'
+#' @concept measures
 #' @param .T undocumented
 #' @return Measure
 #' @export
@@ -60,6 +62,7 @@ max_divergence <- function(
 
 #' Debug a `measure`.
 #'
+#' @concept measures
 #' @param this The measure to debug (stringify).
 #' @return str
 #' @export
@@ -83,6 +86,7 @@ measure_debug <- function(
 
 #' Get the distance type of a `measure`.
 #'
+#' @concept measures
 #' @param this The measure to retrieve the distance type from.
 #' @return str
 #' @export
@@ -106,6 +110,7 @@ measure_distance_type <- function(
 
 #' Get the type of a `measure`.
 #'
+#' @concept measures
 #' @param this The measure to retrieve the type from.
 #' @return str
 #' @export
@@ -131,6 +136,7 @@ measure_type <- function(
 #'
 #' [smoothed_max_divergence in Rust documentation.](https://docs.rs/opendp/latest/opendp/measures/fn.smoothed_max_divergence.html)
 #'
+#' @concept measures
 #' @param .T undocumented
 #' @return Measure
 #' @export
@@ -157,6 +163,7 @@ smoothed_max_divergence <- function(
 #' Construct a new UserDivergence.
 #' Any two instances of an UserDivergence are equal if their string descriptors are equal.
 #'
+#' @concept measures
 #' @param descriptor A string description of the privacy measure.
 #' @return Measure
 #' @export
@@ -187,6 +194,7 @@ user_divergence <- function(
 #'
 #' [zero_concentrated_divergence in Rust documentation.](https://docs.rs/opendp/latest/opendp/measures/fn.zero_concentrated_divergence.html)
 #'
+#' @concept measures
 #' @param .T undocumented
 #' @return Measure
 #' @export

--- a/R/opendp/R/metrics.R
+++ b/R/opendp/R/metrics.R
@@ -8,6 +8,7 @@ NULL
 #'
 #' [absolute_distance in Rust documentation.](https://docs.rs/opendp/latest/opendp/metrics/fn.absolute_distance.html)
 #'
+#' @concept metrics
 #' @param .T undocumented
 #' @return Metric
 #' @export
@@ -33,6 +34,7 @@ absolute_distance <- function(
 
 #' Construct an instance of the `ChangeOneDistance` metric.
 #'
+#' @concept metrics
 #'
 #' @return Metric
 #' @export
@@ -55,6 +57,7 @@ change_one_distance <- function(
 
 #' Construct an instance of the `DiscreteDistance` metric.
 #'
+#' @concept metrics
 #'
 #' @return Metric
 #' @export
@@ -77,6 +80,7 @@ discrete_distance <- function(
 
 #' Construct an instance of the `HammingDistance` metric.
 #'
+#' @concept metrics
 #'
 #' @return Metric
 #' @export
@@ -99,6 +103,7 @@ hamming_distance <- function(
 
 #' Construct an instance of the `InsertDeleteDistance` metric.
 #'
+#' @concept metrics
 #'
 #' @return Metric
 #' @export
@@ -123,6 +128,7 @@ insert_delete_distance <- function(
 #'
 #' [l1_distance in Rust documentation.](https://docs.rs/opendp/latest/opendp/metrics/fn.l1_distance.html)
 #'
+#' @concept metrics
 #' @param .T undocumented
 #' @return Metric
 #' @export
@@ -150,6 +156,7 @@ l1_distance <- function(
 #'
 #' [l2_distance in Rust documentation.](https://docs.rs/opendp/latest/opendp/metrics/fn.l2_distance.html)
 #'
+#' @concept metrics
 #' @param .T undocumented
 #' @return Metric
 #' @export
@@ -177,6 +184,7 @@ l2_distance <- function(
 #'
 #' [linf_distance in Rust documentation.](https://docs.rs/opendp/latest/opendp/metrics/fn.linf_distance.html)
 #'
+#' @concept metrics
 #' @param monotonic set to true if non-monotonicity implies infinite distance
 #' @param .T The type of the distance.
 #' @return Metric
@@ -207,6 +215,7 @@ linf_distance <- function(
 
 #' Debug a `metric`.
 #'
+#' @concept metrics
 #' @param this The metric to debug (stringify).
 #' @return str
 #' @export
@@ -230,6 +239,7 @@ metric_debug <- function(
 
 #' Get the distance type of a `metric`.
 #'
+#' @concept metrics
 #' @param this The metric to retrieve the distance type from.
 #' @return str
 #' @export
@@ -253,6 +263,7 @@ metric_distance_type <- function(
 
 #' Get the type of a `metric`.
 #'
+#' @concept metrics
 #' @param this The metric to retrieve the type from.
 #' @return str
 #' @export
@@ -276,6 +287,7 @@ metric_type <- function(
 
 #' Construct an instance of the `SymmetricDistance` metric.
 #'
+#' @concept metrics
 #'
 #' @return Metric
 #' @export
@@ -299,6 +311,7 @@ symmetric_distance <- function(
 #' Construct a new UserDistance.
 #' Any two instances of an UserDistance are equal if their string descriptors are equal.
 #'
+#' @concept metrics
 #' @param descriptor A string description of the metric.
 #' @return Metric
 #' @export

--- a/R/opendp/R/transformations.R
+++ b/R/opendp/R/transformations.R
@@ -13,6 +13,7 @@ NULL
 #'
 #' * [QYL13 Understanding Hierarchical Methods for Differentially Private Histograms](http://www.vldb.org/pvldb/vol6/p1954-qardaji.pdf)
 #'
+#' @concept transformations
 #' @param size_guess A guess at the size of your dataset.
 #' @return int
 #' @export
@@ -53,6 +54,7 @@ choose_branching_factor <- function(
 #' * Input Metric:   `M`
 #' * Output Metric:  `M`
 #'
+#' @concept transformations
 #' @param input_domain undocumented
 #' @param input_metric undocumented
 #' @param leaf_count The number of leaf nodes in the b-ary tree.
@@ -148,6 +150,7 @@ then_b_ary_tree <- function(
 #' * Input Metric:   `SymmetricDistance`
 #' * Output Metric:  `AbsoluteDistance<S::Item>`
 #'
+#' @concept transformations
 #' @param size_limit Upper bound on number of records to keep in the input data.
 #' @param bounds Tuple of lower and upper bounds for data in the input domain.
 #' @param .S Summation algorithm to use over some data type `T` (`T` is shorthand for `S::Item`)
@@ -248,6 +251,7 @@ then_bounded_float_checked_sum <- function(
 #' * Input Metric:   `InsertDeleteDistance`
 #' * Output Metric:  `AbsoluteDistance<S::Item>`
 #'
+#' @concept transformations
 #' @param size_limit Upper bound on the number of records in input data. Used to bound sensitivity.
 #' @param bounds Tuple of lower and upper bounds for data in the input domain.
 #' @param .S Summation algorithm to use over some data type `T` (`T` is shorthand for `S::Item`)
@@ -334,6 +338,7 @@ then_bounded_float_ordered_sum <- function(
 #' * Input Metric:   `SymmetricDistance`
 #' * Output Metric:  `AbsoluteDistance<T>`
 #'
+#' @concept transformations
 #' @param bounds Tuple of lower and upper bounds for data in the input domain.
 #' @param .T Atomic Input Type and Output Type
 #' @return Transformation
@@ -412,6 +417,7 @@ then_bounded_int_monotonic_sum <- function(
 #' * Input Metric:   `InsertDeleteDistance`
 #' * Output Metric:  `AbsoluteDistance<T>`
 #'
+#' @concept transformations
 #' @param bounds Tuple of lower and upper bounds for data in the input domain.
 #' @param .T Atomic Input Type and Output Type
 #' @return Transformation
@@ -490,6 +496,7 @@ then_bounded_int_ordered_sum <- function(
 #' * Input Metric:   `SymmetricDistance`
 #' * Output Metric:  `AbsoluteDistance<T>`
 #'
+#' @concept transformations
 #' @param bounds Tuple of lower and upper bounds for data in the input domain.
 #' @param .T Atomic Input Type and Output Type
 #' @return Transformation
@@ -565,6 +572,7 @@ then_bounded_int_split_sum <- function(
 #' * Input Metric:   `M`
 #' * Output Metric:  `M`
 #'
+#' @concept transformations
 #' @param input_domain undocumented
 #' @param input_metric undocumented
 #' @param .TOA Atomic Output Type to cast into
@@ -643,6 +651,7 @@ then_cast <- function(
 #' * Input Metric:   `M`
 #' * Output Metric:  `M`
 #'
+#' @concept transformations
 #' @param input_domain undocumented
 #' @param input_metric undocumented
 #' @param .TOA Atomic Output Type to cast into
@@ -719,6 +728,7 @@ then_cast_default <- function(
 #' * Input Metric:   `M`
 #' * Output Metric:  `M`
 #'
+#' @concept transformations
 #' @param input_domain undocumented
 #' @param input_metric undocumented
 #' @param .TOA Atomic Output Type to cast into
@@ -786,6 +796,7 @@ then_cast_inherent <- function(
 #' * Input Type:     `Vec<TA>`
 #' * Output Type:    `Vec<TA>`
 #'
+#' @concept transformations
 #' @param .TA Atomic Type. One of `f32` or `f64`
 #' @return Function
 #' @export
@@ -856,6 +867,7 @@ then_cdf <- function(
 #'
 #' [(Proof Document)](https://docs.opendp.org/en/nightly/proofs/rust/src/transformations/clamp/make_clamp.pdf)
 #'
+#' @concept transformations
 #' @param input_domain Domain of input data.
 #' @param input_metric Metric on input domain.
 #' @param bounds Tuple of inclusive lower and upper bounds.
@@ -938,6 +950,7 @@ then_clamp <- function(
 #' * Input Type:     `Vec<TIA>`
 #' * Output Type:    `Vec<TOA>`
 #'
+#' @concept transformations
 #' @param branching_factor the maximum number of children
 #' @param .TIA Atomic type of the input data. Should be an integer type.
 #' @param .TOA Atomic type of the output data. Should be a float type.
@@ -1023,6 +1036,7 @@ then_consistent_b_ary_tree <- function(
 #'
 #' [(Proof Document)](https://docs.opendp.org/en/nightly/proofs/rust/src/transformations/count/make_count.pdf)
 #'
+#' @concept transformations
 #' @param input_domain Domain of the data type to be privatized.
 #' @param input_metric Metric of the data type to be privatized.
 #' @param .TO Output Type. Must be numeric.
@@ -1097,6 +1111,7 @@ then_count <- function(
 #' * Input Metric:   `SymmetricDistance`
 #' * Output Metric:  `MO`
 #'
+#' @concept transformations
 #' @param input_domain undocumented
 #' @param input_metric undocumented
 #' @param .MO Output Metric.
@@ -1178,6 +1193,7 @@ then_count_by <- function(
 #' * Input Metric:   `SymmetricDistance`
 #' * Output Metric:  `MO`
 #'
+#' @concept transformations
 #' @param input_domain undocumented
 #' @param input_metric undocumented
 #' @param categories The set of categories to compute counts for.
@@ -1273,6 +1289,7 @@ then_count_by_categories <- function(
 #' * Input Metric:   `SymmetricDistance`
 #' * Output Metric:  `AbsoluteDistance<TO>`
 #'
+#' @concept transformations
 #' @param input_domain undocumented
 #' @param input_metric undocumented
 #' @param .TO Output Type. Must be numeric.
@@ -1342,6 +1359,7 @@ then_count_distinct <- function(
 #' * Input Metric:   `SymmetricDistance`
 #' * Output Metric:  `SymmetricDistance`
 #'
+#' @concept transformations
 #' @param col_names Column names for each record entry.
 #' @param .K categorical/hashable data type of column names
 #' @return Transformation
@@ -1423,6 +1441,7 @@ then_create_dataframe <- function(
 #' * Input Metric:   `M`
 #' * Output Metric:  `M`
 #'
+#' @concept transformations
 #' @param input_domain undocumented
 #' @param input_metric undocumented
 #' @param column_name column name to be transformed
@@ -1508,6 +1527,7 @@ then_df_cast_default <- function(
 #' * Input Metric:   `M`
 #' * Output Metric:  `M`
 #'
+#' @concept transformations
 #' @param input_domain undocumented
 #' @param input_metric undocumented
 #' @param column_name Column name to be transformed
@@ -1599,6 +1619,7 @@ then_df_is_equal <- function(
 #' * Input Metric:   `M`
 #' * Output Metric:  `M`
 #'
+#' @concept transformations
 #' @param input_domain undocumented
 #' @param input_metric undocumented
 #' @return Transformation
@@ -1666,6 +1687,7 @@ then_drop_null <- function(
 #' * Input Metric:   `M`
 #' * Output Metric:  `M`
 #'
+#' @concept transformations
 #' @param input_domain The domain of the input vector.
 #' @param input_metric The metric of the input vector.
 #' @param categories The set of categories to find indexes from.
@@ -1747,6 +1769,7 @@ then_find <- function(
 #' * Input Metric:   `M`
 #' * Output Metric:  `M`
 #'
+#' @concept transformations
 #' @param input_domain The domain of the input vector.
 #' @param input_metric The metric of the input vector.
 #' @param edges The set of edges to split bins by.
@@ -1825,6 +1848,7 @@ then_find_bin <- function(
 #' * Input Metric:   `M`
 #' * Output Metric:  `M`
 #'
+#' @concept transformations
 #' @param domain undocumented
 #' @param metric undocumented
 #' @return Transformation
@@ -1896,6 +1920,7 @@ then_identity <- function(
 #' * Input Metric:   `M`
 #' * Output Metric:  `M`
 #'
+#' @concept transformations
 #' @param input_domain Domain of the input data. See table above.
 #' @param input_metric Metric of the input data. A dataset metric.
 #' @param constant Value to replace nulls with.
@@ -1968,6 +1993,7 @@ then_impute_constant <- function(
 #' * Input Metric:   `M`
 #' * Output Metric:  `M`
 #'
+#' @concept transformations
 #' @param input_domain Domain of the input.
 #' @param input_metric Metric of the input.
 #' @param bounds Tuple of inclusive lower and upper bounds.
@@ -2041,6 +2067,7 @@ then_impute_uniform_float <- function(
 #' * Input Metric:   `M`
 #' * Output Metric:  `M`
 #'
+#' @concept transformations
 #' @param input_domain The domain of the input vector.
 #' @param input_metric The metric of the input vector.
 #' @param categories The set of categories to index into.
@@ -2129,6 +2156,7 @@ then_index <- function(
 #'
 #' [(Proof Document)](https://docs.opendp.org/en/nightly/proofs/rust/src/trans/manipulation/make_is_equal.pdf)
 #'
+#' @concept transformations
 #' @param input_domain undocumented
 #' @param input_metric undocumented
 #' @param value value to check against
@@ -2202,6 +2230,7 @@ then_is_equal <- function(
 #' * Input Metric:   `M`
 #' * Output Metric:  `M`
 #'
+#' @concept transformations
 #' @param input_domain undocumented
 #' @param input_metric undocumented
 #' @return Transformation
@@ -2267,6 +2296,7 @@ then_is_null <- function(
 #' * Input Metric:   `M`
 #' * Output Metric:  `M`
 #'
+#' @concept transformations
 #' @param constant The constant to multiply aggregates by.
 #' @param bounds Tuple of inclusive lower and upper bounds.
 #' @param .D Domain of the function. Must be `AtomDomain<T>` or `VectorDomain<AtomDomain<T>>`
@@ -2357,6 +2387,7 @@ then_lipschitz_float_mul <- function(
 #' * Input Metric:   `MI`
 #' * Output Metric:  `AbsoluteDistance<T>`
 #'
+#' @concept transformations
 #' @param input_domain undocumented
 #' @param input_metric undocumented
 #' @return Transformation
@@ -2429,6 +2460,7 @@ then_mean <- function(
 #' * Input Metric:   `MI`
 #' * Output Metric:  `MI::BoundedMetric`
 #'
+#' @concept transformations
 #' @param input_domain undocumented
 #' @param input_metric undocumented
 #' @return Transformation
@@ -2498,6 +2530,7 @@ then_metric_bounded <- function(
 #' * Input Metric:   `MI`
 #' * Output Metric:  `MI::UnboundedMetric`
 #'
+#' @concept transformations
 #' @param input_domain undocumented
 #' @param input_metric undocumented
 #' @return Transformation
@@ -2567,6 +2600,7 @@ then_metric_unbounded <- function(
 #' * Input Metric:   `MI`
 #' * Output Metric:  `MI::OrderedMetric`
 #'
+#' @concept transformations
 #' @param input_domain undocumented
 #' @param input_metric undocumented
 #' @return Transformation
@@ -2634,6 +2668,7 @@ then_ordered_random <- function(
 #'
 #' [(Proof Document)](https://docs.opendp.org/en/nightly/proofs/rust/src/transformations/quantile_score_candidates/make_quantile_score_candidates.pdf)
 #'
+#' @concept transformations
 #' @param input_domain Uses a tighter sensitivity when the size of vectors in the input domain is known.
 #' @param input_metric Either SymmetricDistance or InsertDeleteDistance.
 #' @param candidates Potential quantiles to score
@@ -2711,6 +2746,7 @@ then_quantile_score_candidates <- function(
 #' * Input Type:     `Vec<TA>`
 #' * Output Type:    `Vec<TA>`
 #'
+#' @concept transformations
 #' @param bin_edges The edges that the input data was binned into before counting.
 #' @param alphas Return all specified `alpha`-quantiles.
 #' @param interpolation Must be one of `linear` or `nearest`
@@ -2803,6 +2839,7 @@ then_quantiles_from_counts <- function(
 #' * Input Metric:   `MI`
 #' * Output Metric:  `MO`
 #'
+#' @concept transformations
 #' @param input_domain Domain of input data.
 #' @param input_metric Metric of input data.
 #' @param size Number of records in output data.
@@ -2887,6 +2924,7 @@ then_resize <- function(
 #' * Input Metric:   `SymmetricDistance`
 #' * Output Metric:  `SymmetricDistance`
 #'
+#' @concept transformations
 #' @param key categorical/hashable data type of the key/column name
 #' @param .K data type of key
 #' @param .TOA Atomic Output Type to downcast vector to
@@ -2982,6 +3020,7 @@ then_select_column <- function(
 #' * Input Metric:   `SymmetricDistance`
 #' * Output Metric:  `AbsoluteDistance<S::Item>`
 #'
+#' @concept transformations
 #' @param size Number of records in input data.
 #' @param bounds Tuple of lower and upper bounds for data in the input domain.
 #' @param .S Summation algorithm to use over some data type `T` (`T` is shorthand for `S::Item`)
@@ -3082,6 +3121,7 @@ then_sized_bounded_float_checked_sum <- function(
 #' * Input Metric:   `InsertDeleteDistance`
 #' * Output Metric:  `AbsoluteDistance<S::Item>`
 #'
+#' @concept transformations
 #' @param size Number of records in input data.
 #' @param bounds Tuple of lower and upper bounds for data in the input domain.
 #' @param .S Summation algorithm to use over some data type `T` (`T` is shorthand for `S::Item`)
@@ -3168,6 +3208,7 @@ then_sized_bounded_float_ordered_sum <- function(
 #' * Input Metric:   `SymmetricDistance`
 #' * Output Metric:  `AbsoluteDistance<T>`
 #'
+#' @concept transformations
 #' @param size Number of records in input data.
 #' @param bounds Tuple of lower and upper bounds for data in the input domain.
 #' @param .T Atomic Input Type and Output Type
@@ -3252,6 +3293,7 @@ then_sized_bounded_int_checked_sum <- function(
 #' * Input Metric:   `SymmetricDistance`
 #' * Output Metric:  `AbsoluteDistance<T>`
 #'
+#' @concept transformations
 #' @param size Number of records in input data.
 #' @param bounds Tuple of lower and upper bounds for data in the input domain.
 #' @param .T Atomic Input Type and Output Type
@@ -3338,6 +3380,7 @@ then_sized_bounded_int_monotonic_sum <- function(
 #' * Input Metric:   `InsertDeleteDistance`
 #' * Output Metric:  `AbsoluteDistance<T>`
 #'
+#' @concept transformations
 #' @param size Number of records in input data.
 #' @param bounds Tuple of lower and upper bounds for data in the input domain.
 #' @param .T Atomic Input Type and Output Type
@@ -3424,6 +3467,7 @@ then_sized_bounded_int_ordered_sum <- function(
 #' * Input Metric:   `SymmetricDistance`
 #' * Output Metric:  `AbsoluteDistance<T>`
 #'
+#' @concept transformations
 #' @param size Number of records in input data.
 #' @param bounds Tuple of lower and upper bounds for data in the input domain.
 #' @param .T Atomic Input Type and Output Type
@@ -3503,6 +3547,7 @@ then_sized_bounded_int_split_sum <- function(
 #' * Input Metric:   `SymmetricDistance`
 #' * Output Metric:  `SymmetricDistance`
 #'
+#' @concept transformations
 #' @param separator The token(s) that separate entries in each record.
 #' @param col_names Column names for each record entry.
 #' @param .K categorical/hashable data type of column names
@@ -3580,6 +3625,7 @@ then_split_dataframe <- function(
 #' * Input Metric:   `SymmetricDistance`
 #' * Output Metric:  `SymmetricDistance`
 #'
+#' @concept transformations
 #'
 #' @return Transformation
 #' @export
@@ -3639,6 +3685,7 @@ then_split_lines <- function(
 #' * Input Metric:   `SymmetricDistance`
 #' * Output Metric:  `SymmetricDistance`
 #'
+#' @concept transformations
 #' @param separator The token(s) that separate entries in each record.
 #' @return Transformation
 #' @export
@@ -3700,6 +3747,7 @@ then_split_records <- function(
 #' * Input Metric:   `SymmetricDistance`
 #' * Output Metric:  `SymmetricDistance`
 #'
+#' @concept transformations
 #' @param indicator_column name of the boolean column that indicates inclusion in the subset
 #' @param keep_columns list of column names to apply subset to
 #' @param .TK Type of the column name
@@ -3786,6 +3834,7 @@ then_subset_by <- function(
 #' * Input Metric:   `MI`
 #' * Output Metric:  `AbsoluteDistance<T>`
 #'
+#' @concept transformations
 #' @param input_domain Domain of the input data.
 #' @param input_metric One of `SymmetricDistance` or `InsertDeleteDistance`.
 #' @return Transformation
@@ -3868,6 +3917,7 @@ then_sum <- function(
 #' * Input Metric:   `SymmetricDistance`
 #' * Output Metric:  `AbsoluteDistance<S::Item>`
 #'
+#' @concept transformations
 #' @param input_domain undocumented
 #' @param input_metric undocumented
 #' @param .S Summation algorithm to use on data type `T`. One of `Sequential<T>` or `Pairwise<T>`.
@@ -3945,6 +3995,7 @@ then_sum_of_squared_deviations <- function(
 #' * Input Metric:   `MI`
 #' * Output Metric:  `MI::UnorderedMetric`
 #'
+#' @concept transformations
 #' @param input_domain undocumented
 #' @param input_metric undocumented
 #' @return Transformation
@@ -4015,6 +4066,7 @@ then_unordered <- function(
 #' * Input Metric:   `SymmetricDistance`
 #' * Output Metric:  `AbsoluteDistance<S::Item>`
 #'
+#' @concept transformations
 #' @param input_domain undocumented
 #' @param input_metric undocumented
 #' @param ddof Delta degrees of freedom. Set to 0 if not a sample, 1 for sample estimate.

--- a/R/opendp/_pkgdown.yml
+++ b/R/opendp/_pkgdown.yml
@@ -8,6 +8,13 @@ authors:
     roles: [aut]
 
 reference:
+- title: internal
+  # pkgdown will error if any functions are unreferenced,
+  # but if listed under "internal" they won't be included in output.
+  # https://pkgdown.r-lib.org/reference/build_reference.html#missing-topics
+  contents:
+  - has_concept("data")
+
 - title: Accuracy
   desc: The `accuracy` module provides functions for converting between accuracy and scale parameters.
   contents:
@@ -22,11 +29,6 @@ reference:
   desc: The `core` module provides functions for accessing the fields of transformations and measurements.
   contents:
   - has_concept("core")
-
-- title: Data
-  # desc: TODO
-  contents:
-  - has_concept("data")
 
 - title: Domains
   desc: The `domains` module provides functions for creating and using domains.

--- a/R/opendp/_pkgdown.yml
+++ b/R/opendp/_pkgdown.yml
@@ -9,32 +9,51 @@ authors:
 
 reference:
 - title: Accuracy
-- contents:
+  desc: The `accuracy` module provides functions for converting between accuracy and scale parameters.
+  contents:
   - has_concept("accuracy")
+
 - title: Combinators
-- contents:
+  desc: The `combinators` module provides functions for combining transformations and measurements.
+  contents:
   - has_concept("combinators")
+
 - title: Core
-- contents:
+  desc: The `core` module provides functions for accessing the fields of transformations and measurements.
+  contents:
   - has_concept("core")
+
 - title: Data
-- contents:
+  # desc: TODO
+  contents:
   - has_concept("data")
+
 - title: Domains
-- contents:
+  desc: The `domains` module provides functions for creating and using domains.
+  contents:
   - has_concept("domains")
+
 - title: Measurements
-- contents:
+  desc: The `measurements` module provides functions that apply calibrated noise to data to ensure differential privacy.
+  contents:
   - has_concept("measurements")
+
 - title: Measures
-- contents:
+  desc: The `measures` modules provides functions that measure the distance between probability distributions.
+  contents:
   - has_concept("measures")
+
 - title: Metrics
-- contents:
+  desc: The `metrics` module provides fuctions that measure the distance between two elements of a domain.
+  contents:
   - has_concept("metrics")
+
 - title: Transformations
-- contents:
+  desc: The ``transformations`` module provides functions that deterministicly transform datasets.
+  contents:
   - has_concept("transformations")
+
 - title: Other
-- contents:
+  # desc: TODO
+  contents:
   - lacks_concepts(c("accuracy", "combinators", "core", "data", "domains", "measurements", "measures", "metrics", "transformations"))

--- a/R/opendp/_pkgdown.yml
+++ b/R/opendp/_pkgdown.yml
@@ -6,3 +6,35 @@ authors:
     roles: [aut]
   sidebar:
     roles: [aut]
+
+reference:
+- title: Accuracy
+- contents:
+  - has_concept("accuracy")
+- title: Combinators
+- contents:
+  - has_concept("combinators")
+- title: Core
+- contents:
+  - has_concept("core")
+- title: Data
+- contents:
+  - has_concept("data")
+- title: Domains
+- contents:
+  - has_concept("domains")
+- title: Measurements
+- contents:
+  - has_concept("measurements")
+- title: Measures
+- contents:
+  - has_concept("measures")
+- title: Metrics
+- contents:
+  - has_concept("metrics")
+- title: Transformations
+- contents:
+  - has_concept("transformations")
+- title: Other
+- contents:
+  - lacks_concepts(c("accuracy", "combinators", "core", "data", "domains", "measurements", "measures", "metrics", "transformations"))

--- a/rust/opendp_tooling/src/codegen/r/r.rs
+++ b/rust/opendp_tooling/src/codegen/r/r.rs
@@ -214,6 +214,8 @@ fn generate_doc_block(
         .map(|v| format!("{title}{}\n", v))
         .unwrap_or_else(String::new);
 
+    let concept = format!("@concept {}\n", module_name);
+
     let doc_args = (func.args.iter())
         .map(|v| generate_docstring_arg(v))
         .collect::<Vec<String>>()
@@ -227,7 +229,8 @@ fn generate_doc_block(
 
     format!(
         r#"{description}
-{doc_args}{ret_arg}{export}"#,
+{concept}{doc_args}{ret_arg}{export}"#,
+        concept = concept,
         description = description,
         doc_args = doc_args,
         ret_arg = generate_docstring_return_arg(&func.ret, hierarchy)


### PR DESCRIPTION
- Towards #1244... but keep it open for now.

Tweaked the Rust codegen to include `@concept` in the generated docstrings. With this, R pkgdown can be configured to include headings.

If this much is useful, there are a couple of follow-ups which could be filed.
- Generate `_pkgdown.yml` in Rust, so the list stays consistent.
- Split up the `Other` catch all by adding `@concept` on the non-generated files.