### PR TITLE
Add setuptools, fix nightly?

### DIFF
--- a/tools/python_build.sh
+++ b/tools/python_build.sh
@@ -38,7 +38,7 @@ function run() {
 
 function init() {
   log "Install dependencies"
-  run pip install wheel setuptools
+  run pip install setuptools wheel
 }
 
 function build() {

--- a/tools/python_build.sh
+++ b/tools/python_build.sh
@@ -38,7 +38,7 @@ function run() {
 
 function init() {
   log "Install dependencies"
-  run pip install wheel
+  run pip install wheel setuptools
 }
 
 function build() {


### PR DESCRIPTION
- hopefully fix #1413
- follow-up to #1415
- related to #1426 -- with each script having its own requirements, it's easy to get confused and not add dependencies where needed. Since debugging the CI is annoying, it would be good to make this simpler and more robust.

Will file as draft and start a dry-run: https://github.com/opendp/opendp/actions/runs/8424738627