### PR TITLE
cast int to float if needed in `py_to_c`

### DIFF
--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -39,13 +39,33 @@ _ERROR_URL_298 = "https://github.com/opendp/opendp/discussions/298"
 
 def _check_and_cast_scalar(expected, value):
     '''
-    
-    If expected is not one of a small number of Rust types:
+    Any number is cast to float, if f32 or f64 is expected:
     >>> _check_and_cast_scalar('f32', 1.0)
-    ???
-    >>> _check_and_cast_scalar('f32', 1)
-    ???
+    1.0
+    >>> _check_and_cast_scalar('f64', 1)
+    1.0
 
+    Ints cast to ints, unsurprisingly:
+    >>> _check_and_cast_scalar('u8', 1)
+    1
+
+    ... but there are range checks:
+    >>> _check_and_cast_scalar('u8', 256)
+    Traceback (most recent call last):
+    ...
+    ValueError: 256 is not representable by u8
+
+    Floats cannot be cast to ints:
+    >>> _check_and_cast_scalar('i32', 1.0)
+    Traceback (most recent call last):
+    ...
+    TypeError: inferred type is f64, expected i32. See https://github.com/opendp/opendp/discussions/298
+
+    Unrecognized types will fail, but note that the error message refers to "f64":
+    >>> _check_and_cast_scalar('fake', 1)
+    Traceback (most recent call last):
+    ...
+    TypeError: inferred type is f64, expected fake. See https://github.com/opendp/opendp/discussions/298    
     '''
     inferred = RuntimeType.infer(value)
     

