### PR TITLE
manylinux2014 -> manylinux_2_24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,7 @@ jobs:
       matrix:
         architecture: [x86_64, aarch64]
     env:
-      DOCKER_IMAGE: messense/manylinux2014-cross:${{ matrix.architecture }}
+      DOCKER_IMAGE: messense/manylinux_2_24-cross:${{ matrix.architecture }}
       TARGET: ${{ matrix.architecture }}-unknown-linux-gnu
     steps:
       - name: Checkout repository

--- a/tools/build_tool.py
+++ b/tools/build_tool.py
@@ -44,7 +44,7 @@ def rust_container(args):
     platform_to_docker_image = {
         "windows": "windows-latest",
         "macos": "macos-10.15",
-        "linux": "quay.io/pypa/manylinux2014_x86_64",
+        "linux": "quay.io/pypa/manylinux_2_24_x86_64",
     }
     docker_image = platform_to_docker_image[args.platform]
     mount_point = "/io"


### PR DESCRIPTION
- Fix #1172

There is also a 2_28 out, but maybe be safe? I've confirmed on quay and dockerhub that these images exist. 

[Dry-run of build running now.](https://github.com/opendp/opendp/actions/runs/7935903813)

Also: It doesn't look like `build_tool.py` is referenced anywhere. I've done some linting on it recently, but before that the last commit was
```
commit ae35ac4e7457da687611117c98f279da37a9c3a2
Author: Andrew Vyrros <6577271+andrewvyrros@users.noreply.github.com>
Date:   Tue Oct 25 14:06:42 2022 -0700

    * Try manylinux2014_x86_64 (#592)

    * Switch args to toml.dump()
```

Avoiding vendor lock-in is a good goal, but I don't think we've maintained this, and it may just cause confusion now. Ok to delete?