### PR TITLE
Change test warnings to errors

### DIFF
--- a/python/.pytest.ini
+++ b/python/.pytest.ini
@@ -5,6 +5,9 @@ testpaths =
 	../docs/source
 	../docs/tools
 
+# Treat warnings as errors:
+filterwarnings = error
+
 addopts = --doctest-glob '*.rst' --doctest-modules --ignore=../docs/source/conf.py
 
 # If an xfail starts passes unexpectedly, that should count as a failure:

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -370,8 +370,8 @@ def get_opendp_version_from_file():
     >>> import re
     >>> assert re.match(r'\\d+\\.\\d+\\.\\d+', get_opendp_version_from_file())
     '''
-    version_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), *['..'] * 3, 'VERSION')
-    return open(version_file, 'r').read().strip()
+    version_path = Path(__file__).parent.parent.parent.parent / 'VERSION'
+    return version_path.read_text().strip()
 
 
 def get_docs_ref(version):


### PR DESCRIPTION
Most of the lines in
- #1639

were about fixing
- #1619

but that got fixed elsewhere, which is good, since #1639 never made it all the way to main... but making warnings into errors is useful on its own, so I'm filing a separate PR.

