### PR TITLE
Polars: laplace thresholding for private key-sets

### DIFF
--- a/R/opendp/src/opendp.h
+++ b/R/opendp/src/opendp.h
@@ -903,7 +903,8 @@ struct FfiResult_____AnyMeasurement opendp_measurements__make_private_lazyframe(
                                                                                 const struct AnyMetric *input_metric,
                                                                                 const struct AnyMeasure *output_measure,
                                                                                 const struct AnyObject *lazyframe,
-                                                                                const struct AnyObject *global_scale);
+                                                                                const struct AnyObject *global_scale,
+                                                                                const struct AnyObject *threshold);
 
 struct FfiResult_____AnyMeasurement opendp_measurements__make_user_measurement(const struct AnyDomain *input_domain,
                                                                                const struct AnyMetric *input_metric,

--- a/docs/source/getting-started/examples/histograms.ipynb
+++ b/docs/source/getting-started/examples/histograms.ipynb
@@ -282,7 +282,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/docs/source/getting-started/examples/histograms.ipynb
+++ b/docs/source/getting-started/examples/histograms.ipynb
@@ -191,8 +191,8 @@
     "    def privatize(s, t=1e8):\n",
     "        return preprocess >> dp.m.then_laplace_threshold(scale=s, threshold=t)\n",
     "    \n",
-    "    s = dp.binary_search_param(lambda s: privatize(s=s), d_in, d_out)\n",
-    "    t = dp.binary_search_param(lambda t: privatize(s=s, t=t), d_in, d_out)\n",
+    "    s = dp.binary_search(lambda s: privatize(s=s).map(d_in)[0] <= d_out[0])\n",
+    "    t = dp.binary_search(lambda t: privatize(s=s, t=t).map(d_in)[1] <= d_out[1])\n",
     "\n",
     "    return privatize(s=s, t=t)"
    ]

--- a/python/src/opendp/accuracy.py
+++ b/python/src/opendp/accuracy.py
@@ -184,6 +184,10 @@ def describe_polars_measurement_accuracy(
 ):
     r"""Get noise scale parameters from a measurement that returns a OnceFrame.
 
+    If a threshold is configured for censoring small/sensitive partitions, 
+    a threshold column will be included,
+    containing the cutoff for the respective count query being thresholded.
+
     :param measurement: computation from which you want to read noise scale parameters from
     :type measurement: Measurement
     :param alpha: optional statistical significance to use to compute accuracy estimates

--- a/python/src/opendp/accuracy.py
+++ b/python/src/opendp/accuracy.py
@@ -184,7 +184,7 @@ def describe_polars_measurement_accuracy(
 ):
     r"""Get noise scale parameters from a measurement that returns a OnceFrame.
 
-    If a threshold is configured for censoring small/sensitive partitions, 
+    If a threshold is configured for censoring small/sensitive partitions,
     a threshold column will be included,
     containing the cutoff for the respective count query being thresholded.
 

--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -702,12 +702,18 @@ class PartialChain(object):
 
         The discovered parameter is assigned to the param attribute of the returned transformation or measurement.
         """
-        param = binary_search(
-            lambda x: _cast_measure(self.partial(x), output_measure, d_out).check(
-                d_in, d_out
-            ),
-            T=T,
-        )
+        # When the output measure corresponds to approx-DP, only optimize the epsilon parameter.
+        # The delta parameter should be fixed in _cast_measure, and if not, then the search will be impossible here anyways.
+        if output_measure == fixed_smoothed_max_divergence(T=float):
+            def predicate(param):
+                meas = _cast_measure(self.partial(param), output_measure, d_out)
+                return meas.map(d_in)[0] <= d_out[0] # type: ignore[index] 
+        else:
+            def predicate(param):
+                meas = _cast_measure(self.partial(param), output_measure, d_out)
+                return meas.check(d_in, d_out)
+        
+        param = binary_search(predicate, T=T)
         chain = self.partial(param)
         chain.param = param
         return chain

--- a/python/src/opendp/measurements.py
+++ b/python/src/opendp/measurements.py
@@ -663,7 +663,8 @@ def make_private_lazyframe(
     input_metric: Metric,
     output_measure: Measure,
     lazyframe,
-    global_scale = None
+    global_scale = None,
+    threshold = None
 ) -> Measurement:
     r"""Create a differentially private measurement from a [`LazyFrame`].
 
