### PR TITLE
links between user guide and api reference

### DIFF
--- a/docs/source/api/user-guide/combinators/index.rst
+++ b/docs/source/api/user-guide/combinators/index.rst
@@ -1,4 +1,4 @@
-.. _combinator-constructors:
+.. _combinators-user-guide:
 
 Combinators
 ===========
@@ -104,7 +104,7 @@ This is intended to enable further chaining with preprocessors such as:
 * :py:func:`make_impute_constant <opendp.transformations.make_impute_constant>`
 * :py:func:`make_clamp <opendp.transformations.make_clamp>` 
 * :py:func:`make_resize <opendp.transformations.make_resize>`.
-See the section on :ref:`transformation-constructors` for more information on how to preprocess data in OpenDP.
+See the section on :ref:`transformations-user-guide` for more information on how to preprocess data in OpenDP.
 
 Composition
 -----------

--- a/docs/source/api/user-guide/combinators/index.rst
+++ b/docs/source/api/user-guide/combinators/index.rst
@@ -3,6 +3,8 @@
 Combinators
 ===========
 
+(See also :py:mod:`opendp.combinators` in the API reference.)
+
 Combinator constructors use Transformations or Measurements to produce a new Transformation or Measurement.
 
 .. _chaining:

--- a/docs/source/api/user-guide/context/index.rst
+++ b/docs/source/api/user-guide/context/index.rst
@@ -20,7 +20,6 @@ it can raise an exception and prevent you from running more queries than your bu
     .. code:: python
 
       >>> import opendp.prelude as dp
