### PR TITLE
no more bare excepts

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -49,12 +49,6 @@ extend-ignore =
 per-file-ignores =
     # Use globs here so it works whether it's run from root or from python/.
 
-    # TODO: Bare 'except' should be fixed, but we'll typically want to be more strict,
-    # and there could be unintended consequences, so approach this carefully.
-    # E722: do not use bare 'except'
-    */_convert.py:E722
-    */test_typing.py:E722
-
     # Pseudocode necessarily has a lot of undefined names. No fixes needed!
     # F821: undefined name '...'
     # TODO: Move cdp_epsilon.py to a pseudocode directory? 

--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -264,7 +264,7 @@ def _refcounter(ptr, increment):
             ctypes.pythonapi.Py_IncRef(ctypes.py_object(ptr))
         else:
             ctypes.pythonapi.Py_DecRef(ctypes.py_object(ptr))
-    except:
+    except Exception:
         return False
     return True
 

--- a/python/test/test_typing.py
+++ b/python/test/test_typing.py
@@ -22,15 +22,6 @@ def test_numpy_function():
 
 
 def test_typing_hint():
-    # Python < 3.8 should raise an exception
-    if sys.version_info < (3, 8):
-        try:
-            assert str(RuntimeType.parse(Tuple[int, float])) == "(i32, f64)"
-            raise Exception("typing hints should fail with error below Python 3.8")
-        except:
-            # on Python < 3.8 the remaining tests do not apply
-            return
-
     assert str(RuntimeType.parse(Tuple[int, float])) == "(i32, f64)" # type: ignore[arg-type]
     assert str(RuntimeType.parse(Tuple[int, Tuple[str]])) == "(i32, (String))" # type: ignore[arg-type]
     assert str(RuntimeType.parse(List[int])) == "Vec<i32>"


### PR DESCRIPTION
- Fix #1281

- Drop special handing for python < 3.8 -- If we want to offer some support for versions < 3.8, we should add it to the test matrix. 
- Catch `Exception` instead of implicit `BaseException` -- The tests don't currently exercise this line, so I'm not confident about the change. Since any exception here would be surprising, would we like to log it?