### PR TITLE
regenerate python to include example

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -130,8 +130,8 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.9
-          - 3.12
+          - '3.9'
+          - '3.12'
         extra-install:
           - '.'
           - '.[scikit-learn]'
@@ -178,7 +178,7 @@ jobs:
       - name: Test coverage
         # We only expect test coverage with all extra dependencies.
         # "polars" implies "scikit-learn": see setup.cfg.
-        if: ${{ contains(matrix.extra-install, 'polars') }}
+        if: ${{ contains(matrix.extra-install, 'polars') && contains(matrix.python-version, '3.12') }}
         run: coverage report
 
   docs-links:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -177,6 +177,7 @@ jobs:
 
       - name: Test coverage
         # We only expect test coverage with all extra dependencies.
+        # "polars" implies "scikit-learn": see setup.cfg.
         if: ${{ contains(matrix.extra-install, 'polars') }}
         run: coverage report
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -173,11 +173,11 @@ jobs:
         run: python -m pip install -e ${{ matrix.extra-install }}
 
       - name: Test
-        run: coverage run -m pytest -v ${{ contains(matrix.extra-install, 'polars') && '' || '-k "not make_private_lazyframe"'}}
+        run: coverage run -m pytest -v ${{ contains(matrix.extra-install, 'polars') && '' || '-k "not lazyframe"'}}
 
       - name: Test coverage
         # We only expect test coverage with all extra dependencies.
-        if: ${{ contains(matrix.extra-install, 'scikit-learn,polars') }}
+        if: ${{ contains(matrix.extra-install, 'polars') }}
         run: coverage report
 
   docs-links:

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -48,6 +48,8 @@ polars =
 	# be sure to also change the Polars version in rust/Cargo.toml and test binary compatibility.
 	polars==0.20.16
 	pyarrow
+	# sk-learn is not strictly necessary, but it makes it simpler
+	# to just have a single axis of increasing functionality.
 	%(scikit-learn)s
 
 [bdist_wheel]

--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -194,7 +194,7 @@ def _slice_to_py(raw: FfiSlicePtr, type_name: Union[RuntimeType, str]) -> Any:
             return _slice_to_string(raw)
         
         if type_name == "LazyFrame":
-            return _slice_to_lazyframe(raw)
+            return _slice_to_lazyframe(raw) # pragma: no cover
         
         if type_name == "DataFrame":
             return _slice_to_dataframe(raw)
@@ -244,7 +244,7 @@ def _py_to_slice(value: Any, type_name: Union[RuntimeType, str]) -> FfiSlicePtr:
             return _series_to_slice(value)
         
         if type_name == "LazyFrame":
-            return _lazyframe_to_slice(value)
+            return _lazyframe_to_slice(value) # pragma: no cover
         
         if type_name == "DataFrame":
             return _dataframe_to_slice(value)

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -105,7 +105,7 @@ if pl is not None:
     @pl.api.register_expr_namespace("dp")
     class DPNamespace(object):
         def __init__(self, expr):
-            self.expr = expr
+            self.expr = expr # pragma: no cover
 
         def laplace(self, scale=None):
             """Add Laplace noise to the expression.
@@ -114,8 +114,8 @@ if pl is not None:
 
             :param scale: Noise scale parameter for the Laplace distribution. `scale` == standard_deviation / sqrt(2). 
             """
