### PR TITLE
API ToC just down to modules

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -28,7 +28,7 @@ clean:
 
 html:
 	@set -e
-	$(SPHINXAPIDOC) -f -F -e -H "OpenDP" -A "The OpenDP Project" -V $(VERSION) -o source/api/python ../python/src/opendp --templatedir source/_templates
+	$(SPHINXAPIDOC) -f -F -e -d 3 -H "OpenDP" -A "The OpenDP Project" -V $(VERSION) -o source/api/python ../python/src/opendp --templatedir source/_templates
 	$(SPHINXBUILD) $(SPHINXOPTS) -D version=$(VERSION) -D 'html_sidebars.**'=sidebar-nav-bs.html source $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."


### PR DESCRIPTION
With this change, the ToC looks like:
<img width="371" alt="Screenshot 2024-03-29 at 10 40 15 AM" src="https://github.com/opendp/opendp/assets/730388/ba30dddd-849f-41b3-94f6-af8d54251c54">

I think it's an improvement, but it is subjective.
- Fix #1294