### PR TITLE
Remove epsilon/delta units in docs

### DIFF
--- a/docs/source/api/user-guide/combinators/compositors.rst
+++ b/docs/source/api/user-guide/combinators/compositors.rst
@@ -252,8 +252,8 @@ interactive compositors. In this example, we nest a zCDP sequential
 compositor inside an approximate-DP sequential compositor.
 
 We first make the approximate-DP sequential compositor, accepting two
-queries. The first query must be :math:`(2 ε, 10^{-6} δ)`-DP, and the
-second :math:`(1 ε, 0 δ)`-DP.
+queries. The first query must be (2, 10^-6)-DP, and the
+second (1, 0)-DP.
 
 .. tab-set::
 
@@ -273,7 +273,7 @@ second :math:`(1 ε, 0 δ)`-DP.
             
 
 The first query to the approximate-DP sequential compositor must be an
-approximate-DP measurement that satisfies :math:`(2 ε, 10^{-6} δ)`-DP.
+approximate-DP measurement that satisfies (2, 10^{-6})-DP.
 We will now use the library to find a set of :math:`\rho` parameters
 that will satisfy this level of privacy, under a given set of weights.
 
@@ -284,7 +284,7 @@ that will satisfy this level of privacy, under a given set of weights.
 
         .. code:: python
 
-            >>> # find ρ_1, ρ_2 such that ρ_1 + ρ_2 = ρ <= (2ε, 1e-6δ), 
+            >>> # find ρ_1, ρ_2 such that ρ_1 + ρ_2 = ρ <= (2, 1e-6), 
             >>> #    and ρ_1 is 5 times larger than ρ_2
             >>> weights = [5., 1.]
             


### PR DESCRIPTION
- Fix #1802

Is the right style just the numbers?