### PR TITLE
Measure `__str__` -> `__repr__`

### DIFF
--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -180,10 +180,15 @@ def loss_of(*, epsilon=None, delta=None, rho=None, U=None) -> Tuple[Measure, flo
 
     :param U: The type of the privacy parameter.
 
-    >>> from opendp.context import loss_of
-    >>> measure, distance = loss_of(epsilon=1.0)
-    >>> measure, distance = loss_of(epsilon=1.0, delta=1e-9)
-    >>> measure, distance = loss_of(rho=1.0)
+    :example:
+
+    >>> loss_of(epsilon=1.0)
+    (MaxDivergence(f64), 1.0)
+    >>> loss_of(epsilon=1.0, delta=1e-9)
+    (FixedSmoothedMaxDivergence(f64), (1.0, 1e-09))
+    >>> loss_of(rho=1.0)
+    (ZeroConcentratedDivergence(f64), 1.0)
+
     """
     if epsilon is None and rho is None:
         raise ValueError("Either epsilon or rho must be specified.")

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -429,7 +429,7 @@ class Queryable(object):
         from opendp.typing import RuntimeType
         return RuntimeType.parse(queryable_query_type(self.value))
 
-    def __str__(self):
+    def __repr__(self) -> str:
         return f"Queryable(Q={self.query_type})"
 
     def _depends_on(self, *args):
@@ -492,7 +492,7 @@ class Domain(ctypes.POINTER(AnyDomain)): # type: ignore[misc]
         from opendp.domains import _user_domain_descriptor
         return _user_domain_descriptor(self)
 
-    def __str__(self):
+    def __repr__(self) -> str:
         from opendp.domains import domain_debug
         return domain_debug(self)
     
@@ -504,9 +504,6 @@ class Domain(ctypes.POINTER(AnyDomain)): # type: ignore[misc]
             # an example error that this catches:
             #   ImportError: sys.meta_path is None, Python is likely shutting down
             pass
-
-    def __repr__(self) -> str:
-        return str(self) # pragma: no cover
     
     def __eq__(self, other) -> bool:
         # TODO: consider adding ffi equality
@@ -542,7 +539,7 @@ class Metric(ctypes.POINTER(AnyMetric)): # type: ignore[misc]
         from opendp.typing import RuntimeType
         return RuntimeType.parse(metric_distance_type(self))
 
-    def __str__(self):
+    def __repr__(self) -> str:
         from opendp.metrics import metric_debug
         return metric_debug(self)
     
@@ -554,9 +551,6 @@ class Metric(ctypes.POINTER(AnyMetric)): # type: ignore[misc]
             # an example error that this catches:
             #   ImportError: sys.meta_path is None, Python is likely shutting down
             pass
-
-    def __repr__(self) -> str:
-        return str(self) # pragma: no cover
     
     def __eq__(self, other) -> bool:
         # TODO: consider adding ffi equality

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -558,7 +558,14 @@ class Measure(ctypes.POINTER(AnyMeasure)): # type: ignore[misc]
     See the `Measure <../../api/user-guide/programming-framework/supporting-elements.html#measure>`_
     section in the Programming Framework docs for more context.
 
-    Functions for creating measures are in :py:mod:`opendp.measures`.
+    Measures should be created with the functions in :py:mod:`opendp.measures`
+    or :py:mod:`opendp.context`, for a higher-level interface:
+
+    >>> import opendp.prelude as dp
+    >>> measure, distance = dp.loss_of(epsilon=1.0)
+    >>> measure, distance
+    (MaxDivergence(f64), 1.0)
+
     '''
     _type_ = AnyMeasure
 
@@ -574,7 +581,7 @@ class Measure(ctypes.POINTER(AnyMeasure)): # type: ignore[misc]
         from opendp.typing import RuntimeType
         return RuntimeType.parse(measure_distance_type(self))
 
-    def __str__(self):
+    def __repr__(self):
         from opendp.measures import measure_debug
         return measure_debug(self)
     

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -34,24 +34,30 @@ class Measurement(ctypes.POINTER(AnyMeasurement)): # type: ignore[misc]
     >>> dp.enable_features("contrib")
 
     >>> # create an instance of Measurement using a constructor from the meas module
-    >>> base_dl: dp.Measurement = dp.m.make_laplace(
+    >>> laplace = dp.m.make_laplace(
     ...     dp.atom_domain(T=int), dp.absolute_distance(T=int),
     ...     scale=2.)
+    >>> laplace
+    Measurement(
+        input_domain   = AtomDomain(T=i32),
+        input_metric   = AbsoluteDistance(i32),
+        output_measure = MaxDivergence(f64)
+    )
 
     >>> # invoke the measurement (invoke and __call__ are equivalent)
-    >>> print('explicit: ', base_dl.invoke(100))  # -> 101   # doctest: +ELLIPSIS
+    >>> print('explicit: ', laplace.invoke(100))  # -> 101   # doctest: +ELLIPSIS
     explicit: ...
-    >>> print('concise: ', base_dl(100))  # -> 99            # doctest: +ELLIPSIS
+    >>> print('concise: ', laplace(100))  # -> 99            # doctest: +ELLIPSIS
     concise: ...
     >>> # check the measurement's relation at
     >>> #     (1, 0.5): (AbsoluteDistance<u32>, MaxDivergence)
-    >>> assert base_dl.check(1, 0.5)
+    >>> assert laplace.check(1, 0.5)
 
     >>> # chain with a transformation from the trans module
     >>> chained = (
     ...     (dp.vector_domain(dp.atom_domain(T=int)), dp.symmetric_distance()) >>
     ...     dp.t.then_count() >>
-    ...     base_dl
+    ...     laplace
     ... )
 
     >>> # the resulting measurement has the same features
@@ -191,8 +197,8 @@ class Measurement(ctypes.POINTER(AnyMeasurement)): # type: ignore[misc]
             #   ImportError: sys.meta_path is None, Python is likely shutting down
             pass
     
-    def __str__(self) -> str:
-        return f"Measurement(\n    input_domain   = {self.input_domain}, \n    input_metric   = {self.input_metric}, \n    output_measure = {self.output_measure}\n)" # pragma: no cover
+    def __repr__(self) -> str:
+        return f"Measurement(\n    input_domain   = {self.input_domain},\n    input_metric   = {self.input_metric},\n    output_measure = {self.output_measure}\n)" # pragma: no cover
 
 
 class Transformation(ctypes.POINTER(AnyTransformation)): # type: ignore[misc]
@@ -213,7 +219,14 @@ class Transformation(ctypes.POINTER(AnyTransformation)): # type: ignore[misc]
 
     >>> # create an instance of Transformation using a constructor from the trans module
     >>> input_space = (dp.vector_domain(dp.atom_domain(T=int)), dp.symmetric_distance())
-    >>> count: dp.Transformation = input_space >> dp.t.then_count()
+    >>> count = input_space >> dp.t.then_count()
+    >>> count
+    Transformation(
+        input_domain   = VectorDomain(AtomDomain(T=i32)),
+        output_domain  = AtomDomain(T=i32),
+        input_metric   = SymmetricDistance(),
+        output_metric  = AbsoluteDistance(i32)
+    )
 
     >>> # invoke the transformation (invoke and __call__ are equivalent)
     >>> count.invoke([1, 2, 3])
@@ -393,7 +406,7 @@ class Transformation(ctypes.POINTER(AnyTransformation)): # type: ignore[misc]
             #   ImportError: sys.meta_path is None, Python is likely shutting down
             pass
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         return f"Transformation(\n    input_domain   = {self.input_domain},\n    output_domain  = {self.output_domain},\n    input_metric   = {self.input_metric},\n    output_metric  = {self.output_metric}\n)"
 
 Transformation = cast(Type[Transformation], Transformation) # type: ignore[misc]

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -129,7 +129,7 @@ class RuntimeType(object):
             return False
         return self.origin == other.origin and self.args == other.args
 
-    def __str__(self):
+    def __repr__(self):
         result = self.origin or ''
         if result == 'Tuple':
             return f'({", ".join(map(str, self.args))})'
@@ -376,7 +376,7 @@ class RuntimeType(object):
     
 
 class GenericType(RuntimeType):
-    def __str__(self):
+    def __repr__(self):
         raise UnknownTypeException(f"attempted to create a type_name with an unknown generic: {self.origin}")
 
 
@@ -392,7 +392,7 @@ class UnknownType(RuntimeType):
         self.args = None
         self.reason = reason
 
-    def __str__(self):
+    def __repr__(self):
         raise UnknownTypeException(f"attempted to create a type_name with an unknown type: {self.reason}")
 
 


### PR DESCRIPTION
- Fix #1390
- Will cause a small conflict with #1386, but didn't want to expand the scope of that PR unnecessarily.

Am I correct in thinking that `loss_of` is the most idiomatic way to construct a `Measure`? Change the wording here if not.