### PR TITLE
Add a badge for docs.rs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -17,6 +17,7 @@ provide a broader view of the the develpment and release process.
 #### Nightly
 
 - [`nightly.yml`](nightly.yml) makes a nightly release. [Past runs](https://github.com/opendp/opendp/actions/workflows/nightly.yml). [![nightly status](https://github.com/opendp/opendp/actions/workflows/nightly.yml/badge.svg)](https://github.com/opendp/opendp/actions/workflows/nightly.yml?query=branch%3Amain)
+- [`docs.rs`](https://docs.rs/crate/opendp/latest) also builds the Rust documentation, separate from the GitHub CI. ![docs.rs status](https://img.shields.io/docsrs/opendp?label=docs.rs)
 
 #### Weekly
 


### PR DESCRIPTION
- Follow-up to #1414 -> #1434

Trying to make this page more of a dashboard where any important build problem will show up.

Note that because of our naming convention for the nightlies (adding a suffix to the previous release, rather than a suffix on the upcoming release), docs.rs still reports the build as broken -- or at least I think that's what's going on.