### PR TITLE
feat: thread-safe queryables

### DIFF
--- a/R/opendp/src/convert.c
+++ b/R/opendp/src/convert.c
@@ -560,6 +560,14 @@ char *rt_to_string(SEXP type_name)
     return (char *)sexp_to_charptr(string_type_name);
 }
 
+FfiSlice *sexp_to_ffisliceptr(SEXP data, SEXP type_name)
+{
+    FfiSlice *slice = malloc(sizeof(FfiSlice));
+    *slice = sexp_to_slice(data, type_name);
+    return slice;
+}
+
+
 AnyObject *sexp_to_anyobjectptr(SEXP data, SEXP type_name)
 {
     // Convert arguments to c types.

--- a/R/opendp/src/convert.h
+++ b/R/opendp/src/convert.h
@@ -20,6 +20,7 @@ typedef unsigned char c_bool;
 char *rt_to_string(SEXP type_name);
 SEXP get_private_func(const char *func_name);
 
+FfiSlice *sexp_to_ffisliceptr(SEXP data, SEXP type_name);
 AnyObject *sexp_to_anyobjectptr(SEXP data, SEXP type_name);
 SEXP anyobjectptr_to_sexp(AnyObject *obj);
 

--- a/rust/opendp_tooling/src/codegen/r/c.rs
+++ b/rust/opendp_tooling/src/codegen/r/c.rs
@@ -289,6 +289,7 @@ fn r_to_c(arg: &Argument) -> String {
     // other conversions are handled by hand-written functions from `convert.c` and `convert_elements.c`
     match &c_type {
         ty if ty == "void *" => format!("sexp_to_voidptr({name}, {rust_type})"),
+        ty if ty == "FfiSlice *" => format!("sexp_to_ffisliceptr({name}, {rust_type})"),
         ty if ty == "AnyObject *" => format!("sexp_to_anyobjectptr({name}, {rust_type})"),
         ty if ty == "AnyTransformation *" => format!("sexp_to_anytransformationptr({name})"),
         ty if ty == "AnyMeasurement *" => format!("sexp_to_anymeasurementptr({name})"),

--- a/rust/src/accuracy/ffi.rs
+++ b/rust/src/accuracy/ffi.rs
@@ -1,6 +1,4 @@
-use num::{Float, One, Zero};
 use std::convert::TryFrom;
-use std::fmt::Debug;
 use std::os::raw::{c_char, c_void};
 
 use crate::accuracy::*;
@@ -9,7 +7,7 @@ use crate::err;
 use crate::ffi::any::AnyObject;
 use crate::ffi::util;
 use crate::ffi::util::Type;
-use crate::traits::InfCast;
+use crate::traits::{Float, InfCast};
 
 macro_rules! build_extern_accuracy {
     ($arg:ident, $ffi_func:ident, $func:ident) => {
@@ -22,7 +20,7 @@ macro_rules! build_extern_accuracy {
             fn monomorphize<T>(
                 $arg: *const c_void, alpha: *const c_void
             ) -> FfiResult<*mut AnyObject> where
-                T: 'static + Float + One + Zero + Debug + InfCast<f64>,
+                T: Float + InfCast<f64>,
                 f64: InfCast<T> {
                 let $arg = *try_as_ref!($arg as *const T);
                 let alpha = *try_as_ref!(alpha as *const T);

--- a/rust/src/combinators/sequential_composition/ffi.rs
+++ b/rust/src/combinators/sequential_composition/ffi.rs
@@ -45,7 +45,7 @@ impl SequentialCompositionMeasure for AnyMeasure {
     }
 }
 
-impl<Q: 'static> SequentialCompositionMeasure for TypedMeasure<Q> {
+impl<Q: 'static + Send + Sync> SequentialCompositionMeasure for TypedMeasure<Q> {
     fn concurrent(&self) -> Fallible<bool> {
         self.measure.concurrent()
     }

--- a/rust/src/data/mod.rs
+++ b/rust/src/data/mod.rs
@@ -9,7 +9,7 @@ use crate::traits::CheckNull;
 use std::any::Any;
 use std::fmt::Debug;
 
-pub trait IsVec: Debug {
+pub trait IsVec: Debug + Send + Sync {
     // Not sure if we need into_any() (which consumes the Form), keeping it for now.
     fn into_any(self: Box<Self>) -> Box<dyn Any>;
     fn as_any(&self) -> &dyn Any;
@@ -20,7 +20,7 @@ pub trait IsVec: Debug {
 
 impl<T> IsVec for Vec<T>
 where
-    T: 'static + Debug + Clone + PartialEq,
+    T: 'static + Debug + Clone + PartialEq + Send + Sync,
 {
     fn into_any(self: Box<Self>) -> Box<dyn Any> {
         self
@@ -47,7 +47,7 @@ where
 
 impl<T> From<Vec<T>> for Column
 where
-    T: 'static + Debug + Clone + PartialEq,
+    T: 'static + Debug + Clone + PartialEq + Send + Sync,
 {
     fn from(src: Vec<T>) -> Self {
         Column::new(src)

--- a/rust/src/domains/polars/expr/ffi.rs
+++ b/rust/src/domains/polars/expr/ffi.rs
@@ -1,8 +1,8 @@
 use opendp_derive::bootstrap;
 
 use crate::{
-    core::FfiResult,
-    domains::{Margin, polars::ffi::unpack_series_domains},
+    core::{FfiResult, FfiSlice},
+    domains::{polars::ffi::unpack_series_domains, Margin},
     ffi::{
         any::{AnyDomain, AnyObject, Downcast},
         util,
@@ -27,9 +27,10 @@ use super::{Context, WildExprDomain};
 /// * `by` - optional. Set if expression is applied to grouped data
 /// * `margin` - descriptors for grouped data
 pub extern "C" fn opendp_domains__wild_expr_domain(
-    columns: *const AnyObject,
+    columns: *const FfiSlice,
     margin: *const AnyObject,
 ) -> FfiResult<*mut AnyDomain> {
+
     let columns = try_!(unpack_series_domains(columns));
 
     let context = if let Some(margin) = util::as_ref(margin) {

--- a/rust/src/error/mod.rs
+++ b/rust/src/error/mod.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use std::fmt::Debug;
 
 use std::backtrace::Backtrace as _Backtrace;
+use std::sync::PoisonError;
 
 use dashu::base::ConversionError;
 #[cfg(feature = "polars")]
@@ -154,6 +155,12 @@ impl From<ConversionError> for Error {
             message: Some(err.to_string()),
             backtrace: std::backtrace::Backtrace::capture(),
         }
+    }
+}
+
+impl<T> From<PoisonError<T>> for Error {
+    fn from(value: PoisonError<T>) -> Self {
+        err!(FailedFunction, "{:?}", value)
     }
 }
 

--- a/rust/src/ffi/util.rs
+++ b/rust/src/ffi/util.rs
@@ -31,7 +31,7 @@ use crate::polars::{OnceFrame, OnceFrameAnswer, OnceFrameQuery};
 use crate::transformations::DataFrameDomain;
 use crate::{err, fallible};
 
-use super::any::{AnyDomain, AnyMeasurement, AnyTransformation};
+use super::any::{AnyMeasurement, AnyTransformation};
 
 // If untrusted is not enabled, then these structs don't exist.
 #[cfg(feature = "untrusted")]
@@ -62,7 +62,11 @@ pub struct ExtrinsicObject {
     pub(crate) count: RefCountFn,
 }
 
+/// Rust does not directly manipulate the data behind pointers,
+/// the bindings language enforces Send.
 unsafe impl Send for ExtrinsicObject {}
+/// Rust does not directly manipulate the data behind pointers,
+/// the bindings language enforces Sync.
 unsafe impl Sync for ExtrinsicObject {}
 
 impl Clone for ExtrinsicObject {
@@ -294,7 +298,6 @@ macro_rules! type_vec {
 
 pub type AnyMeasurementPtr = *const AnyMeasurement;
 pub type AnyTransformationPtr = *const AnyTransformation;
-pub type AnyDomainPtr = *const AnyDomain;
 
 lazy_static! {
     /// The set of registered types. We don't need everything here, just the ones that will be looked up by descriptor

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -181,7 +181,6 @@ pub mod combinators;
 pub mod core;
 pub mod data;
 pub mod domains;
-#[cfg(feature = "contrib")]
 pub mod interactive;
 #[cfg(feature = "ffi")]
 pub mod internal;

--- a/rust/src/measurements/gaussian/ffi.rs
+++ b/rust/src/measurements/gaussian/ffi.rs
@@ -1,0 +1,182 @@
+use std::convert::TryFrom;
+use std::os::raw::c_char;
+
+use dashu::rational::RBig;
+
+use crate::core::{Domain, FfiResult, IntoAnyMeasurementFfiResultExt, Measure, MetricSpace};
+use crate::domains::{AtomDomain, VectorDomain};
+use crate::error::Fallible;
+use crate::ffi::any::{AnyDomain, AnyMeasurement, AnyMetric, Downcast};
+use crate::ffi::util::{Type, as_ref};
+use crate::measurements::{GaussianDomain, make_gaussian};
+use crate::measures::ZeroConcentratedDivergence;
+use crate::traits::{CheckAtom, Float, InfCast, Number};
+
+#[unsafe(no_mangle)]
+pub extern "C" fn opendp_measurements__make_gaussian(
+    input_domain: *const AnyDomain,
+    input_metric: *const AnyMetric,
+    scale: f64,
+    k: *const i32,
+    MO: *const c_char,
+) -> FfiResult<*mut AnyMeasurement> {
+    fn monomorphize_float<T: Float>(
+        input_domain: &AnyDomain,
+        input_metric: &AnyMetric,
+        scale: f64,
+        k: Option<i32>,
+        MO: Type,
+    ) -> Fallible<AnyMeasurement>
+    where
+        RBig: TryFrom<T>,
+        AtomDomain<T>: GaussianDomain<ZeroConcentratedDivergence, T>,
+        VectorDomain<AtomDomain<T>>: GaussianDomain<ZeroConcentratedDivergence, T>,
+        <AtomDomain<T> as Domain>::Carrier: Send + Sync,
+        <VectorDomain<AtomDomain<T>> as Domain>::Carrier: Send + Sync,
+        (
+            AtomDomain<T>,
+            <AtomDomain<T> as GaussianDomain<ZeroConcentratedDivergence, T>>::InputMetric,
+        ): MetricSpace,
+        (
+            VectorDomain<AtomDomain<T>>,
+            <VectorDomain<AtomDomain<T>> as GaussianDomain<ZeroConcentratedDivergence, T>>::InputMetric,
+        ): MetricSpace,
+    {
+        fn monomorphize2<D: 'static + GaussianDomain<MO, QI>, MO: 'static + Measure, QI: 'static>(
+            input_domain: &AnyDomain,
+            input_metric: &AnyMetric,
+            scale: f64,
+            k: Option<i32>,
+        ) -> Fallible<AnyMeasurement>
+        where
+            D::Carrier: Send + Sync,
+            (D, D::InputMetric): MetricSpace,
+        {
+            let input_domain = input_domain.downcast_ref::<D>()?.clone();
+            let input_metric = input_metric.downcast_ref::<D::InputMetric>()?.clone();
+            make_gaussian::<D, MO, QI>(input_domain, input_metric, scale, k).into_any()
+        }
+        let D = input_domain.type_.clone();
+        let QI = input_metric.distance_type.clone();
+        dispatch!(monomorphize2, [
+            (D, [AtomDomain<T>, VectorDomain<AtomDomain<T>>]),
+            (MO, [ZeroConcentratedDivergence]),
+            (QI, [T])
+        ], (input_domain, input_metric, scale, k))
+    }
+    fn monomorphize_integer<
+        T: 'static + CheckAtom,
+        QI: 'static + Copy,
+    >(
+        input_domain: &AnyDomain,
+        input_metric: &AnyMetric,
+        scale: f64,
+        k: Option<i32>,
+        MO: Type,
+        QI: Type,
+    ) -> Fallible<AnyMeasurement>
+    where
+        f64: InfCast<QI>,
+        AtomDomain<T>: GaussianDomain<ZeroConcentratedDivergence, QI>,
+        VectorDomain<AtomDomain<T>>: GaussianDomain<ZeroConcentratedDivergence, QI>,
+        <AtomDomain<T> as Domain>::Carrier: Send + Sync,
+        <VectorDomain<AtomDomain<T>> as Domain>::Carrier: Send + Sync,
+        (
+            AtomDomain<T>,
+            <AtomDomain<T> as GaussianDomain<ZeroConcentratedDivergence, QI>>::InputMetric,
+        ): MetricSpace,
+        (
+            VectorDomain<AtomDomain<T>>,
+            <VectorDomain<AtomDomain<T>> as GaussianDomain<ZeroConcentratedDivergence, QI>>::InputMetric,
+        ): MetricSpace,
+    {
+        fn monomorphize2<
+            D: 'static + GaussianDomain<MO, QI>,
+            MO: 'static + Measure,
+            QI: 'static + Copy,
+        >(
+            input_domain: &AnyDomain,
+            input_metric: &AnyMetric,
+            scale: f64,
+            k: Option<i32>,
+        ) -> Fallible<AnyMeasurement>
+        where
+            f64: Number + InfCast<QI>,
+            D::Carrier: Send + Sync,
+            (D, D::InputMetric): MetricSpace,
+        {
+            let input_domain = input_domain.downcast_ref::<D>()?.clone();
+            let input_metric = input_metric.downcast_ref::<D::InputMetric>()?.clone();
+            make_gaussian::<D, MO, QI>(input_domain, input_metric, scale, k).into_any()
+        }
+        let D = input_domain.type_.clone();
+        dispatch!(monomorphize2, [
+            (D, [AtomDomain<T>, VectorDomain<AtomDomain<T>>]),
+            (MO, [ZeroConcentratedDivergence]),
+            (QI, [QI])
+        ], (input_domain, input_metric, scale, k))
+    }
+    let input_domain = try_as_ref!(input_domain);
+    let input_metric = try_as_ref!(input_metric);
+    let k = as_ref(k as *const i32).map(Clone::clone);
+    let T_ = try_!(input_domain.type_.get_atom());
+    let MO = try_!(Type::try_from(MO));
+
+    // This is used to check if the type is in a dispatch set,
+    // without constructing an expensive backtrace upon failed match
+    fn in_set<T>() -> Option<()> {
+        Some(())
+    }
+
+    if let Some(_) = dispatch!(in_set, [(T_, @floats)]) {
+        let QI = try_!(input_metric.distance_type.get_atom());
+        if T_ != QI {
+            return err!(
+                FFI,
+                "since data type is float, input distance type ({}) must match data type ({})",
+                QI.descriptor,
+                T_.descriptor
+            )
+            .into();
+        }
+        dispatch!(monomorphize_float, [
+            (T_, @floats)
+        ], (input_domain, input_metric, scale, k, MO))
+    } else {
+        let QI = input_metric.distance_type.clone();
+        dispatch!(monomorphize_integer, [
+            (T_, @integers),
+            (QI, @numbers)
+        ], (input_domain, input_metric, scale, k, MO, QI))
+    }
+    .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ptr::null;
+
+    use super::*;
+    use crate::core;
+    use crate::error::Fallible;
+    use crate::ffi::any::{AnyObject, Downcast};
+    use crate::ffi::util;
+    use crate::ffi::util::ToCharP;
+    use crate::metrics::AbsoluteDistance;
+
+    #[test]
+    fn test_make_gaussian_ffi() -> Fallible<()> {
+        let measurement = Result::from(opendp_measurements__make_gaussian(
+            util::into_raw(AnyDomain::new(AtomDomain::<i32>::default())),
+            util::into_raw(AnyMetric::new(AbsoluteDistance::<i32>::default())),
+            0.0,
+            null(),
+            "ZeroConcentratedDivergence".to_char_p(),
+        ))?;
+        let arg = AnyObject::new_raw(99);
+        let res = core::opendp_core__measurement_invoke(&measurement, arg);
+        let res: i32 = Fallible::from(res)?.downcast()?;
+        assert_eq!(res, 99);
+        Ok(())
+    }
+}

--- a/rust/src/measurements/geometric/ffi.rs
+++ b/rust/src/measurements/geometric/ffi.rs
@@ -1,0 +1,75 @@
+use super::LaplaceDomain;
+use crate::{
+    core::{Domain, FfiResult, IntoAnyMeasurementFfiResultExt, Metric, MetricSpace},
+    domains::{AtomDomain, VectorDomain},
+    error::Fallible,
+    ffi::{
+        any::{AnyDomain, AnyMeasurement, AnyMetric, AnyObject, Downcast},
+        util::as_ref,
+    },
+    measurements::{GeometricDomain, make_geometric},
+    traits::CheckAtom,
+};
+
+#[unsafe(no_mangle)]
+pub extern "C" fn opendp_measurements__make_geometric(
+    input_domain: *const AnyDomain,
+    input_metric: *const AnyMetric,
+    scale: f64,
+    bounds: *const AnyObject,
+) -> FfiResult<*mut AnyMeasurement> {
+    fn monomorphize_integer<T: 'static + CheckAtom>(
+        input_domain: &AnyDomain,
+        input_metric: &AnyMetric,
+        scale: f64,
+        bounds: *const AnyObject,
+    ) -> Fallible<AnyMeasurement>
+    where
+        AtomDomain<T>: GeometricDomain,
+        <AtomDomain<T> as LaplaceDomain>::InputMetric: Metric<Distance = T>,
+        VectorDomain<AtomDomain<T>>: GeometricDomain,
+        <VectorDomain<AtomDomain<T>> as LaplaceDomain>::InputMetric: Metric<Distance = T>,
+        <AtomDomain<T> as Domain>::Carrier: Send + Sync,
+        <VectorDomain<AtomDomain<T>> as Domain>::Carrier: Send + Sync,
+        (AtomDomain<T>, <AtomDomain<T> as LaplaceDomain>::InputMetric): MetricSpace,
+        (
+            VectorDomain<AtomDomain<T>>,
+            <VectorDomain<AtomDomain<T>> as LaplaceDomain>::InputMetric,
+        ): MetricSpace,
+    {
+        fn monomorphize2<D: 'static + GeometricDomain>(
+            input_domain: &AnyDomain,
+            input_metric: &AnyMetric,
+            scale: f64,
+            bounds: Option<(
+                <D::InputMetric as Metric>::Distance,
+                <D::InputMetric as Metric>::Distance,
+            )>,
+        ) -> Fallible<AnyMeasurement>
+        where
+            D::Carrier: Send + Sync,
+            (D, D::InputMetric): MetricSpace,
+        {
+            let input_domain = input_domain.downcast_ref::<D>()?.clone();
+            let input_metric = input_metric.downcast_ref::<D::InputMetric>()?.clone();
+            make_geometric::<D>(input_domain, input_metric, scale, bounds).into_any()
+        }
+        let D = input_domain.type_.clone();
+        let bounds = if let Some(bounds) = as_ref(bounds) {
+            Some(try_!(bounds.downcast_ref::<(T, T)>()).clone())
+        } else {
+            None
+        };
+        dispatch!(monomorphize2, [
+            (D, [AtomDomain<T>, VectorDomain<AtomDomain<T>>])
+        ], (input_domain, input_metric, scale, bounds))
+    }
+
+    let input_domain = try_as_ref!(input_domain);
+    let input_metric = try_as_ref!(input_metric);
+    let T = try_!(input_domain.type_.get_atom());
+    dispatch!(monomorphize_integer, [
+        (T, @integers)
+    ], (input_domain, input_metric, scale, bounds))
+    .into()
+}

--- a/rust/src/measurements/laplace/ffi.rs
+++ b/rust/src/measurements/laplace/ffi.rs
@@ -1,0 +1,148 @@
+use crate::core::{Domain, FfiResult, IntoAnyMeasurementFfiResultExt, MetricSpace};
+use crate::domains::{AtomDomain, VectorDomain};
+use crate::error::Fallible;
+use crate::ffi::any::{AnyDomain, AnyMeasurement, AnyMetric, Downcast};
+use crate::ffi::util::as_ref;
+use crate::measurements::{LaplaceDomain, make_laplace};
+use crate::traits::CheckAtom;
+
+#[unsafe(no_mangle)]
+pub extern "C" fn opendp_measurements__make_laplace(
+    input_domain: *const AnyDomain,
+    input_metric: *const AnyMetric,
+    scale: f64,
+    k: *const i32,
+) -> FfiResult<*mut AnyMeasurement> {
+    fn monomorphize_float<T: 'static + CheckAtom + Copy>(
+        input_domain: &AnyDomain,
+        input_metric: &AnyMetric,
+        scale: f64,
+        k: Option<i32>,
+    ) -> Fallible<AnyMeasurement>
+    where
+        AtomDomain<T>: LaplaceDomain,
+        VectorDomain<AtomDomain<T>>: LaplaceDomain,
+        <AtomDomain<T> as Domain>::Carrier: Send + Sync,
+        <VectorDomain<AtomDomain<T>> as Domain>::Carrier: Send + Sync,
+        (AtomDomain<T>, <AtomDomain<T> as LaplaceDomain>::InputMetric): MetricSpace,
+        (
+            VectorDomain<AtomDomain<T>>,
+            <VectorDomain<AtomDomain<T>> as LaplaceDomain>::InputMetric,
+        ): MetricSpace,
+    {
+        fn monomorphize2<D: 'static + LaplaceDomain>(
+            input_domain: &AnyDomain,
+            input_metric: &AnyMetric,
+            scale: f64,
+            k: Option<i32>,
+        ) -> Fallible<AnyMeasurement>
+        where
+            D::Carrier: Send + Sync,
+            (D, D::InputMetric): MetricSpace,
+        {
+            let input_domain = input_domain.downcast_ref::<D>()?.clone();
+            let input_metric = input_metric.downcast_ref::<D::InputMetric>()?.clone();
+            make_laplace::<D>(input_domain, input_metric, scale, k).into_any()
+        }
+        let D = input_domain.type_.clone();
+        dispatch!(monomorphize2, [
+            (D, [AtomDomain<T>, VectorDomain<AtomDomain<T>>])
+        ], (input_domain, input_metric, scale, k))
+    }
+    fn monomorphize_integer<T: 'static + CheckAtom>(
+        input_domain: &AnyDomain,
+        input_metric: &AnyMetric,
+        scale: f64,
+        k: Option<i32>,
+    ) -> Fallible<AnyMeasurement>
+    where
+        AtomDomain<T>: LaplaceDomain,
+        VectorDomain<AtomDomain<T>>: LaplaceDomain,
+        <AtomDomain<T> as Domain>::Carrier: Send + Sync,
+        <VectorDomain<AtomDomain<T>> as Domain>::Carrier: Send + Sync,
+        (AtomDomain<T>, <AtomDomain<T> as LaplaceDomain>::InputMetric): MetricSpace,
+        (
+            VectorDomain<AtomDomain<T>>,
+            <VectorDomain<AtomDomain<T>> as LaplaceDomain>::InputMetric,
+        ): MetricSpace,
+    {
+        fn monomorphize2<D: 'static + LaplaceDomain>(
+            input_domain: &AnyDomain,
+            input_metric: &AnyMetric,
+            scale: f64,
+            k: Option<i32>,
+        ) -> Fallible<AnyMeasurement>
+        where
+            D::Carrier: Send + Sync,
+            (D, D::InputMetric): MetricSpace,
+        {
+            let input_domain = input_domain.downcast_ref::<D>()?.clone();
+            let input_metric = input_metric.downcast_ref::<D::InputMetric>()?.clone();
+            make_laplace::<D>(input_domain, input_metric, scale, k).into_any()
+        }
+        let D = input_domain.type_.clone();
+        dispatch!(monomorphize2, [
+            (D, [AtomDomain<T>, VectorDomain<AtomDomain<T>>])
+        ], (input_domain, input_metric, scale, k))
+    }
+    let input_domain = try_as_ref!(input_domain);
+    let input_metric = try_as_ref!(input_metric);
+    let k = as_ref(k).map(Clone::clone);
+    let T_ = try_!(input_domain.type_.get_atom());
+    let QI = try_!(input_metric.distance_type.get_atom());
+
+    // This is used to check if the type is in a dispatch set,
+    // without constructing an expensive backtrace upon failed match
+    fn in_set<T>() -> Option<()> {
+        Some(())
+    }
+
+    if T_ != QI {
+        return err!(
+            FFI,
+            "input distance type ({}) must match data type ({})",
+            QI.descriptor,
+            T_.descriptor
+        )
+        .into();
+    }
+
+    if let Some(_) = dispatch!(in_set, [(T_, @floats)]) {
+        dispatch!(monomorphize_float, [
+            (T_, @floats)
+        ], (input_domain, input_metric, scale, k))
+    } else {
+        dispatch!(monomorphize_integer, [
+            (T_, @integers)
+        ], (input_domain, input_metric, scale, k))
+    }
+    .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ptr::null;
+
+    use crate::core;
+    use crate::error::Fallible;
+    use crate::ffi::any::{AnyObject, Downcast};
+    use crate::ffi::util;
+    use crate::metrics::AbsoluteDistance;
+
+    use super::*;
+
+    #[test]
+    fn test_make_laplace_ffi() -> Fallible<()> {
+        let measurement = Result::from(opendp_measurements__make_laplace(
+            util::into_raw(AnyDomain::new(AtomDomain::<i32>::default())),
+            util::into_raw(AnyMetric::new(AbsoluteDistance::<i32>::default())),
+            0.0,
+            null(),
+        ))?;
+        let arg = AnyObject::new_raw(99);
+        let res = core::opendp_core__measurement_invoke(&measurement, arg);
+        let res: i32 = Fallible::from(res)?.downcast()?;
+        assert_eq!(res, 99);
+        Ok(())
+    }
+}

--- a/rust/src/measurements/make_private_lazyframe/mod.rs
+++ b/rust/src/measurements/make_private_lazyframe/mod.rs
@@ -11,6 +11,7 @@ use crate::{
     core::{Function, Measure, Measurement, Metric, MetricSpace, StabilityMap, Transformation},
     domains::{DslPlanDomain, Invariant, LazyFrameDomain, Margin},
     error::Fallible,
+    interactive::Wrapper,
     measures::{Approximate, MaxDivergence, ZeroConcentratedDivergence},
     metrics::{
         ChangeOneDistance, ChangeOneIdDistance, FrameDistance, HammingDistance, L01InfDistance,
@@ -128,10 +129,10 @@ where
 
     Measurement::new(
         m_lp.input_domain.cast_carrier(),
-        Function::new_fallible(move |arg: &LazyFrame| {
+        Function::new_interactive(move |arg: &LazyFrame, wrapper: Option<Wrapper>| {
             let lf = LazyFrame::from(f_lp.eval(&arg.logical_plan)?)
                 .with_optimizations(arg.get_current_optimizations());
-            Ok(OnceFrame::from(lf))
+            OnceFrame::new_onceframe(lf, wrapper)
         }),
         m_lp.input_metric.clone(),
         m_lp.output_measure.clone(),

--- a/rust/src/measurements/noise/distribution/gaussian/ffi.rs
+++ b/rust/src/measurements/noise/distribution/gaussian/ffi.rs
@@ -51,6 +51,7 @@ pub extern "C" fn opendp_measurements__make_gaussian(
             k: Option<i32>,
         ) -> Fallible<AnyMeasurement>
         where
+            <<MI as GaussianMetric<T>>::Domain as Domain>::Carrier: Send + Sync,
             MI: GaussianMetric<T>,
             DiscreteGaussian: MakeNoise<MI::Domain, MI, MO>,
             (MI::Domain, MI): MetricSpace,

--- a/rust/src/measurements/noise/distribution/geometric/ffi.rs
+++ b/rust/src/measurements/noise/distribution/geometric/ffi.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 use std::os::raw::c_char;
 
-use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt, Measure, Metric, MetricSpace};
+use crate::core::{Domain, FfiResult, IntoAnyMeasurementFfiResultExt, Measure, Metric, MetricSpace};
 use crate::domains::{AtomDomain, VectorDomain};
 use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMeasurement, AnyMetric, AnyObject, Downcast};
@@ -56,6 +56,7 @@ pub extern "C" fn opendp_measurements__make_geometric(
             )>,
         ) -> Fallible<AnyMeasurement>
         where
+            <<MI as GeometricMetric<T>>::Domain as Domain>::Carrier: Send + Sync,
             MI: GeometricMetric<T>,
             DiscreteLaplace: MakeNoise<MI::Domain, MI, MO>,
             ConstantTimeGeometric<<MI::Domain as NoiseDomain>::Atom>: MakeNoise<MI::Domain, MI, MO>,

--- a/rust/src/measurements/noise/distribution/laplace/ffi.rs
+++ b/rust/src/measurements/noise/distribution/laplace/ffi.rs
@@ -51,6 +51,7 @@ pub extern "C" fn opendp_measurements__make_laplace(
             k: Option<i32>,
         ) -> Fallible<AnyMeasurement>
         where
+            <<MI as LaplaceMetric<T>>::Domain as Domain>::Carrier: Send + Sync,
             MI: LaplaceMetric<T>,
             DiscreteLaplace: MakeNoise<MI::Domain, MI, MO>,
             (MI::Domain, MI): MetricSpace,

--- a/rust/src/measures/ffi.rs
+++ b/rust/src/measures/ffi.rs
@@ -387,7 +387,7 @@ impl<Q> Default for TypedMeasure<Q> {
     }
 }
 
-impl<Q> Measure for TypedMeasure<Q> {
+impl<Q: Send + Sync> Measure for TypedMeasure<Q> {
     type Distance = Q;
 }
 

--- a/rust/src/transformations/impute/ffi.rs
+++ b/rust/src/transformations/impute/ffi.rs
@@ -1,6 +1,6 @@
 use rand::distributions::uniform::SampleUniform;
 
-use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt, MetricSpace};
+use crate::core::{Domain, FfiResult, IntoAnyTransformationFfiResultExt, MetricSpace};
 use crate::domains::{AtomDomain, OptionDomain, VectorDomain};
 use crate::err;
 use crate::error::Fallible;
@@ -110,6 +110,7 @@ pub extern "C" fn opendp_transformations__make_impute_constant(
                 AtomDomain<TA>: ImputeConstantDomain<Imputed = TA>,
                 TA: 'static + HasNull + Clone + CheckAtom,
                 M: 'static + EventLevelMetric,
+                <AtomDomain<TA> as Domain>::Carrier: Send + Sync,
                 (VectorDomain<AtomDomain<TA>>, M): MetricSpace,
             {
                 let input_domain = input_domain
@@ -194,6 +195,7 @@ pub extern "C" fn opendp_transformations__make_drop_null(
                 AtomDomain<TA>: ImputeConstantDomain<Imputed = TA>,
                 TA: 'static + HasNull + Clone + CheckAtom,
                 M: 'static + EventLevelMetric,
+                <AtomDomain<TA> as Domain>::Carrier: Send + Sync,
                 (VectorDomain<AtomDomain<TA>>, M): MetricSpace,
             {
                 let input_domain = input_domain

--- a/rust/src/transformations/make_stable_expr/ffi.rs
+++ b/rust/src/transformations/make_stable_expr/ffi.rs
@@ -32,6 +32,7 @@ pub extern "C" fn opendp_transformations__make_stable_expr(
         Expr: StableExpr<M, M>,
         (WildExprDomain, M): MetricSpace,
         (ExprDomain, M): MetricSpace,
+        M::Distance: Send + Sync,
     {
         let input_metric = input_metric.downcast_ref::<M>()?.clone();
         make_stable_expr::<M, M>(input_domain, input_metric, expr).into_any()

--- a/rust/src/transformations/make_stable_lazyframe/ffi.rs
+++ b/rust/src/transformations/make_stable_lazyframe/ffi.rs
@@ -43,6 +43,7 @@ pub extern "C" fn opendp_transformations__make_stable_lazyframe(
             lazyframe: LazyFrame,
         ) -> Fallible<AnyTransformation>
         where
+            MI::Distance: Send + Sync,
             DslPlan: StableDslPlan<MI, MI>,
             (LazyFrameDomain, MI): MetricSpace,
             (DslPlanDomain, MI): MetricSpace,


### PR DESCRIPTION
Closes #1849

The current approach for queryable wrapping is to store a wrapper in a global variable. When multiple wrappers need to be applied, as a query descends through wrapper queryables towards the core queryable, the global wrapper is temporarily swapped with the composition of the prior wrapper and new wrapper. Any new queryable spawned during evaluation of the core queryable is passed through the global wrapper. As the call stack unwinds, and the answer is returned back out through wrapper queryables, the prior wrapper (or none) is swapped back in.

Two drawbacks to this:

**First drawback**: Since the global is thread-local, wrappers won't be applied to queryables spawned in new threads started in the function, or may get wrongly applied if the thread is part of a pool spawned outside the function. 

**Second drawback**: Odometer nesting wants queryables to be thread-safe. When you query an odometer with an odometer, it creates a new privacy map that points to the child odometer. Since privacy maps are thread-safe, queryables must be thread-safe to build this map.


This PR moves wrappers from the thread-local to the call stack.

Now instead of queryables getting their wrapper from the global state automatically, it is up to the implementor to plumb the wrapper through their measurement/odometer function or queryable transition function.

This PR also makes AnyObject thread-safe. Say you are invoking an interactive composition measurement from Python. The function takes in the data as an AnyObject and returns a queryable holding this AnyObject data. Since queryables must now be thread-safe, the compiler now requires that things you store inside it are also thread-safe. Making AnyObject thread-safe requires a fair number of added Send + Sync bounds in FFI code.