### PR TITLE
Python polars version: Extra info on error if mismatch with Rust

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -171,7 +171,7 @@ jobs:
         run: python -m pip install -e ${{ matrix.extra-install }}
 
       - name: Test
-        run: coverage run -m pytest -v ${{ contains(matrix.extra-install, 'polars') && '' || '-k "not lazyframe"'}}
+        run: coverage run -m pytest -v ${{ ! contains(matrix.extra-install, 'polars') && '-k "not lazyframe and not polars"' || ''}}
 
       - name: Test coverage
         # We only expect test coverage with all extra dependencies.

--- a/R/opendp/R/combinators.R
+++ b/R/opendp/R/combinators.R
@@ -336,8 +336,8 @@ then_fix_delta <- function(
 #'
 #' The DIA, DO, MI and MO between the input measurement and amplified output measurement all match.
 #'
-#' Protected by the "honest-but-curious" feature flag
-#' because a dishonest adversary could set the population size to be arbitrarily large.
+#' Requires `honest-but-curious`:
+#' a dishonest adversary could set the population size to be arbitrarily large.
 #'
 #' [make_population_amplification in Rust documentation.](https://docs.rs/opendp/latest/opendp/combinators/fn.make_population_amplification.html)
 #'

--- a/R/opendp/R/measures.R
+++ b/R/opendp/R/measures.R
@@ -162,6 +162,7 @@ smoothed_max_divergence <- function(
 
 #' Construct a new UserDivergence.
 #' Any two instances of an UserDivergence are equal if their string descriptors are equal.
+#' Requires `honest-but-curious`: TODO
 #'
 #' @concept measures
 #' @param descriptor A string description of the privacy measure.

--- a/R/opendp/R/metrics.R
+++ b/R/opendp/R/metrics.R
@@ -336,6 +336,7 @@ symmetric_distance <- function(
 
 #' Construct a new UserDistance.
 #' Any two instances of an UserDistance are equal if their string descriptors are equal.
+#' Requires `honest-but-curious`: TODO
 #'
 #' @concept metrics
 #' @param descriptor A string description of the metric.

--- a/R/opendp/R/transformations.R
+++ b/R/opendp/R/transformations.R
@@ -1856,7 +1856,7 @@ then_find_bin <- function(
 #'
 #' Make a Transformation representing the identity function.
 #'
-#' WARNING: In Python, this function does not ensure that the domain and metric form a valid metric space.
+#' WARNING: Requires `honest-but-curious` because in Python, this function does not ensure that the domain and metric form a valid metric space.
 #' However, if the domain and metric do not form a valid metric space,
 #' then the resulting Transformation won't be chainable with any valid Transformation,
 #' so it cannot be used to introduce an invalid metric space into a chain of valid Transformations.

--- a/R/opendp/src/opendp.h
+++ b/R/opendp/src/opendp.h
@@ -800,6 +800,7 @@ struct FfiResult_____AnyDomain opendp_domains__map_domain(const struct AnyDomain
  * Construct a new UserDomain.
  * Any two instances of an UserDomain are equal if their string descriptors are equal.
  * Contains a function used to check if any value is a member of the domain.
+ * Requires `honest-but-curious`: TODO
  *
  * # Arguments
  * * `identifier` - A string description of the data domain.
@@ -959,6 +960,7 @@ struct FfiResult_____AnyMeasure opendp_measures__zero_concentrated_divergence(co
 /**
  * Construct a new UserDivergence.
  * Any two instances of an UserDivergence are equal if their string descriptors are equal.
+ * Requires `honest-but-curious`: TODO
  *
  * # Arguments
  * * `descriptor` - A string description of the privacy measure.
@@ -1032,6 +1034,7 @@ struct FfiResult_____AnyMetric opendp_metrics__linf_distance(c_bool monotonic, c
 /**
  * Construct a new UserDistance.
  * Any two instances of an UserDistance are equal if their string descriptors are equal.
+ * Requires `honest-but-curious`: TODO
  *
  * # Arguments
  * * `descriptor` - A string description of the metric.
@@ -1225,6 +1228,7 @@ struct FfiResult_____AnyTransformation opendp_transformations__make_lipschitz_fl
 
 /**
  * Construct a Transformation from user-defined callbacks.
+ * Requires `honest-but-curious`: TODO
  *
  * # Arguments
  * * `input_domain` - A domain describing the set of valid inputs for the function.

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -45,7 +45,8 @@ scikit-learn =
 polars =
 	# A strict version requirement is necessary to keep the serialization format of LazyFrames stable.
 	# If you change the version of Polars, 
-	# be sure to also change the Polars version in rust/Cargo.toml and test binary compatibility.
+	# be sure to also change the Polars version in rust/Cargo.toml and test binary compatibility,
+	# and update _EXPECTED_POLARS_VERSION in mod.py as well.
 	polars==0.20.16
 	pyarrow
 	# sk-learn is not strictly necessary, but it makes it simpler

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -293,7 +293,7 @@ def unwrap(result, type_) -> Any:
     if pl is not None:
         from opendp.mod import _EXPECTED_POLARS_VERSION
         if 'polars' in str(message).lower() and pl.__version__ != _EXPECTED_POLARS_VERSION:
-            message = f'Installed python polars version ({pl.__version__}) != expected version ({_EXPECTED_POLARS_VERSION}). {message}'
+            message = f'Installed python polars version ({pl.__version__}) != expected version ({_EXPECTED_POLARS_VERSION}). {message}' # pragma: no cover
     raise OpenDPException(variant, message, backtrace)
 
 

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -289,6 +289,11 @@ def unwrap(result, type_) -> Any:
         raise OpenDPException("Failed to free error.")
 
     # Rust stack traces follow from here:
+    pl = import_optional_dependency('polars', raise_error=False)
+    if pl is not None:
+        from opendp.mod import _EXPECTED_POLARS_VERSION
+        if 'polars' in message.lower() and pl.__version__ != _EXPECTED_POLARS_VERSION:
+            message = f'Installed python polars version ({pl.__version__}) != expected version ({_EXPECTED_POLARS_VERSION}). {message}'
     raise OpenDPException(variant, message, backtrace)
 
 

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -292,8 +292,10 @@ def unwrap(result, type_) -> Any:
     pl = import_optional_dependency('polars', raise_error=False)
     if pl is not None:
         from opendp.mod import _EXPECTED_POLARS_VERSION
-        if 'polars' in str(message).lower() and pl.__version__ != _EXPECTED_POLARS_VERSION:
-            message = f'Installed python polars version ({pl.__version__}) != expected version ({_EXPECTED_POLARS_VERSION}). {message}' # pragma: no cover
+        if 'polars' in str(message).lower() and pl.__version__ != _EXPECTED_POLARS_VERSION: # pragma: no cover
+            message = f'Installed python polars version ({pl.__version__}) != expected version ({_EXPECTED_POLARS_VERSION}). {message}'
+        else:
+            message = f'Installed python polars version ({pl.__version__}) matches expected version, but there is a problem: {message}'
     raise OpenDPException(variant, message, backtrace)
 
 

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -292,7 +292,7 @@ def unwrap(result, type_) -> Any:
     pl = import_optional_dependency('polars', raise_error=False)
     if pl is not None:
         from opendp.mod import _EXPECTED_POLARS_VERSION
-        if 'polars' in message.lower() and pl.__version__ != _EXPECTED_POLARS_VERSION:
+        if 'polars' in str(message).lower() and pl.__version__ != _EXPECTED_POLARS_VERSION:
             message = f'Installed python polars version ({pl.__version__}) != expected version ({_EXPECTED_POLARS_VERSION}). {message}'
     raise OpenDPException(variant, message, backtrace)
 

--- a/python/src/opendp/combinators.py
+++ b/python/src/opendp/combinators.py
@@ -223,8 +223,8 @@ def make_population_amplification(
 
     The DIA, DO, MI and MO between the input measurement and amplified output measurement all match.
 
-    Protected by the "honest-but-curious" feature flag
-    because a dishonest adversary could set the population size to be arbitrarily large.
+    Requires `honest-but-curious`:
+    a dishonest adversary could set the population size to be arbitrarily large.
 
     [make_population_amplification in Rust documentation.](https://docs.rs/opendp/latest/opendp/combinators/fn.make_population_amplification.html)
 

--- a/python/src/opendp/domains.py
+++ b/python/src/opendp/domains.py
@@ -427,6 +427,7 @@ def user_domain(
     r"""Construct a new UserDomain.
     Any two instances of an UserDomain are equal if their string descriptors are equal.
     Contains a function used to check if any value is a member of the domain.
+    Requires `honest-but-curious`: TODO
 
     :param identifier: A string description of the data domain.
     :type identifier: str

--- a/python/src/opendp/measurements.py
+++ b/python/src/opendp/measurements.py
@@ -1104,6 +1104,7 @@ def make_user_measurement(
     TO: RuntimeTypeDescriptor = "ExtrinsicObject"
 ) -> Measurement:
     r"""Construct a Measurement from user-defined callbacks.
+    Requires `honest-but-curious`: TODO
 
     **Supporting Elements:**
 

--- a/python/src/opendp/measures.py
+++ b/python/src/opendp/measures.py
@@ -226,6 +226,7 @@ def user_divergence(
 ) -> Measure:
     r"""Construct a new UserDivergence.
     Any two instances of an UserDivergence are equal if their string descriptors are equal.
+    Requires `honest-but-curious`: TODO
 
     :param descriptor: A string description of the privacy measure.
     :type descriptor: str

--- a/python/src/opendp/metrics.py
+++ b/python/src/opendp/metrics.py
@@ -409,6 +409,7 @@ def user_distance(
 ) -> Metric:
     r"""Construct a new UserDistance.
     Any two instances of an UserDistance are equal if their string descriptors are equal.
+    Requires `honest-but-curious`: TODO
 
     :param descriptor: A string description of the metric.
     :type descriptor: str

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -1053,3 +1053,5 @@ def exponential_bounds_search(
     at_center = predicate(center)
     return signed_band_search(center, at_center, sign)
 
+
+_EXPECTED_POLARS_VERSION = '0.20.16' # Keep in sync with setup.cfg.

--- a/python/src/opendp/transformations.py
+++ b/python/src/opendp/transformations.py
@@ -1604,7 +1604,7 @@ def make_identity(
 ) -> Transformation:
     r"""Make a Transformation representing the identity function.
 
-    WARNING: In Python, this function does not ensure that the domain and metric form a valid metric space.
+    WARNING: Requires `honest-but-curious` because in Python, this function does not ensure that the domain and metric form a valid metric space.
     However, if the domain and metric do not form a valid metric space,
     then the resulting Transformation won't be chainable with any valid Transformation,
     so it cannot be used to introduce an invalid metric space into a chain of valid Transformations.
@@ -3402,6 +3402,7 @@ def make_user_transformation(
     stability_map
 ) -> Transformation:
     r"""Construct a Transformation from user-defined callbacks.
+    Requires `honest-but-curious`: TODO
 
     :param input_domain: A domain describing the set of valid inputs for the function.
     :type input_domain: Domain

--- a/python/test/test_polars.py
+++ b/python/test/test_polars.py
@@ -5,6 +5,12 @@ import opendp.prelude as dp
 dp.enable_features("contrib", "honest-but-curious")
 
 
+def test_polars_version():
+    pl = pytest.importorskip("polars")
+    from opendp.mod import _EXPECTED_POLARS_VERSION
+    assert pl.__version__ == _EXPECTED_POLARS_VERSION
+
+
 def seed(schema):
     pl = pytest.importorskip("polars")
     return pl.DataFrame(None, schema, orient="row").lazy()  # type: ignore[attr-defined]

--- a/rust/opendp_derive/src/full.rs
+++ b/rust/opendp_derive/src/full.rs
@@ -5,7 +5,7 @@ use proc_macro::TokenStream;
 
 use opendp_tooling::{
     bootstrap::{
-        docstring::{get_proof_path, insert_proof_attribute},
+        docstring::{get_proof_path, insert_proof_attribute, confirm_note_for_honest_but_curious},
         partial::generate_partial,
     },
     proven::{filesystem::load_proof_paths, Proven},
@@ -54,6 +54,11 @@ pub(crate) fn bootstrap(attr_args: TokenStream, input: TokenStream) -> TokenStre
         Function::from_ast(attr_args, item_fn.clone(), None),
         original_input
     );
+
+    // check for feature notes
+    if function.features.contains(&String::from("honest-but-curious")) {
+        confirm_note_for_honest_but_curious(function.name, &mut item_fn.attrs)
+    }
 
     let mut output = TokenStream::new();
 

--- a/rust/opendp_tooling/src/bootstrap/docstring.rs
+++ b/rust/opendp_tooling/src/bootstrap/docstring.rs
@@ -315,8 +315,9 @@ pub fn get_proof_path(
 /// confirm prescence of note for honest-but-curious 
 pub fn confirm_note_for_honest_but_curious(name: String, attributes: &mut Vec<Attribute>) -> () {
     let doc_comment = get_doc_comment(attributes.to_vec());
-    if !doc_comment.contains("Requires `honest-but-curious`:") {
-        panic!("honest-but-curious function {name} needs to explain why; {doc_comment}")
+    let requires = "Requires `honest-but-curious`";
+    if !doc_comment.contains(requires) {
+        panic!("In {name} doc comment, add '{requires} because ...'")
     };
 }
 

--- a/rust/opendp_tooling/src/bootstrap/docstring.rs
+++ b/rust/opendp_tooling/src/bootstrap/docstring.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, env, path::PathBuf};
+use std::{collections::HashMap, env, path::PathBuf, thread::panicking};
 
 use darling::{Error, Result};
 use proc_macro2::{Literal, Punct, Spacing, TokenStream, TokenTree};
@@ -310,6 +310,24 @@ pub fn get_proof_path(
             None => None
         }
     })
+}
+
+/// confirm prescence of note for honest-but-curious 
+pub fn confirm_note_for_honest_but_curious(name: String, attributes: &mut Vec<Attribute>) -> () {
+    let doc_comment = get_doc_comment(attributes.to_vec());
+    if !doc_comment.contains("Requires `honest-but-curious`:") {
+        panic!("honest-but-curious function {name} needs to explain why; {doc_comment}")
+    };
+}
+
+fn get_doc_comment(attributes: Vec<Attribute>) -> String {
+    attributes.iter()
+        .filter(|attr| attr.path.get_ident().map(ToString::to_string).as_deref() == Some("doc"))
+        .map(|attr| if let Ok(comment) = parse_doc_attribute(attr.clone()) {
+            comment
+        } else {
+            "".to_string()
+        }).collect::<Vec<_>>().join("\n")
 }
 
 /// add attributes containing the proof link

--- a/rust/src/combinators/amplify/ffi.rs
+++ b/rust/src/combinators/amplify/ffi.rs
@@ -95,8 +95,8 @@ impl IsSizedDomain for AnyDomain {
 ///
 /// The DIA, DO, MI and MO between the input measurement and amplified output measurement all match.
 ///
-/// Protected by the "honest-but-curious" feature flag
-/// because a dishonest adversary could set the population size to be arbitrarily large.
+/// Requires `honest-but-curious`:
+/// a dishonest adversary could set the population size to be arbitrarily large.
 ///
 /// # Arguments
 /// * `measurement` - the computation to amplify

--- a/rust/src/data/ffi.rs
+++ b/rust/src/data/ffi.rs
@@ -210,7 +210,7 @@ pub extern "C" fn opendp_data__slice_as_object(
         // https://github.com/pola-rs/pyo3-polars/blob/5150d4ca27c287ff4be5cafef243d9a878a8879d/pyo3-polars/src/lib.rs#L147-L153
         // the slice is lf.__getstate__ from the python side and then deserialized here
         ciborium::de::from_reader(slice).map_err(
-            |e| err!(FFI, "Error when deserializing {}. This may be due to mismatched polars versions. {}", name, e)
+            |e| err!(FFI, "Error when deserializing {}. {}", name, e)
         )
     }
     #[cfg(feature = "polars")]

--- a/rust/src/domains/ffi.rs
+++ b/rust/src/domains/ffi.rs
@@ -400,6 +400,7 @@ impl Domain for UserDomain {
 /// Construct a new UserDomain.
 /// Any two instances of an UserDomain are equal if their string descriptors are equal.
 /// Contains a function used to check if any value is a member of the domain.
+/// Requires `honest-but-curious`: TODO
 ///
 /// # Arguments
 /// * `identifier` - A string description of the data domain.

--- a/rust/src/measurements/make_user_measurement/mod.rs
+++ b/rust/src/measurements/make_user_measurement/mod.rs
@@ -30,6 +30,7 @@ use crate::{
     )
 )]
 /// Construct a Measurement from user-defined callbacks.
+/// Requires `honest-but-curious`: TODO
 ///
 /// # Arguments
 /// * `input_domain` - A domain describing the set of valid inputs for the function.

--- a/rust/src/measures/ffi.rs
+++ b/rust/src/measures/ffi.rs
@@ -178,7 +178,8 @@ impl Measure for UserDivergence {
 )]
 /// Construct a new UserDivergence.
 /// Any two instances of an UserDivergence are equal if their string descriptors are equal.
-///
+/// Requires `honest-but-curious`: TODO
+/// 
 /// # Arguments
 /// * `descriptor` - A string description of the privacy measure.
 #[no_mangle]

--- a/rust/src/metrics/ffi.rs
+++ b/rust/src/metrics/ffi.rs
@@ -258,6 +258,7 @@ impl Metric for UserDistance {
 )]
 /// Construct a new UserDistance.
 /// Any two instances of an UserDistance are equal if their string descriptors are equal.
+/// Requires `honest-but-curious`: TODO
 ///
 /// # Arguments
 /// * `descriptor` - A string description of the metric.

--- a/rust/src/transformations/make_user_transformation/mod.rs
+++ b/rust/src/transformations/make_user_transformation/mod.rs
@@ -26,6 +26,7 @@ use crate::{
     )
 )]
 /// Construct a Transformation from user-defined callbacks.
+/// Requires `honest-but-curious`: TODO
 ///
 /// # Arguments
 /// * `input_domain` - A domain describing the set of valid inputs for the function.

--- a/rust/src/transformations/manipulation/mod.rs
+++ b/rust/src/transformations/manipulation/mod.rs
@@ -136,7 +136,7 @@ where
 )]
 /// Make a Transformation representing the identity function.
 ///
-/// WARNING: In Python, this function does not ensure that the domain and metric form a valid metric space.
+/// WARNING: Requires `honest-but-curious` because in Python, this function does not ensure that the domain and metric form a valid metric space.
 /// However, if the domain and metric do not form a valid metric space,
 /// then the resulting Transformation won't be chainable with any valid Transformation,
 /// so it cannot be used to introduce an invalid metric space into a chain of valid Transformations.


### PR DESCRIPTION
- Fix #1631

Lots of "keep X in sync with Y" messages across the codebase are generally not a good thing, but maybe the clarity for the user in this case would be worth it.