### PR TITLE
CI: update bindings in release channels

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -59,6 +59,11 @@ graph TD
     end
     latex-release.yml -.- rlatex[latex]
 
+    subgraph update-bindings.yml
+        ubcc[credential-check] --> update-bindings
+    end
+    update-bindings.yml -.- rub[update-bindings]
+
     subgraph prepare.yml
         precc[credential-check] --> prepare
     end
@@ -73,6 +78,7 @@ graph TD
         rpre[prepare] --> build --> sanity-test-pre --> publish
         rpre[prepare] --> publish --> sanity-test-post --> rdocs[docs]
         rpre[prepare] --> rlatex[latex] --> rdocs[docs]
+        build --> rub[update-bindings] --> rdocs[docs]
     end
 
     subgraph sanity-test.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,13 @@ jobs:
       channel: ${{ inputs.channel }}
       fake: ${{ inputs.fake }}
 
+  update-bindings:
+    needs: build
+    uses: ./.github/workflows/update-bindings.yml
+    if: ${{ !inputs.dry_run }}
+    with:
+      channel: ${{ inputs.channel }}
+
   sanity-test-pre:
     needs: build
     uses: ./.github/workflows/sanity-test.yml
@@ -122,7 +129,7 @@ jobs:
     secrets: inherit
 
   docs:
-    needs: [ sanity-test-post, latex ]
+    needs: [ sanity-test-post, update-bindings, latex ]
     uses: ./.github/workflows/docs.yml
     with:
       dry_run: ${{ inputs.dry_run || inputs.fake }}

--- a/.github/workflows/update-bindings.yml
+++ b/.github/workflows/update-bindings.yml
@@ -45,9 +45,6 @@ jobs:
           name: r_bindings
           path: R/opendp/
       
-      - name: Show changes
-        run: git diff
-
       - name: Push changes
         run: |
           git add --force . # Generated files are git-ignored, so we need --force.

--- a/.github/workflows/update-bindings.yml
+++ b/.github/workflows/update-bindings.yml
@@ -1,0 +1,55 @@
+# Prepares a branch for a channel:
+# * Checks out the channel branch
+# * Downloads language binding artifacts
+# * Pushes the channel branch changes to origin
+#
+# INPUTS
+# * channel:  The release channel
+name: Prepare Channel
+on:
+  workflow_call:
+    inputs:
+      channel:
+        type: string
+        required: true
+
+jobs:
+  credential-check:
+    uses: ./.github/workflows/credential-check.yml
+    with:
+      assert_version: false
+
+  update-bindings:
+    needs: credential-check
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.channel }}
+
+      - name: Configure git user
+        run: |
+          git config --global user.name "$GITHUB_ACTOR"
+          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Download Python bindings
+        uses: actions/download-artifact@v4
+        with:
+          name: python_bindings
+          path: python/src/opendp/
+
+      - name: Download R bindings
+        uses: actions/download-artifact@v4
+        with:
+          name: r_bindings
+          path: R/opendp/
+      
+      - name: Show changes
+        run: git diff
+
+      - name: Push changes
+        run: |
+          git add --force . # Generated files are git-ignored, so we need --force.
+          git commit -m "Update bindings"
+          git push origin ${{ inputs.channel }}


### PR DESCRIPTION
Closes #1829
Adds a step in the release workflow that commits the generated code to the channel branch. As a byproduct, this also fixes how links to proofs in releases still point to nightly.

See CI run showing success:
https://github.com/opendp/opendp/actions/runs/10156069432/job/28083949751

dev branch updated:
https://github.com/opendp/opendp/tree/dev

