### PR TITLE
ci: fix r-docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: stable
 
       - name: Set up R
         uses: r-lib/actions/setup-r@v2


### PR DESCRIPTION
Closes #1893

Since no ref is stated in the checkout when building R docs, it defaults to main. However, the ideal behavior is for the docs site to show stable. 

Separately, the r-docs build began to fail because it was pointed at main, where we don't check in generated code.