### PR TITLE
Remove dead_code markers that do not cause warnings in IDE

### DIFF
--- a/rust/opendp_tooling/src/codegen/mod.rs
+++ b/rust/opendp_tooling/src/codegen/mod.rs
@@ -8,7 +8,6 @@ use crate::{Argument, TypeRecipe};
 pub mod python;
 pub mod r;
 
-#[allow(dead_code)]
 pub fn write_bindings(base_dir: PathBuf, files: HashMap<PathBuf, String>) {
     for (file_path, file_contents) in files {
         File::create(base_dir.join(file_path))
@@ -44,7 +43,6 @@ pub(crate) fn tab_c(text: String) -> String {
 }
 
 /// resolve references to derived types
-#[allow(dead_code)]
 fn flatten_type_recipe(type_recipe: &TypeRecipe, derived_types: &Vec<Argument>) -> TypeRecipe {
     let resolve_name = |name: &String| {
         derived_types

--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -281,7 +281,6 @@ where
         })
     }
 
-    #[allow(dead_code)]
     pub(crate) fn with_map<MI2: Metric, MO2: Measure>(
         &self,
         input_metric: MI2,
@@ -368,7 +367,6 @@ where
         })
     }
 
-    #[allow(dead_code)]
     pub(crate) fn with_map<MI2: Metric, MO2: Metric>(
         &self,
         input_metric: MI2,


### PR DESCRIPTION
- Fix #1374

These don't seem to be necessary. 