### PR TITLE
Make docs dependency on r-docs explicit

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -47,6 +47,8 @@ graph TD
 
     subgraph docs.yml
         dcc[credential-check] --> docs
+        dcc[credential-check] --> r-docs
+        r-docs --> docs
     end
     docs.yml -.- rdocs[docs]
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,7 +51,9 @@ jobs:
           path: R/opendp/docs
 
   docs:
-    needs: credential-check
+    needs:
+      - credential-check
+      - r-docs
     # fixed to ubuntu-22.04, which is currently newer than ubuntu-latest, because pandoc needs at least v2.6
     # ubuntu-latest points to ubuntu-20.04, which has pandoc v2.5, which is subject to this bug: https://github.com/jgm/pandoc/issues/5128
     runs-on: ubuntu-22.04


### PR DESCRIPTION
make the dependency on r-docs explicit, at the cost of slowing down the docs build

- Possible fix #1242, but there are other approaches, including doing nothing.