### PR TITLE
Add test for data loader error

### DIFF
--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -530,6 +530,10 @@ def _slice_to_hashmap(raw: FfiSlicePtr) -> dict[Any, Any]:
 
 
 def _lazyframe_to_slice(val) -> FfiSlicePtr:
+    pl = import_optional_dependency('polars')
+    if not isinstance(val, pl.LazyFrame):
+        raise ValueError("expected Polars LazyFrame")
+    
     state = val.__getstate__()
     raw = _wrap_in_slice(state, len(state))
     raw.depends_on(state)
@@ -545,6 +549,10 @@ def _slice_to_lazyframe(raw: FfiSlicePtr):
 
 
 def _expr_to_slice(val) -> FfiSlicePtr:
+    pl = import_optional_dependency('polars')
+    if not isinstance(val, pl.Expr):
+        raise ValueError("expected Polars Expr")
+    
     state = val.__getstate__()
     raw = _wrap_in_slice(state, len(state))
     raw.depends_on(state)
@@ -559,6 +567,10 @@ def _slice_to_expr(raw: FfiSlicePtr):
     return expr
 
 def _dataframe_to_slice(val) -> FfiSlicePtr:
+    pl = import_optional_dependency('polars')
+    if not isinstance(val, pl.DataFrame):
+        raise ValueError("expected Polars DataFrame")
+    
     slices = list(_series_to_slice(s) for s in val.get_columns())
     raw = _wrap_in_slice(ctypes.pointer((FfiSlicePtr * val.width)(*slices)), val.width)
     # extend the lifetime of each series' slice to that of the frame slice
@@ -574,6 +586,10 @@ def _slice_to_dataframe(raw: FfiSlicePtr):
 
 def _series_to_slice(val) -> FfiSlicePtr:
     from opendp._data import new_arrow_array, arrow_array_free
+
+    pl = import_optional_dependency('polars')
+    if not isinstance(val, pl.Series):
+        raise ValueError("expected Polars Series")
 
     raw = new_arrow_array(val.name)
     slice_array = ctypes.cast(raw.contents.ptr, ctypes.POINTER(ctypes.c_void_p))

--- a/python/test/test_usability.py
+++ b/python/test/test_usability.py
@@ -2,7 +2,6 @@ import ctypes
 
 import pytest
 import opendp.prelude as dp
-import polars as pl
 
 
 @pytest.mark.xfail(raises=dp.UnknownTypeException)
@@ -123,6 +122,7 @@ def test_queryable_errors_human_readable():
     #   ctypes.ArgumentError: argument 1: TypeError: wrong type
     # Possible resolution:
     #   Describes what type it was expecting.
+    pl = pytest.importorskip('polars')
     input_domain = dp.lazyframe_domain([
         dp.series_domain("A", dp.option_domain(dp.atom_domain(T=dp.i32))),
         dp.series_domain("B", dp.atom_domain(T=dp.i32))

--- a/python/test/test_usability.py
+++ b/python/test/test_usability.py
@@ -1,5 +1,3 @@
-import ctypes
-
 import pytest
 import opendp.prelude as dp
 
@@ -116,35 +114,16 @@ def test_string_instead_of_tuple_for_margin_key():
     counts.summarize()
     # counts.release().collect()
 
-@pytest.mark.xfail(raises=ctypes.ArgumentError)
-def test_queryable_errors_human_readable():
-    # Currently fails with:
-    #   ctypes.ArgumentError: argument 1: TypeError: wrong type
-    # Possible resolution:
-    #   Describes what type it was expecting.
-    pl = pytest.importorskip('polars')
-    input_domain = dp.lazyframe_domain([
-        dp.series_domain("A", dp.option_domain(dp.atom_domain(T=dp.i32))),
-        dp.series_domain("B", dp.atom_domain(T=dp.i32))
-    ])
-    input_metric = dp.symmetric_distance()
-    output_measure = dp.max_divergence(T=float)
-    d_in = 1
-    eps1 = 1.0
-    eps21 = eps22 = 0.5
-    eps2 = eps21 + eps22
 
-    data = pl.LazyFrame({
-        "A": pl.Series([100, 1, 300], dtype=pl.Int32),
-        "B": pl.Series([4, 4, 6], dtype=pl.Int32)
-    })
-
-    overall_pipeline = dp.c.make_sequential_composition(
-        input_domain, input_metric, output_measure, d_in,
-        d_mids=[eps1, eps2])
-    overall_pipline_comp = overall_pipeline(data)
-
-    specific_pipeline = dp.c.make_sequential_composition(
-        input_domain, input_metric, output_measure, d_in,
-        d_mids = [eps21, eps22])            
-    specific_pipeline(overall_pipline_comp)
+def test_data_loader_error_is_human_readable():
+    pytest.importorskip("polars")
+    for domain in [
+        dp.lazyframe_domain([]),
+        dp.series_domain("A", dp.atom_domain(T=bool)),
+        dp.expr_domain(dp.lazyframe_domain([])),
+    ]:
+        overall_pipeline = dp.c.make_sequential_composition(
+            domain, dp.symmetric_distance(), dp.max_divergence(), d_in=1,
+            d_mids=[1.])
+        with pytest.raises(ValueError, match="expected Polars *"):
+            overall_pipeline("I'm not the right type!")


### PR DESCRIPTION
- Towards #1736

I'd be curious to understand what the expected behavior is.

Right now, the error comes from a `ctypes.cast`, where instead of getting a pointer, it gets a dict. Extracting the pointer from that dict...
```diff
 def _wrap_in_slice(ptr, len_: int) -> FfiSlicePtr:
+    if isinstance(ptr, dict):
+        ptr = ptr['value']
     return FfiSlicePtr(FfiSlice(ctypes.cast(ptr, ctypes.c_void_p), len_))
```
Gives us a different error:
```
E       opendp.mod.OpenDPException:
E         FFI("Error when deserializing LazyFrame. This may be because you're using features from Polars that are not currently supported. Semantic(None, "invalid type: integer `12`, expected enum")")
```
but all the other tests are still passing.