### PR TITLE
Copy existing code-of-conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,15 @@
+<!-- Keep in sync with https://opendp.org/code-conduct -->
+
+[Adapted from the short version of the [NumFocus Code of Conduct](https://numfocus.org/code-of-conduct).]
+
+> Be kind and behave professionally. Be inclusive of people from different backgrounds and of different ways of thinking.
+>
+> Sexual, racial or exclusionary language or imagery is offensive to others and destructive to the entire community.
+>
+> We are dedicated to building a  diverse community that is welcoming for everyone, regardless of disability, gender identity and expression, physical appearance, race, religion, or sexual orientation.  We do not tolerate harassment of or discrimination against community members in any form.
+
+Thank you for helping make OpenDP a positive, friendly community for all.
+
+You can report violations of the Code of Conduct, or any concerns about the environment of OpenDP, to anyone on the [Executive Committee](info@opendp.org).
+
+To learn more about Harvard University’s Sexual and Gender-Based Harassment Policy and related resources, including other reporting mechanisms, you can visit the University Title IX Office website [www.titleix.harvard.edu](http://www.titleix.harvard.edu/). 


### PR DESCRIPTION
- Fix #542  (sorry for typo in branch name)
- Replaces #1641: That should be closed.

We already have a code of conduct: Copy it over. If we actually want different text in the two locations (perhaps a summary on the site here and the full text here) that's not impossible, but there should be a link from the the summary to the full text to avoid confusion.