### PR TITLE
add JS redirect for getting-started

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -26,6 +26,7 @@
                     // Check longer, more precise patterns first:
 
                     '/user/utilities/accuracy/accuracy-pitfalls.html': '/theory/accuracy-pitfalls.html',
+                    '/user/getting-started.html': '/getting-started/index.html',
                     '/user/': '/api/user-guide/',
 
                     '/contact.html': '/contributing/contact.html',


### PR DESCRIPTION
- Complete the fix for #1062, belatedly.

This file is copied into place by the multiversion docs build. Locally, the best way to exercise this is by putting the string to match in the fragment of the url:
```
file:///...../opendp/docs/404.html#/user/getting-started.html
```
The JS redirect will replace the string... although here it's just in the fragment, so the page doesn't actually change, but you can at least confirm there aren't typos.