### PR TITLE
add context, remove raise_error kwarg

### DIFF
--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -266,9 +266,9 @@ def _py_to_slice(value: Any, type_name: Union[RuntimeType, str]) -> FfiSlicePtr:
 
 
 def _scalar_to_slice(val, type_name: str) -> FfiSlicePtr:
-    np = import_optional_dependency('numpy', raise_error=False)
-    if np is not None and isinstance(val, np.ndarray):
-        val = val.item() # pragma: no cover
+    with optional_dependency('numpy') as np:
+        if isinstance(val, np.ndarray):
+            val = val.item() # pragma: no cover
     check_similar_scalar(type_name, val)
     # ctypes.byref has edge-cases that cause use-after-free errors. ctypes.pointer fixes these edge-cases
     return _wrap_in_slice(ctypes.pointer(ATOM_MAP[type_name](val)), 1)
@@ -297,9 +297,9 @@ def _slice_to_extrinsic(raw: FfiSlicePtr):
     return ctypes.cast(raw.contents.ptr, ctypes.POINTER(ExtrinsicObject)).contents.ptr
 
 def _string_to_slice(val: str) -> FfiSlicePtr:
-    np = import_optional_dependency('numpy', raise_error=False)
-    if np is not None and isinstance(val, np.ndarray):
-        val = val.item() # pragma: no cover
+    with optional_dependency('numpy') as np:
+        if isinstance(val, np.ndarray):
+            val = val.item() # pragma: no cover
     return _wrap_in_slice(ctypes.pointer(ctypes.c_char_p(val.encode())), 1)
 
 
@@ -314,9 +314,9 @@ def _vector_to_slice(val: Sequence[Any], type_name: RuntimeType) -> FfiSlicePtr:
     inner_type_name = type_name.args[0]
     # when input is numpy array
     # TODO: can we use the underlying buffer directly?
-    np = import_optional_dependency('numpy', raise_error=False)
-    if np is not None and isinstance(val, np.ndarray):
-        val = val.tolist() # pragma: no cover
+    with optional_dependency('numpy') as np:
+        if isinstance(val, np.ndarray):
+            val = val.tolist() # pragma: no cover
 
     if not isinstance(val, list):
         raise TypeError(f"Expected type is {type_name} but input data is not a list.")

--- a/python/src/opendp/_extrinsics/sklearn/pca.py
+++ b/python/src/opendp/_extrinsics/sklearn/pca.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 from opendp._extrinsics.make_np_pca import make_private_np_pca
 from opendp.mod import Measurement
-from opendp._lib import import_optional_dependency
+from opendp._lib import import_optional_dependency, optional_dependency
 
 
-decomposition = import_optional_dependency('sklearn.decomposition', False)
-if decomposition is not None:
+with optional_dependency('sklearn.decomposition') as decomposition:
     class SKLPCA(decomposition.PCA): # type: ignore[name-defined]
         pass
-else: # pragma: no cover
+if SKLPCA is None: # pragma: no cover
     class SKLPCA(object): # type: ignore[no-redef]
         def __init__(*args, **kwargs):
             raise ImportError(

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -5,6 +5,7 @@ import re
 import sys
 from typing import Dict, List, Optional, Any
 import importlib
+from contextlib import contextmanager
 
 
 # list all acceptable alternative types for each default type
@@ -80,19 +81,25 @@ install_names = {
 }
 
 
-def import_optional_dependency(name, raise_error=True):
+def import_optional_dependency(name):
     '''
     Imports optional dependency, or explains that it is required.
     '''
     try:
         return importlib.import_module(name)
     except ImportError:
-        if raise_error:
-            root_name = name.split(".")[0]
-            install_name = install_names.get(root_name) or root_name
-            raise ImportError(f'The optional install {install_name} is required for this functionality')
-        return None
+        root_name = name.split(".")[0]
+        install_name = install_names.get(root_name) or root_name
+        raise ImportError(f'The optional install {install_name} is required for this functionality')
 
+
+@contextmanager
+def optional_dependency(name):
+    try:
+        module = importlib.import_module(name)
+        yield module
+    except ImportError:
+        return
 
 np_csprng = None
 try:

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -21,7 +21,7 @@ from typing import Dict, Optional, Union, Any, Type, List
 
 
 from opendp.mod import Function, UnknownTypeException, Measurement, Transformation, Domain, Metric, Measure
-from opendp._lib import ATOM_EQUIVALENCE_CLASSES, import_optional_dependency
+from opendp._lib import ATOM_EQUIVALENCE_CLASSES, import_optional_dependency, optional_dependency
 
 
 ELEMENTARY_TYPES: Dict[Any, str] = {
@@ -302,8 +302,7 @@ class RuntimeType(object):
         if isinstance(public_example, (Domain, Metric, Measure)):
             return RuntimeType.parse(public_example.type) # pragma: no cover
         
-        pl = import_optional_dependency("polars", raise_error=False)
-        if pl is not None:
+        with optional_dependency("polars") as pl:
             if isinstance(public_example, pl.LazyFrame):
                 return LazyFrame
             


### PR DESCRIPTION
- Fix #1520

If the optional install isn't so optional, use `import_optional_dependency` and get a good error message; If it really is optional, use `with optional_dependency`, and it will just skip the body if not found.