### PR TITLE
Improve test coverage in `typing.py`

### DIFF
--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -84,8 +84,6 @@ def set_default_int_type(T: RuntimeTypeDescriptor) -> None:
     
     :params T: must be one of [u8, u16, u32, u64, usize, i8, i16, i32, i64]
     :type T: :ref:`RuntimeTypeDescriptor`
-
-    :examples:
     """
     equivalence_class = ATOM_EQUIVALENCE_CLASSES[ELEMENTARY_TYPES[int]]
     T = RuntimeType.parse(T)
@@ -276,32 +274,6 @@ class RuntimeType(object):
         Vec<String>
         >>> dp.RuntimeType.infer((12., True, "A"))
         (f64, bool, String)
-
-        TODO: This one seems strange: Why not have the usual error if types don't match?
-
-        >>> dp.RuntimeType.infer([1, True], py_object=True)
-        Vec<ExtrinsicObject>
-        
-        >>> dp.RuntimeType.infer([])
-        Traceback (most recent call last):
-        ...
-        opendp.mod.UnknownTypeException: attempted to create a type_name with an unknown type: cannot infer atomic type when empty
-
-        >>> dp.RuntimeType.infer(object())
-        Traceback (most recent call last):
-        ...
-        opendp.mod.UnknownTypeException: <class 'object'>
-        
-        >>> dp.RuntimeType.infer(object(), py_object=True)
-        'ExtrinsicObject'
-
-        >>> dp.RuntimeType.infer(lambda _: True)
-        'CallbackFn'
-
-        >>> dp.RuntimeType.infer(None)
-        Traceback (most recent call last):
-        ...
-        opendp.mod.UnknownTypeException: attempted to create a type_name with an unknown type: Constructed Option from a None variant
         """
         if type(public_example) in ELEMENTARY_TYPES:
             return ELEMENTARY_TYPES[type(public_example)]

--- a/python/test/test_typing.py
+++ b/python/test/test_typing.py
@@ -68,6 +68,15 @@ def test_set_feature():
     assert "A" not in GLOBAL_FEATURES
 
 
+def test_default_float_type():
+    assert RuntimeType.parse(float) == f64
+
+    set_default_float_type(f64)
+    assert RuntimeType.parse(float) == f64
+
+    # Can't set to f32 because debug binary has fewer types.
+
+
 disallowed_int_default_types = set([i128, u128, isize])
 
 @pytest.mark.parametrize('integer_type', set(INTEGER_TYPES) - disallowed_int_default_types)

--- a/python/test/test_typing.py
+++ b/python/test/test_typing.py
@@ -14,7 +14,46 @@ def test_numpy_function():
     print(RuntimeType.infer(np.array(["A", "B"])))
 
 
-def test_typing_hint():
+def test_typing_infer():
+    '''
+    >>> dp.RuntimeType.infer(23)
+    'i32'
+    >>> dp.RuntimeType.infer(12.)
+    'f64'
+    >>> dp.RuntimeType.infer(["A", "B"])
+    Vec<String>
+    >>> dp.RuntimeType.infer((12., True, "A"))
+    (f64, bool, String)
+
+    TODO: This one seems strange: Why not have the usual error if types don't match?
+
+    >>> dp.RuntimeType.infer([1, True], py_object=True)
+    Vec<ExtrinsicObject>
+    
+    >>> dp.RuntimeType.infer([])
+    Traceback (most recent call last):
+    ...
+    opendp.mod.UnknownTypeException: attempted to create a type_name with an unknown type: cannot infer atomic type when empty
+
+    >>> dp.RuntimeType.infer(object())
+    Traceback (most recent call last):
+    ...
+    opendp.mod.UnknownTypeException: <class 'object'>
+    
+    >>> dp.RuntimeType.infer(object(), py_object=True)
+    'ExtrinsicObject'
+
+    >>> dp.RuntimeType.infer(lambda _: True)
+    'CallbackFn'
+
+    >>> dp.RuntimeType.infer(None)
+    Traceback (most recent call last):
+    ...
+    opendp.mod.UnknownTypeException: attempted to create a type_name with an unknown type: Constructed Option from a None variant
+    '''
+    pass
+
+def test_typing_parse():
     assert str(RuntimeType.parse(Tuple[int, float])) == "(i32, f64)" # type: ignore[arg-type]
     assert str(RuntimeType.parse(tuple[int, float])) == "(i32, f64)" # type: ignore[arg-type]
     assert str(RuntimeType.parse(Tuple[int, Tuple[str]])) == "(i32, (String))" # type: ignore[arg-type]
@@ -26,12 +65,8 @@ def test_typing_hint():
     assert str(RuntimeType.parse((List[int], (int, bool)))) == '(Vec<i32>, (i32, bool))'
     assert str(RuntimeType.parse((list[int], (int, bool)))) == '(Vec<i32>, (i32, bool))'
     assert isinstance(RuntimeType.parse('L1Distance<f64>'), SensitivityMetric)
-
-    try:
+    with pytest.raises(UnknownTypeException):
         RuntimeType.parse(list[Any])
-        raise Exception("typing.Any should fail to parse")
-    except UnknownTypeException:
-        pass
 
 
 def test_sensitivity():


### PR DESCRIPTION
- Towards #1035
- `infer` has a lot of what seems like odd behavior to me: add comments -- Before merging, decide on next steps and file issues if needed.
- Remove special handling for Measurement and Transformation: canonical examples like `make_gaussian` fall through to the callable check, so these don't seem to be doing what we'd want.
- exercise `set_default_float_type`
- Remove special warning for `AllDomain`: It was deprecated in v0.7, so seems safe to remove now.