### PR TITLE
Now if "stable" and "dry-run" are selected, will append "-dev"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,7 +109,7 @@ jobs:
           git config --global user.name "$GITHUB_ACTOR"
 
           # create brand new history each time
-          BRANCH=r-universe${{ (inputs.channel != 'stable') && '-dev' || '' }}
+          BRANCH=r-universe${{ (inputs.dry_run || inputs.channel != 'stable') && '-dev' || '' }}
           git checkout --orphan $BRANCH
 
           git add R/opendp/ --force


### PR DESCRIPTION
If we want to treat `r-universe-dev` like `testpypi` then this seems appropriate... but if we want to make sure that nothing gets pushed to any branch on github from a dry-run, should try something different.

- fix #1266 