### PR TITLE
python tabs from stand-alone file

### DIFF
--- a/docs/source/quickstart.R
+++ b/docs/source/quickstart.R
@@ -1,7 +1,10 @@
-# 1-library
+# init
 library(opendp)
 enable_features("contrib")
-# 2-use
+# /init
+
+# dp-demo
 space <- c(atom_domain(.T = "f64"), absolute_distance(.T = "f64"))
 base_laplace <- space |> then_base_laplace(1.)
 dp_agg <- base_laplace(arg = 23.4)
+# /dp-demo

--- a/docs/source/quickstart.py
+++ b/docs/source/quickstart.py
@@ -1,0 +1,12 @@
+'''
+# init
+>>> from opendp.mod import enable_features
+>>> enable_features('contrib')
+# /init
+
+# dp-demo
+>>> import opendp.prelude as dp
+>>> base_laplace = dp.space_of(float) >> dp.m.then_base_laplace(scale=1.)
+>>> dp_agg = base_laplace(23.4)
+# /dp-demo
+'''

--- a/docs/source/quickstart.py
+++ b/docs/source/quickstart.py
@@ -2,11 +2,13 @@
 # init
 >>> from opendp.mod import enable_features
 >>> enable_features('contrib')
+
 # /init
 
 # dp-demo
 >>> import opendp.prelude as dp
 >>> base_laplace = dp.space_of(float) >> dp.m.then_base_laplace(scale=1.)
 >>> dp_agg = base_laplace(23.4)
+
 # /dp-demo
 '''

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -31,17 +31,17 @@ Enable ``contrib`` globally with the following snippet:
 
     .. group-tab:: Python
 
-        .. doctest::
-
-            >>> from opendp.mod import enable_features
-            >>> enable_features('contrib')
+        .. literalinclude:: quickstart.py
+            :language: python
+            :start-after: init
+            :end-before: /init
 
     .. group-tab:: R
 
         .. literalinclude:: quickstart.R
             :language: r
-            :start-after: 1-library
-            :end-before: 2-use
+            :start-after: init
+            :end-before: /init
 
 Hello, OpenDP!
 --------------
@@ -54,17 +54,17 @@ then invoke it on a scalar aggregate.
 
     .. group-tab:: Python
 
-        .. doctest::
-
-            >>> import opendp.prelude as dp
-            >>> base_laplace = dp.space_of(float) >> dp.m.then_base_laplace(scale=1.)
-            >>> dp_agg = base_laplace(23.4)
+        .. literalinclude:: quickstart.py
+            :language: python
+            :start-after: dp-demo
+            :end-before: /dp-demo
 
     .. group-tab:: R
 
         .. literalinclude:: quickstart.R
             :language: r
-            :start-after: 2-use
+            :start-after: dp-demo
+            :end-before: /dp-demo
 
 This code snip uses a number of OpenDP concepts:
 


### PR DESCRIPTION
Proposal for including python examples the same way we include R examples.
- simple open-close convention with `/` on the closing tag.
- could distinguish python _Context API_ examples with `.context.py` extension.
- alternative to #1288 / #1274
- could imagine a sphinx extension to simplify the RST -- but I don't think that needs to block any thing.
- I wouldn't do more with this until #1177 is in -- conversely, I wouldn't block that PR to apply this convention.