### PR TITLE
fix nightly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Install cibuildwheel
         run: |
           python -m pip install --upgrade pip
-          python -m pip install cibuildwheel==2.17.0
+          python -m pip install cibuildwheel==2.19.2
     
       - name: Build wheels
         working-directory: python

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -54,4 +54,7 @@ polars =
 	%(scikit-learn)s
 
 [bdist_wheel]
-py-limited-api=cp39
+# This signifies to the packaging system that the bundled binary 
+# only uses limited APIs that are present in all Python versions back to at least Python 3.9
+# For more detail: https://docs.python.org/3/c-api/stable.html#c.Py_LIMITED_API
+py_limited_api=cp39

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -26,7 +26,7 @@ def _load_library():
         lib_dir = Path(__file__).parent / ".." / ".." / ".." / 'rust' / 'target' / build_dir  # pragma: no cover
 
     if lib_dir.exists():
-        lib_dir_file_names = [p for p in lib_dir.iterdir() if p.suffix in {".so", ".dylib", ".dll"}]
+        lib_dir_file_names = [p for p in lib_dir.iterdir() if p.suffix in {".so", ".dylib", ".dll", ".pyd"}]
         if len(lib_dir_file_names) != 1:
             raise Exception(f"Expected exactly one binary to be present. Got: {lib_dir_file_names}")
         

--- a/tools/requirements-tools.txt
+++ b/tools/requirements-tools.txt
@@ -1,7 +1,7 @@
 semver==3.0
 tomlkit==0.11.8
 debmutate==0.61
-twine==4.0.2
+twine==5.1.1
 setuptools==69.2.0
 wheel
 configupdater==3.2


### PR DESCRIPTION
Closes #1765: see https://github.com/pypa/cibuildwheel/releases/tag/v2.19.2 (specifically cibuildwheel 1917)
Closes #1766: see https://github.com/pypa/twine/issues/1125
Closes #1758: whitelist .pyd. See https://docs.python.org/3/faq/windows.html#is-a-pyd-file-the-same-as-a-dll


To verify, the dev build runs smoothly:
https://github.com/opendp/opendp/actions/runs/9881705627

I also pip-installed the above pre-release on a Windows computer and verified that the package runs smoothly.