### PR TITLE
cancel old smoke-test CI runs

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,5 +1,9 @@
 name: Smoke Test
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:


### PR DESCRIPTION
If I ever make a mistake and submit my stack twice, the old batch of CI runs don't get canceled, meaning the CI runners are consumed on useless tasks for an extended time.