### PR TITLE
Fix nightly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -296,7 +296,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           # overrides packages so that dependencies for package in cwd are not installed
-          packages: rlang,RcppTOML
+          packages: RcppTOML,stringr
       
       - name: Download R bindings
         uses: actions/download-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       channel: ${{ inputs.channel }}
-      fake: ${{ inputs.dry_run || inputs.fake }}
+      fake: ${{ inputs.fake }}
 
   sanity-test-pre:
     needs: build
@@ -92,7 +92,7 @@ jobs:
     with:
       channel: ${{ inputs.channel }}
       python_repository: local
-      fake: ${{ inputs.dry_run || inputs.fake }}
+      fake: ${{ inputs.fake }}
 
   publish:
     needs: [ prepare, sanity-test-pre ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,11 +67,6 @@ on:
         required: false
         default: false
 
-env:
-  # env.dry_run should be used instead of inputs.dry_run in each of
-  # the jobs below, to ensure that the fake override always works.
-  dry_run: ${{ inputs.dry_run || inputs.fake }}
-
 jobs:
   prepare:
     uses: ./.github/workflows/prepare.yml
@@ -89,7 +84,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       channel: ${{ inputs.channel }}
-      fake: ${{ inputs.fake }}
+      fake: ${{ ( inputs.dry_run || inputs.fake ) }}
 
   sanity-test-pre:
     needs: build
@@ -97,7 +92,7 @@ jobs:
     with:
       channel: ${{ inputs.channel }}
       python_repository: local
-      fake: ${{ inputs.fake }}
+      fake: ${{ ( inputs.dry_run || inputs.fake ) }}
 
   publish:
     needs: [ prepare, sanity-test-pre ]
@@ -105,7 +100,7 @@ jobs:
     with:
       channel: ${{ inputs.channel }}
       date: ${{ needs.prepare.outputs.date }}
-      dry_run: ${{ env.dry_run }}
+      dry_run: ${{ inputs.dry_run || inputs.fake }}
     secrets: inherit
 
   sanity-test-post:
@@ -130,4 +125,4 @@ jobs:
     needs: [ sanity-test-post, latex ]
     uses: ./.github/workflows/docs.yml
     with:
-      dry_run: ${{ env.dry_run }}
+      dry_run: ${{ inputs.dry_run || inputs.fake }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       channel: ${{ inputs.channel }}
-      fake: ${{ ( inputs.dry_run || inputs.fake ) }}
+      fake: ${{ inputs.dry_run || inputs.fake }}
 
   sanity-test-pre:
     needs: build
@@ -92,7 +92,7 @@ jobs:
     with:
       channel: ${{ inputs.channel }}
       python_repository: local
-      fake: ${{ ( inputs.dry_run || inputs.fake ) }}
+      fake: ${{ inputs.dry_run || inputs.fake }}
 
   publish:
     needs: [ prepare, sanity-test-pre ]

--- a/tools/update_notes.R
+++ b/tools/update_notes.R
@@ -1,9 +1,8 @@
 # This file is adapted from https://github.com/yutannihilation/string2path, under MIT license
 # Based on https://github.com/yutannihilation/string2path/blob/main/update_authors.R
 
-rlang::check_installed("RcppTOML")
-
 library(RcppTOML)
+library(stringr)
 
 ## Update inst/AUTHORS
 


### PR DESCRIPTION
- Fix #1349

envvar usage prevented CI from starting. See https://github.com/opendp/opendp/actions/runs/8135561781/workflow. The problem is really with `release.yml`, not `nightly.yml`. Simplify, by just repeating `inputs.dry_run || inputs.fake`. In some cases, only check `fake`, because not every `dry_run` is also `fake`

- Does the usage of `dry_run` vs `fake` now represent the behavior we want?
- Do we really need to support `fake`? I guess the idea is to speed up the build when we're exercising other parts of this... but I think it has been confusing.
- If we do want to support it, would it be more clear to have a select with three options, rather than than two checkboxes, one of which implies the other?

Need to manually run nightly on this branch and confirm that it works.