### PR TITLE
Improve test coverage in `context.py`

### DIFF
--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -206,17 +206,17 @@ def metric_of(M) -> Metric:
             return metrics.absolute_distance(T=M.args[0])
         if M.origin == "L1Distance":
             return metrics.l1_distance(T=M.args[0])
-        if M.origin == "L2Distance": # pragma: no cover
+        if M.origin == "L2Distance":
             return metrics.l2_distance(T=M.args[0])
 
     if M == ty.HammingDistance:
-        return metrics.hamming_distance() # pragma: no cover
+        return metrics.hamming_distance()
     if M == ty.SymmetricDistance:
         return metrics.symmetric_distance()
     if M == ty.InsertDeleteDistance:
-        return metrics.insert_delete_distance() # pragma: no cover
+        return metrics.insert_delete_distance()
     if M == ty.ChangeOneDistance:
-        return metrics.change_one_distance() # pragma: no cover
+        return metrics.change_one_distance()
     if M == ty.DiscreteDistance:
         return metrics.discrete_distance()
 
@@ -411,10 +411,8 @@ class Context(object):
             d_mids=d_mids,
         )
 
-    def __call__(self, query: Union["Query", Measurement]):
+    def __call__(self, query: Measurement):
         """Executes the given query on the context."""
-        if isinstance(query, Query):
-            query = query.resolve() # pragma: no cover
         answer = self.queryable(query)
         if self.d_mids is not None:
             self.d_mids.pop(0)
@@ -436,6 +434,8 @@ class Context(object):
                 raise ValueError("Privacy allowance has been exhausted")
             d_query = self.d_mids[0]
         elif kwargs: # pragma: no cover
+            # TODO: Is there a way to reach this? The usual ways of constructing a Context will populate d_mids.
+            # TODO: Update the docstring if we do remove this.
             measure, d_query = loss_of(**kwargs)
             if measure != self.output_measure: # type: ignore[attr-defined]
                 raise ValueError(
@@ -554,8 +554,10 @@ class Query(object):
         )
 
     def __dir__(self):
-        """Returns the list of available constructors. Used by Python's error suggestion mechanism."""
-        return super().__dir__() + list(constructors.keys())  # type: ignore[operator] # pragma: no cover
+        """Returns the list of available constructors. Used by Python's error suggestion mechanism.
+        Without this, none of the transformations or measument methods are listed.
+        """
+        return super().__dir__() + list(constructors.keys())  # type: ignore[operator]
 
     def resolve(self, allow_transformations=False):
         """Resolve the query into a measurement.
@@ -645,6 +647,7 @@ class Query(object):
     def _compose_context(self, compositor):
         """Helper function for composition in a context."""
         if isinstance(self._chain, PartialChain):
+            # TODO: Can we exercise this?
             return PartialChain(lambda x: compositor(self._chain(x), self._d_in)) # pragma: no cover
         else:
             return compositor(self._chain, self._d_in)
@@ -665,6 +668,7 @@ class PartialChain(object):
 
     def __call__(self, v):
         """Returns the transformation or measurement with the given parameter."""
+        # TODO: Can we exercise this?
         return self.partial(v) # pragma: no cover
 
     def fix(self, d_in, d_out, output_measure=None, T=None):
@@ -684,6 +688,7 @@ class PartialChain(object):
 
     def __rshift__(self, other):
         # partials may be chained with other transformations or measurements to form a new partial
+        # TODO: Can we exercise this?
         if isinstance(other, (Transformation, Measurement)): # pragma: no cover
             return PartialChain(lambda x: self.partial(x) >> other)
 
@@ -785,9 +790,18 @@ def _cast_measure(chain, to_measure=None, d_to=None):
 
 def _translate_measure_distance(d_from, from_measure, to_measure):
     """Translate a privacy loss ``d_from`` from ``from_measure`` to ``to_measure``.
