### PR TITLE
Polars: enable cutqcut

### DIFF
--- a/python/test/test_polars.py
+++ b/python/test/test_polars.py
@@ -1,6 +1,7 @@
 import pytest
 import opendp.prelude as dp
 import os
+import warnings
 
 
 
@@ -638,3 +639,33 @@ def test_pickle_bomb():
             dp.max_divergence(T=float),
             bomb_lf,
         )
+
+
+def test_cut():
+    pl = pytest.importorskip("polars")
+    pl_testing = pytest.importorskip("polars.testing")
+
+    data = pl.LazyFrame({"x": [0.4, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5]})
+    with warnings.catch_warnings():
+        context = dp.Context.compositor(
+            data=data.with_columns(pl.col("x").cut([1.0, 2.0, 3.0]).to_physical()),
+            privacy_unit=dp.unit_of(contributions=1),
+            privacy_loss=dp.loss_of(epsilon=10000.0),
+            split_evenly_over=1,
+            margins={("x",): dp.polars.Margin(public_info="keys")},
+        )
+    actual = (
+        context.query()
+        .group_by("x")
+        .agg(pl.len().dp.noise())
+        .release()
+        .collect()
+        .sort("x")
+    )
+    expected = pl.DataFrame(
+        {"x": [0, 1, 2, 3], "len": [2, 2, 2, 1]}, 
+        schema={"x": pl.UInt32, "len": pl.UInt32},
+    )
+
+    pl_testing.assert_frame_equal(actual, expected)
+    

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -58,6 +58,7 @@ polars = { version = "=0.41.3", features = [
     "polars-ops",
     "abs",
     "meta",
+    "cutqcut"
 ], optional = true }
 polars-plan = { version = "=0.41.3", features = [
     "ffi_plugin",


### PR DESCRIPTION
Closes #1882

Used to make the following script for a community meeting talk possible:

```python
import numpy as np
import polars as pl
import opendp.prelude as dp

dp.enable_features("contrib")

# Use with OpenDP 0.11 (not yet released) or from https://github.com/opendp/opendp/pull/1883

def synthesize_from_data(data, p_unit, p_loss, bounds, n_bins, target_size):
    edges = [np.linspace(*c_bounds, num=n_bins + 1) for c_bounds in bounds.values()]

    # TODO: cut and to_physical aren't supported in OpenDP Polars, so manipulate the raw data
    # quantize data into bins
    exprs = [pl.col(c).cut(c_edges).to_physical() for c, c_edges in zip(bounds, edges)]

    # release DP counts of the number of records per-bin, with thresholding
    release = (
        dp.Context.compositor(
            data=data.with_columns(exprs),
            privacy_unit=p_unit,
            privacy_loss=p_loss,
            split_evenly_over=1,
        )
        .query()
        .group_by(bounds.keys())
        .agg(pl.len().dp.noise())
        .release()
        .collect()
    )

    # re-form into a 2-d histogram array
    hist = np.zeros((n_bins,) * len(bounds), dtype=int)
    inds = release[[*bounds.keys()]].to_numpy()

    # mask away first/last bins beyond the bounds
    mask = np.all((0 < inds) & (inds <= n_bins), axis=1)
    hist[tuple(inds[mask].T - 1)] = release["len"].to_numpy()[mask]

    synth_array = postprocess_histogram(hist, edges, target_size)
    return pl.DataFrame(dict(zip(bounds, synth_array.T)))


def postprocess_histogram(hist, edges, target_size):
    """Use an n-dimensional histogram to generate a synthetic dataset with `size` records."""
    # sample from the center of each bin
    midpoints = [edge_set[:-1] + np.diff(edge_set) / 2 for edge_set in edges]

    # the cdf is wrt the flattened bins
    cdf = hist.ravel().cumsum().astype(float)
    cdf /= cdf[-1]

    # use inverse transform sampling to sample a set of unraveled bin indexes
    values = np.random.uniform(size=target_size)
    value_bins = np.searchsorted(cdf, values)

    # translate the unraveled bin indexes to nd indexes
    indexes = np.unravel_index(value_bins, tuple(map(len, midpoints)))

    # retrieve the midpoint values from the respective bins
    return np.stack([mids[idxs] for mids, idxs in zip(midpoints, indexes)], axis=1)


def generate_data(bounds, size, true_beta=1.0):
    x = np.random.uniform(*bounds["x"], size)
    y = np.random.normal(true_beta * x, scale=0.02)
    return pl.LazyFrame({"x": x, "y": y})


bounds = {"x": [-0.5, 0.5], "y": [-1, 1]}

print(synthesize_from_data(
    generate_data(bounds, size=10_000, true_beta=-2.0),
    dp.unit_of(contributions=1),
    dp.loss_of(epsilon=1.0, delta=1e-7),
    bounds=bounds,
    n_bins=20,
    target_size=1_000,
))
```