### PR TITLE
Runtime error if non-function is passed to `new_function`

### DIFF
--- a/python/src/opendp/core.py
+++ b/python/src/opendp/core.py
@@ -453,7 +453,7 @@ def measurement_output_measure(
 
 
 def new_function(
-    function: Callable,
+    function,
     TO: RuntimeTypeDescriptor
 ) -> Function:
     r"""Construct a Function from a user-defined callback.
@@ -468,9 +468,6 @@ def new_function(
     :raises OpenDPException: packaged error from the core OpenDP library
     """
     assert_features("contrib")
-
-    if not callable(function):
-        raise ValueError(f'Expected a callable instead of {function}')
 
     # Standardize type arguments.
     TO = RuntimeType.parse(type_name=TO)

--- a/python/src/opendp/core.py
+++ b/python/src/opendp/core.py
@@ -453,7 +453,7 @@ def measurement_output_measure(
 
 
 def new_function(
-    function,
+    function: Callable,
     TO: RuntimeTypeDescriptor
 ) -> Function:
     r"""Construct a Function from a user-defined callback.
@@ -468,6 +468,9 @@ def new_function(
     :raises OpenDPException: packaged error from the core OpenDP library
     """
     assert_features("contrib")
+
+    if not callable(function):
+        raise ValueError(f'Expected a callable instead of {function}')
 
     # Standardize type arguments.
     TO = RuntimeType.parse(type_name=TO)

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -110,7 +110,7 @@ class Measurement(ctypes.POINTER(AnyMeasurement)): # type: ignore[misc]
 
     def __rshift__(self, other: Union["Function", "Transformation", Callable]) -> "Measurement":
         if isinstance(other, Transformation):
-            other = other.function # pragma: no cover
+            other = other.function
 
         if not isinstance(other, Function):
             from opendp.core import new_function

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -113,6 +113,8 @@ class Measurement(ctypes.POINTER(AnyMeasurement)): # type: ignore[misc]
             other = other.function
 
         if not isinstance(other, Function):
+            if not callable(function):
+                raise ValueError(f'Expected a callable instead of {function}')
             from opendp.core import new_function
             other = new_function(other, TO="ExtrinsicObject")
 

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -108,7 +108,7 @@ class Measurement(ctypes.POINTER(AnyMeasurement)): # type: ignore[misc]
                 return False
             raise
 
-    def __rshift__(self, other: Union["Function", "Transformation"]) -> "Measurement":
+    def __rshift__(self, other: Union["Function", "Transformation", Callable]) -> "Measurement":
         if isinstance(other, Transformation):
             other = other.function # pragma: no cover
 
@@ -116,11 +116,8 @@ class Measurement(ctypes.POINTER(AnyMeasurement)): # type: ignore[misc]
             from opendp.core import new_function
             other = new_function(other, TO="ExtrinsicObject")
 
-        if isinstance(other, Function):
-            from opendp.combinators import make_chain_pm
-            return make_chain_pm(other, self)
-
-        raise ValueError(f"rshift expected a postprocessing transformation, got {other}")
+        from opendp.combinators import make_chain_pm
+        return make_chain_pm(other, self)
 
     @property
     def input_domain(self) -> "Domain":

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -113,8 +113,8 @@ class Measurement(ctypes.POINTER(AnyMeasurement)): # type: ignore[misc]
             other = other.function
 
         if not isinstance(other, Function):
-            if not callable(function):
-                raise ValueError(f'Expected a callable instead of {function}')
+            if not callable(other):
+                raise ValueError(f'Expected a callable instead of {other}')
             from opendp.core import new_function
             other = new_function(other, TO="ExtrinsicObject")
 

--- a/python/test/test_user_transform.py
+++ b/python/test/test_user_transform.py
@@ -40,9 +40,14 @@ def test_make_user_transformation():
 
 
 def test_make_custom_transformation_error():
-    import pytest
     with pytest.raises(Exception):
         make_duplicate(2, raises=True)([1, 2, 3])
+
+
+def test_new_function_on_non_function():
+    not_a_function = 'not a function'
+    with pytest.raises(ValueError, match='Expected a callable'):
+        dp.new_function(not_a_function, float)
 
 
 def make_constant_mechanism(constant):

--- a/python/test/test_user_transform.py
+++ b/python/test/test_user_transform.py
@@ -44,12 +44,6 @@ def test_make_custom_transformation_error():
         make_duplicate(2, raises=True)([1, 2, 3])
 
 
-def test_new_function_on_non_function():
-    not_a_function = 'not a function'
-    with pytest.raises(ValueError, match='Expected a callable'):
-        dp.new_function(not_a_function, float)
-
-
 def make_constant_mechanism(constant):
     """An example user-defined measurement from Python"""
     def function(_arg):


### PR DESCRIPTION
- Fix #1190
- Fix #1339
- Test the failing behavior
- Update the typing
- Remove coverage skip that isn't needed.

I think this does what we need, but I could be missing something.
