### PR TITLE
Add link to the new Learning Resources list, and to Hands-On Differential Privacy

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,8 +13,10 @@ Differential privacy achieves this by carefully injecting random noise into the 
 For more background on differential privacy and its applications:
 
 * "`Designing Access with Differential Privacy <https://admindatahandbook.mit.edu/book/v1.0/diffpriv.html>`_" from *Handbook on Using Administrative Data for Research and Evidence-based Policy*
-* `Resources list <https://differentialprivacy.org/resources/>`_ from *differentialprivacy.org*
+* The `Resources list <https://differentialprivacy.org/resources/>`_ from *differentialprivacy.org*
+* A shorter list of `Educational Resources <https://opendp.github.io/learning/>`_
 * OpenDP's own :doc:`theory/resources`
+* `Hand-On Differential Privacy <https://www.oreilly.com/library/view/hands-on-differential-privacy/9781492097730/>_`
 
 Why OpenDP?
 -----------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,7 +16,7 @@ For more background on differential privacy and its applications:
 * The `Resources list <https://differentialprivacy.org/resources/>`_ from *differentialprivacy.org*
 * A shorter list of `Educational Resources <https://opendp.github.io/learning/>`_
 * OpenDP's own :doc:`theory/resources`
-* `Hand-On Differential Privacy <https://www.oreilly.com/library/view/hands-on-differential-privacy/9781492097730/>`_ is co-authored the lead OpenDP developer
+* `Hand-On Differential Privacy <https://www.oreilly.com/library/view/hands-on-differential-privacy/9781492097730/>`_ is co-authored by the OpenDP Library architect
 
 Why OpenDP?
 -----------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,7 +16,7 @@ For more background on differential privacy and its applications:
 * The `Resources list <https://differentialprivacy.org/resources/>`_ from *differentialprivacy.org*
 * A shorter list of `Educational Resources <https://opendp.github.io/learning/>`_
 * OpenDP's own :doc:`theory/resources`
-* `Hand-On Differential Privacy <https://www.oreilly.com/library/view/hands-on-differential-privacy/9781492097730/>_`
+* `Hand-On Differential Privacy <https://www.oreilly.com/library/view/hands-on-differential-privacy/9781492097730/>`_ is co-authored the lead OpenDP developer
 
 Why OpenDP?
 -----------

--- a/docs/source/theory/resources.rst
+++ b/docs/source/theory/resources.rst
@@ -14,7 +14,7 @@ Learning About Differential Privacy
 * `Designing Access with Differential Privacy <https://admindatahandbook.mit.edu/book/latest/diffpriv.html>`_
 * `Programming Differential Privacy <https://programming-dp.com/>`_
 * `Privacy and Confidentiality Protection Overview <https://www2.census.gov/cac/nac/meetings/2019-05/garfinkel-privacy-confidentiality-protection.pdf>`_
-* `Hand-On Differential Privacy <https://www.oreilly.com/library/view/hands-on-differential-privacy/9781492097730/>_`
+* `Hand-On Differential Privacy <https://www.oreilly.com/library/view/hands-on-differential-privacy/9781492097730/>`_ is co-authored the lead OpenDP developer
 * A short list of `Educational Resources <https://opendp.github.io/learning/>`_ maintained by the community
 
 Papers

--- a/docs/source/theory/resources.rst
+++ b/docs/source/theory/resources.rst
@@ -14,6 +14,8 @@ Learning About Differential Privacy
 * `Designing Access with Differential Privacy <https://admindatahandbook.mit.edu/book/latest/diffpriv.html>`_
 * `Programming Differential Privacy <https://programming-dp.com/>`_
 * `Privacy and Confidentiality Protection Overview <https://www2.census.gov/cac/nac/meetings/2019-05/garfinkel-privacy-confidentiality-protection.pdf>`_
+* `Hand-On Differential Privacy <https://www.oreilly.com/library/view/hands-on-differential-privacy/9781492097730/>_`
+* A short list of `Educational Resources <https://opendp.github.io/learning/>`_ maintained by the community
 
 Papers
 ------

--- a/docs/source/theory/resources.rst
+++ b/docs/source/theory/resources.rst
@@ -14,7 +14,7 @@ Learning About Differential Privacy
 * `Designing Access with Differential Privacy <https://admindatahandbook.mit.edu/book/latest/diffpriv.html>`_
 * `Programming Differential Privacy <https://programming-dp.com/>`_
 * `Privacy and Confidentiality Protection Overview <https://www2.census.gov/cac/nac/meetings/2019-05/garfinkel-privacy-confidentiality-protection.pdf>`_
-* `Hand-On Differential Privacy <https://www.oreilly.com/library/view/hands-on-differential-privacy/9781492097730/>`_ is co-authored the lead OpenDP developer
+* `Hand-On Differential Privacy <https://www.oreilly.com/library/view/hands-on-differential-privacy/9781492097730/>`_ is co-authored by the OpenDP Library architect
 * A short list of `Educational Resources <https://opendp.github.io/learning/>`_ maintained by the community
 
 Papers


### PR DESCRIPTION
- Fix #1892

Alternatively, we could have a more thorough rewrite, perhaps only including the link to the resources page on the home page? 