+
+    >>> _translate_measure_distance(1, dp.max_divergence(dp.f64), dp.max_divergence(dp.f64))
+    1
+    >>> _translate_measure_distance(1, dp.max_divergence(dp.f64), dp.fixed_smoothed_max_divergence(dp.f64))
+    (1, 0.0)
+    >>> _translate_measure_distance((1.5, 5e-07), dp.fixed_smoothed_max_divergence(dp.f64), dp.zero_concentrated_divergence(dp.f64))
+    0.0489...
+    >>> _translate_measure_distance(0.05, dp.zero_concentrated_divergence(dp.f64), dp.max_divergence(dp.f64))
+    0.316...
     """
     if from_measure == to_measure:
-        return d_from # pragma: no cover
+        return d_from
 
     from_to = from_measure.type.origin, to_measure.type.origin
     T = to_measure.type.args[0]
@@ -795,9 +809,9 @@ def _translate_measure_distance(d_from, from_measure, to_measure):
     constant = 1.0  # the choice of constant doesn't matter
 
     if from_to == ("MaxDivergence", "FixedSmoothedMaxDivergence"):
-        return (d_from, 0.0) # pragma: no cover
+        return (d_from, 0.0)
 
-    if from_to == ("ZeroConcentratedDivergence", "MaxDivergence"): # pragma: no cover
+    if from_to == ("ZeroConcentratedDivergence", "MaxDivergence"):
         space = atom_domain(T=T), absolute_distance(T=T)
         scale = binary_search_param(
             lambda eps: make_pureDP_to_zCDP(make_laplace(*space, eps)),

--- a/python/test/test_context_usability.py
+++ b/python/test/test_context_usability.py
@@ -77,3 +77,14 @@ def test_scalar_instead_of_vector():
             split_evenly_over=1,
             domain=dp.domain_of(int),
         )
+
+def test_query_dir():
+    context = dp.Context.compositor(
+        data=[1, 2, 3, 4, 5],
+        privacy_unit=dp.unit_of(contributions=1),
+        privacy_loss=dp.loss_of(epsilon=1.0),
+        split_evenly_over=1,
+    )
+    query_dir = dir(context.query())
+    assert 'count' in query_dir
+    assert 'laplace' in query_dir

--- a/python/test/test_space_of.py
+++ b/python/test/test_space_of.py
@@ -9,6 +9,14 @@ def test_typed_space_of():
     space = dp.space_of(list[int], dp.L2Distance)
     assert space == (dp.vector_domain(dp.atom_domain(T=dp.i32)), dp.l2_distance(T=dp.i32))
 
+    # not all metrics are parmeterized
+    space = dp.space_of(list[int], dp.HammingDistance)
+    assert space == (dp.vector_domain(dp.atom_domain(T=dp.i32)), dp.hamming_distance())
+    space = dp.space_of(list[int], dp.InsertDeleteDistance)
+    assert space == (dp.vector_domain(dp.atom_domain(T=dp.i32)), dp.insert_delete_distance())
+    space = dp.space_of(list[int], dp.ChangeOneDistance)
+    assert space == (dp.vector_domain(dp.atom_domain(T=dp.i32)), dp.change_one_distance())
+
     # when type is scalar, domain defaults to atom_domain and metric defaults to absolute_distance
     space = dp.space_of(float)
     assert space == (dp.atom_domain(T=dp.f64), dp.absolute_distance(T=dp.f64))

--- a/python/test/test_space_of.py
+++ b/python/test/test_space_of.py
@@ -6,8 +6,8 @@ def test_typed_space_of():
     assert space == (dp.vector_domain(dp.atom_domain(T=dp.i32)), dp.symmetric_distance())
 
     # can specify metric explicitly. If not fully specified, will infer distance type from domain
-    space = dp.space_of(list[int], dp.L1Distance)
-    assert space == (dp.vector_domain(dp.atom_domain(T=dp.i32)), dp.l1_distance(T=dp.i32))
+    space = dp.space_of(list[int], dp.L2Distance)
+    assert space == (dp.vector_domain(dp.atom_domain(T=dp.i32)), dp.l2_distance(T=dp.i32))
 
     # when type is scalar, domain defaults to atom_domain and metric defaults to absolute_distance
     space = dp.space_of(float)


### PR DESCRIPTION
- Towards #1035
- Add some tests where the behavior seems clear enough.
- Where there are still gaps, add an explicit TODO.
- On `context.__call__` suggest deleting unused/untested branch, particularly since it simplifies the typing.
- Add typing, and a couple run-time checks.

There is the risk here of just hardening behavior that isn't what we really want, but I'm hoping that this at least helps to make gaps visible.