-            scale = float("nan") if scale is None else scale
-            return pl.plugins.register_plugin_function(
+            scale = float("nan") if scale is None else scale # pragma: no cover
+            return pl.plugins.register_plugin_function( # pragma: no cover
                 plugin_path=lib_path,
                 function_name="laplace",
                 kwargs={"scale": scale},
@@ -131,7 +131,7 @@ if pl is not None:
             :param bounds: The bounds of the input data.
             :param scale: Noise scale parameter for the Laplace distribution. `scale` == standard_deviation / sqrt(2). 
             """
-            return self.expr.clip(*bounds).sum().dp.laplace(scale)
+            return self.expr.clip(*bounds).sum().dp.laplace(scale) # pragma: no cover
         
         
         def mean(self, bounds, scale=None):

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -143,7 +143,7 @@ if pl is not None:
             :param bounds: The bounds of the input data.
             :param scale: Noise scale parameter for the Laplace distribution. `scale` == standard_deviation / sqrt(2). 
             """
-            return self.expr.dp.sum(bounds, scale) / pl.len()
+            return self.expr.dp.sum(bounds, scale) / pl.len() # pragma: no cover
 
 
 # This enables backtraces in Rust by default.

--- a/python/src/opendp/measurements.py
+++ b/python/src/opendp/measurements.py
@@ -787,6 +787,72 @@ def then_private_lazyframe(
     :type output_measure: Measure
     :param lazyframe: A description of the computations to be run, in the form of a [`LazyFrame`].
     :param global_scale: A tune-able parameter that affects the privacy-utility tradeoff.
+
+    :example:
+
+    >>> dp.enable_features("contrib")
+    >>> import polars as pl
+
+    We'll imagine an elementary school is taking a pet census.
+    The private census data will have two columns: 
+
+    >>> lf_domain = dp.lazyframe_domain([
+    ...     dp.series_domain("grade", dp.atom_domain(T=dp.i32)),
+    ...     dp.series_domain("pet_count", dp.atom_domain(T=dp.i32))])
+
+    We also need to specify the column we'll be grouping by.
+
+    >>> lf_domain_with_margin = dp.with_margin(
+    ...     lf_domain,
+    ...     by=["grade"],
+    ...     public_info="keys",
+    ...     max_partition_length=50)
+
+    With that in place, we can plan the Polars computation, using the `dp` plugin. 
+
+    >>> plan = (
+    ...     pl.LazyFrame(schema={'grade': pl.Int32, 'pet_count': pl.Int32})
+    ...     .group_by("grade")
+    ...     .agg(pl.col("pet_count").dp.sum((0, 10), scale=1.0)))
+
+    We now have all the pieces to make our measurement function using `make_private_lazyframe`:
+
+    >>> dp_sum_pets_by_grade = dp.m.make_private_lazyframe(
+    ...     input_domain=lf_domain_with_margin,
+    ...     input_metric=dp.symmetric_distance(),
+    ...     output_measure=dp.max_divergence(T=float),
+    ...     lazyframe=plan,
+    ...     global_scale=1.0)
+
+    It's only at this point that we need to introduce the private data.
+
+    >>> df = pl.from_records(
+    ...     [
+    ...         [0, 0], # No kindergarteners with pets.
+    ...         [0, 0],
+    ...         [0, 0],
+    ...         [1, 1], # Each first grader has 1 pet.
+    ...         [1, 1],
+    ...         [1, 1],
+    ...         [2, 1], # One second grader has chickens!
+    ...         [2, 1],
+    ...         [2, 9]
+    ...     ],
+    ...     schema=['grade', 'pet_count'])
+    >>> lf = pl.LazyFrame(df)
+    >>> results = dp_sum_pets_by_grade(lf).sort("grade").collect()
+    >>> print(results) # doctest: +ELLIPSIS
+    shape: (3, 2)
+    ┌───────┬───────────┐
+    │ grade ┆ pet_count │
+    │ ---   ┆ ---       │
+    │ i64   ┆ i64       │
+    ╞═══════╪═══════════╡
+    │ 0     ┆ ...       │
+    │ 1     ┆ ...       │
+    │ 2     ┆ ...       │
+    └───────┴───────────┘
+
     """
     return PartialConstructor(lambda input_domain, input_metric: make_private_lazyframe(
         input_domain=input_domain,


### PR DESCRIPTION
This PR:
- #1576

clobbered the API example from
- #1581 

and caused the tests to fail when merged. 

The longterm fix to avoid this problem is
- #1430 
 
though I have some ambivalence there.