### PR TITLE
xfail usability tests

### DIFF
--- a/python/test/test_context_usability.py
+++ b/python/test/test_context_usability.py
@@ -1,0 +1,51 @@
+import pytest
+import opendp.prelude as dp
+
+
+@pytest.mark.xfail(raises=dp.UnknownTypeException)
+def test_iterable_data():
+    # Currently fails with:
+    #   opendp.mod.UnknownTypeException: <class 'range'>
+    # Possible resolution:
+    #   The data kwarg accepts iterables.
+    context = dp.Context.compositor(
+        data=range(100),
+        privacy_unit=dp.unit_of(contributions=1),
+        privacy_loss=dp.loss_of(epsilon=1.0),
+        split_evenly_over=1,
+    )
+    sum_query = context.query().clamp((1.0, 10.0)).sum()
+    sum_query.laplace()
+
+
+@pytest.mark.xfail(raises=TypeError)
+def test_int_data_laplace_param():
+    # Currently fails with:
+    #   TypeError: inferred type is i32, expected f64. See https://github.com/opendp/opendp/discussions/298
+    # Possible resolution:
+    #   Explicit parameter on laplace works with int data, or the error message should suggest the fix.
+    context = dp.Context.compositor(
+        data=[1, 2, 3, 4, 5],
+        privacy_unit=dp.unit_of(contributions=1),
+        privacy_loss=dp.loss_of(epsilon=1.0),
+        split_evenly_over=1,
+    )
+    sum_query = context.query().clamp((1, 10)).sum()
+    sum_query.laplace(100)
+
+
+@pytest.mark.xfail(raises=dp.OpenDPException)
+def test_mean_without_size():
+    # Currently fails with:
+    #   opendp.mod.OpenDPException:
+    #     MakeTransformation("dataset size must be known. Either specify size in the input domain or use make_resize")
+    # Possible resolution:
+    #   Error message suggests fixes in terms on the new Context API.
+    context = dp.Context.compositor(
+        data=[1.0, 2.0, 3.0, 4.0, 5.0],
+        privacy_unit=dp.unit_of(contributions=1),
+        privacy_loss=dp.loss_of(epsilon=1.0),
+        split_evenly_over=1,
+    )
+    mean_query = context.query().clamp((1.0, 10.0)).mean()
+    mean_query.laplace()

--- a/python/test/test_context_usability.py
+++ b/python/test/test_context_usability.py
@@ -1,5 +1,4 @@
 import pytest
-from typing import List
 import opendp.prelude as dp
 
 


### PR DESCRIPTION
I tripped several times coming up with the simple `Context` example in #1458, and wanted to capture the errors a typical user might hit. I don't know enough about the project direction to immediately file new issues for each of these: Maybe work that's in progress will take care of them?

Going forward, when we ourselves or outside users hit an error that isn't helpful, we might consider adding a test here.

- Towards #1422 
- With #1456 merged, and strict turned on, if one of these stops erroring, it will fail the test.