--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -37,7 +37,16 @@ INT_SIZES = {
 _ERROR_URL_298 = "https://github.com/opendp/opendp/discussions/298"
 
 
-def check_and_cast_scalar(expected, value):
+def _check_and_cast_scalar(expected, value):
+    '''
+    
+    If expected is not one of a small number of Rust types:
+    >>> _check_and_cast_scalar('f32', 1.0)
+    ???
+    >>> _check_and_cast_scalar('f32', 1)
+    ???
+
+    '''
     inferred = RuntimeType.infer(value)
     
     if inferred in ATOM_EQUIVALENCE_CLASSES:
@@ -103,7 +112,7 @@ def py_to_c(value: Any, c_type, type_name: RuntimeTypeDescriptor = None) -> Any:
 
         rust_type = str(type_name)
         
-        value = check_and_cast_scalar(rust_type, value)
+        value = _check_and_cast_scalar(rust_type, value)
 
         if rust_type in ATOM_MAP:
             return ctypes.byref(ATOM_MAP[rust_type](value))
@@ -287,7 +296,7 @@ def _scalar_to_slice(val, type_name: str) -> FfiSlicePtr:
     np = import_optional_dependency('numpy', raise_error=False)
     if np is not None and isinstance(val, np.ndarray):
         val = val.item()
-    val = check_and_cast_scalar(type_name, val)
+    val = _check_and_cast_scalar(type_name, val)
     # ctypes.byref has edge-cases that cause use-after-free errors. ctypes.pointer fixes these edge-cases
     return _wrap_in_slice(ctypes.pointer(ATOM_MAP[type_name](val)), 1)
 
@@ -357,7 +366,7 @@ def _vector_to_slice(val: Sequence[Any], type_name: RuntimeType) -> FfiSlicePtr:
         ffi_slice.depends_on(c_repr)
         return ffi_slice
 
-    val = [check_and_cast_scalar(inner_type_name, v) for v in val]
+    val = [_check_and_cast_scalar(inner_type_name, v) for v in val]
 
     if inner_type_name == "String":
         def str_to_slice(val):
@@ -431,7 +440,7 @@ def _tuple_to_slice(val: tuple[Any, ...], type_name: Union[RuntimeType, str]) ->
 
     # check that actual type can be represented by the inner_type_name
     val = tuple(
-        check_and_cast_scalar(inner_type_name, val[i])
+        _check_and_cast_scalar(inner_type_name, val[i])
         for i, inner_type_name in zip(range(len(val)), inner_type_names)
     )
     
@@ -467,8 +476,8 @@ def _hashmap_to_slice(val: dict[Any, Any], type_name: RuntimeType) -> FfiSlicePt
         raise TypeError(f"Expected type is {type_name} but input data is not a dict.")
 
     val = {
-        check_and_cast_scalar(key_type, k):
-            check_and_cast_scalar(val_type, v) if val_type != "ExtrinsicObject" else v
+        _check_and_cast_scalar(key_type, k):
+            _check_and_cast_scalar(val_type, v) if val_type != "ExtrinsicObject" else v
         for k, v in val.items()
     }
     

--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -55,11 +55,37 @@ def _check_and_cast_scalar(expected, value):
     ...
     ValueError: 256 is not representable by u8
 
+    ... but not for floats? TODO?
+    >>> _check_and_cast_scalar('f32', 1e100)
+    1e+100
+
     Floats cannot be cast to ints:
     >>> _check_and_cast_scalar('i32', 1.0)
     Traceback (most recent call last):
     ...
     TypeError: inferred type is f64, expected i32. See https://github.com/opendp/opendp/discussions/298
+
+    Bools cast to bools:
+    >>> _check_and_cast_scalar('bool', True)
+    True
+
+    Bools cannot cast to ints:
+    >>> _check_and_cast_scalar('u8', True)
+    Traceback (most recent call last):
+    ...
+    TypeError: inferred type is f64, expected u8. See https://github.com/opendp/opendp/discussions/298
+
+    ... but bools can cast to floats: Is this right? TODO
+    >>> _check_and_cast_scalar('f64', True)
+    1.0
+
+    >>> _check_and_cast_scalar('f32', True)
+    1.0
+
+    >>> _check_and_cast_scalar('bool', 1)
+    Traceback (most recent call last):
+    ...
+    TypeError: inferred type is f64, expected bool. See https://github.com/opendp/opendp/discussions/298
 
     Unrecognized types will fail, but note that the error message refers to "f64":
     >>> _check_and_cast_scalar('fake', 1)

--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -429,10 +429,10 @@ def _tuple_to_slice(val: tuple[Any, ...], type_name: Union[RuntimeType, str]) ->
             raise TypeError(f"Tuple members must be one of {ATOM_MAP.keys()}. Got {t}")
 
     # check that actual type can be represented by the inner_type_name
-    val = [
+    val = tuple(
         check_and_cast_scalar(inner_type_name, val[i])
         for i, inner_type_name in zip(range(len(val)), inner_type_names)
-    ]
+    )
     
     # ctypes.byref has edge-cases that cause use-after-free errors. ctypes.pointer fixes these edge-cases
     ptr_data = (

--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -36,6 +36,7 @@ INT_SIZES = {
 }
 _ERROR_URL_298 = "https://github.com/opendp/opendp/discussions/298"
 
+
 def check_and_cast_scalar(expected, value):
     inferred = RuntimeType.infer(value)
     

--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -235,8 +235,7 @@ def metric_of(M) -> Metric:
 def loss_of(
         epsilon: Optional[float] = None,
         delta: Optional[float] = None,
-        rho: Optional[float] = None,
-        U = None) -> tuple[Measure, Union[float, tuple[float, float]]]:
+        rho: Optional[float] = None) -> tuple[Measure, Union[float, tuple[float, float]]]:
     """Constructs a privacy loss, consisting of a privacy measure and a privacy loss parameter.
 
     >>> import opendp.prelude as dp
@@ -250,7 +249,6 @@ def loss_of(
     :param epsilon: Parameter for pure ε-DP.
     :param delta: Parameter for approximate (ε,δ)-DP.
     :param rho: Parameter for zero-concentrated ρ-DP.
-    :param U: The type of the privacy parameter; Inferred if not provided.
 
     """
     def range_warning(name, value, info_level, warn_level):
@@ -264,20 +262,17 @@ def loss_of(
 
     if rho:
         range_warning('rho', rho, 0.25, 0.5)
-        U = RuntimeType.parse_or_infer(U, rho)
-        return zero_concentrated_divergence(T=U), rho
+        return zero_concentrated_divergence(T=float), rho
 
     if epsilon is None:
         raise ValueError("Either epsilon or rho must be specified.")
  
     range_warning('epsilon', epsilon, 1, 5)
     if delta is None:
-        U = RuntimeType.parse_or_infer(U, epsilon)
-        return max_divergence(T=U), epsilon
+        return max_divergence(T=float), epsilon
 
     range_warning('delta', delta, 1e-6, 1e-6)
-    U = RuntimeType.parse_or_infer(U, epsilon)
-    return fixed_smoothed_max_divergence(T=U), (epsilon, delta)
+    return fixed_smoothed_max_divergence(T=float), (epsilon, delta)
 
 
 def unit_of(

--- a/python/test/context/test_context.py
+++ b/python/test/context/test_context.py
@@ -27,7 +27,7 @@ def test_unit_of():
 
 
 def test_privacy_loss_of():
-    assert dp.loss_of(epsilon=3.0) == (dp.max_divergence(T=float), 3.0)
+    assert dp.loss_of(epsilon=3) == (dp.max_divergence(T=float), 3.0)
     assert dp.loss_of(rho=2.0) == (dp.zero_concentrated_divergence(T=float), 2.0)
     assert dp.loss_of(epsilon=2.0, delta=1e-6) == (
         dp.fixed_smoothed_max_divergence(T=float),
@@ -93,7 +93,7 @@ def test_context_init_split_evenly_over():
     context = dp.Context.compositor(
         data=[1, 2, 3],
         privacy_unit=dp.unit_of(contributions=3),
-        privacy_loss=dp.loss_of(epsilon=3.0),
+        privacy_loss=dp.loss_of(epsilon=3),
         split_evenly_over=3,
         domain=dp.domain_of(list[int]),
     )

--- a/python/test/test_binary_search.py
+++ b/python/test/test_binary_search.py
@@ -53,7 +53,7 @@ def test_type_inference():
         return dp.t.make_sum(
             dp.vector_domain(dp.atom_domain(bounds=(-b, b)), size=1000), 
             dp.symmetric_distance())
-    assert dp.binary_search_param(chainer, 2, 100) == 50
+    assert dp.binary_search_param(chainer, 2, 100) == pytest.approx(50)
 
     def mean_chainer_n(n):
         return dp.t.make_mean(

--- a/python/test/test_context_usability.py
+++ b/python/test/test_context_usability.py
@@ -18,12 +18,7 @@ def test_iterable_data():
     sum_query.laplace()
 
 
-@pytest.mark.xfail(raises=TypeError)
 def test_int_data_laplace_param():
-    # Currently fails with:
-    #   TypeError: inferred type is i32, expected f64. See https://github.com/opendp/opendp/discussions/298
-    # Possible resolution:
-    #   Explicit parameter on laplace works with int data, or the error message should suggest the fix.
     context = dp.Context.compositor(
         data=[1, 2, 3, 4, 5],
         privacy_unit=dp.unit_of(contributions=1),

--- a/python/test/test_convert.py
+++ b/python/test/test_convert.py
@@ -4,6 +4,7 @@ from opendp._convert import (
     _vector_to_slice, _slice_to_vector,
     _hashmap_to_slice, _slice_to_hashmap,
 )
+from opendp._convert import _check_and_cast_scalar
 from opendp.typing import *
 import pytest
 
@@ -165,3 +166,40 @@ def test_polars_expr():
     obj = py_to_c(val_in, AnyObjectPtr, "Expr")
     val_out = c_to_py(obj)
     assert str(val_out) == str(val_in)
+
+
+def test_check_and_cast_scalar():
+    # Any number is cast to float, if f32 or f64 is expected:
+    assert _check_and_cast_scalar('f32', 1.0) == 1.0
+    assert _check_and_cast_scalar('f64', 1) == 1.0
+
+    # Ints cast to ints, unsurprisingly:
+    assert _check_and_cast_scalar('u8', 1) == 1
+
+    # There are range checks for ints:
+    with pytest.raises(ValueError, match="256 is not representable by u8"):
+        _check_and_cast_scalar('u8', 256)
+
+    # Floats don't have range checks because inf is a valid float:
+    assert _check_and_cast_scalar('f32', 1e100) == 1e+100
+
+    # Floats cannot be cast to ints:
+    with pytest.raises(TypeError, match="inferred type is f64, expected i32."):
+        _check_and_cast_scalar('i32', 1.0)
+    
+    # Bools can only cast to bools:
+    assert _check_and_cast_scalar('bool', True)
+
+    # Bools cannot cast to ints:
+    with pytest.raises(TypeError, match="inferred type is bool, expected u8."):
+        _check_and_cast_scalar('u8', True)
+    
+    # Bools cannot cast to floats:
+    with pytest.raises(TypeError, match="inferred type is bool, expected f64."):
+        _check_and_cast_scalar('f64', True)
+    
+    with pytest.raises(TypeError, match="inferred type is i32, expected bool."):
+        _check_and_cast_scalar('bool', 1)
+    
+    with pytest.raises(TypeError, match="inferred type is i32, expected fake."):
+        _check_and_cast_scalar('fake', 1)

--- a/python/test/test_convert.py
+++ b/python/test/test_convert.py
@@ -11,7 +11,13 @@ import pytest
 def test_data_object_int():
     val_in = 123
     obj = py_to_c(val_in, c_type=AnyObjectPtr)
-    print(obj)
+    val_out = c_to_py(obj)
+    assert val_out == val_in
+
+
+def test_data_object_int_to_float():
+    val_in = 123
+    obj = py_to_c(val_in, c_type=AnyObjectPtr, type_name='f64')
     val_out = c_to_py(obj)
     assert val_out == val_in
 

--- a/python/test/test_typing.py
+++ b/python/test/test_typing.py
@@ -106,6 +106,9 @@ def test_default_float_type():
 
     # Can't set to f32 because debug binary has fewer types.
 
+def test_runtime_type_hash():
+    assert {Vec[int]} == {RuntimeType.parse("Vec<int>")}
+
 
 disallowed_int_default_types = set([i128, u128, isize])
 


### PR DESCRIPTION
- Towards #943 (not sure if there are other coercions we'd also like to see?)
- Fix #1468

Not super confident about this approach, but `check_similar_scalar` really seems to be the center of things: This gets called from many different points, so doing it outside this function seemed like a piecemeal solution.

This does fix `test_int_data_laplace_param` and I've added a lower level conversion test, but there is a change in behavior in binary search, but maybe that's ok?

Draft for now, but feedback welcome.