### PR TITLE
add polars feature to instructions

### DIFF
--- a/docs/source/contributing/development-environment.rst
+++ b/docs/source/contributing/development-environment.rst
@@ -48,7 +48,7 @@ Now run ``cargo build`` in the ``rust`` subdirectory of the repo:
 .. code-block:: bash
 
     cd rust
-    cargo build --features untrusted,bindings
+    cargo build --features untrusted,bindings,polars
 
 This will compile a debug build of the OpenDP shared library, placing it in the directory ``opendp/rust/target/debug``. 
 (The specific name of the library file will vary depending on your platform.)


### PR DESCRIPTION
- Without this, python tests fail at the collection phase
- If we wanted to be sure these didn't fall out of sync again, I could imagine:
  - pulling the `cargo build` in the RST out into an include.
  - treating that include as a shell script in CI, so docs and CI would reflect the same features.
  - ... but probably overkill?