### PR TITLE
deprecation machinery

### DIFF
--- a/rust/opendp_tooling/src/bootstrap/mod.rs
+++ b/rust/opendp_tooling/src/bootstrap/mod.rs
@@ -78,6 +78,7 @@ pub fn reconcile_function(
         dependencies: bootstrap.dependencies.0,
         supports_partial: signature.supports_partial,
         has_ffi: bootstrap.has_ffi.unwrap_or(true),
+        deprecated: doc_comments.deprecated,
     })
 }
 

--- a/rust/opendp_tooling/src/codegen/python.rs
+++ b/rust/opendp_tooling/src/codegen/python.rs
@@ -228,9 +228,15 @@ def {then_name}(
         String::new()
     };
 
+    let deprecated = func
+        .deprecated
+        .as_ref()
+        .map(|msg| format!("@deprecated(\"{msg}\")\n"))
+        .unwrap_or_default();
+
     format!(
         r#"
-def {func_name}(
+{deprecated}def {func_name}(
 {args}
 ){sig_return}:
 {docstring}

--- a/rust/opendp_tooling/src/lib.rs
+++ b/rust/opendp_tooling/src/lib.rs
@@ -27,6 +27,8 @@ pub struct Function {
     pub supports_partial: bool,
     // whether to generate FFI
     pub has_ffi: bool,
+    // deprecation warning if applicable
+    pub deprecated: Option<String>,
 }
 
 // Metadata for function arguments, derived types and returns.

--- a/rust/src/transformations/dataframe/select/mod.rs
+++ b/rust/src/transformations/dataframe/select/mod.rs
@@ -14,6 +14,7 @@ use super::{DataFrame, DataFrameDomain};
 mod ffi;
 
 #[bootstrap(features("contrib"))]
+#[deprecated(note = "please use polars functionality instead")]
 /// Make a Transformation that retrieves the column `key` from a dataframe as `Vec<TOA>`.
 ///
 /// # Arguments


### PR DESCRIPTION
Closes #1928

Might consider renaming docstring.rs to attributes.rs.

I am no longer tracking/maintaining this PR. In Rust parlance, ownership goes to @mccalluc: feel free to mutate or drop/replace the PR, as you see fit.