### PR TITLE
use `--all-features` in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,6 @@ on:
         type: boolean
         required: false
         default: false
-env:
-  FEATURES: untrusted,ffi,polars
 
 jobs:
   credential-check:
@@ -85,7 +83,7 @@ jobs:
 
       - name: Create Rust build for windows
         if: ${{ !inputs.fake }}
-        run: bash tools/rust_build.sh -i -r -t -f "$FEATURES"
+        run: bash tools/rust_build.sh -i -r -t
 
       - name: Create Rust build for windows (FAKE)
         if: ${{ inputs.fake }}
@@ -136,7 +134,7 @@ jobs:
         env:
           # Only run tests for native compile
           FLAGS: ${{ matrix.architecture == 'x86_64' && '-i -r -t' || '-i -r' }}
-        run: bash tools/rust_build.sh $FLAGS -g $TARGET -f "$FEATURES"
+        run: bash tools/rust_build.sh $FLAGS -g $TARGET
 
       - name: Create Rust build for macos (FAKE)
         if: ${{ inputs.fake }}
@@ -187,7 +185,7 @@ jobs:
         env:
           # Only run tests for native compile
           FLAGS: ${{ matrix.architecture == 'x86_64' && '-i -r -t' || '-i -r' }}
-        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh $FLAGS -g $TARGET -f \"$FEATURES\""
+        run: docker run --rm -v `pwd`:/io $DOCKER_IMAGE bash -c "cd /io && bash tools/rust_build.sh $FLAGS -g $TARGET
 
       - name: Create Rust build for linux (FAKE)
         if: ${{ inputs.fake }}
@@ -231,7 +229,7 @@ jobs:
 
       - name: Create bindings
         if: ${{ !inputs.fake }}
-        run: bash tools/rust_build.sh -r -n -f "$FEATURES,bindings"
+        run: bash tools/rust_build.sh -r -n
 
       - name: Upload Python bindings
         uses: actions/upload-artifact@v4

--- a/R/opendp/configure
+++ b/R/opendp/configure
@@ -4,8 +4,6 @@ echo "***** CONFIGURE *****"
 BEFORE_CARGO_BUILD=''
 AFTER_CARGO_BUILD=''
 
-RUST_FEATURES=untrusted,ffi
-
 # Even when `cargo` is on `PATH`, `rustc` might not. We need to source
 # ~/.cargo/env to ensure PATH is configured correctly in some cases
 # (c.f. https://github.com/yutannihilation/string2path/issues/4). However, this file is not always
@@ -30,7 +28,6 @@ if [ "${NOT_CRAN}" != "true" ]; then
 fi
 
 sed \
-    -e "s|@RUST_FEATURES@|${RUST_FEATURES}|" \
     -e "s|@BEFORE_CARGO_BUILD@|${BEFORE_CARGO_BUILD}|" \
     -e "s|@AFTER_CARGO_BUILD@|${AFTER_CARGO_BUILD}|" \
     -e "s|@OPENDP_LIB_DIR@|${OPENDP_LIB_DIR}|" \

--- a/R/opendp/configure.win
+++ b/R/opendp/configure.win
@@ -4,8 +4,6 @@ set -e
 BEFORE_CARGO_BUILD=''
 AFTER_CARGO_BUILD=''
 
-RUST_FEATURES=untrusted,ffi
-
 # Even when `cargo` is on `PATH`, `rustc` might not. We need to source
 # ~/.cargo/env to ensure PATH is configured correctly in some cases
 # (c.f. https://github.com/yutannihilation/string2path/issues/4). However, this file is not always
@@ -35,7 +33,6 @@ if [ "${NOT_CRAN}" != "true" ]; then
 fi
 
 sed \
-    -e "s|@RUST_FEATURES@|${RUST_FEATURES}|" \
     -e "s|@BEFORE_CARGO_BUILD@|${BEFORE_CARGO_BUILD}|" \
     -e "s|@AFTER_CARGO_BUILD@|${AFTER_CARGO_BUILD}|" \
     -e "s|@OPENDP_LIB_DIR@|${OPENDP_LIB_DIR}|" \

