### PR TITLE
report dir name if binary not found

### DIFF
--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -28,7 +28,7 @@ def _load_library():
     if lib_dir.exists():
         lib_dir_file_names = [p for p in lib_dir.iterdir() if p.suffix in {".so", ".dylib", ".dll", ".pyd"}]
         if len(lib_dir_file_names) != 1:
-            raise Exception(f"Expected exactly one binary to be present. Got: {lib_dir_file_names}")
+            raise Exception(f"Expected exactly one binary to be present in {lib_dir}. Got: {lib_dir_file_names}")
         
         lib_path = lib_dir / lib_dir_file_names[0]
         try:


### PR DESCRIPTION
Proposal. Would help debug cases like 
- #1758 
- #1885
 
Hopefully we don't hit this error again, but if we did, we could ask the user to list what was in that directory. It's also possible that someday there will be a problem in the logic to determine the lib_dir, and this would help us debug that.