### PR TITLE
feat: add `make_fixed_approxDP_to_approxDP`

### DIFF
--- a/R/opendp/src/convert_elements.c
+++ b/R/opendp/src/convert_elements.c
@@ -414,13 +414,13 @@ SEXP privacyprofileptr_to_sexp(AnyObject *input, SEXP info)
 
     int errorOccurred;
     SEXP new_privacy_profile = get_private_func("new_privacy_profile");
-    SEXP privacyprofile_expr = lang2(new_privacy_profile, XPtr);
-    SEXP privacyprofile = R_tryEval(privacyprofile_expr, R_GlobalEnv, &errorOccurred);
+    SEXP privacy_profile_expr = lang2(new_privacy_profile, XPtr);
+    SEXP privacy_profile = R_tryEval(privacy_profile_expr, R_GlobalEnv, &errorOccurred);
     if (errorOccurred)
-        error("failed to construct privacy_profile");
+        error("failed to construct privacy profile");
 
     UNPROTECT(1);
-    return privacyprofile;
+    return privacy_profile;
 }
 
 // AnyObject: Queryable

--- a/docs/source/api/user-guide/combinators/index.rst
+++ b/docs/source/api/user-guide/combinators/index.rst
@@ -153,6 +153,9 @@ These combinators are used to cast the output measure of a Measurement.
      - ``Approximate<ZeroConcentratedDivergence>``
      - :func:`opendp.combinators.make_approximate`
    * - ``MaxDivergence``
+     - ``SmoothedMaxDivergence``
+     - :func:`opendp.combinators.make_fixed_approxDP_to_approxDP`
+   * - ``MaxDivergence``
      - ``ZeroConcentratedDivergence``
      - :func:`opendp.combinators.make_pureDP_to_zCDP`
    * - ``ZeroConcentratedDivergence``

--- a/python/test/test_comb.py
+++ b/python/test/test_comb.py
@@ -145,5 +145,12 @@ def test_make_pureDP_to_zCDP():
     # (1/10)^2 / 2 + 1 / 10^2 / 2
     assert meas.map(1.) == 0.010000000000000002
 
-if __name__ == "__main__":
-    test_make_approximate()
+
+def test_make_fixed_approxDP_to_approxDP():
+    input_space = dp.atom_domain(T=float), dp.absolute_distance(T=float)
+    fadp_meas = dp.c.make_approximate(dp.m.make_laplace(*input_space, 10.))
+
+    adp_meas = dp.c.make_fixed_approxDP_to_approxDP(fadp_meas)
+
+    assert adp_meas.map(1.).epsilon(delta=1e-7) == 0.1
+

