### PR TITLE
randomgen guards, again

### DIFF
--- a/python/src/opendp/_extrinsics/_make_np_eigenvector/__init__.py
+++ b/python/src/opendp/_extrinsics/_make_np_eigenvector/__init__.py
@@ -1,6 +1,6 @@
 from opendp._extrinsics.domains import _np_sscp_domain
 from opendp._extrinsics._utilities import to_then
-from opendp._lib import np_csprng, import_optional_dependency
+from opendp._lib import get_np_csprng, import_optional_dependency
 from opendp.mod import Domain, Metric, Transformation, Measurement
 from typing import List
 
@@ -21,9 +21,7 @@ def make_private_np_eigenvector(
 
     dp.assert_features("contrib", "floating-point")
     
-    if np_csprng is None:
-        raise ImportError('The optional install randomgen is required for this functionality')
-
+    np_csprng = get_np_csprng()
     input_desc = input_domain.descriptor
 
     if input_desc.p != 2:

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -95,7 +95,7 @@ def import_optional_dependency(name, raise_error=True):
 
 
 _np_csprng = None
-_buffer_pos = 0
+_buffer_pos = 0 # TODO: Make this into a class rather than using ad-hoc globals.
 def get_np_csprng():
     global _np_csprng
     global _buffer_pos

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -94,10 +94,15 @@ def import_optional_dependency(name, raise_error=True):
         return None
 
 
-np_csprng = None
-try:
-    np = import_optional_dependency('numpy')
+_np_csprng = None
+
+def get_np_csprng():
+    global _np_csprng
+    if _np_csprng is not None:
+        return _np_csprng
+
     randomgen = import_optional_dependency('randomgen')
+    np = import_optional_dependency('numpy')
 
     buffer_len = 1024
     buffer = np.empty(buffer_len, dtype=np.uint64)
@@ -119,10 +124,9 @@ try:
         buffer_pos += 1
         return int(out)
 
-    np_csprng = np.random.Generator(bit_generator=randomgen.UserBitGenerator(next_raw)) # type:ignore
+    _np_csprng = np.random.Generator(bit_generator=randomgen.UserBitGenerator(next_raw)) # type:ignore
+    return _np_csprng
 
-except ImportError:  # pragma: no cover
-    pass
 
 # This enables backtraces in Rust by default.
 # It can be disabled by setting RUST_BACKTRACE=0.

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -95,9 +95,10 @@ def import_optional_dependency(name, raise_error=True):
 
 
 _np_csprng = None
-
+_buffer_pos = 0
 def get_np_csprng():
     global _np_csprng
+    global _buffer_pos
     if _np_csprng is not None:
         return _np_csprng
 
@@ -107,21 +108,21 @@ def get_np_csprng():
     buffer_len = 1024
     buffer = np.empty(buffer_len, dtype=np.uint64)
     buffer_ptr = ctypes.cast(buffer.ctypes.data, ctypes.POINTER(ctypes.c_uint8))
-    buffer_pos = buffer_len
+    _buffer_pos = buffer_len
 
     def next_raw(_voidp):
-        global buffer_pos
-        if buffer_len == buffer_pos:
+        global _buffer_pos
+        if buffer_len == _buffer_pos:
             from opendp._data import fill_bytes
 
             # there are 8x as many u8s as there are u64s
             if not fill_bytes(buffer_ptr, buffer_len * 8): # pragma: no cover
                 from opendp.mod import OpenDPException
                 raise OpenDPException("FailedFunction", "Failed to sample from CSPRNG")
-            buffer_pos = 0
+            _buffer_pos = 0
 
-        out = buffer[buffer_pos]
-        buffer_pos += 1
+        out = buffer[_buffer_pos]
+        _buffer_pos += 1
         return int(out)
 
     _np_csprng = np.random.Generator(bit_generator=randomgen.UserBitGenerator(next_raw)) # type:ignore

--- a/python/test/extrinsics/test_csprng.py
+++ b/python/test/extrinsics/test_csprng.py
@@ -1,14 +1,16 @@
-from opendp._lib import np_csprng
+from opendp._lib import get_np_csprng
 import pytest
+from ..helpers import optional_dependency
 
-@pytest.mark.skipif(np_csprng is None, reason='randomgen not installed')
 def test_np_rng():
     n_cats = 100
     n_samples = 100_000
-
+    
+    with optional_dependency('randomgen'):
+        np_csprng = get_np_csprng()
+    
     np = pytest.importorskip('numpy')
-    assert np_csprng is not None # for mypy
     counts = np.unique(np_csprng.integers(n_cats, size=n_samples), return_counts=True)[1]
-    pytest.importorskip('sklearn')
+    pytest.importorskip('sklearn') # TODO: implicit dependency should use optional_dependency
     scipy = pytest.importorskip('scipy')
     assert scipy.stats.chisquare(counts).pvalue > .0001

--- a/python/test/extrinsics/test_csprng.py
+++ b/python/test/extrinsics/test_csprng.py
@@ -16,6 +16,6 @@ def test_np_rng():
     
     np = pytest.importorskip('numpy')
     counts = np.unique(np_csprng.integers(n_cats, size=n_samples), return_counts=True)[1]
-    pytest.importorskip('sklearn') # TODO: implicit dependency should use optional_dependency
-    scipy = pytest.importorskip('scipy')
-    assert scipy.stats.chisquare(counts).pvalue > .0001
+    with optional_dependency('sklearn'):
+        scipy = pytest.importorskip('scipy')
+        assert scipy.stats.chisquare(counts).pvalue > .0001

--- a/python/test/extrinsics/test_csprng.py
+++ b/python/test/extrinsics/test_csprng.py
@@ -1,6 +1,11 @@
 from opendp._lib import get_np_csprng
 import pytest
 from ..helpers import optional_dependency
+try:
+    # So randomgen will be in sys.modules, if possible.
+    import randomgen # type: ignore[import-not-found] # noqa F401
+except ModuleNotFoundError:
+    pass
 
 def test_np_rng():
     n_cats = 100

--- a/python/test/extrinsics/test_np_pca.py
+++ b/python/test/extrinsics/test_np_pca.py
@@ -132,12 +132,12 @@ def flaky_assert_pca_compare_sklearn():
 
 
 def test_pca_compare_sklearn():
-    with optional_dependency('randomgen'):
-        for _ in range(5):
-            try:
+    for _ in range(5):
+        try:
+            with optional_dependency('randomgen'):
                 flaky_assert_pca_compare_sklearn()
-                break
-            except AssertionError:
-                pass
-        else:
-            assert False, "PCA failed too many times"
+            break
+        except AssertionError:
+            pass
+    else:
+        assert False, "PCA failed too many times"

--- a/python/test/extrinsics/test_np_pca.py
+++ b/python/test/extrinsics/test_np_pca.py
@@ -1,6 +1,6 @@
 import pytest
 import opendp.prelude as dp
-from opendp._lib import get_np_csprng, import_optional_dependency
+from opendp._lib import import_optional_dependency
 from ..helpers import optional_dependency
 
 dp.enable_features("honest-but-curious", "contrib", "floating-point")

--- a/python/test/helpers.py
+++ b/python/test/helpers.py
@@ -37,4 +37,4 @@ def optional_dependency(name):
     with pytest.raises(Exception, match=expected_message_re):
         yield
     # ... and then skip the rest of the test.
-    raise pytest.skip('Saw expected OpenDPException; skipping rest of test')
+    raise pytest.skip(f'Saw expected exception "{expected_message}". Skipping rest of test.')

--- a/python/test/test_tests.py
+++ b/python/test/test_tests.py
@@ -1,3 +1,3 @@
 def test_number_of_tests_found(request):
     tests_found = len(request.session.items)
-    assert tests_found >= 322
+    assert tests_found >= 308

--- a/python/test/test_tests.py
+++ b/python/test/test_tests.py
@@ -1,3 +1,3 @@
 def test_number_of_tests_found(request):
     tests_found = len(request.session.items)
-    assert tests_found >= 225
+    assert tests_found >= 322


### PR DESCRIPTION
- Replace #1433: Just easier to start fresh.
- Extends #1348
- Finally fix #1347

As a TODO notes, it would be cleaner to use a class to hide state rather than module level private variables... but that would also be a bigger change, and I think this is sufficient for now.

With this change, there is only one use of `skipif` and it's not for optional dependencies:
```
@pytest.mark.skipif(sys.version_info < (3, 11), reason='mypy will fail on 3.8')
```