### PR TITLE
update links to match new docs structure

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-contribution.md
+++ b/.github/ISSUE_TEMPLATE/new-contribution.md
@@ -5,9 +5,9 @@ about: Solicit feedback for a contribution you'd like to make
 ---
 How exciting!
 
-Please review [the information to include in your issue](https://docs.opendp.org/en/nightly/contributor/getting-involved.html#code-and-proof-contributions),
+Please review [the information to include in your issue](https://docs.opendp.org/en/nightly/contributing/getting-involved.html#code-and-proof-contributions),
 and we will try to get back with you shortly.
 
-In the meantime, you might want to [review the contribution process](https://docs.opendp.org/en/nightly/contributor/contribution-process.html),
+In the meantime, you might want to [review the contribution process](https://docs.opendp.org/en/nightly/contributing/contribution-process.html),
 [join the discussion on Slack](https://join.slack.com/t/opendp/shared_invite/zt-zw7o1k2s-dHg8NQE8WTfAGFnN_cwomA),
 and start getting your development environment set up.


### PR DESCRIPTION
- Fix #1637

Also, this was a chance to exercise the new 404 page JS-redirect machinery. For both of these, it works: Users are directed from the old URLs to the new.