--- a/R/opendp/src/Makevars.in
+++ b/R/opendp/src/Makevars.in
@@ -27,7 +27,7 @@ rust_build:
 		mkdir -p .cargo; \
 		cp cargo_vendor_config.toml .cargo/config.toml; \
 		echo "* build OpenDP Library (libopendp.a)"; \
-		@BEFORE_CARGO_BUILD@ cargo build --manifest-path rust/Cargo.toml --color always --release --jobs 2 --offline --features @RUST_FEATURES@; \
+		@BEFORE_CARGO_BUILD@ cargo build --manifest-path rust/Cargo.toml --color always --release --jobs 2 --offline --all-features; \
 		@AFTER_CARGO_BUILD@ \
 		cp rust/target/release/libopendp.a .; \
 	elif [ ! -z "@OPENDP_LIB_DIR@" ]; then \

--- a/R/opendp/src/Makevars.win.in
+++ b/R/opendp/src/Makevars.win.in
@@ -31,7 +31,7 @@ rust_build:
 		mkdir -p .cargo; \
 		cp cargo_vendor_config.toml .cargo/config.toml; \
 		echo "* building OpenDP Library (libopendp.a)"; \
-		@BEFORE_CARGO_BUILD@ cargo build --manifest-path rust/Cargo.toml --target=$(TARGET) --color always --release --jobs 2 --offline --features @RUST_FEATURES@; \
+		@BEFORE_CARGO_BUILD@ cargo build --manifest-path rust/Cargo.toml --target=$(TARGET) --color always --release --jobs 2 --offline --all-features; \
 		@AFTER_CARGO_BUILD@ \
 		cp rust/target/$(TARGET)/release/libopendp.a .; \
 	elif [ ! -z "@OPENDP_LIB_DIR@" ]; then \

--- a/tools/rust_build.sh
+++ b/tools/rust_build.sh
@@ -4,7 +4,7 @@
 set -e -u
 
 function usage() {
-  echo "Usage: $(basename "$0") [-irtn] [-p <PLATFORM>] [-c <TOOLCHAIN>] [-g <TARGET>] [-f <FEATURES>]" >&2
+  echo "Usage: $(basename "$0") [-irtn] [-p <PLATFORM>] [-c <TOOLCHAIN>] [-g <TARGET>]" >&2
 }
 
 INIT=false
@@ -14,7 +14,6 @@ CHECK=false
 PLATFORM=UNSET
 TARGET=UNSET
 TOOLCHAIN=stable
-FEATURES=default
 while getopts ":irtnp:c:g:f:" OPT; do
   case "$OPT" in
   i) INIT=true ;;
@@ -24,7 +23,6 @@ while getopts ":irtnp:c:g:f:" OPT; do
   p) PLATFORM="$OPTARG" ;;
   c) TOOLCHAIN="$OPTARG" ;;
   g) TARGET="$OPTARG" ;;
-  f) FEATURES="$OPTARG" ;;
   *) usage && exit 1 ;;
   esac
 done
@@ -83,7 +81,7 @@ function run_cargo() {
   [[ $TOOLCHAIN != UNSET ]] && CMD+=(+"$TOOLCHAIN")
   CMD+=(--verbose --verbose --color=always $ACTION)
   [[ $TARGET != UNSET ]] && CMD+=(--target "$TARGET")
-  CMD+=(--manifest-path=rust/Cargo.toml --features="$FEATURES")
+  CMD+=(--manifest-path=rust/Cargo.toml --all-features)
   [[ $RELEASE_MODE == true ]] && CMD+=(--release)
   run "${CMD[@]}"
 }


### PR DESCRIPTION
- Complements #1526

My guess is that this isn't quite what we want (for example, I think this would include the `test` feature), but the solution may be to define a default set that is defined in one place rather than trying to keep sets in sync across the codebase