### PR TITLE
Proposal: Interleave python and R

### DIFF
--- a/docs/source/quickstart.R
+++ b/docs/source/quickstart.R
@@ -1,7 +1,27 @@
-# 1-library
+"
+# py-init
+>>> from opendp.mod import enable_features
+>>> enable_features('contrib')
+
+# /py-init
+"
+
+# r-init
 library(opendp)
 enable_features("contrib")
-# 2-use
+# /r-init
+
+"
+# py-demo
+>>> import opendp.prelude as dp
+>>> base_laplace = dp.space_of(float) >> dp.m.then_base_laplace(scale=1.)
+>>> dp_agg = base_laplace(23.4)
+
+# /py-demo
+"
+
+# r-demo
 space <- c(atom_domain(.T = "f64"), absolute_distance(.T = "f64"))
 base_laplace <- space |> then_base_laplace(1.)
 dp_agg <- base_laplace(arg = 23.4)
+# /r-demo

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -31,17 +31,17 @@ Enable ``contrib`` globally with the following snippet:
 
     .. group-tab:: Python
 
-        .. doctest::
-
-            >>> from opendp.mod import enable_features
-            >>> enable_features('contrib')
+        .. literalinclude:: quickstart.R
+            :language: python
+            :start-after: py-init
+            :end-before: /py-init
 
     .. group-tab:: R
 
         .. literalinclude:: quickstart.R
             :language: r
-            :start-after: 1-library
-            :end-before: 2-use
+            :start-after: r-init
+            :end-before: /r-init
 
 Hello, OpenDP!
 --------------
@@ -54,17 +54,17 @@ then invoke it on a scalar aggregate.
 
     .. group-tab:: Python
 
-        .. doctest::
-
-            >>> import opendp.prelude as dp
-            >>> base_laplace = dp.space_of(float) >> dp.m.then_base_laplace(scale=1.)
-            >>> dp_agg = base_laplace(23.4)
+        .. literalinclude:: quickstart.R
+            :language: python
+            :start-after: py-demo
+            :end-before: /py-demo
 
     .. group-tab:: R
 
         .. literalinclude:: quickstart.R
             :language: r
-            :start-after: 2-use
+            :start-after: r-demo
+            :end-before: /r-demo
 
 This code snip uses a number of OpenDP concepts:
 

--- a/python/.pytest.ini
+++ b/python/.pytest.ini
@@ -4,4 +4,4 @@ testpaths =
 	src
 	../docs
 
-addopts = --doctest-glob *.rst --doctest-modules --ignore=../docs/source/conf.py
+addopts = --doctest-glob *.rst --doctest-glob *.R --doctest-modules --ignore=../docs/source/conf.py


### PR DESCRIPTION
- Fix #1274

Feedback from you both would be great. Here are the pluses and minus I can come up with:

Plus
- RST is simple and predictable; Could even imagine writing an extension so all you'd need is  ``.. examples:: init`` and ``.. examples:: demo`` here.
- Python and R snippets in one file, so it's easy to make sure they are in maintained in parallel

Minus
- No code in the RST source: examples decoupled from text
- Big initial lift to get the python examples into R
- Need to be sure the python code doesn't use `"` and prematurely end string.
- No obvious way to add Rust examples... Maybe `///` inside R strings, `grep -v` to remove everything else, and then pipe to `rustdoc --test`?