### PR TITLE
1605 fix r failure in nightly

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,8 @@ jobs:
   r-docs:
     needs: credential-check
     runs-on: ubuntu-22.04
+    env:
+      OPENDP_LIB_DIR: ${{ github.workspace }}/libs
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -274,6 +274,9 @@ jobs:
           working-directory: R/opendp
           extra-packages: devtools, RcppTOML, lintr
 
+      - name: Build R docs (and run API examples)
+        run: bash tools/r_stage.sh -d
+
       # running the OpenDP install in a separate command (instead of local::. above)
       #   provides significantly more debug info if it fails
       - name: Install OpenDP
@@ -289,9 +292,6 @@ jobs:
 
       - name: Lint sphinx examples
         run: Rscript -e 'lintr::lint_dir("docs/source")'
-
-      - name: Document
-        run: cd R/opendp/ && Rscript -e 'devtools::document()'
 
       - name: Check
         run: cd R/opendp/ && Rscript -e 'devtools::check(error_on="warning")'


### PR DESCRIPTION
- Fix #1605

Draft: Not entirely confident about this, but using the same  script in smoketest as we do in nightly seems like a good direction. (`r_stage.sh` also calls `pkgdown::build_site`, so there is a difference.)