### PR TITLE
r-docs artifact: We were uploading r-docs with v2, downloading with v4

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
         run: bash tools/r_stage.sh -d
 
       - name: Upload docs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: r-docs
           path: R/opendp/docs

--- a/docs/tools/rst-to-nb.py
+++ b/docs/tools/rst-to-nb.py
@@ -1,6 +1,0 @@
-# Given
-# - RST using our convention for tabbed code examples
-# - The "sync" value for the tabs to extract
-# Return
-# - Intermediate markdown
-# - Final notebook format

--- a/docs/tools/rst-to-nb.py
+++ b/docs/tools/rst-to-nb.py
@@ -1,0 +1,6 @@
+# Given
+# - RST using our convention for tabbed code examples
+# - The "sync" value for the tabs to extract
+# Return
+# - Intermediate markdown
+# - Final notebook format


### PR DESCRIPTION
I didn't file a new issue for currently nightly failure.

Haven't dug into the git history to understand what went wrong, but the fix seems simple. Confirmed that with this commit every `actions/upload-artifact` is v4.