### PR TITLE
upgrade python dev dependencies

### DIFF
--- a/python/requirements-dev.in
+++ b/python/requirements-dev.in
@@ -5,11 +5,11 @@
 #
 # and then commit this file and requirements-dev.txt.
 
-flake8 ~= 7.0
-pytest ~= 7.4
-wheel ~= 0.41
-coverage ~= 7.3
-mypy ~= 1.7
+flake8
+pytest
+wheel
+coverage
+mypy
 pip-tools==7.3.0
 
 # Just needed for examples in documentation:

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -4,25 +4,25 @@
 #
 #    pip-compile requirements-dev.in
 #
-build==1.0.3
+build==1.2.1
     # via pip-tools
 click==8.1.7
     # via pip-tools
-coverage==7.3.2
+coverage==7.6.1
     # via -r requirements-dev.in
-flake8==7.0.0
+flake8==7.1.1
     # via -r requirements-dev.in
 iniconfig==2.0.0
     # via pytest
 mccabe==0.7.0
     # via flake8
-mypy==1.7.1
+mypy==1.11.1
     # via -r requirements-dev.in
 mypy-extensions==1.0.0
     # via mypy
-numpy==1.26.4
+numpy==2.0.1
     # via pandas
-packaging==23.2
+packaging==24.1
     # via
     #   build
     #   pytest
@@ -30,15 +30,15 @@ pandas==2.2.2
     # via -r requirements-dev.in
 pip-tools==7.3.0
     # via -r requirements-dev.in
-pluggy==1.3.0
+pluggy==1.5.0
     # via pytest
-pycodestyle==2.11.1
+pycodestyle==2.12.1
     # via flake8
 pyflakes==3.2.0
     # via flake8
-pyproject-hooks==1.0.0
+pyproject-hooks==1.1.0
     # via build
-pytest==7.4.3
+pytest==8.3.2
     # via -r requirements-dev.in
 python-dateutil==2.9.0.post0
     # via pandas
@@ -46,11 +46,11 @@ pytz==2024.1
     # via pandas
 six==1.16.0
     # via python-dateutil
-typing-extensions==4.8.0
+typing-extensions==4.12.2
     # via mypy
 tzdata==2024.1
     # via pandas
-wheel==0.42.0
+wheel==0.44.0
     # via
     #   -r requirements-dev.in
     #   pip-tools


### PR DESCRIPTION
Not urgent: Just keeping things up-to-date. I can't remember if we had a compelling reason to soft pin these, so just taking that off.