-      >>> dp.enable_features("contrib")
       >>> context = dp.Context.compositor(
       ...     data=[5.0] * 100,
       ...     privacy_unit=dp.unit_of(contributions=1),

--- a/docs/source/api/user-guide/context/index.rst
+++ b/docs/source/api/user-guide/context/index.rst
@@ -20,12 +20,19 @@ it can raise an exception and prevent you from running more queries than your bu
 
     .. code:: python
 
+      >>> from typing import List
       >>> import opendp.prelude as dp
       >>> dp.enable_features("contrib")
       >>> context = dp.Context.compositor(
-      ...     data=[1, 2, 3],
-      ...     privacy_unit=dp.unit_of(contributions=3),
-      ...     privacy_loss=dp.loss_of(epsilon=3.0),
+      ...     data=[1.0, 2.0, 3.0, 4.0, 5.0],
+      ...     privacy_unit=dp.unit_of(contributions=1),
+      ...     privacy_loss=dp.loss_of(epsilon=1.0),
       ...     split_evenly_over=1,
-      ...     domain=dp.domain_of(List[int]),
       ... )
+
+
+      >>> sum_query = context.query().clamp((1.0, 10.0)).sum()
+      
+      >>> dp_sum_query = sum_query.laplace(100.0)
+      >>> dp_sum_query.release()
+      ...

--- a/docs/source/api/user-guide/context/index.rst
+++ b/docs/source/api/user-guide/context/index.rst
@@ -13,26 +13,20 @@ Because it knows the total privacy budget,
 it can raise an exception and prevent you from running more queries than your budget allows.
 
 
-
 .. tab-set::
 
   .. tab-item:: Python
 
     .. code:: python
 
-      >>> from typing import List
       >>> import opendp.prelude as dp
-      >>> dp.enable_features("contrib")
       >>> context = dp.Context.compositor(
-      ...     data=[1.0, 2.0, 3.0, 4.0, 5.0],
+      ...     data=[5.0] * 100,
       ...     privacy_unit=dp.unit_of(contributions=1),
       ...     privacy_loss=dp.loss_of(epsilon=1.0),
       ...     split_evenly_over=1,
       ... )
-
-
       >>> sum_query = context.query().clamp((1.0, 10.0)).sum()
-      
-      >>> dp_sum_query = sum_query.laplace(100.0)
-      >>> dp_sum_query.release()
-      ...
+      >>> dp_sum_query = sum_query.laplace()
+      >>> print('DP sum should be near 500:', dp_sum_query.release())  # doctest: +ELLIPSIS
+      DP sum should be near 500: ...

--- a/docs/source/api/user-guide/context/index.rst
+++ b/docs/source/api/user-guide/context/index.rst
@@ -1,0 +1,8 @@
+.. _context-user-guide:
+
+Context
+=======
+
+(See also :py:mod:`opendp.context` in the API reference.)
+
+TODO

--- a/docs/source/api/user-guide/context/index.rst
+++ b/docs/source/api/user-guide/context/index.rst
@@ -5,4 +5,27 @@ Context
 
 (See also :py:mod:`opendp.context` in the API reference.)
 
-TODO
+The Context API wraps the lower-level Framework API elements.
+It is currently only available for Python.
+Rather than just applying noise at the end of the process,
+the Context API requires you to specify your privacy budget at the start.
+Because it knows the total privacy budget,
+it can raise an exception and prevent you from running more queries than your budget allows.
+
+
+
+.. tab-set::
+
+  .. tab-item:: Python
+
+    .. code:: python
+
+      >>> import opendp.prelude as dp
+      >>> dp.enable_features("contrib")
+      >>> context = dp.Context.compositor(
+      ...     data=[1, 2, 3],
+      ...     privacy_unit=dp.unit_of(contributions=3),
+      ...     privacy_loss=dp.loss_of(epsilon=3.0),
+      ...     split_evenly_over=1,
+      ...     domain=dp.domain_of(List[int]),
+      ... )

--- a/docs/source/api/user-guide/context/index.rst
+++ b/docs/source/api/user-guide/context/index.rst
@@ -20,6 +20,7 @@ it can raise an exception and prevent you from running more queries than your bu
     .. code:: python
 
       >>> import opendp.prelude as dp
+      >>> dp.enable_features("contrib")
       >>> context = dp.Context.compositor(
       ...     data=[5.0] * 100,
       ...     privacy_unit=dp.unit_of(contributions=1),

--- a/docs/source/api/user-guide/index.rst
+++ b/docs/source/api/user-guide/index.rst
@@ -14,3 +14,4 @@ it complements the bottom-up view provided by the `Python API Reference <../pyth
    measurements/index
    combinators/index
    utilities/index
+   context/index

--- a/docs/source/api/user-guide/measurements/index.rst
+++ b/docs/source/api/user-guide/measurements/index.rst
@@ -4,7 +4,7 @@ Measurements
 ============
 
 This section gives a high-level overview of the measurements that are available in the library.
-Refer to the :ref:`measurement` section for an explanation of what a measurement is.
+Refer to the :ref:`measurements-user-guide` for an explanation of what a measurement is.
 
 The intermediate domains and metrics need to match when chaining.
 This means you will need to choose a measurement that chains with your :ref:`aggregator <aggregators>`.

--- a/docs/source/api/user-guide/programming-framework/core-structures.rst
+++ b/docs/source/api/user-guide/programming-framework/core-structures.rst
@@ -1,7 +1,9 @@
-.. _core-structures:
+.. _core-user-guide:
 
 Core Structures
 ===============
+
+(See also :py:mod:`opendp.core` in the API reference.)
 
 OpenDP is focused on creating computations with specific privacy characteristics.
 These computations are modeled with two core structures in OpenDP:
@@ -74,6 +76,8 @@ Transformations need to be :ref:`chained <chaining>` with a measurement before t
 
 Measurement
 -----------
+
+(See also :py:mod:`opendp.measurements` in the API reference.)
 
 A :py:class:`Measurement <opendp.mod.Measurement>` is, in contrast, a `randomized` mapping from datasets to outputs.
 Measurements are used to create differentially private releases.

--- a/docs/source/api/user-guide/programming-framework/core-structures.rst
+++ b/docs/source/api/user-guide/programming-framework/core-structures.rst
@@ -22,10 +22,10 @@ Similarities
 Both transformations and measurements are mappings from inputs to outputs,
 and they share these four fields:
 
-:``input_domain``: A :ref:`domain <domains>` that describes the set of all possible input values for the function.
-:``output_domain``: A :ref:`domain <domains>` that describes the set of all possible output values of the function.
-:``function``: A :ref:`function <functions>` that transforms data.
-:``input_metric``: A :ref:`metric <metrics>` used to compute distance between two members of the input domain.
+:``input_domain``: A :ref:`domain <domains-user-guide>` that describes the set of all possible input values for the function.
+:``output_domain``: A :ref:`domain <domains-user-guide>` that describes the set of all possible output values of the function.
+:``function``: A :ref:`function <functions-user-guide>` that transforms data.
+:``input_metric``: A :ref:`metric <metrics-user-guide>` used to compute distance between two members of the input domain.
 
 Transformations and measurements have two additional fields, and this is where they differ:
 
@@ -70,7 +70,7 @@ Invoking the function transforms the data, but the output is not differentially 
 Transformations need to be :ref:`chained <chaining>` with a measurement before they can be used to create a differentially-private release.
 
 
-.. _measurement:
+.. _measurements-user-guide:
 
 Measurement
 -----------

--- a/docs/source/api/user-guide/programming-framework/index.rst
+++ b/docs/source/api/user-guide/programming-framework/index.rst
@@ -18,7 +18,7 @@ There is also an illustrative notebook `A Framework to Understand DP <../../../t
 .. note::
 
     In this section, we've used lower case when writing the names of OpenDP concepts. 
-    Later, when we talk about :doc:`programming elements <core-structures>`, we'll use the capitalized form to refer to the concrete data types that implement these concepts. 
+    Later, when we talk about :ref:`programming elements <core-user-guide>`, we'll use the capitalized form to refer to the concrete data types that implement these concepts. 
     (The concept names link to their corresponding type descriptions.)
 
 * :ref:`measurements <measurements-user-guide>` are randomized mappings from a private, 

--- a/docs/source/api/user-guide/programming-framework/index.rst
+++ b/docs/source/api/user-guide/programming-framework/index.rst
@@ -21,17 +21,17 @@ There is also an illustrative notebook `A Framework to Understand DP <../../../t
     Later, when we talk about :doc:`programming elements <core-structures>`, we'll use the capitalized form to refer to the concrete data types that implement these concepts. 
     (The concept names link to their corresponding type descriptions.)
 
-* :ref:`measurements <measurement>` are randomized mappings from a private, 
+* :ref:`measurements <measurements-user-guide>` are randomized mappings from a private, 
   potentially sensitive dataset or value to an arbitrary output value that is safe to release.
   They are a controlled means of introducing privacy protection (e.g. noise) to a computation. 
   An example of a measurement is one that adds Laplace noise to a value.
-* :ref:`transformations <transformation>` are deterministic mappings from a private dataset to another private dataset or value.
+* :ref:`transformations <transformations-user-guide>` are deterministic mappings from a private dataset to another private dataset or value.
   They are used to summarize or transform values in some way.
   An example of a transformation is one which calculates the mean of a set of values.
-* :ref:`domains <domains>` are sets which identify the possible values that some object can take. 
+* :ref:`domains <domains-user-guide>` are sets which identify the possible values that some object can take. 
   They are used to constrain the input or output of measurements and transformations. 
   Examples of domains are the integers between 1 and 10, or vectors of length 5 containing floating point numbers.
-* :ref:`measures <measures>` and :ref:`metrics <metrics>` are things that specify distances between two mathematical objects.
+* :ref:`measures <measures-user-guide>` and :ref:`metrics <metrics-user-guide>` are things that specify distances between two mathematical objects.
 
   * Measures characterize a distance between two probability distributions.
     An example measure is the "max-divergence" of pure differential privacy.

--- a/docs/source/api/user-guide/programming-framework/supporting-elements.rst
+++ b/docs/source/api/user-guide/programming-framework/supporting-elements.rst
@@ -4,7 +4,7 @@ Supporting Elements
 This section builds on the :ref:`core-structures` documentation to expand on the constituent pieces of Measurements and Transformations.
 
 
-.. _functions:
+.. _functions-user-guide:
 
 Function
 --------
@@ -45,7 +45,7 @@ Or ``invoke`` can be used equivalently:
 A mathematical function associates each value in some input set with some value in the output set (or a distribution over such values, in the case of a randomized function).
 In OpenDP, as discussed in the next section, we capture these sets with domains.
 
-.. _domains:
+.. _domains-user-guide:
 
 Domain
 ------
@@ -149,7 +149,7 @@ These domains serve two purposes:
    to guarantee that the output of the first function is always a valid input to the second function.
 
 
-.. _metrics:
+.. _metrics-user-guide:
 
 Metric
 ------
@@ -176,7 +176,7 @@ In practice, you may not have a need to provide global sensitivities to stabilit
 because they are a midway distance bound encountered while relating dataset distances and privacy distances.
 However, there are situations where constructors accept a metric for specifying the metric for sensitivities.
 
-.. _measures:
+.. _measures-user-guide:
 
 Measure
 -------
@@ -287,6 +287,6 @@ Practically speaking, the smaller the ``d_out``, the tighter your analysis will 
 You might find it surprising that metrics and measures are never actually evaluated!
 The framework does not evaluate these because it only needs to relate a user-provided input distance to another user-provided output distance.
 Even the user should not directly compute input and output distances:
-they are :ref:`solved-for <determining-accuracy>`, :ref:`bisected <parameter-search>`, or provided by the Context API.
+they are :ref:`solved-for <accuracy-user-guide>`, :ref:`bisected <parameter-search>`, or provided by the Context API.
 
 Be careful: even a dataset query to determine the greatest number of contributions made by any one individual can itself be private information.

--- a/docs/source/api/user-guide/programming-framework/supporting-elements.rst
+++ b/docs/source/api/user-guide/programming-framework/supporting-elements.rst
@@ -297,6 +297,6 @@ Practically speaking, the smaller the ``d_out``, the tighter your analysis will 
 You might find it surprising that metrics and measures are never actually evaluated!
 The framework does not evaluate these because it only needs to relate a user-provided input distance to another user-provided output distance.
 Even the user should not directly compute input and output distances:
-they are :ref:`solved-for <accuracy-user-guide>`, :ref:`bisected <parameter-search>`, or provided by the Context API.
+they are :ref:`solved-for <accuracy-user-guide>`, :ref:`bisected <parameter-search>`, or provided by the :ref:`Context API <context-user-guide>`.
 
 Be careful: even a dataset query to determine the greatest number of contributions made by any one individual can itself be private information.

--- a/docs/source/api/user-guide/programming-framework/supporting-elements.rst
+++ b/docs/source/api/user-guide/programming-framework/supporting-elements.rst
@@ -1,13 +1,14 @@
 Supporting Elements
 ===================
 
-This section builds on the :ref:`core-structures` documentation to expand on the constituent pieces of Measurements and Transformations.
+This section builds on the :ref:`core-user-guide` documentation to expand on the constituent pieces of Measurements and Transformations.
 
 
 .. _functions-user-guide:
 
 Function
 --------
+
 As one would expect, all data processing is handled via a function.
 The function member stored in a Transformation or Measurement struct is straightforward representation of an idealized mathematical function.
 
@@ -49,6 +50,9 @@ In OpenDP, as discussed in the next section, we capture these sets with domains.
 
 Domain
 ------
+
+(See also :py:mod:`opendp.domains` in the API reference.)
+
 A domain describes the set of all possible input values of a function, or all possible output values of a function.
 Transformations have both an ``input_domain`` and ``output_domain``, while measurements only have an ``input_domain``.
 
@@ -153,6 +157,9 @@ These domains serve two purposes:
 
 Metric
 ------
+
+(See also :py:mod:`opendp.metrics` in the API reference.)
+
 A metric is a function that computes the distance between two elements of a domain.
 Transformations have both an ``input_metric`` and ``output_metric``, while measurements only have an ``input_metric``.
 
@@ -180,6 +187,9 @@ However, there are situations where constructors accept a metric for specifying 
 
 Measure
 -------
+
+(See also :py:mod:`opendp.measures` in the API reference.)
+
 In OpenDP, a measure is a function for measuring the distance between probability distributions.
 Transformations don't make use of a measure, but measurements do have an ``output_measure``.
 

--- a/docs/source/api/user-guide/programming-framework/supporting-elements.rst
+++ b/docs/source/api/user-guide/programming-framework/supporting-elements.rst
@@ -10,7 +10,7 @@ Function
 --------
 
 As one would expect, all data processing is handled via a function.
-The function member stored in a Transformation or Measurement struct is straightforward representation of an idealized mathematical function.
+The function member stored in a Transformation or Measurement struct is a straightforward representation of an idealized mathematical function.
 
 To use the function, the Transformation or Measurement can be called directly:
 

--- a/docs/source/api/user-guide/transformations/index.rst
+++ b/docs/source/api/user-guide/transformations/index.rst
@@ -1,4 +1,4 @@
-.. _transformation-constructors:
+.. _transformations-user-guide:
 
 Transformations
 ===============

--- a/docs/source/api/user-guide/transformations/index.rst
+++ b/docs/source/api/user-guide/transformations/index.rst
@@ -3,10 +3,12 @@
 Transformations
 ===============
 
+(See also :py:mod:`opendp.transformations` in the API reference.)
+
 This section gives a high-level overview of the transformations that are available in the library.
 Refer to the :ref:`transformation` section for an explanation of what a transformation is.
 
-As covered in the :ref:`chaining` section, the intermediate :ref:`domains <domains>` need to match when chaining.
+As covered in the :ref:`chaining` section, the intermediate :ref:`domains <domains-user-guide>` need to match when chaining.
 Each transformation has a carefully chosen input domain and output domain that supports their relation.
 
 

--- a/docs/source/api/user-guide/utilities/accuracy.rst
+++ b/docs/source/api/user-guide/utilities/accuracy.rst
@@ -4,6 +4,8 @@
 Accuracy
 --------
 
+(See also :py:mod:`opendp.accuracy` in the API reference.)
+
 The library contains utilities to estimate accuracy at a given noise scale and statistical significance level
 or derive the necessary noise scale to meet a given target accuracy and statistical significance level.
 

--- a/docs/source/api/user-guide/utilities/accuracy.rst
+++ b/docs/source/api/user-guide/utilities/accuracy.rst
@@ -1,5 +1,5 @@
 
-.. _determining-accuracy:
+.. _accuracy-user-guide:
 
 Accuracy
 --------

--- a/docs/source/api/user-guide/utilities/typing.rst
+++ b/docs/source/api/user-guide/utilities/typing.rst
@@ -1,5 +1,9 @@
+.. _typing-user-guide:
+
 Typing
 ======
+
+(See also :py:mod:`opendp.typing` in the API reference.)
 
 OpenDP computations are always strict about the types being used. 
 Integers and floats are never treated interchangeably and there is never implicit casting between types.
@@ -92,7 +96,7 @@ Examples of these types include:
 * L1Distance[u128]
 
 The docstrings on the constructor APIs should typically guide you as to what types are permissible.
-If you aren't familiar with these concepts, it may help to review :ref:`domains` and :ref:`metrics`.
+If you aren't familiar with these concepts, it may help to review :ref:`domains-user-guide` and :ref:`metrics-user-guide`.
 
 
 Type Aliases

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,6 +48,8 @@ def is_rst(line):
 def docstring(app, what, name, obj, options, lines):
     path = name.split(".")
 
+    # "len(path) > 2": We only need special processing for the contents of modules.
+    # The top-of-module docstrings are plain RST.
     if len(path) > 2 and path[1] in markdown_modules:
         # split docstring into description and params
         param_index = next((i for i, line in enumerate(lines) if is_rst(line)), len(lines))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,7 +48,7 @@ def is_rst(line):
 def docstring(app, what, name, obj, options, lines):
     path = name.split(".")
 
-    if len(path) > 1 and path[1] in markdown_modules:
+    if len(path) > 2 and path[1] in markdown_modules:
         # split docstring into description and params
         param_index = next((i for i, line in enumerate(lines) if is_rst(line)), len(lines))
         description, params = lines[:param_index], lines[param_index:]

--- a/python/src/opendp/accuracy.py
+++ b/python/src/opendp/accuracy.py
@@ -1,6 +1,8 @@
 # Auto-generated. Do not edit!
 '''
+
 The ``accuracy`` module provides functions for converting between accuracy and scale parameters.
+For more context, see :ref:`Accuracy in the User Guide <accuracy-user-guide>`
 '''
 from opendp._convert import *
 from opendp._lib import *

--- a/python/src/opendp/accuracy.py
+++ b/python/src/opendp/accuracy.py
@@ -1,8 +1,14 @@
 # Auto-generated. Do not edit!
 '''
-
 The ``accuracy`` module provides functions for converting between accuracy and scale parameters.
-For more context, see :ref:`Accuracy in the User Guide <accuracy-user-guide>`
+For more context, see :ref:`accuracy in the User Guide <accuracy-user-guide>`.
+
+For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+We suggest importing under the conventional name ``dp``:
+
+.. code:: python
+
+    >>> import opendp.prelude as dp
 '''
 from opendp._convert import *
 from opendp._lib import *

--- a/python/src/opendp/combinators.py
+++ b/python/src/opendp/combinators.py
@@ -1,8 +1,14 @@
 # Auto-generated. Do not edit!
 '''
-
 The ``combinators`` module provides functions for combining transformations and measurements.
-For more context, see :ref:`Combinators in the User Guide <combinators-user-guide>`
+For more context, see :ref:`combinators in the User Guide <combinators-user-guide>`.
+
+For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+We suggest importing under the conventional name ``dp``:
+
+.. code:: python
+
+    >>> import opendp.prelude as dp
 '''
 from opendp._convert import *
 from opendp._lib import *

--- a/python/src/opendp/combinators.py
+++ b/python/src/opendp/combinators.py
@@ -9,6 +9,8 @@ We suggest importing under the conventional name ``dp``:
 .. code:: python
 
     >>> import opendp.prelude as dp
+
+The methods of this module will then be accessible at ``dp.c``.
 '''
 from opendp._convert import *
 from opendp._lib import *

--- a/python/src/opendp/combinators.py
+++ b/python/src/opendp/combinators.py
@@ -1,6 +1,8 @@
 # Auto-generated. Do not edit!
 '''
+
 The ``combinators`` module provides functions for combining transformations and measurements.
+For more context, see :ref:`Combinators in the User Guide <combinators-user-guide>`
 '''
 from opendp._convert import *
 from opendp._lib import *

--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -1,5 +1,14 @@
 '''
 The ``context`` module provides :py:class:`opendp.context.Context` and supporting utilities.
+
+For more context, see :ref:`context in the User Guide <context-user-guide>`.
+
+For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+We suggest importing under the conventional name ``dp``:
+
+.. code:: python
+
+    >>> import opendp.prelude as dp
 '''
 
 from typing import Any, Callable, List, Optional, Tuple, Union

--- a/python/src/opendp/core.py
+++ b/python/src/opendp/core.py
@@ -1,6 +1,14 @@
 # Auto-generated. Do not edit!
 '''
 The ``core`` module provides functions for accessing the fields of transformations and measurements.
+For more context, see :ref:`core in the User Guide <core-user-guide>`.
+
+For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+We suggest importing under the conventional name ``dp``:
+
+.. code:: python
+
+    >>> import opendp.prelude as dp
 '''
 from opendp._convert import *
 from opendp._lib import *

--- a/python/src/opendp/core.py
+++ b/python/src/opendp/core.py
@@ -1,5 +1,6 @@
 # Auto-generated. Do not edit!
 '''
+
 The ``core`` module provides functions for accessing the fields of transformations and measurements.
 '''
 from opendp._convert import *

--- a/python/src/opendp/core.py
+++ b/python/src/opendp/core.py
@@ -1,6 +1,5 @@
 # Auto-generated. Do not edit!
 '''
-
 The ``core`` module provides functions for accessing the fields of transformations and measurements.
 '''
 from opendp._convert import *

--- a/python/src/opendp/domains.py
+++ b/python/src/opendp/domains.py
@@ -1,8 +1,14 @@
 # Auto-generated. Do not edit!
 '''
-
 The ``domains`` module provides functions for creating and using domains.
-For more context, see :ref:`Domains in the User Guide <domains-user-guide>`
+For more context, see :ref:`domains in the User Guide <domains-user-guide>`.
+
+For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+We suggest importing under the conventional name ``dp``:
+
+.. code:: python
+
+    >>> import opendp.prelude as dp
 '''
 from opendp._convert import *
 from opendp._lib import *

--- a/python/src/opendp/domains.py
+++ b/python/src/opendp/domains.py
@@ -1,6 +1,8 @@
 # Auto-generated. Do not edit!
 '''
-The ``domains`` modules provides functions for creating and using domains.
+
+The ``domains`` module provides functions for creating and using domains.
+For more context, see :ref:`Domains in the User Guide <domains-user-guide>`
 '''
 from opendp._convert import *
 from opendp._lib import *

--- a/python/src/opendp/measurements.py
+++ b/python/src/opendp/measurements.py
@@ -1,6 +1,8 @@
 # Auto-generated. Do not edit!
 '''
+
 The ``measurements`` module provides functions that apply calibrated noise to data to ensure differential privacy.
+For more context, see :ref:`Measurements in the User Guide <measurements-user-guide>`
 '''
 from opendp._convert import *
 from opendp._lib import *

--- a/python/src/opendp/measurements.py
+++ b/python/src/opendp/measurements.py
@@ -9,6 +9,8 @@ We suggest importing under the conventional name ``dp``:
 .. code:: python
 
     >>> import opendp.prelude as dp
+
+The methods of this module will then be accessible at ``dp.m``.
 '''
 from opendp._convert import *
 from opendp._lib import *

--- a/python/src/opendp/measurements.py
+++ b/python/src/opendp/measurements.py
@@ -1,8 +1,14 @@
 # Auto-generated. Do not edit!
 '''
-
 The ``measurements`` module provides functions that apply calibrated noise to data to ensure differential privacy.
-For more context, see :ref:`Measurements in the User Guide <measurements-user-guide>`
+For more context, see :ref:`measurements in the User Guide <measurements-user-guide>`.
+
+For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+We suggest importing under the conventional name ``dp``:
+
+.. code:: python
+
+    >>> import opendp.prelude as dp
 '''
 from opendp._convert import *
 from opendp._lib import *

--- a/python/src/opendp/measures.py
+++ b/python/src/opendp/measures.py
@@ -1,6 +1,8 @@
 # Auto-generated. Do not edit!
 '''
-The ``measures`` modules provides functions that measure the distance between probability distributions.
+
+The ``measures`` module provides functions that measure the distance between probability distributions.
+For more context, see :ref:`Measures in the User Guide <measures-user-guide>`
 '''
 from opendp._convert import *
 from opendp._lib import *

--- a/python/src/opendp/measures.py
+++ b/python/src/opendp/measures.py
@@ -1,8 +1,14 @@
 # Auto-generated. Do not edit!
 '''
-
 The ``measures`` module provides functions that measure the distance between probability distributions.
-For more context, see :ref:`Measures in the User Guide <measures-user-guide>`
+For more context, see :ref:`measures in the User Guide <measures-user-guide>`.
+
+For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+We suggest importing under the conventional name ``dp``:
+
+.. code:: python
+
+    >>> import opendp.prelude as dp
 '''
 from opendp._convert import *
 from opendp._lib import *

--- a/python/src/opendp/metrics.py
+++ b/python/src/opendp/metrics.py
@@ -1,6 +1,8 @@
 # Auto-generated. Do not edit!
 '''
+
 The ``metrics`` module provides fuctions that measure the distance between two elements of a domain.
+For more context, see :ref:`Metrics in the User Guide <metrics-user-guide>`
 '''
 from opendp._convert import *
 from opendp._lib import *

--- a/python/src/opendp/metrics.py
+++ b/python/src/opendp/metrics.py
@@ -1,8 +1,14 @@
 # Auto-generated. Do not edit!
 '''
-
 The ``metrics`` module provides fuctions that measure the distance between two elements of a domain.
-For more context, see :ref:`Metrics in the User Guide <metrics-user-guide>`
+For more context, see :ref:`metrics in the User Guide <metrics-user-guide>`.
+
+For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+We suggest importing under the conventional name ``dp``:
+
+.. code:: python
+
+    >>> import opendp.prelude as dp
 '''
 from opendp._convert import *
 from opendp._lib import *

--- a/python/src/opendp/transformations.py
+++ b/python/src/opendp/transformations.py
@@ -1,8 +1,14 @@
 # Auto-generated. Do not edit!
 '''
-
 The ``transformations`` module provides functions that deterministicly transform datasets.
-For more context, set :ref:`Transformations in the User Guide <transformations-user-guide>`
+For more context, see :ref:`transformations in the User Guide <transformations-user-guide>`.
+
+For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+We suggest importing under the conventional name ``dp``:
+
+.. code:: python
+
+    >>> import opendp.prelude as dp
 '''
 from opendp._convert import *
 from opendp._lib import *

--- a/python/src/opendp/transformations.py
+++ b/python/src/opendp/transformations.py
@@ -1,6 +1,8 @@
 # Auto-generated. Do not edit!
 '''
+
 The ``transformations`` module provides functions that deterministicly transform datasets.
+For more context, set :ref:`Transformations in the User Guide <transformations-user-guide>`
 '''
 from opendp._convert import *
 from opendp._lib import *

--- a/python/src/opendp/transformations.py
+++ b/python/src/opendp/transformations.py
@@ -9,6 +9,8 @@ We suggest importing under the conventional name ``dp``:
 .. code:: python
 
     >>> import opendp.prelude as dp
+
+The methods of this module will then be accessible at ``dp.t``.
 '''
 from opendp._convert import *
 from opendp._lib import *

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -3,6 +3,15 @@ The ``typing`` module provides utilities that bridge between Python and Rust typ
 OpenDP relies on precise descriptions of data types to make its security guarantees:
 These are more natural in Rust with its fine-grained type system,
 but they may feel out of place in Python. These utilities try to fill that gap.
+
+For more context, see :ref:`typing in the User Guide <typing-user-guide>`.
+
+For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+We suggest importing under the conventional name ``dp``:
+
+.. code:: python
+
+    >>> import opendp.prelude as dp
 '''
 from __future__ import annotations
 import sys

--- a/rust/opendp_tooling/src/codegen/python.rs
+++ b/rust/opendp_tooling/src/codegen/python.rs
@@ -103,8 +103,10 @@ We suggest importing under the conventional name ``dp``:
             "{}{}",
             "The ``combinators`` module provides functions for combining transformations and measurements.",
             special_boilerplate("combinators".to_string())),
-        "core" =>
+        "core" => format!(
+            "{}{}",
             "The ``core`` module provides functions for accessing the fields of transformations and measurements.".to_string(),
+            boilerplate("core".to_string())),
         "domains" => format!(
             "{}{}",
             "The ``domains`` module provides functions for creating and using domains.",

--- a/rust/opendp_tooling/src/codegen/python.rs
+++ b/rust/opendp_tooling/src/codegen/python.rs
@@ -70,14 +70,29 @@ from opendp.measures import *"#
     };
 
     let module_docs = match module_name {
-        "accuracy" => "The ``accuracy`` module provides functions for converting between accuracy and scale parameters.",
-        "combinators" => "The ``combinators`` module provides functions for combining transformations and measurements.",
-        "core" => "The ``core`` module provides functions for accessing the fields of transformations and measurements.",
-        "domains" => "The ``domains`` modules provides functions for creating and using domains.",
-        "measurements" => "The ``measurements`` module provides functions that apply calibrated noise to data to ensure differential privacy.",
-        "measures" => "The ``measures`` modules provides functions that measure the distance between probability distributions.",
-        "metrics" => "The ``metrics`` module provides fuctions that measure the distance between two elements of a domain.",
-        "transformations" => "The ``transformations`` module provides functions that deterministicly transform datasets.",
+        "accuracy" => "
+The ``accuracy`` module provides functions for converting between accuracy and scale parameters.
+For more context, see :ref:`Accuracy in the User Guide <accuracy-user-guide>`",
+        "combinators" => "
+The ``combinators`` module provides functions for combining transformations and measurements.
+For more context, see :ref:`Combinators in the User Guide <combinators-user-guide>`",
+        "core" => "
+The ``core`` module provides functions for accessing the fields of transformations and measurements.",
+        "domains" => "
+The ``domains`` module provides functions for creating and using domains.
+For more context, see :ref:`Domains in the User Guide <domains-user-guide>`",
+        "measurements" => "
+The ``measurements`` module provides functions that apply calibrated noise to data to ensure differential privacy.
+For more context, see :ref:`Measurements in the User Guide <measurements-user-guide>`",
+        "measures" => "
+The ``measures`` module provides functions that measure the distance between probability distributions.
+For more context, see :ref:`Measures in the User Guide <measures-user-guide>`",
+        "metrics" => "
+The ``metrics`` module provides fuctions that measure the distance between two elements of a domain.
+For more context, see :ref:`Metrics in the User Guide <metrics-user-guide>`",
+        "transformations" => "
+The ``transformations`` module provides functions that deterministicly transform datasets.
+For more context, set :ref:`Transformations in the User Guide <transformations-user-guide>`",
         _ => "TODO!"
     };
 

--- a/rust/opendp_tooling/src/codegen/python.rs
+++ b/rust/opendp_tooling/src/codegen/python.rs
@@ -69,31 +69,52 @@ from opendp.measures import *"#
         ""
     };
 
+    fn boilerplate(name: String) -> String {
+        format!(
+            "
+For more context, see :ref:`{name} in the User Guide <{name}-user-guide>`.
+
+For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+We suggest importing under the conventional name ``dp``:
+
+.. code:: python
+
+    >>> import opendp.prelude as dp"
+        )
+    }
+
     let module_docs = match module_name {
-        "accuracy" => "
-The ``accuracy`` module provides functions for converting between accuracy and scale parameters.
-For more context, see :ref:`Accuracy in the User Guide <accuracy-user-guide>`",
-        "combinators" => "
-The ``combinators`` module provides functions for combining transformations and measurements.
-For more context, see :ref:`Combinators in the User Guide <combinators-user-guide>`",
-        "core" => "
-The ``core`` module provides functions for accessing the fields of transformations and measurements.",
-        "domains" => "
-The ``domains`` module provides functions for creating and using domains.
-For more context, see :ref:`Domains in the User Guide <domains-user-guide>`",
-        "measurements" => "
-The ``measurements`` module provides functions that apply calibrated noise to data to ensure differential privacy.
-For more context, see :ref:`Measurements in the User Guide <measurements-user-guide>`",
-        "measures" => "
-The ``measures`` module provides functions that measure the distance between probability distributions.
-For more context, see :ref:`Measures in the User Guide <measures-user-guide>`",
-        "metrics" => "
-The ``metrics`` module provides fuctions that measure the distance between two elements of a domain.
-For more context, see :ref:`Metrics in the User Guide <metrics-user-guide>`",
-        "transformations" => "
-The ``transformations`` module provides functions that deterministicly transform datasets.
-For more context, set :ref:`Transformations in the User Guide <transformations-user-guide>`",
-        _ => "TODO!"
+        "accuracy" => format!(
+            "{}{}",
+            "The ``accuracy`` module provides functions for converting between accuracy and scale parameters.",
+            boilerplate("accuracy".to_string())),
+        "combinators" => format!(
+            "{}{}",
+            "The ``combinators`` module provides functions for combining transformations and measurements.",
+            boilerplate("combinators".to_string())),
+        "core" =>
+            "The ``core`` module provides functions for accessing the fields of transformations and measurements.".to_string(),
+        "domains" => format!(
+            "{}{}",
+            "The ``domains`` module provides functions for creating and using domains.",
+            boilerplate("domains".to_string())),
+        "measurements" => format!(
+            "{}{}",
+            "The ``measurements`` module provides functions that apply calibrated noise to data to ensure differential privacy.",
+            boilerplate("measurements".to_string())),
+        "measures" => format!(
+            "{}{}",
+            "The ``measures`` module provides functions that measure the distance between probability distributions.",
+            boilerplate("measures".to_string())),
+        "metrics" => format!(
+            "{}{}",
+            "The ``metrics`` module provides fuctions that measure the distance between two elements of a domain.",
+            boilerplate("metrics".to_string())),
+        "transformations" => format!(
+            "{}{}",
+            "The ``transformations`` module provides functions that deterministicly transform datasets.",
+            boilerplate("transformations".to_string())),
+        _ => "TODO!".to_string()
     };
 
     format!(

--- a/rust/opendp_tooling/src/codegen/python.rs
+++ b/rust/opendp_tooling/src/codegen/python.rs
@@ -83,6 +83,17 @@ We suggest importing under the conventional name ``dp``:
         )
     }
 
+    fn special_boilerplate(name: String) -> String {
+        let initial = name.chars().nth(0);
+        format!("{}\n\nThe methods of this module will then be accessible at ``dp.{}``.",
+            boilerplate(name),
+            match initial {
+                Some(s) => s.to_string(),
+                None => "".to_string()
+            }
+        )
+    }
+
     let module_docs = match module_name {
         "accuracy" => format!(
             "{}{}",
@@ -91,7 +102,7 @@ We suggest importing under the conventional name ``dp``:
         "combinators" => format!(
             "{}{}",
             "The ``combinators`` module provides functions for combining transformations and measurements.",
-            boilerplate("combinators".to_string())),
+            special_boilerplate("combinators".to_string())),
         "core" =>
             "The ``core`` module provides functions for accessing the fields of transformations and measurements.".to_string(),
         "domains" => format!(
@@ -101,7 +112,7 @@ We suggest importing under the conventional name ``dp``:
         "measurements" => format!(
             "{}{}",
             "The ``measurements`` module provides functions that apply calibrated noise to data to ensure differential privacy.",
-            boilerplate("measurements".to_string())),
+            special_boilerplate("measurements".to_string())),
         "measures" => format!(
             "{}{}",
             "The ``measures`` module provides functions that measure the distance between probability distributions.",
@@ -113,7 +124,7 @@ We suggest importing under the conventional name ``dp``:
         "transformations" => format!(
             "{}{}",
             "The ``transformations`` module provides functions that deterministicly transform datasets.",
-            boilerplate("transformations".to_string())),
+            special_boilerplate("transformations".to_string())),
         _ => "TODO!".to_string()
     };
 

--- a/rust/opendp_tooling/src/codegen/python.rs
+++ b/rust/opendp_tooling/src/codegen/python.rs
@@ -85,11 +85,12 @@ We suggest importing under the conventional name ``dp``:
 
     fn special_boilerplate(name: String) -> String {
         let initial = name.chars().nth(0);
-        format!("{}\n\nThe methods of this module will then be accessible at ``dp.{}``.",
+        format!(
+            "{}\n\nThe methods of this module will then be accessible at ``dp.{}``.",
             boilerplate(name),
             match initial {
                 Some(s) => s.to_string(),
-                None => "".to_string()
+                None => "".to_string(),
             }
         )
     }


### PR DESCRIPTION
- Fix #1388 (Replaces #1445)
- Fix #973 (could do more, but enough for now)
- Link from every module to a corresponding section of the user guide
- Link from many sections of the user guide to corresponding modules
- And special boilerplate for our three special modules.
- Make the anchors more consistent.

