### PR TITLE
Add `number_of_spaces` param to `indent`

### DIFF
--- a/rust/opendp_tooling/src/codegen/mod.rs
+++ b/rust/opendp_tooling/src/codegen/mod.rs
@@ -18,8 +18,7 @@ pub fn write_bindings(base_dir: PathBuf, files: HashMap<PathBuf, String>) {
     }
 }
 
-#[allow(dead_code)]
-pub(crate) fn indent(number_of_spaces: usize, text: String) -> String {
+fn tab(number_of_spaces: usize, text: String) -> String {
     text.split('\n')
         .map(|v| {
             if v.is_empty() {
@@ -30,6 +29,18 @@ pub(crate) fn indent(number_of_spaces: usize, text: String) -> String {
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+pub(crate) fn tab_r(text: String) -> String {
+    tab(4, text) // TODO: Reduce to 2, and regenerate.
+}
+
+pub(crate) fn tab_py(text: String) -> String {
+    tab(4, text)
+}
+
+pub(crate) fn tab_c(text: String) -> String {
+    tab(4, text)
 }
 
 /// resolve references to derived types

--- a/rust/opendp_tooling/src/codegen/mod.rs
+++ b/rust/opendp_tooling/src/codegen/mod.rs
@@ -19,13 +19,13 @@ pub fn write_bindings(base_dir: PathBuf, files: HashMap<PathBuf, String>) {
 }
 
 #[allow(dead_code)]
-pub(crate) fn indent(text: String) -> String {
+pub(crate) fn indent(number_of_spaces: usize, text: String) -> String {
     text.split('\n')
         .map(|v| {
             if v.is_empty() {
                 String::new()
             } else {
-                format!("    {}", v)
+                format!("{}{}", " ".repeat(number_of_spaces), v)
             }
         })
         .collect::<Vec<_>>()

--- a/rust/opendp_tooling/src/codegen/python.rs
+++ b/rust/opendp_tooling/src/codegen/python.rs
@@ -120,8 +120,8 @@ fn generate_function(
         .map(|v| format!(" -> {}", v))
         .unwrap_or_else(String::new);
 
-    let docstring = indent(generate_docstring(func, hierarchy));
-    let body = indent(generate_body(module_name, func, typemap));
+    let docstring = indent(4, generate_docstring(func, hierarchy));
+    let body = indent(4, generate_body(module_name, func, typemap));
 
     let then_func = if func.supports_partial {
         format!(
@@ -143,6 +143,7 @@ def {then_name}(
             then_name = func.name.replacen("make_", "then_", 1),
             func_name = func.name,
             doc_params = indent(
+                4,
                 func.args
                     .iter()
                     .skip(2)
@@ -150,20 +151,24 @@ def {then_name}(
                     .collect::<Vec<String>>()
                     .join("\n")
             ),
-            then_args = indent(args[2..].join(",\n")),
+            then_args = indent(4, args[2..].join(",\n")),
             dom_met = func.args[..2]
                 .iter()
                 .map(|arg| arg.name())
                 .collect::<Vec<_>>()
                 .join(", "),
             name = func.name,
-            args = indent(indent(
-                func.args
-                    .iter()
-                    .map(|arg| format!("{name}={name}", name = arg.name()))
-                    .collect::<Vec<_>>()
-                    .join(",\n")
-            ))
+            args = indent(
+                4,
+                indent(
+                    4,
+                    func.args
+                        .iter()
+                        .map(|arg| format!("{name}={name}", name = arg.name()))
+                        .collect::<Vec<_>>()
+                        .join(",\n")
+                )
+            )
         )
     } else {
         String::new()
@@ -178,7 +183,7 @@ def {func_name}(
 {body}{then_func}
 "#,
         func_name = func.name,
-        args = indent(args.join(",\n"))
+        args = indent(4, args.join(",\n"))
     )
 }
 

--- a/rust/opendp_tooling/src/codegen/python.rs
+++ b/rust/opendp_tooling/src/codegen/python.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use crate::{Argument, Function, TypeRecipe, Value};
 
-use crate::codegen::indent;
+use crate::codegen::tab_py;
 
 use super::flatten_type_recipe;
 
@@ -120,8 +120,8 @@ fn generate_function(
         .map(|v| format!(" -> {}", v))
         .unwrap_or_else(String::new);
 
-    let docstring = indent(4, generate_docstring(func, hierarchy));
-    let body = indent(4, generate_body(module_name, func, typemap));
+    let docstring = tab_py(generate_docstring(func, hierarchy));
+    let body = tab_py(generate_body(module_name, func, typemap));
 
     let then_func = if func.supports_partial {
         format!(
@@ -142,8 +142,7 @@ def {then_name}(
 "#,
             then_name = func.name.replacen("make_", "then_", 1),
             func_name = func.name,
-            doc_params = indent(
-                4,
+            doc_params = tab_py(
                 func.args
                     .iter()
                     .skip(2)
@@ -151,17 +150,15 @@ def {then_name}(
                     .collect::<Vec<String>>()
                     .join("\n")
             ),
-            then_args = indent(4, args[2..].join(",\n")),
+            then_args = tab_py(args[2..].join(",\n")),
             dom_met = func.args[..2]
                 .iter()
                 .map(|arg| arg.name())
                 .collect::<Vec<_>>()
                 .join(", "),
             name = func.name,
-            args = indent(
-                4,
-                indent(
-                    4,
+            args = tab_py(
+                tab_py(
                     func.args
                         .iter()
                         .map(|arg| format!("{name}={name}", name = arg.name()))
@@ -183,7 +180,7 @@ def {func_name}(
 {body}{then_func}
 "#,
         func_name = func.name,
-        args = indent(4, args.join(",\n"))
+        args = tab_py(args.join(",\n"))
     )
 }
 

--- a/rust/opendp_tooling/src/codegen/python.rs
+++ b/rust/opendp_tooling/src/codegen/python.rs
@@ -157,15 +157,13 @@ def {then_name}(
                 .collect::<Vec<_>>()
                 .join(", "),
             name = func.name,
-            args = tab_py(
-                tab_py(
-                    func.args
-                        .iter()
-                        .map(|arg| format!("{name}={name}", name = arg.name()))
-                        .collect::<Vec<_>>()
-                        .join(",\n")
-                )
-            )
+            args = tab_py(tab_py(
+                func.args
+                    .iter()
+                    .map(|arg| format!("{name}={name}", name = arg.name()))
+                    .collect::<Vec<_>>()
+                    .join(",\n")
+            ))
         )
     } else {
         String::new()

--- a/rust/opendp_tooling/src/codegen/r/c.rs
+++ b/rust/opendp_tooling/src/codegen/r/c.rs
@@ -170,8 +170,8 @@ SEXP {module_name}__{func_name}(
 }}
 "#,
         func_name = func.name,
-        args = indent(format!("{args}SEXP log")),
-        body = indent(generate_c_body(module_name, func))
+        args = indent(4, format!("{args}SEXP log")),
+        body = indent(4, generate_c_body(module_name, func))
     )
 }
 

--- a/rust/opendp_tooling/src/codegen/r/c.rs
+++ b/rust/opendp_tooling/src/codegen/r/c.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::{
-    codegen::{indent, r::BLACKLIST},
+    codegen::{tab_c, r::BLACKLIST},
     Argument, Function, TypeRecipe,
 };
 
@@ -170,8 +170,8 @@ SEXP {module_name}__{func_name}(
 }}
 "#,
         func_name = func.name,
-        args = indent(4, format!("{args}SEXP log")),
-        body = indent(4, generate_c_body(module_name, func))
+        args = tab_c(format!("{args}SEXP log")),
+        body = tab_c(generate_c_body(module_name, func))
     )
 }
 

--- a/rust/opendp_tooling/src/codegen/r/c.rs
+++ b/rust/opendp_tooling/src/codegen/r/c.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::{
-    codegen::{tab_c, r::BLACKLIST},
+    codegen::{r::BLACKLIST, tab_c},
     Argument, Function, TypeRecipe,
 };
 

--- a/rust/opendp_tooling/src/codegen/r/r.rs
+++ b/rust/opendp_tooling/src/codegen/r/r.rs
@@ -72,34 +72,42 @@ fn generate_r_function(
             then_docs = generate_then_doc_block(module_name, func, hierarchy),
             then_name = func.name.replacen("make_", "then_", 1),
             then_args = indent(
+                4,
                 once("lhs".to_string())
                     .chain(args[offset..].to_owned())
                     .collect::<Vec<_>>()
                     .join(",\n")
             ),
-            then_log = indent(generate_logger(module_name, func, true)),
+            then_log = indent(4, generate_logger(module_name, func, true)),
             name = func.name,
-            args = indent(indent(indent(
-                if func.supports_partial {
-                    vec![
-                        "output_domain(lhs)".to_string(),
-                        "output_metric(lhs)".to_string(),
-                    ]
-                } else {
-                    vec![]
-                }
-                .into_iter()
-                .chain(func.args[offset..].iter().map(|arg| {
-                    let name = if arg.is_type {
-                        format!(".{}", arg.name())
-                    } else {
-                        sanitize_r(arg.name(), arg.is_type)
-                    };
-                    format!("{name} = {name}")
-                }))
-                .collect::<Vec<_>>()
-                .join(",\n")
-            )))
+            args = indent(
+                4,
+                indent(
+                    4,
+                    indent(
+                        4,
+                        if func.supports_partial {
+                            vec![
+                                "output_domain(lhs)".to_string(),
+                                "output_metric(lhs)".to_string(),
+                            ]
+                        } else {
+                            vec![]
+                        }
+                        .into_iter()
+                        .chain(func.args[offset..].iter().map(|arg| {
+                            let name = if arg.is_type {
+                                format!(".{}", arg.name())
+                            } else {
+                                sanitize_r(arg.name(), arg.is_type)
+                            };
+                            format!("{name} = {name}")
+                        }))
+                        .collect::<Vec<_>>()
+                        .join(",\n")
+                    )
+                )
+            )
         )
     } else {
         String::default()
@@ -116,8 +124,8 @@ fn generate_r_function(
 "#,
         doc_block = generate_doc_block(module_name, func, hierarchy),
         func_name = func.name.trim_start_matches("_"),
-        args = indent(args.join(",\n")),
-        body = indent(generate_r_body(module_name, func))
+        args = indent(4, args.join(",\n")),
+        body = indent(4, generate_r_body(module_name, func))
     )
 }
 

--- a/rust/opendp_tooling/src/codegen/r/r.rs
+++ b/rust/opendp_tooling/src/codegen/r/r.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, iter::once};
 
 use crate::{
-    codegen::{flatten_type_recipe, indent},
+    codegen::{flatten_type_recipe, tab_r},
     Argument, Function, TypeRecipe, Value,
 };
 
@@ -71,21 +71,17 @@ fn generate_r_function(
 }}"#,
             then_docs = generate_then_doc_block(module_name, func, hierarchy),
             then_name = func.name.replacen("make_", "then_", 1),
-            then_args = indent(
-                4,
+            then_args = tab_r(
                 once("lhs".to_string())
                     .chain(args[offset..].to_owned())
                     .collect::<Vec<_>>()
                     .join(",\n")
             ),
-            then_log = indent(4, generate_logger(module_name, func, true)),
+            then_log = tab_r(generate_logger(module_name, func, true)),
             name = func.name,
-            args = indent(
-                4,
-                indent(
-                    4,
-                    indent(
-                        4,
+            args = tab_r(
+                tab_r(
+                    tab_r(
                         if func.supports_partial {
                             vec![
                                 "output_domain(lhs)".to_string(),
@@ -124,8 +120,8 @@ fn generate_r_function(
 "#,
         doc_block = generate_doc_block(module_name, func, hierarchy),
         func_name = func.name.trim_start_matches("_"),
-        args = indent(4, args.join(",\n")),
-        body = indent(4, generate_r_body(module_name, func))
+        args = tab_r(args.join(",\n")),
+        body = tab_r(generate_r_body(module_name, func))
     )
 }
 

--- a/rust/opendp_tooling/src/codegen/r/r.rs
+++ b/rust/opendp_tooling/src/codegen/r/r.rs
@@ -79,31 +79,27 @@ fn generate_r_function(
             ),
             then_log = tab_r(generate_logger(module_name, func, true)),
             name = func.name,
-            args = tab_r(
-                tab_r(
-                    tab_r(
-                        if func.supports_partial {
-                            vec![
-                                "output_domain(lhs)".to_string(),
-                                "output_metric(lhs)".to_string(),
-                            ]
-                        } else {
-                            vec![]
-                        }
-                        .into_iter()
-                        .chain(func.args[offset..].iter().map(|arg| {
-                            let name = if arg.is_type {
-                                format!(".{}", arg.name())
-                            } else {
-                                sanitize_r(arg.name(), arg.is_type)
-                            };
-                            format!("{name} = {name}")
-                        }))
-                        .collect::<Vec<_>>()
-                        .join(",\n")
-                    )
-                )
-            )
+            args = tab_r(tab_r(tab_r(
+                if func.supports_partial {
+                    vec![
+                        "output_domain(lhs)".to_string(),
+                        "output_metric(lhs)".to_string(),
+                    ]
+                } else {
+                    vec![]
+                }
+                .into_iter()
+                .chain(func.args[offset..].iter().map(|arg| {
+                    let name = if arg.is_type {
+                        format!(".{}", arg.name())
+                    } else {
+                        sanitize_r(arg.name(), arg.is_type)
+                    };
+                    format!("{name} = {name}")
+                }))
+                .collect::<Vec<_>>()
+                .join(",\n")
+            )))
         )
     } else {
         String::default()

--- a/rust/src/combinators/mod.rs
+++ b/rust/src/combinators/mod.rs
@@ -11,7 +11,6 @@ mod chain;
 pub use crate::combinators::chain::*;
 
 mod sequential_compositor;
-pub use crate::combinators::sequential_compositor::*;
 
 #[cfg(feature = "contrib")]
 mod measure_cast;


### PR DESCRIPTION
Prereq for 
- #1364 / #1342

steps:
- added param to function
- search and replace usages
- cargo fmt, which introduces most of the changes, considered line by line.

Thought about introducing wrapper functions `indent_2` and `indent_4`, but this seems simpler, but no strong feelings.

Implicitly tested by the check for local changes to the generated code after the cargo build.