### PR TITLE
Upgrade pydata theme for search snippets

### DIFF
--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -9,7 +9,7 @@ sphinx
 sphinx-prompt
 sphinx-design
 git+https://github.com/samtygier-stfc/sphinx-multiversion.git@prebuild_command
-pydata-sphinx-theme==0.15.3rc1
+pydata-sphinx-theme==0.15.3rc1 # TODO: Remove version pin when RC is released.
 nbsphinx
 ipython  # for notebook syntax highlighting in docs
 pandoc

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -9,7 +9,7 @@ sphinx
 sphinx-prompt
 sphinx-design
 git+https://github.com/samtygier-stfc/sphinx-multiversion.git@prebuild_command
-pydata-sphinx-theme
+pydata-sphinx-theme==0.15.3rc1
 nbsphinx
 ipython  # for notebook syntax highlighting in docs
 pandoc

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -125,7 +125,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pydata-sphinx-theme==0.15.2
+pydata-sphinx-theme==0.15.3rc1
     # via -r requirements.in
 pygments==2.17.2
     # via


### PR DESCRIPTION
- Fix #1517 

Confirmed locally that search now shows snippets. The only other difference I see with this release is the styling of tabs: They seem clunkier to me, but I don't think it's something we should fight.

<img width="499" alt="Screenshot 2024-05-21 at 5 43 41 PM" src="https://github.com/opendp/opendp/assets/730388/d463590b-b881-45c2-9288-386b3035900d">

When there is a final release, we should certainly use it, but I'm not seeing any problems with the RC, and the search snippets are a big win.

Took me longer than I'd like to admit to confirm that it works locally. The upstream fix is a change to the document template (to restore a `role="main"` attribute) so there are a number a cache layers to clear:
- Checkout the branch and `pip install -r requirements.txt`
- Clear the sphinx build cache with `rm -r build/html`
- Because of browser security rules, it doesn't work with just `file:///`: Instead you'll need `python -m http.server` or similar.
- My browser was also caching old versions of page, so clear the browser cache.