### PR TITLE
chore: remove `UnknownType` and instead immediately raise exception

### DIFF
--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -279,7 +279,7 @@ class RuntimeType(object):
         >>> dp.RuntimeType.infer([])
         Traceback (most recent call last):
         ...
-        opendp.mod.UnknownTypeException: cannot infer atomic type when empty
+        opendp.mod.UnknownTypeException: Cannot infer atomic type when empty
         """
         if type(public_example) in ELEMENTARY_TYPES:
             return ELEMENTARY_TYPES[type(public_example)]
@@ -308,7 +308,7 @@ class RuntimeType(object):
             types = {cls.infer(v, py_object=py_object) for v in value}
 
             if len(types) == 0:
-                raise UnknownTypeException("cannot infer atomic type when empty")
+                raise UnknownTypeException("Cannot infer atomic type when empty")
             if len(types) == 1:
                 return next(iter(types))
             if py_object:

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -266,7 +266,6 @@ class RuntimeType(object):
 
         :examples:
 
-        >>> import opendp.prelude as dp
         >>> dp.RuntimeType.infer(23)
         'i32'
         >>> dp.RuntimeType.infer(12.)
@@ -336,13 +335,7 @@ class RuntimeType(object):
                 infer_homogeneous(public_example.values())
             ])
 
-        if isinstance(public_example, Measurement): # pragma: no cover
-            return "AnyMeasurementPtr"
-
-        if isinstance(public_example, Transformation): # pragma: no cover
-            return "AnyTransformationPtr"
-
-        if public_example is None: # pragma: no cover
+        if public_example is None:
             raise UnknownTypeException("Type of Option cannot be inferred from None")
         
         if callable(public_example):

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -343,7 +343,7 @@ class RuntimeType(object):
             return "AnyTransformationPtr"
 
         if public_example is None: # pragma: no cover
-            raise UnknownTypeException("Constructed Option from a None variant")
+            raise UnknownTypeException("Type of Option cannot be inferred from None")
         
         if callable(public_example):
             return "CallbackFn"

--- a/python/test/test_typing.py
+++ b/python/test/test_typing.py
@@ -43,13 +43,10 @@ def test_typing_infer_to_object():
     with pytest.raises(UnknownTypeException, match=re.escape("<class 'object'>")):
         RuntimeType.infer(object())
     
-    # TODO: Raising an exception in __repr__ seems strange: Why not raise exception earlier, like infer(object())?
-    infer_none = RuntimeType.infer(None)
-    with pytest.raises(UnknownTypeException, match=re.escape("Constructed Option from a None variant")):
-        str(infer_none)
-    infer_empty = RuntimeType.infer([])
-    with pytest.raises(UnknownTypeException, match=re.escape('cannot infer atomic type when empty')):
-        str(infer_empty)
+    with pytest.raises(UnknownTypeException, match=re.escape("Type of Option cannot be inferred from None")):
+        RuntimeType.infer(None)
+    with pytest.raises(UnknownTypeException, match=re.escape('Cannot infer atomic type when empty')):
+        RuntimeType.infer([])
 
 def test_typing_parse():
     assert str(RuntimeType.parse(Tuple[int, float])) == "(i32, f64)" # type: ignore[arg-type]


### PR DESCRIPTION
Prompted by https://github.com/opendp/opendp/pull/1652/files#r1642781252 

I don't understand the data load process in detail, but at least on the evidence of our tests it doesn't seem to be needed now.