### PR TITLE
Fix masked mypy errors

### DIFF
--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -681,7 +681,7 @@ def _translate_measure_distance(d_from, from_measure, to_measure):
             d_out=d_from,
             T=float,
         )
-        return make_base_laplace(scale).map(constant)
+        return make_base_laplace(*space, scale).map(constant)
 
     if from_to == (
         "FixedSmoothedMaxDivergence",

--- a/python/test/test_comb.py
+++ b/python/test/test_comb.py
@@ -55,7 +55,9 @@ def test_make_basic_composition_leak():
 
     # choose a vector-valued mechanism that should run quickly for large inputs
     # we want to add as little noise as possible, so that execution time is small
-    meas = dp.m.make_base_discrete_laplace(scale=1e-6, D=dp.VectorDomain[dp.AtomDomain[int]])
+    domain = dp.VectorDomain[dp.AtomDomain[int]]
+    metric = ... # TODO!
+    meas = dp.m.make_base_discrete_laplace(domain, metric, 1e-6)
 
     # memory usage remains the same when this line is commented,
     # supporting that AnyObject's free recursively frees children

--- a/python/test/test_comb.py
+++ b/python/test/test_comb.py
@@ -55,9 +55,8 @@ def test_make_basic_composition_leak():
 
     # choose a vector-valued mechanism that should run quickly for large inputs
     # we want to add as little noise as possible, so that execution time is small
-    domain = dp.VectorDomain[dp.AtomDomain[int]]
-    metric = ... # TODO!
-    meas = dp.m.make_base_discrete_laplace(domain, metric, 1e-6)
+    space = dp.vector_domain(dp.atom_domain(T=int)), dp.l1_distance(T=int)
+    meas = space >> dp.m.then_laplace(0.)
 
     # memory usage remains the same when this line is commented,
     # supporting that AnyObject's free recursively frees children
@@ -67,8 +66,8 @@ def test_make_basic_composition_leak():
     # memory would jump by ~40mb every iteration
     for i in range(1000):
         print('iteration', i)
-        meas([0] * 10_000_000)
-    
+        meas([0] * 1_000_000)
+
 
 def test_make_basic_composition_approx():
     input_space = dp.atom_domain(T=float), dp.absolute_distance(T=float)


### PR DESCRIPTION
I'm not sure of the metric in `test_comb.py`: @Shoeboxam, can you make a suggestion there?

My sense is that `context` might go away, to be replaced by Polars, so we don't need to invest more time there? Though if it is staying, the test coverage could be improved.

- Fix #1264
- Unblock #1263