### PR TITLE
speed up smoke-test

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -21,6 +21,7 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
 
+      # We're no longer running out of space, but freeing disk space uses time, so disable. Re-enable if needed.
       # - name: Free disk space
       #   uses: jlumbroso/free-disk-space@v1.3.1
       #   with:
@@ -89,6 +90,7 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       
+      # We're no longer running out of space, but freeing disk space uses time, so disable. Re-enable if needed.
       # - name: Free disk space
       #   uses: jlumbroso/free-disk-space@v1.3.1
       #   with:
@@ -114,7 +116,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Test
-        run: cargo test --verbose --all-features --lib
+        run: cargo test --verbose --all-features
         
 
   rust-examples:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -21,16 +21,16 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
 
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: false     # no: will remove rust
-          android: true         # 8.7GiB
-          dotnet: true          # 1.6GiB
-          docker-images: true   # 3.2GiB
-          haskell: false        # no: little/no benefit
-          large-packages: false # no: slow
-          swap-storage: false   # no: having swap is useful
+      # - name: Free disk space
+      #   uses: jlumbroso/free-disk-space@v1.3.1
+      #   with:
+      #     tool-cache: false     # no: will remove rust
+      #     android: true         # 8.7GiB
+      #     dotnet: true          # 1.6GiB
+      #     docker-images: true   # 3.2GiB
+      #     haskell: false        # no: little/no benefit
+      #     large-packages: false # no: slow
+      #     swap-storage: false   # no: having swap is useful
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -58,9 +58,6 @@ jobs:
       - name: Check --no-default-features
         run: cargo check --verbose --no-default-features --features untrusted,bindings
 
-      - name: Test
-        run: cargo test --verbose --all-features
-
       - name: Check that generated python is up to date
         run: git diff --exit-code
 
@@ -82,15 +79,6 @@ jobs:
           name: static_lib
           path: rust/target/debug/libopendp.a
       
-      - name: Prepare vendored sources
-        run: cd .. && bash tools/r_stage.sh -v
-          
-      - name: Upload vendored sources
-        uses: actions/upload-artifact@v4
-        with:
-          name: vendor
-          path: R/opendp/src/vendor.tar.xz
-
   rust-test:
     needs: rust-build
     runs-on: ubuntu-22.04
@@ -101,27 +89,16 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: false     # no: will remove rust
-          android: true         # 8.7GiB
-          dotnet: true          # 1.6GiB
-          docker-images: true   # 3.2GiB
-          haskell: false        # no: little/no benefit
-          large-packages: false # no: slow
-          swap-storage: false   # no: having swap is useful
-
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: false     # no: will remove rust
-          android: true         # 8.7GiB
-          dotnet: true          # 1.6GiB
-          docker-images: true   # 3.2GiB
-          haskell: false        # no: little/no benefit
-          large-packages: false # no: slow
-          swap-storage: false   # no: having swap is useful
+      # - name: Free disk space
+      #   uses: jlumbroso/free-disk-space@v1.3.1
+      #   with:
+      #     tool-cache: false     # no: will remove rust
+      #     android: true         # 8.7GiB
+      #     dotnet: true          # 1.6GiB
+      #     docker-images: true   # 3.2GiB
+      #     haskell: false        # no: little/no benefit
+      #     large-packages: false # no: slow
+      #     swap-storage: false   # no: having swap is useful
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -137,7 +114,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Test
-        run: cargo test --verbose --features untrusted,ffi,polars
+        run: cargo test --verbose --all-features --lib
         
 
   rust-examples:


### PR DESCRIPTION
* -3 Don't run rust tests twice (these got re-introduced in the rust-build task from the --all-features pr)
* -12 Don't run the disk cleaner (not actually seeing CI fail now, and it didn't used to take this long. leaving commented)
* -3 Don't vendor dependencies (they're not used by the r tests)
* -5 Don't run rust doctests (just the 31 doctests, many of which are internal, take 5 minutes on their own)
    * Perhaps we can move rust doctests out to unit tests in future work

This reduces smoke-test from 31 minutes to 7 minutes.