### PR TITLE
R doc README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,6 +191,5 @@ vendor.tar.xz
 source.tar.xz
 R/opendp/src/.cargo
 NEWS.md
-R/opendp/README.md
 R/opendp/docs
 R/opendp-docs

--- a/R/opendp/README.md
+++ b/R/opendp/README.md
@@ -6,4 +6,5 @@ These hints will help you apply the Python examples to R.
 
 - After invoking `library(opendp)` all functions are available: There are no namespaces like those of the Python library.
 - The chaining operator in R is `|>`, as opposed to `>>` in Python.
+- Type arguments like `.T` are prefixed with a period in R to avoid name conflicts, while in Python it is plain `T`.
 - All portions of the Python API that are derived from Rust have parallels in the R API, but packages like `context` that exist only in Python have not yet been implemented in R.

--- a/R/opendp/README.md
+++ b/R/opendp/README.md
@@ -1,0 +1,9 @@
+# OpenDP R API
+
+The OpenDP R API largely mirrors the Python API, with some key differences.
+Most Python examples have not yet been translated to R:
+These hints will help you apply the Python examples to R.
+
+- After invoking `library(opendp)` all functions are available: There are no namespaces like those of the Python library.
+- The chaining operator in R is `|>`, as opposed to `>>` in Python.
+- All portions of the Python API that are derived from Rust have parallels in the R API, but packages like `context` that exist only in Python have not yet been implemented in R.

--- a/tools/r_stage.sh
+++ b/tools/r_stage.sh
@@ -38,7 +38,6 @@ function clean() {
   run rm -rf R/opendp/opendp.Rcheck
   run rm -rf R/opendp/man
   run rm -f R/opendp/src/*.tar.xz
-  run rm -f R/opendp/README.md
   run rm -f R/opendp/inst/AUTHORS
   run rm -f R/opendp/LICENSE.note
   run rm -f R/opendp/src/*.o R/opendp/src/opendp.so
@@ -106,8 +105,7 @@ function docs() {
   run cp -r R/opendp R/opendp-docs
   run rm -rf R/opendp-docs/src
 
-  log "copy README and CHANGELOG into the docs"
-  run cp README.md R/opendp-docs/
+  log "copy CHANGELOG into the docs"
   # https://pkgdown.r-lib.org/reference/build_news.html
   sed "s|^## |# Version |" CHANGELOG.md > R/opendp-docs/NEWS.md
 


### PR DESCRIPTION
Towards #1244

Just repeating the top-level README doesn't tell R users much, but I think there are a few things we could point out to them before letting them loose on the generated docs.

We are a little constrained: It should work both as a readme for this directory, and as a source for generated docs. Considered relative link to the API reference... but that wouldn't work when the README is viewed in github.