@@ -686,7 +687,8 @@ def make_private_lazyframe(
     :param output_measure: How to measure privacy loss.
     :type output_measure: Measure
     :param lazyframe: A description of the computations to be run, in the form of a [`LazyFrame`].
-    :param global_scale: A tune-able parameter that affects the privacy-utility tradeoff.
+    :param global_scale: Optional. A tune-able parameter that affects the privacy-utility tradeoff.
+    :param threshold: Optional. Minimum number of rows in each released partition.
     :rtype: Measurement
     :raises TypeError: if an argument's type differs from the expected type
     :raises UnknownTypeException: if a type argument fails to parse
@@ -768,20 +770,22 @@ def make_private_lazyframe(
     c_output_measure = py_to_c(output_measure, c_type=Measure, type_name=None)
     c_lazyframe = py_to_c(lazyframe, c_type=AnyObjectPtr, type_name=LazyFrame)
     c_global_scale = py_to_c(global_scale, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Option', args=[f64]))
+    c_threshold = py_to_c(threshold, c_type=AnyObjectPtr, type_name=RuntimeType(origin='Option', args=[u32]))
 
     # Call library function.
     lib_function = lib.opendp_measurements__make_private_lazyframe
-    lib_function.argtypes = [Domain, Metric, Measure, AnyObjectPtr, AnyObjectPtr]
+    lib_function.argtypes = [Domain, Metric, Measure, AnyObjectPtr, AnyObjectPtr, AnyObjectPtr]
     lib_function.restype = FfiResult
 
-    output = c_to_py(unwrap(lib_function(c_input_domain, c_input_metric, c_output_measure, c_lazyframe, c_global_scale), Measurement))
+    output = c_to_py(unwrap(lib_function(c_input_domain, c_input_metric, c_output_measure, c_lazyframe, c_global_scale, c_threshold), Measurement))
 
     return output
 
 def then_private_lazyframe(
     output_measure: Measure,
     lazyframe,
-    global_scale = None
+    global_scale = None,
+    threshold = None
 ):  
     r"""partial constructor of make_private_lazyframe
 
@@ -791,7 +795,8 @@ def then_private_lazyframe(
     :param output_measure: How to measure privacy loss.
     :type output_measure: Measure
     :param lazyframe: A description of the computations to be run, in the form of a [`LazyFrame`].
-    :param global_scale: A tune-able parameter that affects the privacy-utility tradeoff.
+    :param global_scale: Optional. A tune-able parameter that affects the privacy-utility tradeoff.
+    :param threshold: Optional. Minimum number of rows in each released partition.
 
     :example:
 
@@ -865,7 +870,8 @@ def then_private_lazyframe(
         input_metric=input_metric,
         output_measure=output_measure,
         lazyframe=lazyframe,
-        global_scale=global_scale))
+        global_scale=global_scale,
+        threshold=threshold))
 
 
 

--- a/python/src/opendp/polars.py
+++ b/python/src/opendp/polars.py
@@ -423,6 +423,7 @@ try:
                     threshold=threshold,
                 )
             
+            # when the output measure is δ-approximate, then there are two free parameters to tune
             if query._output_measure.type.origin == "FixedSmoothedMaxDivergence":  # type: ignore[union-attr]
 
                 # search for a scale parameter. Solve for epsilon first, 
@@ -434,7 +435,7 @@ try:
 
                 # attempt to return without setting a threshold
                 try:
-                    return make(scale)
+                    return make(scale, threshold=None)
                 except OpenDPException:
                     pass
                 
@@ -444,8 +445,11 @@ try:
                     T=int,
                 )
                 
+                # return a measurement with the discovered scale and threshold
                 return make(scale, threshold)
 
+            # when no delta parameter is involved, 
+            # finding a suitable measurement just comes down to finding scale
             return binary_search_chain(make, d_in, d_out, T=float)
 
         def release(self) -> OnceFrame:
@@ -458,6 +462,10 @@ try:
             """Retrieve noise scale parameters and accuracy estimates for each output.
 
             If ``alpha`` is passed, the resulting data frame includes an ``accuracy`` column.
+
+            If a threshold is configured for censoring small/sensitive partitions, 
+            a threshold column will be included,
+            containing the cutoff for the respective count query being thresholded.
             
             :example:
 

--- a/python/src/opendp/polars.py
+++ b/python/src/opendp/polars.py
@@ -425,9 +425,10 @@ try:
             
             if query._output_measure.type.origin == "FixedSmoothedMaxDivergence":  # type: ignore[union-attr]
 
-                # search for a scale parameter. If threshold unknown, set it to u32::MAX so as not to interfere
+                # search for a scale parameter. Solve for epsilon first, 
+                # setting threshold to u32::MAX so as not to interfere with the search for a suitable scale parameter
                 scale = binary_search(
-                    lambda s: make(s, 2**32 - 1).map(d_in)[0] < d_out[0],  # type: ignore[index]
+                    lambda s: make(s, threshold=2**32 - 1).map(d_in)[0] < d_out[0],  # type: ignore[index]
                     T=float,
                 )
 
@@ -437,7 +438,7 @@ try:
                 except OpenDPException:
                     pass
                 
-                # find a new threshold
+                # now that scale has been solved, find a suitable threshold
                 threshold = binary_search(
                     lambda t: make(scale, t).map(d_in)[1] < d_out[1],  # type: ignore[index]
                     T=int,

--- a/python/src/opendp/polars.py
+++ b/python/src/opendp/polars.py
@@ -463,7 +463,7 @@ try:
 
             If ``alpha`` is passed, the resulting data frame includes an ``accuracy`` column.
 
-            If a threshold is configured for censoring small/sensitive partitions, 
+            If a threshold is configured for censoring small/sensitive partitions,
             a threshold column will be included,
             containing the cutoff for the respective count query being thresholded.
             

--- a/python/test/integration/test_histogram.py
+++ b/python/test/integration/test_histogram.py
@@ -56,15 +56,11 @@ def test_count_by_threshold():
     )
     budget = (1.0, 1e-8)
 
-    scale = dp.binary_search_param(
-        lambda s: pre >> dp.m.then_laplace_threshold(scale=s, threshold=1e8),
-        d_in=1,
-        d_out=budget,
+    scale = dp.binary_search(
+        lambda s: (pre >> dp.m.then_laplace_threshold(scale=s, threshold=1e8)).map(1)[0] <= budget[0]
     )
-    threshold = dp.binary_search_param(
-        lambda t: pre >> dp.m.then_laplace_threshold(scale=scale, threshold=t),
-        d_in=1,
-        d_out=budget,
+    threshold = dp.binary_search(
+        lambda t: (pre >> dp.m.then_laplace_threshold(scale=scale, threshold=t)).map(1)[1] <= budget[1],
     )
 
     laplace_histogram_from_dataframe = pre >> dp.m.then_laplace_threshold(

--- a/python/test/test_polars.py
+++ b/python/test/test_polars.py
@@ -496,7 +496,7 @@ def test_polars_threshold():
     pl_testing.assert_frame_equal(actual, expected)
 
     # check that query runs.
-    # output should be two columns ("A" and "len") with one row (1, ~1000)
+    print('output should be two columns ("A" and "len") with one row (1, ~1000)')
     print(
         context.query()
         .group_by("A")
@@ -524,7 +524,7 @@ def test_polars_threshold():
     pl_testing.assert_frame_equal(actual, expected)
 
     # check that query runs.
-    # output should be two columns ("B" and "len") with two rows (1, ~500) each
+    print('output should be two columns ("B" and "len") with two rows (1, ~500) each')
     print(
         context.query()
         .group_by("B")

--- a/rust/src/accuracy/integrate_discrete_laplacian_tail.tex
+++ b/rust/src/accuracy/integrate_discrete_laplacian_tail.tex
@@ -1,0 +1,39 @@
+\documentclass{article}
+\input{../lib.sty}
+
+\title{\texttt{fn integrate\_discrete\_laplacian\_tail}}
+\author{Michael Shoemate}
+
+\begin{document}
+\maketitle
+
+Proof for \rustdoc{accuracy/tail\_bounds/fn}{integrate\_discrete\_laplace\_tail}.
+
+\begin{definition}
+    Define $Y \sim \mathcal{L}_\mathbb{Z}(0, s)$, a random variable following the discrete laplace distribution:
+    \begin{equation}
+        \forall x \in \mathbb{Z} \qquad \Pr[X = x] = \frac{e^{1/s} - 1}{e^{1/s} + 1} e^{-|x|/s}
+    \end{equation}
+\end{definition}
+
+\begin{theorem}
+    Assume $X \sim \mathcal{L}_\mathbb{Z}(0, s)$, and $t > 0$.
+    \begin{equation}
+        \alpha = P[X > t] = \frac{e^{-t/s}}{e^{-1/s} + 1}
+    \end{equation}
+\end{theorem}
+
+\begin{proof}
+    \begin{align*}
+        \alpha &= P[X > t] \\
+        &= \sum_{x=t + 1}^{\infty} \frac{e^{1/s} - 1}{e^{1/s} + 1} e^{-|x|/s} \\
+        &= \frac{e^{1/s} - 1}{e^{1/s} + 1} \sum_{x=t + 1}^{\infty} e^{-x/s} 
+            && \text{since } t > 0 \\
+        &= \frac{e^{1/s} - 1}{e^{1/s} + 1} \frac{e^{(1-(t + 1))/s}}{e^{1/s} - 1} 
+            && \text{since } \sum_{x=t}^\infty p^x = \frac{p^x}{1 - p} \text{ if } |p| < 1 \text{, let } p = e^{1/s}\\
+        &= \frac{e^{-t/s}}{e^{1/s} + 1}
+    \end{align*}
+
+\end{proof}
+
+\end{document}

--- a/rust/src/accuracy/integrate_discrete_laplacian_tail.tex
+++ b/rust/src/accuracy/integrate_discrete_laplacian_tail.tex
@@ -7,6 +7,8 @@
 \begin{document}
 \maketitle
 
+\contrib
+
 Proof for \rustdoc{accuracy/tail\_bounds/fn}{integrate\_discrete\_laplace\_tail}.
 
 \begin{definition}
@@ -30,7 +32,7 @@ Proof for \rustdoc{accuracy/tail\_bounds/fn}{integrate\_discrete\_laplace\_tail}
         &= \frac{e^{1/s} - 1}{e^{1/s} + 1} \sum_{x=t + 1}^{\infty} e^{-x/s} 
             && \text{since } t > 0 \\
         &= \frac{e^{1/s} - 1}{e^{1/s} + 1} \frac{e^{(1-(t + 1))/s}}{e^{1/s} - 1} 
-            && \text{since } \sum_{x=t}^\infty p^x = \frac{p^x}{1 - p} \text{ if } |p| < 1 \text{, let } p = e^{1/s}\\
+            && \text{since } \sum_{x=t}^\infty p^x = \frac{p^t}{1 - p} \text{ if } |p| < 1 \text{, let } p = e^{1/s}\\
         &= \frac{e^{-t/s}}{e^{1/s} + 1}
     \end{align*}
 

--- a/rust/src/accuracy/polars/mod.rs
+++ b/rust/src/accuracy/polars/mod.rs
@@ -23,6 +23,7 @@ use crate::{
     measurements::{
         expr_noise::{match_noise, Distribution, Support},
         expr_report_noisy_max_gumbel::match_report_noisy_max_gumbel,
+        is_threshold_predicate,
     },
     polars::{ExtractLazyFrame, OnceFrame},
     transformations::expr_discrete_quantile_score::match_discrete_quantile_score,
@@ -67,6 +68,7 @@ struct UtilitySummary {
     pub distribution: Option<String>,
     pub scale: f64,
     pub accuracy: Option<f64>,
+    pub threshold: Option<u32>,
 }
 
 /// Get noise scale parameters from a LazyFrame.
@@ -75,21 +77,29 @@ struct UtilitySummary {
 /// * `lazyframe` - computation from which you want to read noise scale parameters from
 /// * `alpha` - optional statistical significance to use to compute accuracy estimates
 pub fn lazyframe_utility(lazyframe: &LazyFrame, alpha: Option<f64>) -> Fallible<DataFrame> {
-    let mut utility = logical_plan_utility(&lazyframe.logical_plan, alpha)?;
+    let mut utility = logical_plan_utility(&lazyframe.logical_plan, alpha, None)?;
 
     // only include the accuracy column if alpha is passed
     if alpha.is_none() {
         utility = utility.drop("accuracy")?;
     }
+    // only include the threshold column if a threshold is set
+    if utility.column("threshold")?.is_null().all() {
+        utility = utility.drop("threshold")?;
+    }
     Ok(utility)
 }
 
-fn logical_plan_utility(logical_plan: &DslPlan, alpha: Option<f64>) -> Fallible<DataFrame> {
+fn logical_plan_utility(
+    logical_plan: &DslPlan,
+    alpha: Option<f64>,
+    threshold: Option<(String, u32)>,
+) -> Fallible<DataFrame> {
     match logical_plan {
         DslPlan::Select { expr: exprs, .. } | DslPlan::GroupBy { aggs: exprs, .. } => {
             let rows = exprs
                 .iter()
-                .map(|e| expr_utility(&e, alpha))
+                .map(|e| expr_utility(&e, alpha, threshold.clone()))
                 .collect::<Fallible<Vec<Vec<UtilitySummary>>>>()?;
 
             Ok(DataFrame::from_rows_and_schema(
@@ -104,6 +114,7 @@ fn logical_plan_utility(logical_plan: &DslPlan, alpha: Option<f64>) -> Fallible<
                             },
                             AnyValue::from(summary.scale),
                             AnyValue::from(summary.accuracy),
+                            AnyValue::from(summary.threshold),
                         ])
                     })
                     .collect::<Vec<_>>(),
@@ -113,20 +124,32 @@ fn logical_plan_utility(logical_plan: &DslPlan, alpha: Option<f64>) -> Fallible<
                     Field::new("distribution", DataType::String),
                     Field::new("scale", DataType::Float64),
                     Field::new("accuracy", DataType::Float64),
+                    Field::new("threshold", DataType::UInt32),
                 ]),
             )?)
         }
-        DslPlan::Filter { input, .. }
-        | DslPlan::Sort { input, .. }
+        DslPlan::Filter { input, predicate } => {
+            let threshold = is_threshold_predicate(predicate.clone()).ok();
+            logical_plan_utility(input.as_ref(), alpha, threshold)
+        }
+        DslPlan::Sort { input, .. }
         | DslPlan::Slice { input, .. }
-        | DslPlan::Sink { input, .. } => logical_plan_utility(input.as_ref(), alpha),
+        | DslPlan::Sink { input, .. } => logical_plan_utility(input.as_ref(), alpha, threshold),
         dsl => fallible!(FailedFunction, "unrecognized dsl: {:?}", dsl.describe()),
     }
 }
 
-fn expr_utility<'a>(expr: &Expr, alpha: Option<f64>) -> Fallible<Vec<UtilitySummary>> {
+fn expr_utility<'a>(
+    expr: &Expr,
+    alpha: Option<f64>,
+    threshold: Option<(String, u32)>,
+) -> Fallible<Vec<UtilitySummary>> {
     let name = expr.clone().meta().output_name()?.to_string();
     let expr = expr.clone().meta().undo_aliases();
+    let t_value = threshold
+        .clone()
+        .and_then(|(t_name, t_value)| (name == t_name).then_some(t_value));
+
     if let Some((input, plugin)) = match_noise(&expr)? {
         let scale = plugin
             .scale
@@ -158,6 +181,7 @@ fn expr_utility<'a>(expr: &Expr, alpha: Option<f64>) -> Fallible<Vec<UtilitySumm
             distribution: Some(format!("{:?} {:?}", support, distribution)),
             scale,
             accuracy,
+            threshold: t_value,
         }]);
     }
 
@@ -165,11 +189,12 @@ fn expr_utility<'a>(expr: &Expr, alpha: Option<f64>) -> Fallible<Vec<UtilitySumm
         return Ok(vec![UtilitySummary {
             name,
             aggregate: expr_aggregate(input)?.to_string(),
-            distribution: Some("Gumbel".to_string()),
+            distribution: Some("Gumbel Max".to_string()),
             scale: plugin
                 .scale
                 .ok_or_else(|| err!(FailedFunction, "scale must be known"))?,
             accuracy: None,
+            threshold: t_value,
         }]);
     }
 
