### PR TITLE
Fix `assert_feature` check

### DIFF
--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -735,8 +735,10 @@ def disable_features(*features: str) -> None:
 
 
 def assert_features(*features: str) -> None:
-    for feature in features:
-        assert feature in GLOBAL_FEATURES, f"Attempted to use function that requires {feature}, but {feature} is not enabled. See https://github.com/opendp/opendp/discussions/304, then call enable_features(\"{feature}\")"
+    missing_features = [f for f in features if f not in GLOBAL_FEATURES]
+    if missing_features:
+        features_string = ', '.join(f'"{f}"' for f in features)
+        raise OpenDPException(f"Attempted to use function that requires {features_string}, but not enabled. See https://github.com/opendp/opendp/discussions/304, then call enable_features({features_string})")
 
 
 M = TypeVar("M", Transformation, Measurement)

--- a/python/test/test_typing.py
+++ b/python/test/test_typing.py
@@ -86,7 +86,7 @@ def test_c():
 
 
 def test_feature_fails():
-    with pytest.raises(AssertionError):
+    with pytest.raises(OpenDPException):
         assert_features("A")
 
 

--- a/python/test/test_typing.py
+++ b/python/test/test_typing.py
@@ -86,8 +86,8 @@ def test_c():
 
 
 def test_feature_fails():
-    with pytest.raises(OpenDPException):
-        assert_features("A")
+    with pytest.raises(OpenDPException, match=re.escape('enable_features("A", "Z")')):
+        assert_features("A", "Z")
 
 
 def test_set_feature():


### PR DESCRIPTION
- Fix #1930

Optimized python now fails where it should:
```
$ python -O
Python 3.11.7 (main, Dec  4 2023, 18:10:11) [Clang 15.0.0 (clang-1500.1.0.2.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import opendp.prelude as dp
>>> space = (dp.atom_domain(T=float), dp.absolute_distance(T=float))
>>> laplace_mechanism = space >> dp.m.then_laplace(scale=1.)
Traceback (most recent call last):
...
opendp.mod.OpenDPException:
  Attempted to use function that requires "contrib", but not enabled. See https://github.com/opendp/opendp/discussions/304, then call enable_features("contrib")
```