### PR TITLE
Python polars version: Extra info on error if mismatch with Rust

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -171,7 +171,7 @@ jobs:
         run: python -m pip install -e ${{ matrix.extra-install }}
 
       - name: Test
-        run: coverage run -m pytest -v ${{ contains(matrix.extra-install, 'polars') && '' || '-k "not lazyframe"'}}
+        run: coverage run -m pytest -v ${{ ! contains(matrix.extra-install, 'polars') && '-k "not lazyframe and not polars"' || ''}}
 
       - name: Test coverage
         # We only expect test coverage with all extra dependencies.

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -45,7 +45,8 @@ scikit-learn =
 polars =
 	# A strict version requirement is necessary to keep the serialization format of LazyFrames stable.
 	# If you change the version of Polars, 
-	# be sure to also change the Polars version in rust/Cargo.toml and test binary compatibility.
+	# be sure to also change the Polars version in rust/Cargo.toml and test binary compatibility,
+	# and update _EXPECTED_POLARS_VERSION in mod.py as well.
 	polars==0.20.16
 	pyarrow
 	# sk-learn is not strictly necessary, but it makes it simpler

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -293,7 +293,7 @@ def unwrap(result, type_) -> Any:
     if pl is not None:
         from opendp.mod import _EXPECTED_POLARS_VERSION
         if 'polars' in str(message).lower() and pl.__version__ != _EXPECTED_POLARS_VERSION:
-            message = f'Installed python polars version ({pl.__version__}) != expected version ({_EXPECTED_POLARS_VERSION}). {message}'
+            message = f'Installed python polars version ({pl.__version__}) != expected version ({_EXPECTED_POLARS_VERSION}). {message}' # pragma: no cover
     raise OpenDPException(variant, message, backtrace)
 
 

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -289,6 +289,11 @@ def unwrap(result, type_) -> Any:
         raise OpenDPException("Failed to free error.")
 
     # Rust stack traces follow from here:
+    pl = import_optional_dependency('polars', raise_error=False)
+    if pl is not None:
+        from opendp.mod import _EXPECTED_POLARS_VERSION
+        if 'polars' in message.lower() and pl.__version__ != _EXPECTED_POLARS_VERSION:
+            message = f'Installed python polars version ({pl.__version__}) != expected version ({_EXPECTED_POLARS_VERSION}). {message}'
     raise OpenDPException(variant, message, backtrace)
 
 

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -292,7 +292,7 @@ def unwrap(result, type_) -> Any:
     pl = import_optional_dependency('polars', raise_error=False)
     if pl is not None:
         from opendp.mod import _EXPECTED_POLARS_VERSION
-        if 'polars' in message.lower() and pl.__version__ != _EXPECTED_POLARS_VERSION:
+        if 'polars' in str(message).lower() and pl.__version__ != _EXPECTED_POLARS_VERSION:
             message = f'Installed python polars version ({pl.__version__}) != expected version ({_EXPECTED_POLARS_VERSION}). {message}'
     raise OpenDPException(variant, message, backtrace)
 

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -1053,3 +1053,5 @@ def exponential_bounds_search(
     at_center = predicate(center)
     return signed_band_search(center, at_center, sign)
 
+
+_EXPECTED_POLARS_VERSION = '0.20.16' # Keep in sync with setup.cfg.

--- a/python/test/test_polars.py
+++ b/python/test/test_polars.py
@@ -5,6 +5,12 @@ import opendp.prelude as dp
 dp.enable_features("contrib", "honest-but-curious")
 
 
+def test_polars_version():
+    pl = pytest.importorskip("polars")
+    from opendp.mod import _EXPECTED_POLARS_VERSION
+    assert pl.__version__ == _EXPECTED_POLARS_VERSION
+
+
 def seed(schema):
     pl = pytest.importorskip("polars")
     return pl.DataFrame(None, schema, orient="row").lazy()  # type: ignore[attr-defined]

--- a/rust/src/data/ffi.rs
+++ b/rust/src/data/ffi.rs
@@ -210,7 +210,7 @@ pub extern "C" fn opendp_data__slice_as_object(
         // https://github.com/pola-rs/pyo3-polars/blob/5150d4ca27c287ff4be5cafef243d9a878a8879d/pyo3-polars/src/lib.rs#L147-L153
         // the slice is lf.__getstate__ from the python side and then deserialized here
         ciborium::de::from_reader(slice).map_err(
-            |e| err!(FFI, "Error when deserializing {}. This may be due to mismatched polars versions. {}", name, e)
+            |e| err!(FFI, "Error when deserializing {}. {}", name, e)
         )
     }
     #[cfg(feature = "polars")]


### PR DESCRIPTION
- Replaces #1636
 
Mistakenly added new commits to that branch, and a new PR seems like the least confusing way to go forward.

Last comment from that PR:

> For users, this doesn't enforce strict version matches... but if there is an error, and there is a mismatch, it includes more information, saying exactly what version it saw and what version it expected. With the current state, I think it could be frustrating to be a downstream user, particularly if some other library includes opendp as a dependency, but forgot to reference our `[polars]` extra. The user is going to have some trouble figuring out what version _would_ fix the error.
> 
> ... it's also possible that version mismatch is not the problem... I think I hit this at one point, though I don't remember the details, and I may be misremembering. But if anyone else were to hit it, it would be good not to point them in the wrong direction.
> 
> This does require an exact version match for devs (at least for passing tests), and it is an additional thing to track -- though I think we'll be bumping this version pretty infrequently. It is a tradeoff, but I think it will be relatively painless for devs.