### PR TITLE
Polars: filter

### DIFF
--- a/python/test/test_polars.py
+++ b/python/test/test_polars.py
@@ -213,6 +213,21 @@ def test_private_lazyframe_median():
     pl_testing.assert_frame_equal(m_lf(lf).collect(), expect)
 
 
+def test_filter():
+    """ensure that expr domain's carrier type can be passed to/from Rust"""
+    pl = pytest.importorskip("polars")
+    pl_testing = pytest.importorskip("polars.testing")
+
+    lf_domain, lf = example_lf(margin=[], public_info="keys", max_partition_length=50)
+
+    plan = lf.filter(pl.col("B") < 2).select(pl.len().dp.laplace(scale=0.))
+
+    m_lf = dp.m.make_private_lazyframe(lf_domain, dp.symmetric_distance(), dp.max_divergence(T=float), plan)
+
+    expect = pl.DataFrame([pl.Series("len", [10], dtype=pl.UInt32)])
+    pl_testing.assert_frame_equal(m_lf(lf).collect(), expect)
+
+
 def test_onceframe_multi_collect():
     pl = pytest.importorskip("polars")
 

--- a/rust/src/transformations/make_stable_lazyframe/filter/mod.rs
+++ b/rust/src/transformations/make_stable_lazyframe/filter/mod.rs
@@ -28,7 +28,7 @@ where
     Expr: StableExpr<M, M>,
 {
     let LogicalPlan::Selection { input, predicate } = plan else {
-        return fallible!(MakeTransformation, "Expected Aggregate logical plan");
+        return fallible!(MakeTransformation, "Expected filter in logical plan");
     };
 
     let t_prior = (*input).make_stable(input_domain.clone(), input_metric.clone())?;
@@ -42,7 +42,7 @@ where
 
     let pred_dtype = t_pred.output_domain.active_series()?.field.dtype.clone();
 
-    if pred_dtype != DataType::Boolean {
+    if !pred_dtype.is_bool() {
         return fallible!(
             MakeTransformation,
             "Expected predicate to return a boolean value, got: {:?}",

--- a/rust/src/transformations/make_stable_lazyframe/filter/mod.rs
+++ b/rust/src/transformations/make_stable_lazyframe/filter/mod.rs
@@ -1,0 +1,72 @@
+use crate::core::{Function, Metric, MetricSpace, StabilityMap, Transformation};
+use crate::domains::{ExprContext, ExprDomain, LogicalPlanDomain};
+use crate::error::*;
+use crate::transformations::traits::UnboundedMetric;
+use crate::transformations::StableExpr;
+use polars::prelude::*;
+
+use super::StableLogicalPlan;
+
+#[cfg(test)]
+mod test;
+
+/// Transformation for creating a stable LazyFrame filter.
+///
+/// # Arguments
+/// * `input_domain` - The domain of the input LazyFrame.
+/// * `input_metric` - The metric of the input LazyFrame.
+/// * `plan` - The LazyFrame to transform.
+pub fn make_stable_filter<M: Metric>(
+    input_domain: LogicalPlanDomain,
+    input_metric: M,
+    plan: LogicalPlan,
+) -> Fallible<Transformation<LogicalPlanDomain, LogicalPlanDomain, M, M>>
+where
+    M: UnboundedMetric + 'static,
+    (LogicalPlanDomain, M): MetricSpace,
+    LogicalPlan: StableLogicalPlan<M, M>,
+    Expr: StableExpr<M, M>,
+{
+    let LogicalPlan::Selection { input, predicate } = plan else {
+        return fallible!(MakeTransformation, "Expected Aggregate logical plan");
+    };
+
+    let t_prior = (*input).make_stable(input_domain.clone(), input_metric.clone())?;
+    let (middle_domain, middle_metric) = t_prior.output_space();
+
+    let expr_domain = ExprDomain::new(middle_domain.clone(), ExprContext::RowByRow);
+
+    let t_pred = predicate
+        .clone()
+        .make_stable(expr_domain, middle_metric.clone())?;
+
+    let pred_dtype = t_pred.output_domain.active_series()?.field.dtype.clone();
+
+    if pred_dtype != DataType::Boolean {
+        return fallible!(
+            MakeTransformation,
+            "Expected predicate to return a boolean value, got: {:?}",
+            pred_dtype
+        );
+    }
+
+    let mut output_domain = middle_domain.clone();
+
+    output_domain.margins.values_mut().for_each(|m| {
+        // After filtering you no longer know partition lengths or keys.
+        m.public_info = None;
+    });
+
+    t_prior
+        >> Transformation::new(
+            middle_domain,
+            output_domain,
+            Function::new(move |plan: &LogicalPlan| LogicalPlan::Selection {
+                input: Box::new(plan.clone()),
+                predicate: predicate.clone(),
+            }),
+            middle_metric.clone(),
+            middle_metric,
+            StabilityMap::new(Clone::clone),
+        )?
+}

--- a/rust/src/transformations/make_stable_lazyframe/filter/test.rs
+++ b/rust/src/transformations/make_stable_lazyframe/filter/test.rs
@@ -8,7 +8,7 @@ use super::*;
 
 #[test]
 fn test_filter() -> Fallible<()> {
-    let lf = df!("chunk_2_null" => [[Some(1i64); 500], [None; 500]].concat())?.lazy();
+    let lf = df!("chunk_2_null" => [Some(1i64), None])?.lazy();
 
     let lf_domain = LazyFrameDomain::new(vec![SeriesDomain::new(
         "chunk_2_null",
@@ -23,7 +23,7 @@ fn test_filter() -> Fallible<()> {
     )?;
 
     let actual = t_filter.invoke(&lf)?.collect()?;
-    assert_eq!(actual, df!("chunk_2_null" => [Some(1); 500])?);
+    assert_eq!(actual, df!("chunk_2_null" => [Some(1)])?);
 
     assert!(t_filter
         .output_domain
@@ -35,8 +35,8 @@ fn test_filter() -> Fallible<()> {
 }
 
 #[test]
-fn test_fail_filter() -> Fallible<()> {
-    let lf = df!("chunk_2_null" => [[Some(1i64); 500], [None; 500]].concat())?.lazy();
+fn test_filter_fail_with_non_bool_predicate() -> Fallible<()> {
+    let lf = df!("chunk_2_null" => [Some(1i64), None])?.lazy();
 
     let lf_domain = LazyFrameDomain::new(vec![SeriesDomain::new(
         "chunk_2_null",

--- a/rust/src/transformations/make_stable_lazyframe/filter/test.rs
+++ b/rust/src/transformations/make_stable_lazyframe/filter/test.rs
@@ -1,0 +1,59 @@
+use crate::{
+    domains::{AtomDomain, LazyFrameDomain, Margin, OptionDomain, SeriesDomain},
+    metrics::SymmetricDistance,
+    transformations::make_stable_lazyframe,
+};
+
+use super::*;
+
+#[test]
+fn test_filter() -> Fallible<()> {
+    let lf = df!("chunk_2_null" => [[Some(1i64); 500], [None; 500]].concat())?.lazy();
+
+    let lf_domain = LazyFrameDomain::new(vec![SeriesDomain::new(
+        "chunk_2_null",
+        OptionDomain::new(AtomDomain::<i64>::default()),
+    )])?
+    .with_margin(&["chunk_2_null"], Margin::new().with_public_keys())?;
+
+    let t_filter = make_stable_lazyframe(
+        lf_domain.clone(),
+        SymmetricDistance,
+        lf.clone().filter(col("chunk_2_null").is_not_null()),
+    )?;
+
+    let actual = t_filter.invoke(&lf)?.collect()?;
+    assert_eq!(actual, df!("chunk_2_null" => [Some(1); 500])?);
+
+    assert!(t_filter
+        .output_domain
+        .margins
+        .values()
+        .all(|m| { m.public_info.is_none() }));
+
+    Ok(())
+}
+
+#[test]
+fn test_fail_filter() -> Fallible<()> {
+    let lf = df!("chunk_2_null" => [[Some(1i64); 500], [None; 500]].concat())?.lazy();
+
+    let lf_domain = LazyFrameDomain::new(vec![SeriesDomain::new(
+        "chunk_2_null",
+        OptionDomain::new(AtomDomain::<i64>::default()),
+    )])?
+    .with_margin(&["chunk_2_null"], Margin::new().with_public_keys())?;
+
+    let variant = make_stable_lazyframe(
+        lf_domain.clone(),
+        SymmetricDistance,
+        lf.clone().filter(col("chunk_2_null").fill_nan(0)),
+    )
+    .map(|_| ())
+    .unwrap_err()
+    .variant;
+
+    assert_eq!(variant, ErrorVariant::MakeTransformation);
+
+    Ok(())
+}

--- a/rust/src/transformations/make_stable_lazyframe/mod.rs
+++ b/rust/src/transformations/make_stable_lazyframe/mod.rs
@@ -15,6 +15,9 @@ mod ffi;
 #[cfg(feature = "contrib")]
 mod source;
 
+#[cfg(feature = "contrib")]
+mod filter;
+
 #[bootstrap(
     features("contrib"),
     arguments(output_metric(c_type = "AnyMetric *", rust_type = b"null")),
@@ -75,6 +78,9 @@ impl StableLogicalPlan<SymmetricDistance, SymmetricDistance> for LogicalPlan {
         match &self {
             LogicalPlan::DataFrameScan { .. } => {
                 source::make_stable_source(input_domain, input_metric, self)
+            }
+            LogicalPlan::Selection { .. } => {
+                filter::make_stable_filter(input_domain, input_metric, self)
             }
             lp => fallible!(
                 MakeTransformation,


### PR DESCRIPTION
Closes #899
Example usage.

```python
import opendp.prelude as dp
import polars as pl


# TODO: a version of this should be in the library proper
def placeholder(schema):
    return pl.DataFrame(None, schema, orient="row").lazy()


dp.enable_features("contrib")


lf = pl.LazyFrame(
    [
        pl.Series("A", [1.0] * 50, dtype=pl.Float64),
        pl.Series("B", [1, 2, 3, 4, 5] * 10, dtype=pl.Int32),
        pl.Series("C", ["1"] * 49 + [None], dtype=pl.String),
        pl.Series("D", [2] * 50, dtype=pl.Int32),
    ]
)

# specify domain descriptors of the lazyframe (without the data)
lf_domain = dp.lazyframe_domain(
    [
        dp.series_domain("A", dp.atom_domain(T=dp.f64)),
        dp.series_domain("B", dp.atom_domain(T=dp.i32)),
        dp.series_domain("C", dp.option_domain(dp.atom_domain(T=dp.String))),
        dp.series_domain("D", dp.atom_domain(T=dp.i32)),
    ]
)

# TODO: support imputation, then replace the above with this shortened version:
# lf_domain = dp.infer_lazyframe_domain(lf)

# specify properties of the data when grouped by "C"
lf_domain = dp.with_margin(
    lf_domain, by=["C"], public_info="keys", max_partition_length=50
)

# USER STARTS HERE
proposed_plan = (
    placeholder(lf.schema)
    .filter(pl.col("A") < pl.col("B"))
    .group_by("C")
    .agg(pl.col("D").dp.sum(bounds=(1, 5), scale=1))
)

# Context API to look like this:
# release = (
#     context.query()
#     .filter(pl.col("A") < pl.col("B"))
#     .group_by("C")
#     .agg(pl.col("D").dp.sum(bounds=(1, 5), scale=1))
#     .release()
# )


# IN SERVER
m_lf = dp.m.make_private_lazyframe(
    input_domain=lf_domain,
    input_metric=dp.symmetric_distance(),
    output_measure=dp.max_divergence(T=float),
    lazyframe=proposed_plan,
)

df_release = m_lf(lf).collect()

print(df_release)
```