### PR TITLE
Error on warning from devtools::check

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -263,4 +263,4 @@ jobs:
         run: cd R/opendp/ && Rscript -e 'devtools::document()'
 
       - name: Check
-        run: cd R/opendp/ && Rscript -e 'devtools::check()'
+        run: cd R/opendp/ && Rscript -e 'devtools::check(error_on="warning")'


### PR DESCRIPTION
- Elevate check warnings to errors, just to be safe.
- Does not address #1251, sadly: `devtools::document` does not support `error_on` and I haven't found an alternative.