@@ -180,11 +205,12 @@ fn expr_utility<'a>(expr: &Expr, alpha: Option<f64>) -> Fallible<Vec<UtilitySumm
             distribution: None,
             scale: 0.0,
             accuracy: alpha.is_some().then_some(0.0),
+            threshold: t_value,
         }]),
 
         Expr::Function { input, .. } => Ok(input
             .iter()
-            .map(|e| expr_utility(e, alpha))
+            .map(|e| expr_utility(e, alpha, threshold.clone()))
             .collect::<Fallible<Vec<_>>>()?
             .into_iter()
             .flatten()

--- a/rust/src/accuracy/polars/mod.rs
+++ b/rust/src/accuracy/polars/mod.rs
@@ -44,6 +44,10 @@ mod ffi;
 )]
 /// Get noise scale parameters from a measurement that returns a OnceFrame.
 ///
+/// If a threshold is configured for censoring small/sensitive partitions,
+/// a threshold column will be included,
+/// containing the cutoff for the respective count query being thresholded.
+///
 /// # Arguments
 /// * `measurement` - computation from which you want to read noise scale parameters from
 /// * `alpha` - optional statistical significance to use to compute accuracy estimates
@@ -129,7 +133,7 @@ fn logical_plan_utility(
             )?)
         }
         DslPlan::Filter { input, predicate } => {
-            let threshold = is_threshold_predicate(predicate.clone()).ok();
+            let threshold = is_threshold_predicate(predicate.clone());
             logical_plan_utility(input.as_ref(), alpha, threshold)
         }
         DslPlan::Sort { input, .. }

--- a/rust/src/accuracy/polars/test.rs
+++ b/rust/src/accuracy/polars/test.rs
@@ -41,6 +41,7 @@ fn test_describe_polars_measurement_accuracy() -> Fallible<()> {
             col("A").dp().sum((0, 1), None),
         ]),
         Some(1.0),
+        None,
     )?;
 
     let description = describe_polars_measurement_accuracy(meas.clone(), None)?;

--- a/rust/src/accuracy/test.rs
+++ b/rust/src/accuracy/test.rs
@@ -236,6 +236,7 @@ pub fn test_empirical_laplace_accuracy() -> Fallible<()> {
     println!("Laplacian significance levels/alpha");
     println!("Theoretical: {:?}", theoretical_alpha);
     println!("Empirical:   {:?}", empirical_alpha);
+    // this test has a small likelihood of failing
     assert!((empirical_alpha - theoretical_alpha).abs() < 1e-2);
     Ok(())
 }
@@ -260,6 +261,7 @@ pub fn test_empirical_gaussian_accuracy() -> Fallible<()> {
     println!("Gaussian significance levels/alpha");
     println!("Theoretical: {:?}", theoretical_alpha);
     println!("Empirical:   {:?}", empirical_alpha);
+    // this test has a small likelihood of failing
     assert!((empirical_alpha - theoretical_alpha).abs() < 1e-2);
     Ok(())
 }
@@ -282,6 +284,7 @@ pub fn test_empirical_discrete_laplace_accuracy() -> Fallible<()> {
     println!("Discrete laplace significance levels/alpha");
     println!("Theoretical: {:?}", theoretical_alpha);
     println!("Empirical:   {:?}", empirical_alpha);
+    // this test has a small likelihood of failing
     assert!((empirical_alpha - theoretical_alpha).abs() < 1e-2);
     Ok(())
 }
@@ -309,6 +312,7 @@ pub fn test_empirical_discrete_gaussian_accuracy() -> Fallible<()> {
     println!("Discrete gaussian significance levels/alpha");
     println!("Theoretical: {:?}", theoretical_alpha);
     println!("Empirical:   {:?}", empirical_alpha);
+    // this test has a small likelihood of failing
     assert!((empirical_alpha - theoretical_alpha).abs() < 1e-2);
     Ok(())
 }
@@ -335,6 +339,7 @@ pub fn test_empirical_integrate_discrete_laplace_tail() -> Fallible<()> {
     println!("Discrete Laplace tail significance levels/alpha");
     println!("Theoretical: {:?}", theoretical_alpha);
     println!("Empirical:   {:?}", empirical_alpha);
+    // this test has a small likelihood of failing
     assert!((empirical_alpha - theoretical_alpha).abs() < 1e-2);
     Ok(())
 }

