### PR TITLE
Remove `@versioned` from generated code

### DIFF
--- a/python/src/opendp/_data.py
+++ b/python/src/opendp/_data.py
@@ -23,7 +23,6 @@ __all__ = [
 ]
 
 
-@versioned
 def bool_free(
     this
 ):
@@ -49,7 +48,6 @@ def bool_free(
     return output
 
 
-@versioned
 def extrinsic_object_free(
     this
 ):
@@ -75,7 +73,6 @@ def extrinsic_object_free(
     return output
 
 
-@versioned
 def ffislice_of_anyobjectptrs(
     raw: Any
 ) -> Any:
@@ -102,7 +99,6 @@ def ffislice_of_anyobjectptrs(
     return output
 
 
-@versioned
 def fill_bytes(
     ptr,
     len: int
@@ -132,7 +128,6 @@ def fill_bytes(
     return output
 
 
-@versioned
 def object_as_slice(
     obj: Any
 ) -> Any:
@@ -160,7 +155,6 @@ def object_as_slice(
     return output
 
 
-@versioned
 def object_free(
     this
 ):
@@ -186,7 +180,6 @@ def object_free(
     return output
 
 
-@versioned
 def object_type(
     this: Any
 ) -> str:
@@ -213,7 +206,6 @@ def object_type(
     return output
 
 
-@versioned
 def slice_as_object(
     raw: FfiSlicePtr,
     T: str
@@ -248,7 +240,6 @@ def slice_as_object(
     return output
 
 
-@versioned
 def slice_free(
     this
 ):
@@ -276,7 +267,6 @@ def slice_free(
     return output
 
 
-@versioned
 def smd_curve_epsilon(
     curve: Any,
     delta: Any
@@ -308,7 +298,6 @@ def smd_curve_epsilon(
     return output
 
 
-@versioned
 def str_free(
     this
 ):
@@ -335,7 +324,6 @@ def str_free(
     return output
 
 
-@versioned
 def to_string(
     this: Any
 ) -> str:

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -251,28 +251,6 @@ def unwrap(result, type_) -> Any:
     raise OpenDPException(variant, message, backtrace)
 
 
-def versioned(function):
-    """Decorator to update version numbers in docstrings.
-    This is shown in the help(*) and Sphinx documentation (like docs.opendp.org)."""
-
-    version = get_opendp_version()
-    channel = get_channel(version)
-
-    if channel != "dev": # pragma: no cover
-        # docs.rs keeps all releases, so we can use the full version.
-        function.__doc__ = function.__doc__.replace(
-            "https://docs.rs/opendp/latest/", f"https://docs.rs/opendp/{version}/"
-        )
-
-        docs_ref = get_docs_ref(version)
-        function.__doc__ = function.__doc__.replace(
-            "https://docs.opendp.org/en/latest/",
-            f"https://docs.opendp.org/en/{docs_ref}/",
-        )
-
-    return function
-
-
 proof_doc_re = re.compile(r"\[\(Proof Document\)\]\(([^)]+)\)")
 
 

--- a/python/src/opendp/accuracy.py
+++ b/python/src/opendp/accuracy.py
@@ -19,7 +19,6 @@ __all__ = [
 ]
 
 
-@versioned
 def accuracy_to_discrete_gaussian_scale(
     accuracy,
     alpha,
@@ -60,7 +59,6 @@ def accuracy_to_discrete_gaussian_scale(
     return output
 
 
-@versioned
 def accuracy_to_discrete_laplacian_scale(
     accuracy,
     alpha,
@@ -102,7 +100,6 @@ def accuracy_to_discrete_laplacian_scale(
     return output
 
 
-@versioned
 def accuracy_to_gaussian_scale(
     accuracy,
     alpha,
@@ -139,7 +136,6 @@ def accuracy_to_gaussian_scale(
     return output
 
 
-@versioned
 def accuracy_to_laplacian_scale(
     accuracy,
     alpha,
@@ -177,7 +173,6 @@ def accuracy_to_laplacian_scale(
     return output
 
 
-@versioned
 def discrete_gaussian_scale_to_accuracy(
     scale,
     alpha,
@@ -218,7 +213,6 @@ def discrete_gaussian_scale_to_accuracy(
     return output
 
 
-@versioned
 def discrete_laplacian_scale_to_accuracy(
     scale,
     alpha,
@@ -265,7 +259,6 @@ def discrete_laplacian_scale_to_accuracy(
     return output
 
 
-@versioned
 def gaussian_scale_to_accuracy(
     scale,
     alpha,
@@ -302,7 +295,6 @@ def gaussian_scale_to_accuracy(
     return output
 
 
-@versioned
 def laplacian_scale_to_accuracy(
     scale,
     alpha,

--- a/python/src/opendp/combinators.py
+++ b/python/src/opendp/combinators.py
@@ -25,7 +25,6 @@ __all__ = [
 ]
 
 
-@versioned
 def make_basic_composition(
     measurements: Any
 ) -> Measurement:
@@ -66,7 +65,6 @@ def make_basic_composition(
     return output
 
 
-@versioned
 def make_chain_mt(
     measurement1: Measurement,
     transformation0: Transformation
@@ -102,7 +100,6 @@ def make_chain_mt(
     return output
 
 
-@versioned
 def make_chain_pm(
     postprocess1: Function,
     measurement0: Measurement
@@ -139,7 +136,6 @@ def make_chain_pm(
     return output
 
 
-@versioned
 def make_chain_tt(
     transformation1: Transformation,
     transformation0: Transformation
@@ -175,7 +171,6 @@ def make_chain_tt(
     return output
 
 
-@versioned
 def make_fix_delta(
     measurement: Measurement,
     delta: Any
@@ -210,7 +205,6 @@ def make_fix_delta(
     return output
 
 
-@versioned
 def make_population_amplification(
     measurement: Measurement,
     population_size: int
@@ -252,7 +246,6 @@ def make_population_amplification(
     return output
 
 
-@versioned
 def make_pureDP_to_fixed_approxDP(
     measurement: Measurement
 ) -> Measurement:
@@ -284,7 +277,6 @@ def make_pureDP_to_fixed_approxDP(
     return output
 
 
-@versioned
 def make_pureDP_to_zCDP(
     measurement: Measurement
 ) -> Measurement:
@@ -320,7 +312,6 @@ def make_pureDP_to_zCDP(
     return output
 
 
-@versioned
 def make_sequential_composition(
     input_domain: Domain,
     input_metric: Metric,
@@ -413,7 +404,6 @@ def then_sequential_composition(
 
 
 
-@versioned
 def make_zCDP_to_approxDP(
     measurement: Measurement
 ) -> Measurement:

--- a/python/src/opendp/core.py
+++ b/python/src/opendp/core.py
@@ -41,7 +41,6 @@ __all__ = [
 ]
 
 
-@versioned
 def _error_free(
     this
 ) -> bool:
@@ -68,7 +67,6 @@ def _error_free(
     return output
 
 
-@versioned
 def _function_free(
     this
 ):
@@ -94,7 +92,6 @@ def _function_free(
     return output
 
 
-@versioned
 def _measurement_free(
     this
 ):
@@ -120,7 +117,6 @@ def _measurement_free(
     return output
 
 
-@versioned
 def _transformation_free(
     this
 ):
@@ -146,7 +142,6 @@ def _transformation_free(
     return output
 
 
-@versioned
 def function_eval(
     this: Function,
     arg: Any,
@@ -181,7 +176,6 @@ def function_eval(
     return output
 
 
-@versioned
 def measurement_check(
     measurement: Measurement,
     distance_in: Any,
@@ -216,7 +210,6 @@ def measurement_check(
     return output
 
 
-@versioned
 def measurement_function(
     this: Measurement
 ) -> Function:
@@ -243,7 +236,6 @@ def measurement_function(
     return output
 
 
-@versioned
 def measurement_input_carrier_type(
     this: Measurement
 ) -> str:
@@ -270,7 +262,6 @@ def measurement_input_carrier_type(
     return output
 
 
-@versioned
 def measurement_input_distance_type(
     this: Measurement
 ) -> str:
@@ -297,7 +288,6 @@ def measurement_input_distance_type(
     return output
 
 
-@versioned
 def measurement_input_domain(
     this: Measurement
 ) -> Domain:
@@ -324,7 +314,6 @@ def measurement_input_domain(
     return output
 
 
-@versioned
 def measurement_input_metric(
     this: Measurement
 ) -> Metric:
@@ -351,7 +340,6 @@ def measurement_input_metric(
     return output
 
 
-@versioned
 def measurement_invoke(
     this: Measurement,
     arg: Any
@@ -382,7 +370,6 @@ def measurement_invoke(
     return output
 
 
-@versioned
 def measurement_map(
     measurement: Measurement,
     distance_in: Any
@@ -413,7 +400,6 @@ def measurement_map(
     return output
 
 
-@versioned
 def measurement_output_distance_type(
     this: Measurement
 ) -> str:
@@ -440,7 +426,6 @@ def measurement_output_distance_type(
     return output
 
 
-@versioned
 def measurement_output_measure(
     this: Measurement
 ) -> Measure:
@@ -467,7 +452,6 @@ def measurement_output_measure(
     return output
 
 
-@versioned
 def new_function(
     function,
     TO: RuntimeTypeDescriptor
@@ -502,7 +486,6 @@ def new_function(
     return output
 
 
-@versioned
 def new_queryable(
     transition,
     Q: RuntimeTypeDescriptor = "ExtrinsicObject",
@@ -541,7 +524,6 @@ def new_queryable(
     return output
 
 
-@versioned
 def queryable_eval(
     queryable: Any,
     query: Any
@@ -572,7 +554,6 @@ def queryable_eval(
     return output
 
 
-@versioned
 def queryable_query_type(
     this: Any
 ) -> str:
@@ -599,7 +580,6 @@ def queryable_query_type(
     return output
 
 
-@versioned
 def transformation_check(
     transformation: Transformation,
     distance_in: Any,
@@ -634,7 +614,6 @@ def transformation_check(
     return output
 
 
-@versioned
 def transformation_function(
     this: Transformation
 ) -> Function:
@@ -661,7 +640,6 @@ def transformation_function(
     return output
 
 
-@versioned
 def transformation_input_carrier_type(
     this: Transformation
 ) -> str:
@@ -688,7 +666,6 @@ def transformation_input_carrier_type(
     return output
 
 
-@versioned
 def transformation_input_distance_type(
     this: Transformation
 ) -> str:
@@ -715,7 +692,6 @@ def transformation_input_distance_type(
     return output
 
 
-@versioned
 def transformation_input_domain(
     this: Transformation
 ) -> Domain:
@@ -742,7 +718,6 @@ def transformation_input_domain(
     return output
 
 
-@versioned
 def transformation_input_metric(
     this: Transformation
 ) -> Metric:
@@ -769,7 +744,6 @@ def transformation_input_metric(
     return output
 
 
-@versioned
 def transformation_invoke(
     this: Transformation,
     arg: Any
@@ -800,7 +774,6 @@ def transformation_invoke(
     return output
 
 
-@versioned
 def transformation_map(
     transformation: Transformation,
     distance_in: Any
@@ -831,7 +804,6 @@ def transformation_map(
     return output
 
 
-@versioned
 def transformation_output_distance_type(
     this: Transformation
 ) -> str:
@@ -858,7 +830,6 @@ def transformation_output_distance_type(
     return output
 
 
-@versioned
 def transformation_output_domain(
     this: Transformation
 ) -> Domain:
@@ -885,7 +856,6 @@ def transformation_output_domain(
     return output
 
 
-@versioned
 def transformation_output_metric(
     this: Transformation
 ) -> Metric:

--- a/python/src/opendp/domains.py
+++ b/python/src/opendp/domains.py
@@ -22,7 +22,6 @@ __all__ = [
 ]
 
 
-@versioned
 def _domain_free(
     this
 ):
@@ -48,7 +47,6 @@ def _domain_free(
     return output
 
 
-@versioned
 def _user_domain_descriptor(
     domain: Domain
 ):
@@ -74,7 +72,6 @@ def _user_domain_descriptor(
     return output
 
 
-@versioned
 def atom_domain(
     bounds: Optional[Any] = None,
     nullable: bool = False,
@@ -113,7 +110,6 @@ def atom_domain(
     return output
 
 
-@versioned
 def domain_carrier_type(
     this: Domain
 ) -> str:
@@ -140,7 +136,6 @@ def domain_carrier_type(
     return output
 
 
-@versioned
 def domain_debug(
     this: Domain
 ) -> str:
@@ -167,7 +162,6 @@ def domain_debug(
     return output
 
 
-@versioned
 def domain_type(
     this: Domain
 ) -> str:
@@ -194,7 +188,6 @@ def domain_type(
     return output
 
 
-@versioned
 def map_domain(
     key_domain: Domain,
     value_domain: Domain
@@ -225,7 +218,6 @@ def map_domain(
     return output
 
 
-@versioned
 def member(
     this: Domain,
     val: Any
@@ -255,7 +247,6 @@ def member(
     return output
 
 
-@versioned
 def option_domain(
     element_domain: Domain,
     D: Optional[RuntimeTypeDescriptor] = None
@@ -290,7 +281,6 @@ def option_domain(
     return output
 
 
-@versioned
 def user_domain(
     identifier: str,
     member,
@@ -327,7 +317,6 @@ def user_domain(
     return output
 
 
-@versioned
 def vector_domain(
     atom_domain: Domain,
     size: Optional[Any] = None

--- a/python/src/opendp/measurements.py
+++ b/python/src/opendp/measurements.py
@@ -42,7 +42,6 @@ __all__ = [
 ]
 
 
-@versioned
 def make_alp_queryable(
     input_domain: Domain,
     input_metric: Metric,
@@ -149,7 +148,6 @@ def then_alp_queryable(
 
 
 
-@versioned
 def make_base_discrete_gaussian(
     input_domain: Domain,
     input_metric: Metric,
@@ -229,7 +227,6 @@ def then_base_discrete_gaussian(
 
 
 
-@versioned
 def make_base_discrete_laplace(
     input_domain: Domain,
     input_metric: Metric,
@@ -314,7 +311,6 @@ def then_base_discrete_laplace(
 
 
 
-@versioned
 def make_base_discrete_laplace_cks20(
     input_domain: Domain,
     input_metric: Metric,
@@ -397,7 +393,6 @@ def then_base_discrete_laplace_cks20(
 
 
 
-@versioned
 def make_base_discrete_laplace_linear(
     input_domain: Domain,
     input_metric: Metric,
@@ -491,7 +486,6 @@ def then_base_discrete_laplace_linear(
 
 
 
-@versioned
 def make_base_gaussian(
     input_domain: Domain,
     input_metric: Metric,
@@ -583,7 +577,6 @@ def then_base_gaussian(
 
 
 
-@versioned
 def make_base_geometric(
     input_domain: Domain,
     input_metric: Metric,
@@ -666,7 +659,6 @@ def then_base_geometric(
 
 
 
-@versioned
 def make_base_laplace(
     input_domain: Domain,
     input_metric: Metric,
@@ -748,7 +740,6 @@ def then_base_laplace(
 
 
 
-@versioned
 def make_base_laplace_threshold(
     input_domain: Domain,
     input_metric: Metric,
@@ -829,7 +820,6 @@ def then_base_laplace_threshold(
 
 
 
-@versioned
 def make_gaussian(
     input_domain: Domain,
     input_metric: Metric,
@@ -909,7 +899,6 @@ def then_gaussian(
 
 
 
-@versioned
 def make_laplace(
     input_domain: Domain,
     input_metric: Metric,
@@ -994,7 +983,6 @@ def then_laplace(
 
 
 
-@versioned
 def make_randomized_response(
     categories: Any,
     prob,
@@ -1050,7 +1038,6 @@ def make_randomized_response(
     return output
 
 
-@versioned
 def make_randomized_response_bool(
     prob,
     constant_time: bool = False,
@@ -1101,7 +1088,6 @@ def make_randomized_response_bool(
     return output
 
 
-@versioned
 def make_report_noisy_max_gumbel(
     input_domain: Domain,
     input_metric: Metric,
@@ -1186,7 +1172,6 @@ def then_report_noisy_max_gumbel(
 
 
 
-@versioned
 def make_user_measurement(
     input_domain: Domain,
     input_metric: Metric,

--- a/python/src/opendp/measures.py
+++ b/python/src/opendp/measures.py
@@ -20,7 +20,6 @@ __all__ = [
 ]
 
 
-@versioned
 def _measure_free(
     this
 ):
@@ -46,7 +45,6 @@ def _measure_free(
     return output
 
 
-@versioned
 def fixed_smoothed_max_divergence(
     T: RuntimeTypeDescriptor
 ) -> Measure:
@@ -77,7 +75,6 @@ def fixed_smoothed_max_divergence(
     return output
 
 
-@versioned
 def max_divergence(
     T: RuntimeTypeDescriptor
 ) -> Measure:
@@ -108,7 +105,6 @@ def max_divergence(
     return output
 
 
-@versioned
 def measure_debug(
     this: Measure
 ) -> str:
@@ -135,7 +131,6 @@ def measure_debug(
     return output
 
 
-@versioned
 def measure_distance_type(
     this: Measure
 ) -> str:
@@ -162,7 +157,6 @@ def measure_distance_type(
     return output
 
 
-@versioned
 def measure_type(
     this: Measure
 ) -> str:
@@ -189,7 +183,6 @@ def measure_type(
     return output
 
 
-@versioned
 def smoothed_max_divergence(
     T: RuntimeTypeDescriptor
 ) -> Measure:
@@ -220,7 +213,6 @@ def smoothed_max_divergence(
     return output
 
 
-@versioned
 def user_divergence(
     descriptor: str
 ) -> Measure:
@@ -250,7 +242,6 @@ def user_divergence(
     return output
 
 
-@versioned
 def zero_concentrated_divergence(
     T: RuntimeTypeDescriptor
 ) -> Measure:

--- a/python/src/opendp/metrics.py
+++ b/python/src/opendp/metrics.py
@@ -25,7 +25,6 @@ __all__ = [
 ]
 
 
-@versioned
 def _metric_free(
     this
 ):
@@ -51,7 +50,6 @@ def _metric_free(
     return output
 
 
-@versioned
 def absolute_distance(
     T: RuntimeTypeDescriptor
 ) -> Metric:
@@ -82,7 +80,6 @@ def absolute_distance(
     return output
 
 
-@versioned
 def change_one_distance(
 
 ) -> Metric:
@@ -106,7 +103,6 @@ def change_one_distance(
     return output
 
 
-@versioned
 def discrete_distance(
 
 ) -> Metric:
@@ -130,7 +126,6 @@ def discrete_distance(
     return output
 
 
-@versioned
 def hamming_distance(
 
 ) -> Metric:
@@ -154,7 +149,6 @@ def hamming_distance(
     return output
 
 
-@versioned
 def insert_delete_distance(
 
 ) -> Metric:
@@ -178,7 +172,6 @@ def insert_delete_distance(
     return output
 
 
-@versioned
 def l1_distance(
     T: RuntimeTypeDescriptor
 ) -> Metric:
@@ -209,7 +202,6 @@ def l1_distance(
     return output
 
 
-@versioned
 def l2_distance(
     T: RuntimeTypeDescriptor
 ) -> Metric:
@@ -240,7 +232,6 @@ def l2_distance(
     return output
 
 
-@versioned
 def linf_distance(
     T: RuntimeTypeDescriptor,
     monotonic: bool = False
@@ -275,7 +266,6 @@ def linf_distance(
     return output
 
 
-@versioned
 def metric_debug(
     this: Metric
 ) -> str:
@@ -302,7 +292,6 @@ def metric_debug(
     return output
 
 
-@versioned
 def metric_distance_type(
     this: Metric
 ) -> str:
@@ -329,7 +318,6 @@ def metric_distance_type(
     return output
 
 
-@versioned
 def metric_type(
     this: Metric
 ) -> str:
@@ -356,7 +344,6 @@ def metric_type(
     return output
 
 
-@versioned
 def symmetric_distance(
 
 ) -> Metric:
@@ -380,7 +367,6 @@ def symmetric_distance(
     return output
 
 
-@versioned
 def user_distance(
     descriptor: str
 ) -> Metric:

--- a/python/src/opendp/transformations.py
+++ b/python/src/opendp/transformations.py
@@ -97,7 +97,6 @@ __all__ = [
 ]
 
 
-@versioned
 def choose_branching_factor(
     size_guess: int
 ) -> int:
@@ -132,7 +131,6 @@ def choose_branching_factor(
     return output
 
 
-@versioned
 def make_b_ary_tree(
     input_domain: Domain,
     input_metric: Metric,
@@ -204,7 +202,6 @@ def then_b_ary_tree(
 
 
 
-@versioned
 def make_bounded_float_checked_sum(
     size_limit: int,
     bounds: Tuple[Any, Any],
@@ -273,7 +270,6 @@ def make_bounded_float_checked_sum(
     return output
 
 
-@versioned
 def make_bounded_float_ordered_sum(
     size_limit: int,
     bounds: Tuple[Any, Any],
@@ -343,7 +339,6 @@ def make_bounded_float_ordered_sum(
     return output
 
 
-@versioned
 def make_bounded_int_monotonic_sum(
     bounds: Tuple[Any, Any],
     T: Optional[RuntimeTypeDescriptor] = None
@@ -393,7 +388,6 @@ def make_bounded_int_monotonic_sum(
     return output
 
 
-@versioned
 def make_bounded_int_ordered_sum(
     bounds: Tuple[Any, Any],
     T: Optional[RuntimeTypeDescriptor] = None
@@ -443,7 +437,6 @@ def make_bounded_int_ordered_sum(
     return output
 
 
-@versioned
 def make_bounded_int_split_sum(
     bounds: Tuple[Any, Any],
     T: Optional[RuntimeTypeDescriptor] = None
@@ -493,7 +486,6 @@ def make_bounded_int_split_sum(
     return output
 
 
-@versioned
 def make_cast(
     input_domain: Domain,
     input_metric: Metric,
@@ -561,7 +553,6 @@ def then_cast(
 
 
 
-@versioned
 def make_cast_default(
     input_domain: Domain,
     input_metric: Metric,
@@ -637,7 +628,6 @@ def then_cast_default(
 
 
 
-@versioned
 def make_cast_inherent(
     input_domain: Domain,
     input_metric: Metric,
@@ -707,7 +697,6 @@ def then_cast_inherent(
 
 
 
-@versioned
 def make_cdf(
     TA: RuntimeTypeDescriptor = "float"
 ) -> Function:
@@ -745,7 +734,6 @@ def make_cdf(
     return output
 
 
-@versioned
 def make_clamp(
     input_domain: Domain,
     input_metric: Metric,
@@ -817,7 +805,6 @@ def then_clamp(
 
 
 
-@versioned
 def make_consistent_b_ary_tree(
     branching_factor: int,
     TIA: RuntimeTypeDescriptor = "int",
@@ -875,7 +862,6 @@ def make_consistent_b_ary_tree(
     return output
 
 
-@versioned
 def make_count(
     input_domain: Domain,
     input_metric: Metric,
@@ -948,7 +934,6 @@ def then_count(
 
 
 
-@versioned
 def make_count_by(
     input_domain: Domain,
     input_metric: Metric,
@@ -1028,7 +1013,6 @@ def then_count_by(
 
 
 
-@versioned
 def make_count_by_categories(
     input_domain: Domain,
     input_metric: Metric,
@@ -1126,7 +1110,6 @@ def then_count_by_categories(
 
 
 
-@versioned
 def make_count_distinct(
     input_domain: Domain,
     input_metric: Metric,
@@ -1195,7 +1178,6 @@ def then_count_distinct(
 
 
 
-@versioned
 def make_create_dataframe(
     col_names: Any,
     K: Optional[RuntimeTypeDescriptor] = None
@@ -1239,7 +1221,6 @@ def make_create_dataframe(
     return output
 
 
-@versioned
 def make_df_cast_default(
     input_domain: Domain,
     input_metric: Metric,
@@ -1332,7 +1313,6 @@ def then_df_cast_default(
 
 
 
-@versioned
 def make_df_is_equal(
     input_domain: Domain,
     input_metric: Metric,
@@ -1415,7 +1395,6 @@ def then_df_is_equal(
 
 
 
-@versioned
 def make_drop_null(
     input_domain: Domain,
     input_metric: Metric
@@ -1478,7 +1457,6 @@ def then_drop_null(
 
 
 
-@versioned
 def make_find(
     input_domain: Domain,
     input_metric: Metric,
@@ -1547,7 +1525,6 @@ def then_find(
 
 
 
-@versioned
 def make_find_bin(
     input_domain: Domain,
     input_metric: Metric,
@@ -1620,7 +1597,6 @@ def then_find_bin(
 
 
 
-@versioned
 def make_identity(
     domain: Domain,
     metric: Metric
@@ -1682,7 +1658,6 @@ def then_identity(
 
 
 
-@versioned
 def make_impute_constant(
     input_domain: Domain,
     input_metric: Metric,
@@ -1753,7 +1728,6 @@ def then_impute_constant(
 
 
 
-@versioned
 def make_impute_uniform_float(
     input_domain: Domain,
     input_metric: Metric,
@@ -1818,7 +1792,6 @@ def then_impute_uniform_float(
 
 
 
-@versioned
 def make_index(
     input_domain: Domain,
     input_metric: Metric,
@@ -1899,7 +1872,6 @@ def then_index(
 
 
 
-@versioned
 def make_is_equal(
     input_domain: Domain,
     input_metric: Metric,
@@ -1969,7 +1941,6 @@ def then_is_equal(
 
 
 
-@versioned
 def make_is_null(
     input_domain: Domain,
     input_metric: Metric
@@ -2026,7 +1997,6 @@ def then_is_null(
 
 
 
-@versioned
 def make_lipschitz_float_mul(
     constant,
     bounds: Tuple[Any, Any],
@@ -2083,7 +2053,6 @@ def make_lipschitz_float_mul(
     return output
 
 
-@versioned
 def make_mean(
     input_domain: Domain,
     input_metric: Metric
@@ -2143,7 +2112,6 @@ def then_mean(
 
 
 
-@versioned
 def make_metric_bounded(
     input_domain: Domain,
     input_metric: Metric
@@ -2209,7 +2177,6 @@ def then_metric_bounded(
 
 
 
-@versioned
 def make_metric_unbounded(
     input_domain: Domain,
     input_metric: Metric
@@ -2272,7 +2239,6 @@ def then_metric_unbounded(
 
 
 
-@versioned
 def make_ordered_random(
     input_domain: Domain,
     input_metric: Metric
@@ -2335,7 +2301,6 @@ def then_ordered_random(
 
 
 
-@versioned
 def make_quantile_score_candidates(
     input_domain: Domain,
     input_metric: Metric,
@@ -2412,7 +2377,6 @@ def then_quantile_score_candidates(
 
 
 
-@versioned
 def make_quantiles_from_counts(
     bin_edges: Any,
     alphas: Any,
@@ -2467,7 +2431,6 @@ def make_quantiles_from_counts(
     return output
 
 
-@versioned
 def make_resize(
     input_domain: Domain,
     input_metric: Metric,
@@ -2550,7 +2513,6 @@ def then_resize(
 
 
 
-@versioned
 def make_select_column(
     key: Any,
     TOA: RuntimeTypeDescriptor,
@@ -2599,7 +2561,6 @@ def make_select_column(
     return output
 
 
-@versioned
 def make_sized_bounded_float_checked_sum(
     size: int,
     bounds: Tuple[Any, Any],
@@ -2667,7 +2628,6 @@ def make_sized_bounded_float_checked_sum(
     return output
 
 
-@versioned
 def make_sized_bounded_float_ordered_sum(
     size: int,
     bounds: Tuple[Any, Any],
@@ -2737,7 +2697,6 @@ def make_sized_bounded_float_ordered_sum(
     return output
 
 
-@versioned
 def make_sized_bounded_int_checked_sum(
     size: int,
     bounds: Tuple[Any, Any],
@@ -2791,7 +2750,6 @@ def make_sized_bounded_int_checked_sum(
     return output
 
 
-@versioned
 def make_sized_bounded_int_monotonic_sum(
     size: int,
     bounds: Tuple[Any, Any],
@@ -2845,7 +2803,6 @@ def make_sized_bounded_int_monotonic_sum(
     return output
 
 
-@versioned
 def make_sized_bounded_int_ordered_sum(
     size: int,
     bounds: Tuple[Any, Any],
@@ -2901,7 +2858,6 @@ def make_sized_bounded_int_ordered_sum(
     return output
 
 
-@versioned
 def make_sized_bounded_int_split_sum(
     size: int,
     bounds: Tuple[Any, Any],
@@ -2957,7 +2913,6 @@ def make_sized_bounded_int_split_sum(
     return output
 
 
-@versioned
 def make_split_dataframe(
     separator: str,
     col_names: Any,
@@ -3006,7 +2961,6 @@ def make_split_dataframe(
     return output
 
 
-@versioned
 def make_split_lines(
 
 ) -> Transformation:
@@ -3041,7 +2995,6 @@ def make_split_lines(
     return output
 
 
-@versioned
 def make_split_records(
     separator: str
 ) -> Transformation:
@@ -3079,7 +3032,6 @@ def make_split_records(
     return output
 
 
-@versioned
 def make_subset_by(
     indicator_column: Any,
     keep_columns: Any,
@@ -3127,7 +3079,6 @@ def make_subset_by(
     return output
 
 
-@versioned
 def make_sum(
     input_domain: Domain,
     input_metric: Metric
@@ -3192,7 +3143,6 @@ def then_sum(
 
 
 
-@versioned
 def make_sum_of_squared_deviations(
     input_domain: Domain,
     input_metric: Metric,
@@ -3278,7 +3228,6 @@ def then_sum_of_squared_deviations(
 
 
 
-@versioned
 def make_unordered(
     input_domain: Domain,
     input_metric: Metric
@@ -3341,7 +3290,6 @@ def then_unordered(
 
 
 
-@versioned
 def make_user_transformation(
     input_domain: Domain,
     input_metric: Metric,
@@ -3388,7 +3336,6 @@ def make_user_transformation(
     return output
 
 
-@versioned
 def make_variance(
     input_domain: Domain,
     input_metric: Metric,

--- a/rust/opendp_tooling/src/codegen/python.rs
+++ b/rust/opendp_tooling/src/codegen/python.rs
@@ -171,7 +171,6 @@ def {then_name}(
 
     format!(
         r#"
-@versioned
 def {func_name}(
 {args}
 ){sig_return}:


### PR DESCRIPTION
- Remove one line from Rust code and regenerate Python
- Since it's now unused, remove function
- Fix #1145

(If you're looking at that issue, note that it started from a misunderstanding on my part: it's `@versioned` rather than `@proven` which is vestigial.)