--- a/rust/src/combinators/measure_cast/fixed_approxDP_to_approxDP/ffi.rs
+++ b/rust/src/combinators/measure_cast/fixed_approxDP_to_approxDP/ffi.rs
@@ -1,0 +1,47 @@
+use opendp_derive::bootstrap;
+
+use crate::{
+    core::{FfiResult, PrivacyMap},
+    error::Fallible,
+    ffi::any::{AnyMeasure, AnyMeasurement, AnyObject, Downcast},
+    measures::{Approximate, MaxDivergence},
+};
+
+#[bootstrap(features("contrib"))]
+/// Constructs a new output measurement where the output measure
+/// is casted from `Approximate<MaxDivergence>` to `SmoothedMaxDivergence`.
+///
+/// # Arguments
+/// * `measurement` - a measurement with a privacy measure to be casted
+fn make_fixed_approxDP_to_approxDP(measurement: &AnyMeasurement) -> Fallible<AnyMeasurement> {
+    let privacy_map = measurement.privacy_map.clone();
+
+    let measurement = measurement.with_map(
+        measurement.input_metric.clone(),
+        measurement
+            .output_measure
+            .clone()
+            .downcast::<Approximate<MaxDivergence>>()?,
+        PrivacyMap::new_fallible(move |d_in: &AnyObject| {
+            privacy_map.eval(d_in)?.downcast::<(f64, f64)>()
+        }),
+    )?;
+
+    let m = super::make_fixed_approxDP_to_approxDP(measurement)?;
+
+    let privacy_map = m.privacy_map.clone();
+    m.with_map(
+        m.input_metric.clone(),
+        AnyMeasure::new(m.output_measure.clone()),
+        PrivacyMap::new_fallible(move |d_in: &AnyObject| {
+            privacy_map.eval(d_in).map(AnyObject::new)
+        }),
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn opendp_combinators__make_fixed_approxDP_to_approxDP(
+    measurement: *const AnyMeasurement,
+) -> FfiResult<*mut AnyMeasurement> {
+    make_fixed_approxDP_to_approxDP(try_as_ref!(measurement)).into()
+}

--- a/rust/src/combinators/measure_cast/fixed_approxDP_to_approxDP/mod.rs
+++ b/rust/src/combinators/measure_cast/fixed_approxDP_to_approxDP/mod.rs
@@ -1,0 +1,54 @@
+use crate::{
+    core::{Domain, Measurement, Metric, MetricSpace, PrivacyMap},
+    error::Fallible,
+    measures::{Approximate, MaxDivergence, PrivacyProfile, SmoothedMaxDivergence},
+};
+
+#[cfg(feature = "ffi")]
+mod ffi;
+
+#[cfg(test)]
+mod test;
+
+/// Constructs a new output measurement where the output measure
+/// is casted from `Approximate<MaxDivergence>` to `SmoothedMaxDivergence`
+///
+/// # Arguments
+/// * `measurement` - a measurement with a privacy measure to be casted
+///
+/// # Generics
+/// * `DI` - Input Domain
+/// * `DO` - Output Domain
+/// * `MI` - Input Metric
+pub fn make_fixed_approxDP_to_approxDP<DI, TO, MI>(
+    measurement: Measurement<DI, TO, MI, Approximate<MaxDivergence>>,
+) -> Fallible<Measurement<DI, TO, MI, SmoothedMaxDivergence>>
+where
+    DI: Domain,
+    MI: 'static + Metric,
+    (DI, MI): MetricSpace,
+{
+    let privacy_map = measurement.privacy_map.clone();
+    measurement.with_map(
+        measurement.input_metric.clone(),
+        SmoothedMaxDivergence::default(),
+        PrivacyMap::new_fallible(move |d_in: &MI::Distance| {
+            privacy_map
+                .eval(d_in)
+                .map(|(eps, delta)| PrivacyProfile::new(fixed_approx_dp_privacy_curve(eps, delta)))
+        }),
+    )
+}
+
+fn fixed_approx_dp_privacy_curve(
+    fixed_epsilon: f64,
+    fixed_delta: f64,
+) -> impl Fn(f64) -> Fallible<f64> {
+    move |epsilon: f64| {
+        Ok(if epsilon >= fixed_epsilon {
+            fixed_delta
+        } else {
+            1.0
+        })
+    }
+}

--- a/rust/src/combinators/measure_cast/fixed_approxDP_to_approxDP/test.rs
+++ b/rust/src/combinators/measure_cast/fixed_approxDP_to_approxDP/test.rs
@@ -1,0 +1,31 @@
+use crate::{
+    domains::{AtomDomain, MapDomain},
+    measurements::make_laplace_threshold,
+    metrics::L1Distance,
+    traits::NextFloat,
+};
+
+use super::*;
+
+#[test]
+fn test_fixed_approxDP_to_approxDP() -> Fallible<()> {
+    let meas_fixed = make_laplace_threshold(
+        MapDomain::<AtomDomain<String>, _>::default(),
+        L1Distance::<f64>::default(),
+        1.,
+        10.,
+        None,
+    )?;
+    let meas_smooth = make_fixed_approxDP_to_approxDP(meas_fixed.clone())?;
+
+    let (eps, del) = meas_fixed.map(&1.)?;
+
+    let profile = meas_smooth.map(&1.)?;
+
+    assert_eq!(profile.delta(0.)?, 1.0);
+    assert_eq!(profile.delta(eps.next_down_())?, 1.0);
+    assert_eq!(profile.delta(eps)?, del);
+    assert_eq!(profile.delta(eps.next_up_())?, del);
+
+    Ok(())
+}

--- a/rust/src/combinators/measure_cast/mod.rs
+++ b/rust/src/combinators/measure_cast/mod.rs
@@ -1,4 +1,8 @@
 #[allow(non_snake_case)]
+mod fixed_approxDP_to_approxDP;
+pub use fixed_approxDP_to_approxDP::*;
+
+#[allow(non_snake_case)]
 mod zCDP_to_approxDP;
 pub use zCDP_to_approxDP::*;
 


### PR DESCRIPTION
Closes #2021 
Translate mechanisms with an (ε, δ) guarantee into a trivial δ(ε) guarantee (with a piecewise constant profile). This will make it possible to view relative risk and α(β) curves on any pure-DP or fixed approx-DP mechanism.