--- a/rust/src/data/ffi/mod.rs
+++ b/rust/src/data/ffi/mod.rs
@@ -727,6 +727,7 @@ impl std::fmt::Debug for AnyObject {
         let type_arg = &self.type_;
         f.write_str(dispatch!(monomorphize, [(type_arg, [
             u32, u64, i32, i64, f32, f64, bool, String, u8, Column,
+            (f64, f64),
             Vec<u32>, Vec<u64>, Vec<i32>, Vec<i64>, Vec<f32>, Vec<f64>, Vec<bool>, Vec<String>, Vec<u8>, Vec<Column>, Vec<Vec<String>>,
             HashMap<String, Column>,
             // FIXME: The following are for Python demo use of compositions. Need to figure this out!!!

--- a/rust/src/domains/polars/expr/mod.rs
+++ b/rust/src/domains/polars/expr/mod.rs
@@ -46,11 +46,9 @@ impl ExprContext {
         let frame = LazyFrame::from(lp);
         match self {
             ExprContext::RowByRow => frame.select([expr]),
-            ExprContext::Aggregate {
-                grouping_columns: grouping_keys,
-            } => frame
+            ExprContext::Aggregate { grouping_columns } => frame
                 .group_by(
-                    &grouping_keys
+                    &grouping_columns
                         .iter()
                         .map(AsRef::as_ref)
                         .map(col)

--- a/rust/src/domains/polars/frame/mod.rs
+++ b/rust/src/domains/polars/frame/mod.rs
@@ -206,15 +206,15 @@ impl<F: Frame> FrameDomain<F> {
     #[must_use]
     pub fn with_margin<I: AsRef<str>>(
         mut self,
-        grouping_keys: &[I],
+        grouping_columns: &[I],
         margin: Margin,
     ) -> Fallible<Self> {
-        let grouping_keys =
-            BTreeSet::from_iter(grouping_keys.iter().map(|v| v.as_ref().to_string()));
-        if self.margins.contains_key(&grouping_keys) {
+        let grouping_columns =
+            BTreeSet::from_iter(grouping_columns.iter().map(|v| v.as_ref().to_string()));
+        if self.margins.contains_key(&grouping_columns) {
             return fallible!(MakeDomain, "margin already exists");
         }
-        self.margins.insert(grouping_keys, margin);
+        self.margins.insert(grouping_columns, margin);
         Ok(self)
     }
 }
@@ -259,9 +259,9 @@ impl<F: Frame> Domain for FrameDomain<F> {
         }
 
         // check that margins are satisfied
-        for (grouping_keys, margin) in self.margins.iter() {
-            let grouping_keys = grouping_keys.iter().map(|c| col(c)).collect::<Vec<_>>();
-            if !margin.member(val.clone().lazyframe().group_by(grouping_keys))? {
+        for (grouping_columns, margin) in self.margins.iter() {
+            let grouping_columns = grouping_columns.iter().map(|c| col(c)).collect::<Vec<_>>();
+            if !margin.member(val.clone().lazyframe().group_by(grouping_columns))? {
                 return Ok(false);
             }
         }

--- a/rust/src/measurements/make_private_expr/expr_len/mod.rs
+++ b/rust/src/measurements/make_private_expr/expr_len/mod.rs
@@ -57,7 +57,7 @@ where
     if Some(MarginPub::Lengths) != margin.public_info {
         return fallible!(
             MakeMeasurement,
-            "The length of partitions when grouped by {:?} is not public information.",
+            "The length of partitions when grouped by {:?} is not public information. You may have forgotten to add noise to your query.",
             by
         );
     }

--- a/rust/src/measurements/make_private_expr/expr_literal/test.rs
+++ b/rust/src/measurements/make_private_expr/expr_literal/test.rs
@@ -40,6 +40,7 @@ fn test_make_expr_private_lit_groupby() -> Fallible<()> {
             .agg([lit(1)])
             .sort(["chunk_2_bool"], Default::default()),
         None,
+        None,
     )?;
 
     let actual = m_lit.invoke(&lf)?.collect()?;

--- a/rust/src/measurements/make_private_expr/expr_noise/mod.rs
+++ b/rust/src/measurements/make_private_expr/expr_noise/mod.rs
@@ -37,7 +37,7 @@ mod test;
 
 /// Arguments for the noise expression
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
-pub(crate) struct NoiseArgs {
+pub struct NoiseArgs {
     /// The distribution to sample from
     pub distribution: Option<Distribution>,
 
@@ -123,6 +123,9 @@ where
     let scale = scale.unwrap_or(1.);
     let global_scale = global_scale.unwrap_or(1.);
     let scale = scale.inf_mul(&global_scale)?;
+    if scale.is_sign_negative() {
+        return fallible!(MakeTransformation, "noise scale must not be negative");
+    }
 
     if middle_domain.active_series()?.nullable {
         return fallible!(

--- a/rust/src/measurements/make_private_expr/expr_noise/test.rs
+++ b/rust/src/measurements/make_private_expr/expr_noise/test.rs
@@ -117,6 +117,7 @@ fn test_make_laplace_grouped() -> Fallible<()> {
         MaxDivergence::default(),
         lf.clone().group_by(["chunk_2_bool"]).agg([expr_exp]),
         Some(scale),
+        None,
     )?;
     // sum([0, 1, 2, 3, 4]) * 100 = 1000
     // sum([5, 6, 7, 8, 8]) * 100 = 3400

--- a/rust/src/measurements/make_private_lazyframe/group_by/make_private_group_by.bib
+++ b/rust/src/measurements/make_private_lazyframe/group_by/make_private_group_by.bib
@@ -1,0 +1,9 @@
+@misc{rogers2023unifyingprivacyanalysisframework,
+    title={A Unifying Privacy Analysis Framework for Unknown Domain Algorithms in Differential Privacy}, 
+    author={Ryan Rogers},
+    year={2023},
+    eprint={2309.09170},
+    archivePrefix={arXiv},
+    primaryClass={cs.CR},
+    url={https://arxiv.org/abs/2309.09170}, 
+}

--- a/rust/src/measurements/make_private_lazyframe/group_by/make_private_group_by.tex
+++ b/rust/src/measurements/make_private_lazyframe/group_by/make_private_group_by.tex
@@ -38,34 +38,50 @@ To ensure the correctness of the output, we require the following preconditions:
 We now prove the postcondition of \texttt{make\_private\_group\_by}.
 \begin{proof}
 
-Start by establishing proof properties of the following three variable.
+Start by establishing properties of the following variables, 
+which hold for any setting of the input arguments.
 
 \begin{itemize}
-    \item By the postcondition of \texttt{StableDslPlan.make\_stable}, \texttt{t\_prior} is a valid transformation.
+    \item By the postcondition of \texttt{StableDslPlan.make\_stable}, \texttt{t\_prior} is a valid transformation. \ref{line:tprior}
     \item By the postcondition of \texttt{match\_grouping\_columns}, \texttt{grouping\_columns} holds the names of the grouping columns.
         \texttt{margin} denotes what is considered public information about the key set, 
-        pulled from descriptors in the input domain.
-        By the postcondition of \texttt{make\_basic\_composition}, 
-    \item \texttt{m\_exprs} is a valid measurement that prepares a batch of expressions that, 
-    when executed, satisfies the privacy guarantee of \texttt{m\_exprs}.
+        pulled from descriptors in the input domain. \ref{line:groupcols}
+    \item By the postcondition of \texttt{make\_basic\_composition}, 
+        \texttt{m\_exprs} is a valid measurement that prepares a batch of expressions that, 
+        when executed, satisfies the privacy guarantee of \texttt{m\_exprs}.  \ref{line:joint}
 \end{itemize}
-In the case where grouping keys are considered public,
-no thresholding is performed.
-In the setting when grouping keys are considered private information,
-it is necessary to know if a suitable release for the data set length is made
-that can be used to filter sensitive keys.
 
+We now reconcile information about the censoring threshold. \ref{line:reconcile-threshold}
+In the setting where grouping keys are considered public, no thresholding is necessary.
+In the setting where grouping keys are considered private information,
+threshold information is prepared from either \texttt{predicate} or \texttt{threshold}.
+By the post-condition of \texttt{find\_len\_expr}, filtering on \texttt{name} can be used to satisfy 
+$\delta$-approximate DP.
+
+The final predicate to be applied is the intersection of conditions necessary for filtering, 
+and initial conditions set in the predicate.
+The thresholding predicate is only added to the final predicate 
+if the threshold is not already present in the predicate.
+
+We now move on to the implementation of the function. \ref{line:function}
 The function returns a DslPlan that applies each expression from \texttt{m\_exprs}
 to \texttt{arg} grouped by \texttt{keys}.
+\texttt{threshold\_info} is conveyed into the plan, if set, 
+to ensure that the keys are also privatized if necessary.
+It is assumed that the emitted DSL is executed in the same fashion as is done by Polars.
+This proof/implementation does not take into consideration side-channels involved in the execution of the DSL.
 
+We now move on to the implementation of the privacy map. \ref{line:privacy-map}
 The measurement for each expression expects data set distances in terms of a triple:
 \begin{itemize}
     \item $L^0$: the greatest number of partitions that can be influenced by any one individual. 
     This is no greater than the input distance (an individual can only ever influence as many partitions as they contribute rows), 
-    but could be tighter when supplemented by the \texttt{max\_influenced\_partitions} metric descriptor.
+    but could be smaller when supplemented by 
+    the \texttt{max\_influenced\_partitions} metric descriptor or \texttt{max\_num\_partitions} domain descriptor.
     \item $L^\infty$: the greatest number of records that can be added or removed by any one individual in each partition. 
     This is no greater than the input distance, 
-    but could be tighter when supplemented by the \texttt{max\_partition\_contributions} metric descriptor.
+    but could be tighter when supplemented by 
+    the \texttt{max\_partition\_contributions} metric descriptor or the \texttt{max\_partition\_length} domain descriptor.
     \item $L^1$: the greatest total number of records that can be added or removed across all partitions.
     This is no greater than the input distance,
     but could be tighter when accounting for the $L^0$ and $L^\infty$ distances.
@@ -86,7 +102,7 @@ is \texttt{d\_out}.
 % that an unstable partition an individual contributes is still present in the release,
 % because noise added to release the DP count estimate exceeds \texttt{d\_instability}.
 
-Adapted from \cite{rogers2023unifyingprivacyanalysisframework} (Theorem 7).
+We now adapt the proof from \cite{rogers2023unifyingprivacyanalysisframework} (Theorem 7).
 Consider $S$ to be the set of labels that are common between $x$ and $x'$.
 Define event $E$ to be any potential outcome of the mechanism for which all labels are in $S$
 (where only stable partitions are released).
@@ -116,7 +132,7 @@ Therefore $\delta = 1 - (1 - \texttt{delta\_single})^{\Delta_0}$.
 This privacy loss is then added to \texttt{d\_out}.
 
 Together with the potential increase in delta for the release of the key set,
-then it is shown that \function(u), \function(v) are \dout-close under \texttt{output\_measure}.
+then it is shown that \function(x), \function(x') are \dout-close under \texttt{output\_measure}.
 
 \end{proof}
 

--- a/rust/src/measurements/make_private_lazyframe/group_by/make_private_group_by.tex
+++ b/rust/src/measurements/make_private_lazyframe/group_by/make_private_group_by.tex
@@ -1,0 +1,125 @@
+\documentclass{article}
+\input{../../../lib.sty}
+
+\title{\texttt{fn make\_private\_group\_by}}
+\author{Michael Shoemate}
+\date{}
+
+\begin{document}
+
+\maketitle
+
+\contrib
+Proves soundness of \texttt{fn make\_private\_group\_by} in \asOfCommit{mod.rs}{0db9c6036}.
+
+\subsection*{Vetting History}
+\begin{itemize}
+    \item \vettingPR{512}
+\end{itemize}
+
+\section{Hoare Triple}
+\subsection*{Precondition}
+To ensure the correctness of the output, we require the following preconditions:
+
+\begin{itemize}
+    \item Type \texttt{MS} must have trait \texttt{DatasetMetric}.
+    \item Type \texttt{MI} must have trait \texttt{UnboundedMetric}.
+    \item Type \texttt{MO} must have trait \texttt{ApproximateMeasure}.
+\end{itemize}
+
+\subsection*{Pseudocode}
+\lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/make_private_group_by.py}
+
+\subsubsection*{Postconditions}
+\validMeasurement{\texttt{(input\_domain, input\_metric, output\_measure, \\plan, global\_scale, threshold)}}{\texttt{make\_private\_group\_by}}
+
+\section{Proof}
+
+We now prove the postcondition of \texttt{make\_private\_group\_by}.
+\begin{proof}
+
+Start by establishing proof properties of the following three variable.
+
+\begin{itemize}
+    \item By the postcondition of \texttt{StableDslPlan.make\_stable}, \texttt{t\_prior} is a valid transformation.
+    \item By the postcondition of \texttt{match\_grouping\_columns}, \texttt{grouping\_columns} holds the names of the grouping columns.
+        \texttt{margin} denotes what is considered public information about the key set, 
+        pulled from descriptors in the input domain.
+        By the postcondition of \texttt{make\_basic\_composition}, 
+    \item \texttt{m\_exprs} is a valid measurement that prepares a batch of expressions that, 
+    when executed, satisfies the privacy guarantee of \texttt{m\_exprs}.
+\end{itemize}
+In the case where grouping keys are considered public,
+no thresholding is performed.
+In the setting when grouping keys are considered private information,
+it is necessary to know if a suitable release for the data set length is made
+that can be used to filter sensitive keys.
+
+The function returns a DslPlan that applies each expression from \texttt{m\_exprs}
+to \texttt{arg} grouped by \texttt{keys}.
+
+The measurement for each expression expects data set distances in terms of a triple:
+\begin{itemize}
+    \item $L^0$: the greatest number of partitions that can be influenced by any one individual. 
+    This is no greater than the input distance (an individual can only ever influence as many partitions as they contribute rows), 
+    but could be tighter when supplemented by the \texttt{max\_influenced\_partitions} metric descriptor.
+    \item $L^\infty$: the greatest number of records that can be added or removed by any one individual in each partition. 
+    This is no greater than the input distance, 
+    but could be tighter when supplemented by the \texttt{max\_partition\_contributions} metric descriptor.
+    \item $L^1$: the greatest total number of records that can be added or removed across all partitions.
+    This is no greater than the input distance,
+    but could be tighter when accounting for the $L^0$ and $L^\infty$ distances.
+\end{itemize}
+
+By the postcondition of the map on \texttt{m\_exprs}, the privacy loss, 
+when grouped data sets may differ by this distance triple,
+is \texttt{d\_out}.
+
+% If the grouping keys are private, then the threshold has been prepared in \ref{reconcile-threshold}.
+% At this point, it is necessary to show that the probability that any unstable partition is released is at most $\delta$.
+% An unstable partition is any partition that may not exist on a neighboring data set:
+% that is, an unstable partition is a partition whose data is unique to an individual.
+% Therefore, unstable partitions have \texttt{li} records or fewer.
+
+% The distance to instability (\texttt{d\_instability}) denotes the gap between the size of the largest unstable partition and the threshold.
+% The additional delta parameter (\texttt{delta\_p}) denotes the worst-case probability 
+% that an unstable partition an individual contributes is still present in the release,
+% because noise added to release the DP count estimate exceeds \texttt{d\_instability}.
+
+Adapted from \cite{rogers2023unifyingprivacyanalysisframework} (Theorem 7).
+Consider $S$ to be the set of labels that are common between $x$ and $x'$.
+Define event $E$ to be any potential outcome of the mechanism for which all labels are in $S$
+(where only stable partitions are released).
+We then lower bound the probability of the mechanism returning an event $E$.
+In the following, $c_j$ denotes the exact count for partition $j$,
+and $Z_j$ is a random variable distributed according to the distribution used to release a noisy count.
+
+\begin{align*}
+    \Pr[E] &= \prod_{j \in x \backslash x'} \Pr[c_j + Z_j \le T] \\
+    &\ge \prod_{j \in x \backslash x'} \Pr[\Delta_\infty + Z_j \le T] \\
+    &\ge \Pr[\Delta_\infty + Z_j \le T]^{\Delta_0}
+\end{align*}
+
+The probability of returning a set of stable partitions ($\Pr[E]$) 
+is the probability of not returning any of the unstable partitions.
+We now solve for the choice of threshold $T$ such that $\Pr[E] \ge 1 - \delta$.
+
+\begin{align*}
+    \Pr[\Delta_\infty + Z_j \le T]^{\Delta_0} &= \Pr[Z_j \le T - \Delta_\infty]^{\Delta_0} \\
+    &= (1 - \Pr[Z_j > T - \Delta_\infty])^{\Delta_0}
+\end{align*}
+
+Let \texttt{d\_instability} denote the distance to instability of $T - \Delta_\infty$.
+By the postcondition of \\ \texttt{integrate\_discrete\_noise\_tail},
+the probability that a random noise sample exceeds \texttt{d\_instability} is at most \texttt{delta\_single}.
+Therefore $\delta = 1 - (1 - \texttt{delta\_single})^{\Delta_0}$.
+This privacy loss is then added to \texttt{d\_out}.
+
+Together with the potential increase in delta for the release of the key set,
+then it is shown that \function(u), \function(v) are \dout-close under \texttt{output\_measure}.
+
+\end{proof}
+
+\bibliographystyle{alpha}
+\bibliography{make_private_group_by}
+\end{document}

--- a/rust/src/measurements/make_private_lazyframe/group_by/matching.rs
+++ b/rust/src/measurements/make_private_lazyframe/group_by/matching.rs
@@ -1,0 +1,144 @@
+use std::{collections::BTreeSet, sync::Arc};
+
+use polars_plan::{
+    dsl::{Expr, Operator},
+    plans::DslPlan,
+    prelude::GroupbyOptions,
+    utils::expr_output_name,
+};
+
+use crate::{measurements::expr_noise::NoiseArgs, polars::match_plugin};
+
+use super::Fallible;
+
+pub(crate) struct MatchGroupBy {
+    pub input: DslPlan,
+    pub keys: Vec<Expr>,
+    pub aggs: Vec<Expr>,
+    pub threshold: Option<(String, u32)>,
+}
+
+pub(crate) fn match_group_by(mut plan: DslPlan) -> Fallible<Option<MatchGroupBy>> {
+    let threshold = if let DslPlan::Filter { input, predicate } = plan {
+        plan = input.as_ref().clone();
+        Some(is_threshold_predicate(predicate)?)
+    } else {
+        None
+    };
+
+    let DslPlan::GroupBy {
+        input,
+        keys,
+        aggs,
+        apply,
+        maintain_order,
+        options,
+    } = plan
+    else {
+        return Ok(None);
+    };
+
+    if options.as_ref() != &GroupbyOptions::default() {
+        return fallible!(MakeMeasurement, "Unsupported options in logical plan. Do not optimize the lazyframe passed into the constructor. Options should be default, but are {:?}", options);
+    }
+
+    if apply.is_some() {
+        return fallible!(MakeMeasurement, "Apply is not supported in logical plan");
+    }
+
+    if maintain_order {
+        return fallible!(MakeMeasurement, "The order of keys is sensitive");
+    }
+
+    Ok(Some(MatchGroupBy {
+        input: Arc::unwrap_or_clone(input),
+        keys,
+        aggs,
+        threshold,
+    }))
+}
+
+pub fn match_grouping_columns(keys: Vec<Expr>) -> Fallible<BTreeSet<String>> {
+    Ok(keys
+        .iter()
+        .map(|e| {
+            Ok(match e {
+                Expr::Column(name) => vec![(*name).to_string()],
+                Expr::Columns(names) => names.iter().map(|s| s.to_string()).collect(),
+                e => {
+                    return fallible!(
+                        MakeMeasurement,
+                        "Expected column expression in keys, found {:?}",
+                        e
+                    )
+                }
+            })
+        })
+        .collect::<Fallible<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect())
+}
+
+pub(super) fn find_len_expr(
+    exprs: &Vec<Expr>,
+    name: Option<&str>,
+) -> Fallible<(String, NoiseArgs)> {
+    // only keep expressions that compute the length
+    (exprs.iter())
+        .find_map(|e| is_len_expr(e, name))
+        .ok_or_else(|| {
+            err!(
+                MakeMeasurement,
+                "expected exactly one DP length expression with name: {:?}",
+                name
+            )
+        })
+}
+
+fn is_len_expr(expr: &Expr, name: Option<&str>) -> Option<(String, NoiseArgs)> {
+    let output_name = expr_output_name(expr).ok()?;
+
+    // check if the expression matches the expected name
+    if let Some(name) = name {
+        if name != output_name.as_ref() {
+            return None;
+        }
+    }
+    // remove any aliasing in the expression
+    let expr = expr.clone().meta().undo_aliases();
+
+    let (inputs, args) = match_plugin(&expr, "noise").ok().flatten()?;
+
+    let [input] = <&[Expr; 1]>::try_from(inputs.as_slice()).ok()?;
+
+    if input != &Expr::Len {
+        return None;
+    }
+
+    Some((output_name.to_string(), args))
+}
+
+pub(crate) fn is_threshold_predicate(expr: Expr) -> Fallible<(String, u32)> {
+    let Expr::BinaryExpr { left, op, right } = expr else {
+        return fallible!(MakeMeasurement, "threshold must be a binary expression");
+    };
+
+    use Operator::{Gt, Lt};
+
+    let (name, value) = match (left.as_ref(), op, right.as_ref()) {
+        (Expr::Column(name), Gt, Expr::Literal(value)) => (name, value),
+        (Expr::Literal(value), Lt, Expr::Column(name)) => (name, value),
+        _ => {
+            return fallible!(
+                MakeMeasurement,
+                "expected an expression of the form 'col(name) > threshold'"
+            )
+        }
+    };
+
+    Ok((
+        name.to_string(),
+        value.to_any_value().unwrap().extract().unwrap(),
+    ))
+}

--- a/rust/src/measurements/make_private_lazyframe/group_by/mod.rs
+++ b/rust/src/measurements/make_private_lazyframe/group_by/mod.rs
@@ -1,17 +1,29 @@
-use std::collections::BTreeSet;
+use std::fmt::Debug;
+use std::sync::Arc;
 
+use crate::accuracy::integrate_discrete_laplacian_tail;
 use crate::combinators::{make_basic_composition, BasicCompositionMeasure};
-use crate::core::{Function, Measurement, MetricSpace, StabilityMap, Transformation};
+use crate::core::{Function, Measurement, MetricSpace, PrivacyMap};
 use crate::domains::{DslPlanDomain, ExprContext, ExprDomain};
 use crate::error::*;
+use crate::measurements::expr_noise::Distribution;
 use crate::measurements::make_private_expr;
+use crate::measures::{FixedSmoothedMaxDivergence, MaxDivergence, ZeroConcentratedDivergence};
 use crate::metrics::PartitionDistance;
-use crate::traits::InfMul;
+use crate::traits::{InfAdd, InfMul, InfPowI, InfSub};
 use crate::transformations::traits::UnboundedMetric;
 use crate::transformations::{DatasetMetric, StableDslPlan};
+use dashu::integer::IBig;
 use make_private_expr::PrivateExpr;
-use polars::prelude::*;
-use polars_plan::prelude::GroupbyOptions;
+use matching::{find_len_expr, match_grouping_columns, MatchGroupBy};
+use polars_plan::dsl::{all, col, lit, Expr};
+use polars_plan::plans::DslPlan;
+
+#[cfg(test)]
+mod test;
+
+mod matching;
+pub(crate) use matching::{is_threshold_predicate, match_group_by};
 
 /// Create a private version of an aggregate operation on a LazyFrame.
 ///
@@ -21,17 +33,20 @@ use polars_plan::prelude::GroupbyOptions;
 /// * `output_measure` - The measure of the output LazyFrame.
 /// * `plan` - The LazyFrame to transform.
 /// * `global_scale` - The parameter for the measurement.
+/// * `threshold` - Only keep groups with length greater than threshold
 pub fn make_private_group_by<MS, MI, MO>(
     input_domain: DslPlanDomain,
     input_metric: MS,
     output_measure: MO,
     plan: DslPlan,
     global_scale: Option<f64>,
+    threshold: Option<u32>,
 ) -> Fallible<Measurement<DslPlanDomain, DslPlan, MS, MO>>
 where
     MS: 'static + DatasetMetric,
     MI: 'static + UnboundedMetric,
-    MO: 'static + BasicCompositionMeasure,
+    MO: 'static + ApproximateMeasure,
+    MO::Distance: Debug,
     Expr: PrivateExpr<PartitionDistance<MI>, MO>,
     DslPlan: StableDslPlan<MS, MI>,
     (DslPlanDomain, MS): MetricSpace,
@@ -39,118 +54,163 @@ where
     (ExprDomain, MI): MetricSpace,
     (ExprDomain, PartitionDistance<MI>): MetricSpace,
 {
-    let DslPlan::GroupBy {
+    let Some(MatchGroupBy {
         input,
         keys,
         aggs,
-        apply,
-        options,
-        ..
-    } = plan.clone()
+        threshold: expr_threshold,
+    }) = match_group_by(plan)?
     else {
-        return fallible!(MakeMeasurement, "Expected Aggregate logical plan");
+        return fallible!(MakeMeasurement, "expected group by");
     };
 
-    let t_prior = input
-        .as_ref()
-        .clone()
-        .make_stable(input_domain.clone(), input_metric.clone())?;
+    let t_prior = input.clone().make_stable(input_domain, input_metric)?;
     let (middle_domain, middle_metric) = t_prior.output_space();
 
-    if options.as_ref() != &GroupbyOptions::default() {
-        return fallible!(MakeMeasurement, "Unsupported options in logical plan. Do not optimize the lazyframe passed into the constructor. Options should be default, but are {:?}", options);
-    }
-
-    if apply.is_some() {
-        return fallible!(MakeMeasurement, "Apply is not supported in logical plan");
-    }
-
-    let keys = keys
-        .iter()
-        .map(|e| {
-            Ok(match e {
-                Expr::Column(name) => vec![(*name).to_string()],
-                Expr::Columns(names) => names.iter().map(|s| s.to_string()).collect(),
-                e => {
-                    return fallible!(
-                        MakeMeasurement,
-                        "Expected column expression in keys, found {:?}",
-                        e
-                    )
-                }
-            })
-        })
-        .collect::<Fallible<Vec<_>>>()?
-        .into_iter()
-        .flatten()
-        .collect::<BTreeSet<_>>();
+    let grouping_columns = match_grouping_columns(keys.clone())?;
 
     let margin = middle_domain
         .margins
-        .get(&keys)
-        .ok_or_else(|| err!(MakeMeasurement, "Failed to find margin for {:?}", keys))?
-        .clone();
+        .get(&grouping_columns)
+        .cloned()
+        .unwrap_or_default();
 
     let expr_domain = ExprDomain::new(
         middle_domain.clone(),
         ExprContext::Aggregate {
-            grouping_columns: keys,
+            grouping_columns: grouping_columns.clone(),
         },
     );
 
-    let t_group_by = Transformation::new(
-        expr_domain.clone(),
-        expr_domain.clone(),
-        Function::new(Clone::clone),
-        middle_metric.clone(),
-        PartitionDistance(middle_metric.clone()),
-        StabilityMap::new_fallible(move |&d_in| {
+    let m_exprs = make_basic_composition(
+        aggs.into_iter()
+            .map(|expr| {
+                make_private_expr(
+                    expr_domain.clone(),
+                    PartitionDistance(middle_metric.clone()),
+                    output_measure.clone(),
+                    expr.clone(),
+                    global_scale,
+                )
+            })
+            .collect::<Fallible<_>>()?,
+    )?;
+
+    let f_comp = m_exprs.function.clone();
+    let privacy_map = m_exprs.privacy_map.clone();
+    let dp_exprs = m_exprs.invoke(&(input, all()))?;
+
+    if threshold.is_some() && expr_threshold.is_some() {
+        return fallible!(MakeMeasurement, "two thresholds set: one via the constructor and another via filtering. Please remove one");
+    }
+
+    let threshold = if margin.public_info.is_some() {
+        None
+    } else if let Some((name, threshold_value)) = expr_threshold {
+        let noise = find_len_expr(&dp_exprs, Some(name.as_str()))?.1;
+        Some((name, noise, threshold_value))
+    } else if let Some(threshold_value) = threshold {
+        let (name, noise) = find_len_expr(&dp_exprs, None)?;
+        Some((name, noise, threshold_value))
+    } else {
+        // TODO: link to documentation page showing how to filter.
+        return fallible!(
+            MakeMeasurement,
+            "The key set of {:?} is unknown and cannot be released. Try adding filtering to your query.",
+            grouping_columns);
+    };
+
+    let m_group_by_agg = Measurement::new(
+        middle_domain,
+        Function::new_fallible(enclose!(threshold, move |arg: &DslPlan| {
+            let mut output = DslPlan::GroupBy {
+                input: Arc::new(arg.clone()),
+                keys: keys.clone(),
+                aggs: f_comp.eval(&(arg.clone(), all()))?,
+                apply: None,
+                maintain_order: false,
+                options: Default::default(),
+            };
+
+            if let Some((name, _, threshold)) = &threshold {
+                output = DslPlan::Filter {
+                    input: Arc::new(output),
+                    predicate: col(&name).gt(lit(*threshold)),
+                }
+            }
+            Ok(output)
+        })),
+        middle_metric,
+        output_measure,
+        PrivacyMap::new_fallible(move |&d_in| {
             let l0 = margin.max_influenced_partitions.unwrap_or(d_in).min(d_in);
             let li = margin.max_partition_contributions.unwrap_or(d_in).min(d_in);
             let l1 = l0.inf_mul(&li)?.min(d_in);
-            Ok((l0, l1, li))
+
+            let mut d_out = privacy_map.eval(&(l0, l1, li))?;
+
+            if let Some((_, noise, threshold_value)) = &threshold {
+                let distribution = noise.distribution.expect("distribution is known");
+                let scale = noise.scale.expect("scale is known");
+
+                if li >= *threshold_value {
+                    return fallible!(FailedMap, "threshold must be greater than {:?}", li);
+                }
+
+                let d_instability = threshold_value.inf_sub(&li)?;
+                let delta_single =
+                    integrate_discrete_noise_tail(distribution, scale, d_instability)?;
+                let delta_joint =
+                    (1.0).inf_sub(&(1.0).inf_sub(&delta_single)?.inf_powi(IBig::from(l0))?)?;
+                d_out = MO::add_delta(d_out, delta_joint)?;
+            } else if margin.public_info.is_none() {
+                return fallible!(FailedMap, "keys must be public if threshold is unknown");
+            }
+
+            Ok(d_out)
         }),
     )?;
 
-    let m_exprs = (t_group_by
-        >> make_basic_composition(
-            aggs.into_iter()
-                .map(|expr| {
-                    make_private_expr(
-                        expr_domain.clone(),
-                        PartitionDistance(middle_metric.clone()),
-                        output_measure.clone(),
-                        expr.clone(),
-                        global_scale,
-                    )
-                })
-                .collect::<Fallible<_>>()?,
-        )?)?;
-
-    let f_exprs = m_exprs.function.clone();
-    let privacy_map = m_exprs.privacy_map.clone();
-
-    t_prior
-        >> Measurement::new(
-            middle_domain,
-            Function::new_fallible(move |arg: &DslPlan| {
-                let mut output = plan.clone();
-                if let DslPlan::GroupBy {
-                    ref mut input,
-                    ref mut aggs,
-                    ..
-                } = output
-                {
-                    *input = Arc::new(arg.clone());
-                    *aggs = f_exprs.eval(&(arg.clone(), all()))?;
-                };
-                Ok(output)
-            }),
-            middle_metric,
-            output_measure,
-            privacy_map,
-        )?
+    t_prior >> m_group_by_agg
 }
 
-#[cfg(test)]
-mod test;
+pub trait ApproximateMeasure: BasicCompositionMeasure {
+    fn add_delta(d_out: Self::Distance, delta_p: f64) -> Fallible<Self::Distance>;
+}
+
+macro_rules! impl_measure_non_catastrophic {
+    ($ty:ty) => {
+        impl ApproximateMeasure for $ty {
+            fn add_delta(_d_out: Self::Distance, _delta_p: f64) -> Fallible<Self::Distance> {
+                return fallible!(
+                    MakeMeasurement,
+                    "key-sets cannot be privatized under {:?}. Approximate-DP is necessary.",
+                    stringify!($ty)
+                );
+            }
+        }
+    };
+}
+
+impl_measure_non_catastrophic!(MaxDivergence<f64>);
+impl_measure_non_catastrophic!(ZeroConcentratedDivergence<f64>);
+
+impl ApproximateMeasure for FixedSmoothedMaxDivergence<f64> {
+    fn add_delta((epsilon, delta): Self::Distance, delta_p: f64) -> Fallible<Self::Distance> {
+        Ok((epsilon, delta.inf_add(&delta_p)?))
+    }
+}
+
+fn integrate_discrete_noise_tail(
+    distribution: Distribution,
+    scale: f64,
+    tail_bound: u32,
+) -> Fallible<f64> {
+    match distribution {
+        Distribution::Laplace => integrate_discrete_laplacian_tail(scale, tail_bound),
+        Distribution::Gaussian => fallible!(
+            MakeMeasurement,
+            "gaussian tail bounds are not currently implemented"
+        ),
+    }
+}

--- a/rust/src/measurements/make_private_lazyframe/group_by/pseudocode/make_private_group_by.py
+++ b/rust/src/measurements/make_private_lazyframe/group_by/pseudocode/make_private_group_by.py
@@ -14,9 +14,11 @@ def make_private_group_by(
 
     grouping_columns = match_grouping_columns(keys)  # |\label{line:groupcols}|
 
-    margin = (middle_domain
+    margin = (
+        middle_domain
         .margins
-        .get(grouping_columns, Margin.default()))  # |\label{line:margin}|
+        .get(grouping_columns, Margin.default())
+    )  # |\label{line:margin}|
 
     # prepare a joint measurement over all expressions
     expr_domain = ExprDomain(  # |\label{line:joint}|

--- a/rust/src/measurements/make_private_lazyframe/group_by/pseudocode/make_private_group_by.py
+++ b/rust/src/measurements/make_private_lazyframe/group_by/pseudocode/make_private_group_by.py
@@ -1,0 +1,101 @@
+# type: ignore
+def make_private_group_by(
+    input_domain,
+    input_metric,
+    output_measure,
+    plan,
+    global_scale,
+    threshold,
+):
+    input_, keys, aggs, expr_threshold = match_group_by(plan)
+
+    t_prior = input_.make_stable(input_domain, input_metric)
+    middle_domain, middle_metric = t_prior.output_space()
+
+    grouping_columns = match_grouping_columns(keys)
+
+    margin = middle_domain \
+        .margins \
+        .get(grouping_columns, Margin.default())
+
+    # prepare a join measurement over all expressions
+    expr_domain = ExprDomain(
+        middle_domain,
+        ExprContext.Aggregate(grouping_columns),
+    )
+
+    m_exprs = make_basic_composition([
+        make_private_expr(
+             expr_domain,
+             PartitionDistance(middle_metric),
+             output_measure,
+             expr,
+             global_scale,
+        ) for expr in aggs
+    ])
+
+    # reconcile information about the threshold |\label{reconcile-threshold}|
+    dp_exprs = m_exprs.invoke((input_, all()))
+
+    if threshold is not None and expr_threshold is not None:
+        raise "two thresholds set"
+
+    if margin.public_info is not None:
+        threshold = None
+    elif expr_threshold is not None:
+        name, threshold = expr_threshold
+        plugin = find_len_expr(dp_exprs, name.as_str())[1]
+        threshold = name, plugin, threshold
+    elif threshold is not None:
+        name, plugin = find_len_expr(dp_exprs, None)
+        threshold = name, plugin, threshold
+    else:
+        raise f"The key set of {grouping_columns} is unknown and cannot be released."
+
+    # prepare supporting elements
+    def function(arg):
+        output = DslPlan.GroupBy(
+            input=arg,
+            keys=keys,
+            aggs=m_exprs((arg, all())),
+            apply=None,
+            maintain_order=false,
+        )
+
+        if threshold is not None:
+            name, _, threshold_value = threshold
+            output = DslPlan.Filter(
+                input=output,
+                predicate=col(name).gt(lit(threshold_value)),
+            )
+        return output
+    
+    def privacy_map(d_in):
+        l0 = margin.max_influenced_partitions.unwrap_or(d_in).min(d_in)
+        li = margin.max_partition_contributions.unwrap_or(d_in).min(d_in)
+        l1 = l0.inf_mul(li).min(d_in)
+
+        d_out = m_exprs.map((l0, l1, li))
+
+        if threshold is not None:
+            _, plugin, threshold_value = threshold
+            if li >= threshold_value:
+                raise f"Threshold must be greater than {li}."
+            d_instability = f64.inf_cast(threshold_value.inf_sub(li))
+            delta_single = integrate_discrete_noise_tail(plugin.distribution, plugin.scale, d_instability)
+            delta_joint = 1 - (1 - delta_single).inf_powi(l0)
+            d_out = MO.add_delta(d_out, delta_joint)
+        elif margin.public_info is None:
+            raise "keys must be public if threshold is unknown"
+
+        return d_out
+
+    m_group_by_agg = Measurement(
+        middle_domain,
+        function,
+        middle_metric,
+        output_measure,
+        privacy_map,
+    )
+
+    return t_prior >> m_group_by_agg

--- a/rust/src/measurements/make_private_lazyframe/group_by/test.rs
+++ b/rust/src/measurements/make_private_lazyframe/group_by/test.rs
@@ -31,6 +31,7 @@ fn test_aggregate() -> Fallible<()> {
             .agg(&[col("B").sum()])
             .logical_plan,
         Some(1.),
+        None,
     )
     .map(|_| ())
     .unwrap_err()

--- a/rust/src/measurements/make_private_lazyframe/mod.rs
+++ b/rust/src/measurements/make_private_lazyframe/mod.rs
@@ -1,13 +1,16 @@
 use polars::prelude::LazyFrame;
 use polars_plan::{dsl::Expr, plans::DslPlan};
 
+use group_by::ApproximateMeasure;
 use opendp_derive::bootstrap;
+use std::fmt::Debug;
 
 use crate::{
-    combinators::BasicCompositionMeasure,
+    combinators::make_pureDP_to_fixed_approxDP,
     core::{Function, Measure, Measurement, Metric, MetricSpace},
     domains::{DslPlanDomain, ExprDomain, LazyFrameDomain},
     error::Fallible,
+    measures::{FixedSmoothedMaxDivergence, MaxDivergence, ZeroConcentratedDivergence},
     metrics::PartitionDistance,
     polars::{get_disabled_features_message, OnceFrame},
     transformations::{traits::UnboundedMetric, DatasetMetric, StableDslPlan},
@@ -20,6 +23,7 @@ mod ffi;
 
 #[cfg(feature = "contrib")]
 mod group_by;
+pub(crate) use group_by::is_threshold_predicate;
 
 #[cfg(feature = "contrib")]
 mod postprocess;
@@ -27,11 +31,60 @@ mod postprocess;
 #[cfg(feature = "contrib")]
 mod select;
 
+fn make_private_aggregation<MS, MI, MO>(
+    input_domain: DslPlanDomain,
+    input_metric: MS,
+    output_measure: MO,
+    plan: DslPlan,
+    global_scale: Option<f64>,
+    threshold: Option<u32>,
+) -> Fallible<Measurement<DslPlanDomain, DslPlan, MS, MO>>
+where
+    MS: 'static + UnboundedMetric + DatasetMetric,
+    MI: Metric,
+    MO: 'static + ApproximateMeasure,
+    MO::Distance: Debug,
+    Expr: PrivateExpr<PartitionDistance<MS>, MO>,
+    DslPlan: StableDslPlan<MS, MS>,
+    (DslPlanDomain, MS): MetricSpace,
+    (ExprDomain, MS): MetricSpace,
+{
+    #[cfg(feature = "contrib")]
+    if group_by::match_group_by(plan.clone())?.is_some() {
+        return group_by::make_private_group_by(
+            input_domain,
+            input_metric,
+            output_measure,
+            plan,
+            global_scale,
+            threshold,
+        );
+    }
+    match plan {
+        #[cfg(feature = "contrib")]
+        plan if matches!(plan, DslPlan::Select { .. }) => select::make_private_select(
+            input_domain,
+            input_metric,
+            output_measure,
+            plan,
+            global_scale,
+        ),
+
+        plan => fallible!(
+            MakeMeasurement,
+            "A step in your query is not recognized at this time: {:?}. {:?}If you would like to see this supported, please file an issue.",
+            plan.describe()?,
+            get_disabled_features_message()
+        )
+    }
+}
+
 #[bootstrap(
     features("contrib"),
     arguments(
         output_measure(c_type = "AnyMeasure *", rust_type = b"null"),
-        global_scale(rust_type = "Option<f64>", c_type = "AnyObject *", default = b"null")
+        global_scale(rust_type = "Option<f64>", c_type = "AnyObject *", default = b"null"),
+        threshold(rust_type = "Option<u32>", c_type = "AnyObject *", default = b"null")
     ),
     generics(MI(suppress), MO(suppress))
 )]
@@ -45,13 +98,15 @@ mod select;
 /// * `input_metric` - How to measure distances between neighboring input data sets.
 /// * `output_measure` - How to measure privacy loss.
 /// * `lazyframe` - A description of the computations to be run, in the form of a [`LazyFrame`].
-/// * `global_scale` - A tune-able parameter that affects the privacy-utility tradeoff.
+/// * `global_scale` - Optional. A tune-able parameter that affects the privacy-utility tradeoff.
+/// * `threshold` - Optional. Minimum number of rows in each released partition.
 pub fn make_private_lazyframe<MI: Metric, MO: 'static + Measure>(
     input_domain: LazyFrameDomain,
     input_metric: MI,
     output_measure: MO,
     lazyframe: LazyFrame,
     global_scale: Option<f64>,
+    threshold: Option<u32>,
 ) -> Fallible<Measurement<LazyFrameDomain, OnceFrame, MI, MO>>
 where
     DslPlan: PrivateDslPlan<MI, MO>,
@@ -63,6 +118,7 @@ where
         input_metric,
         output_measure,
         global_scale,
+        threshold,
     )?;
     let f_lp = m_lp.function.clone();
 
@@ -86,14 +142,14 @@ pub trait PrivateDslPlan<MI: Metric, MO: Measure> {
         input_metric: MI,
         output_measure: MO,
         global_scale: Option<f64>,
+        threshold: Option<u32>,
     ) -> Fallible<Measurement<DslPlanDomain, DslPlan, MI, MO>>;
 }
 
-impl<MS, MO> PrivateDslPlan<MS, MO> for DslPlan
+impl<MS> PrivateDslPlan<MS, MaxDivergence<f64>> for DslPlan
 where
     MS: 'static + UnboundedMetric + DatasetMetric,
-    MO: 'static + BasicCompositionMeasure,
-    Expr: PrivateExpr<PartitionDistance<MS>, MO>,
+    Expr: PrivateExpr<PartitionDistance<MS>, MaxDivergence<f64>>,
     DslPlan: StableDslPlan<MS, MS>,
     (DslPlanDomain, MS): MetricSpace,
     (ExprDomain, MS): MetricSpace,
@@ -102,46 +158,115 @@ where
         self,
         input_domain: DslPlanDomain,
         input_metric: MS,
-        output_measure: MO,
+        output_measure: MaxDivergence<f64>,
         global_scale: Option<f64>,
-    ) -> Fallible<Measurement<DslPlanDomain, DslPlan, MS, MO>> {
+        threshold: Option<u32>,
+    ) -> Fallible<Measurement<DslPlanDomain, DslPlan, MS, MaxDivergence<f64>>> {
         if let Some(meas) = postprocess::match_postprocess(
             input_domain.clone(),
             input_metric.clone(),
             output_measure.clone(),
             self.clone(),
             global_scale,
+            threshold,
         )? {
             return Ok(meas);
         }
 
-        match &self {
-            #[cfg(feature = "contrib")]
-            dsl if matches!(dsl, DslPlan::GroupBy { .. }) => {
-                group_by::make_private_group_by(
-                    input_domain,
-                    input_metric,
-                    output_measure,
-                    self,
-                    global_scale,
-                )
-            }
+        make_private_aggregation::<MS, MS, _>(
+            input_domain,
+            input_metric,
+            output_measure,
+            self,
+            global_scale,
+            threshold,
+        )
+    }
+}
 
-            #[cfg(feature = "contrib")]
-            dsl if matches!(dsl, DslPlan::Select { .. }) => select::make_private_select(
-                input_domain,
-                input_metric,
-                output_measure,
-                self,
-                global_scale,
-            ),
-
-            dsl => fallible!(
-                MakeMeasurement,
-                "A step in your query is not recognized at this time: {:?}. {:?}If you would like to see this supported, please file an issue.",
-                dsl.describe()?,
-                get_disabled_features_message()
-            )
+impl<MS> PrivateDslPlan<MS, ZeroConcentratedDivergence<f64>> for DslPlan
+where
+    MS: 'static + UnboundedMetric + DatasetMetric,
+    Expr: PrivateExpr<PartitionDistance<MS>, ZeroConcentratedDivergence<f64>>,
+    DslPlan: StableDslPlan<MS, MS>,
+    (DslPlanDomain, MS): MetricSpace,
+    (ExprDomain, MS): MetricSpace,
+{
+    fn make_private(
+        self,
+        input_domain: DslPlanDomain,
+        input_metric: MS,
+        output_measure: ZeroConcentratedDivergence<f64>,
+        global_scale: Option<f64>,
+        threshold: Option<u32>,
+    ) -> Fallible<Measurement<DslPlanDomain, DslPlan, MS, ZeroConcentratedDivergence<f64>>> {
+        if let Some(meas) = postprocess::match_postprocess(
+            input_domain.clone(),
+            input_metric.clone(),
+            output_measure.clone(),
+            self.clone(),
+            global_scale,
+            threshold,
+        )? {
+            return Ok(meas);
         }
+
+        make_private_aggregation::<MS, MS, _>(
+            input_domain,
+            input_metric,
+            output_measure,
+            self,
+            global_scale,
+            threshold,
+        )
+    }
+}
+
+impl<MS> PrivateDslPlan<MS, FixedSmoothedMaxDivergence<f64>> for DslPlan
+where
+    MS: 'static + UnboundedMetric + DatasetMetric,
+    Expr: PrivateExpr<PartitionDistance<MS>, MaxDivergence<f64>>
+        + PrivateExpr<PartitionDistance<MS>, FixedSmoothedMaxDivergence<f64>>,
+    DslPlan: StableDslPlan<MS, MS>,
+    (DslPlanDomain, MS): MetricSpace,
+    (ExprDomain, MS): MetricSpace,
+{
+    fn make_private(
+        self,
+        input_domain: DslPlanDomain,
+        input_metric: MS,
+        output_measure: FixedSmoothedMaxDivergence<f64>,
+        global_scale: Option<f64>,
+        threshold: Option<u32>,
+    ) -> Fallible<Measurement<DslPlanDomain, DslPlan, MS, FixedSmoothedMaxDivergence<f64>>> {
+        if let Some(meas) = postprocess::match_postprocess(
+            input_domain.clone(),
+            input_metric.clone(),
+            output_measure.clone(),
+            self.clone(),
+            global_scale,
+            threshold,
+        )? {
+            return Ok(meas);
+        }
+
+        if let Ok(meas) = make_private_aggregation::<MS, MS, _>(
+            input_domain.clone(),
+            input_metric.clone(),
+            output_measure.clone(),
+            self.clone(),
+            global_scale,
+            threshold,
+        ) {
+            return Ok(meas);
+        }
+
+        make_pureDP_to_fixed_approxDP(self.make_private(
+            input_domain,
+            input_metric,
+            MaxDivergence::<f64>::default(),
+            global_scale,
+            threshold,
+        )?)
     }
 }

--- a/rust/src/measurements/make_private_lazyframe/postprocess/mod.rs
+++ b/rust/src/measurements/make_private_lazyframe/postprocess/mod.rs
@@ -27,6 +27,7 @@ pub fn match_postprocess<MI: 'static + Metric, MO: 'static + BasicCompositionMea
     output_measure: MO,
     plan: DslPlan,
     global_scale: Option<f64>,
+    threshold: Option<u32>,
 ) -> Fallible<Option<Measurement<DslPlanDomain, DslPlan, MI, MO>>>
 where
     DslPlan: PrivateDslPlan<MI, MO>,
@@ -46,6 +47,7 @@ where
                 input_metric,
                 output_measure,
                 global_scale,
+                threshold,
             )?;
             let sort = Function::new_fallible(move |arg: &DslPlan| {
                 Ok(DslPlan::Sort {

--- a/rust/src/measurements/make_private_lazyframe/postprocess/test.rs
+++ b/rust/src/measurements/make_private_lazyframe/postprocess/test.rs
@@ -35,6 +35,7 @@ fn test_make_private_lazyframe_sort() -> Fallible<()> {
         MaxDivergence::default(),
         query,
         None,
+        None,
     )?;
 
     Ok(())

--- a/rust/src/measurements/make_private_lazyframe/select/test.rs
+++ b/rust/src/measurements/make_private_lazyframe/select/test.rs
@@ -23,6 +23,7 @@ fn test_select_no_margin() -> Fallible<()> {
         MaxDivergence::<f64>::default(),
         lf.clone().select(&[len().dp().laplace(Some(0.))]),
         Some(1.),
+        None,
     )?;
 
     let actual = m_select.invoke(&lf)?.collect()?;
@@ -49,6 +50,7 @@ fn test_select() -> Fallible<()> {
             len().dp().laplace(Some(0.)),
         ]),
         Some(1.),
+        None,
     )?;
 
     let actual = m_select.invoke(&lf)?.collect()?;

--- a/rust/src/traits/operations/mod.rs
+++ b/rust/src/traits/operations/mod.rs
@@ -351,14 +351,24 @@ fn min_by<T, F: FnOnce(&T, &T) -> Fallible<Ordering>>(v1: T, v2: T, compare: F) 
     })
 }
 
-impl<T1: ProductOrd, T2: ProductOrd> ProductOrd for (T1, T2) {
+impl<T1: ProductOrd + Debug, T2: ProductOrd + Debug> ProductOrd for (T1, T2) {
     fn total_cmp(&self, other: &Self) -> Fallible<Ordering> {
-        let cmp = self.0.total_cmp(&other.0)?;
-        if Ordering::Equal == cmp {
-            self.1.total_cmp(&other.1)
-        } else {
-            Ok(cmp)
-        }
+        use Ordering::*;
+        Ok(
+            match (self.0.total_cmp(&other.0)?, self.1.total_cmp(&other.1)?) {
+                (Equal, Equal) => Equal,
+                (Less | Equal, Less | Equal) => Less,
+                (Greater | Equal, Greater | Equal) => Greater,
+                _ => {
+                    return fallible!(
+                        FailedFunction,
+                        "unknown ordering between {:?} and {:?}",
+                        self,
+                        other
+                    )
+                }
+            },
+        )
     }
 }
 

--- a/rust/src/transformations/make_stable_expr/expr_sum/mod.rs
+++ b/rust/src/transformations/make_stable_expr/expr_sum/mod.rs
@@ -1,5 +1,5 @@
 use crate::core::{Function, MetricSpace, StabilityMap, Transformation};
-use crate::domains::{ExprDomain, Margin, MarginPub, NumericDataType, SeriesDomain};
+use crate::domains::{ExprDomain, Margin, MarginPub::Lengths, NumericDataType, SeriesDomain};
 use crate::error::*;
 use crate::metrics::{IntDistance, LpDistance, PartitionDistance};
 use crate::polars::ExprFunction;
@@ -59,8 +59,9 @@ where
 
     // we only care about the margin that matches the current grouping columns
     let margin_id = middle_domain.context.grouping_columns()?;
-    let input_margin = (output_domain.frame_domain.margins.remove(&margin_id))
-        .ok_or_else(|| err!(MakeTransformation, "failed to find margin {:?}", margin_id))?;
+    let input_margin = (output_domain.frame_domain.margins.get(&margin_id))
+        .cloned()
+        .unwrap_or_default();
 
     // Set the margins on the output domain to consist of only one margin: 1 row per group, with at most 1 record in each group.
     let output_margin = input_margin.clone().with_max_partition_length(1);
@@ -102,9 +103,7 @@ where
     let (l, u) = series_domain.atom_domain::<TI>()?.get_closed_bounds()?;
     let (l, u) = (TI::Sum::neg_inf_cast(l)?, TI::Sum::inf_cast(u)?);
 
-    let public_info = margin
-        .public_info
-        .ok_or_else(|| err!(MakeTransformation, "keys must be public information"))?;
+    let public_info = margin.public_info;
 
     let max_size = usize::exact_int_cast(margin.max_partition_length.ok_or_else(|| {
         err!(
@@ -122,8 +121,8 @@ where
     };
 
     let pp_map = move |d_in: &IntDistance| match public_info {
-        MarginPub::Keys => TI::Sum::inf_cast(*d_in)?.inf_mul(&l.alerting_abs()?.total_max(u)?),
-        MarginPub::Lengths => TI::Sum::inf_cast(*d_in / 2)?.inf_mul(&u.inf_sub(&l)?),
+        Some(Lengths) => TI::Sum::inf_cast(*d_in / 2)?.inf_mul(&u.inf_sub(&l)?),
+        _ => TI::Sum::inf_cast(*d_in)?.inf_mul(&l.alerting_abs()?.total_max(u)?),
     };
 
     Ok(StabilityMap::new_fallible(


### PR DESCRIPTION
In this setting, the key set is not public:

```python
context = dp.Context.compositor(
    data=pl.LazyFrame(schema={"A": pl.Int32, "B": pl.String}),
    privacy_unit=dp.unit_of(contributions=1),
    privacy_loss=dp.loss_of(epsilon=1.0, delta=1e-7),
    split_evenly_over=2,
    margins={
        ("B",): dp.Margin(max_partition_length=5),
    },
)
```

However, you can still release grouped queries on it:
```python
query = (
    context.query()
    .group_by("B")
    .agg(pl.len().dp.noise(), pl.col("A").fill_null(2).dp.sum((0, 3)))
)
```

This is because the library adds thresholding to the query based on the noisy `pl.len()` to satisfy approximate-DP.

## ProductOrd change
This PR also changes the behavior of `ProductOrd` on tuples:
A tuple is only considered greater than another if all elements are greater than the corresponding element in the other tuple. The library previously used a lexicographic ordering, which, while this makes tuples totally ordered, effectively only guarantees that the epsilon in the epsilon/delta tuple is solved for. This is not really what we want from the check in our maps: the check should only succeed if both epsilon and delta are satisfied.

While the new product ordering makes check perform as expected, it also means tuples no longer have a total ordering, so binary searches over approx-DP mechanisms now fail. I've adjusted all of these call locations to first solve for epsilon, and then delta.