### PR TITLE
1338 test minimal cargo

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -65,6 +65,20 @@ jobs:
           name: vendor
           path: R/opendp/src/vendor.tar.xz
 
+  rust-examples:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: docs/source/getting-started
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Cargo run
+        run: cargo run
+
   python-lint:
     runs-on: ubuntu-22.04
     steps:

--- a/docs/source/getting-started/Cargo.toml
+++ b/docs/source/getting-started/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "getting-started"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+opendp = { version = "0.9.2", features = ["contrib", "honest-but-curious"] }

--- a/docs/source/getting-started/quickstart.R
+++ b/docs/source/getting-started/quickstart.R
@@ -1,8 +1,10 @@
 # init
 library(opendp)
-enable_features("contrib") # /init
+enable_features("contrib")
+# /init
 
 # demo
 space <- c(atom_domain(.T = "f64"), absolute_distance(.T = "f64"))
 base_laplace <- space |> then_base_laplace(1.)
-dp_value <- base_laplace(arg = 123.0) # /demo
+dp_value <- base_laplace(arg = 123.0)
+# /demo

--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -1,7 +1,7 @@
 Quickstart
 ==========
 
-OpenDP is available for Python and R.
+OpenDP is available for Python, R, and Rust.
 
 .. tab-set::
 
@@ -22,6 +22,15 @@ OpenDP is available for Python and R.
         .. code:: r
 
             install.packages('opendp', repos = 'https://opendp.r-universe.dev/')
+
+    .. tab-item:: Rust
+        :sync: rust
+
+        In a new directory run ``cargo init`` and then specify OpenDP as a dependency in ``Cargo.toml``:
+
+        .. literalinclude:: Cargo.toml
+            :language: toml
+            :start-at: dependencies
 
 
 This will make the OpenDP modules available to your local environment.
@@ -48,6 +57,12 @@ Enable ``contrib`` globally with the following snippet:
             :start-after: init
             :end-before: /init
 
+    .. tab-item:: Rust
+        :sync: rust
+
+        In Rust, ``contrib`` is specified in ``Cargo.toml``.
+
+
 Once you've installed OpenDP, you can write your first program.
 Let's apply Laplace noise to a value.
 
@@ -69,10 +84,16 @@ Let's apply Laplace noise to a value.
             :start-after: demo
             :end-before: /demo
 
+    .. tab-item:: Rust
+        :sync: rust
+
+        .. literalinclude:: src/main.rs
+            :language: rust
+
 This is obviously not the easiest way to add noise to a number,
 but it demonstrates a number of OpenDP patterns:
 
-* Defining your metric space with ``space_of`` in Python.
-* Chaining operators together with ``>>`` in Python, or ``|>`` in R.
+* Defining your metric space with ``space_of`` with Python's Context API, or a (domain, distance) tuple in any language.
+* Chaining operators together with ``>>`` in Python and Rust, or ``|>`` in R.
 * Constructing a ``Measurement`` function on your metric space with ``then_base_laplace``.
 * Invoking that measurement on a value to get a DP release.

--- a/docs/source/getting-started/src/main.rs
+++ b/docs/source/getting-started/src/main.rs
@@ -1,0 +1,12 @@
+use opendp::{
+    domains::AtomDomain,
+    measurements::then_base_laplace,
+    metrics::AbsoluteDistance,
+};
+
+fn main() {
+    let space = (AtomDomain::default(), AbsoluteDistance::default());
+    let base_laplace = space >> then_base_laplace(1.0, None);
+    let dp_value = base_laplace.expect("unexpected error").invoke(&123.0);
+    println!("DP value: {}", dp_value.expect("unexpected error"));
+}


### PR DESCRIPTION
- Towards #1338

We want to make sure Rust OpenDP works with a minimal set of features. A place to start is a test of the current behavior, and it would also be nice to integrate it with the docs.

Down the road we probably want to do something like rewrite the `Cargo.toml` during test so it uses the local source code... but for documentation for external users, we need something that pulls from crates.io, rather than the local checkout.

I'm not sure if there's a more elegant way to organize this than to running `cargo init` on the directory: It would be nice to have the rust code sample next to the other code samples, but cargo works well because of conventions and I'm not sure we should fight that.

Some other edits to the RST, and move closing tags to the next line: the snippets were being truncated.