### PR TITLE
Polars: auto-calibrate noise scale in bounded-DP

### DIFF
--- a/rust/src/measurements/make_private_expr/expr_noise/mod.rs
+++ b/rust/src/measurements/make_private_expr/expr_noise/mod.rs
@@ -1,4 +1,5 @@
 use crate::core::{Measure, Metric, MetricSpace, PrivacyMap};
+use crate::domains::MarginPub;
 use crate::measurements::{gaussian_zcdp_map, get_discretization_consts, laplace_puredp_map};
 use crate::measures::ZeroConcentratedDivergence;
 use crate::metrics::{L1Distance, L2Distance, PartitionDistance};
@@ -182,7 +183,11 @@ where
         None => {
             // when scale is unknown, set it relative to the sensitivity of the query
             let margin = input_domain.active_margin().cloned().unwrap_or_default();
-            t_prior.map(&(margin.l_0(1), 1, margin.l_inf(1)))?
+            let d_in = match margin.public_info {
+                Some(MarginPub::Lengths) => 2,
+                _ => 1,
+            };
+            t_prior.map(&(margin.l_0(d_in), d_in, margin.l_inf(d_in)))?
         }
     };
     let global_scale = global_scale.unwrap_or(1.);

--- a/rust/src/measurements/make_private_expr/expr_report_noisy_max/mod.rs
+++ b/rust/src/measurements/make_private_expr/expr_report_noisy_max/mod.rs
@@ -1,5 +1,4 @@
 use crate::core::{MetricSpace, PrivacyMap};
-use crate::domains::MarginPub;
 use crate::measurements::{report_noisy_max_gumbel_map, select_score, Optimize};
 use crate::metrics::{IntDistance, LInfDistance, Parallel, PartitionDistance};
 use crate::polars::{apply_plugin, literal_value_of, match_plugin, ExprFunction, OpenDPPlugin};
@@ -30,6 +29,8 @@ use polars_plan::prelude::{ApplyOptions, FunctionOptions};
 use pyo3_polars::derive::polars_expr;
 use serde::de::IntoDeserializer;
 use serde::{Deserialize, Serialize};
+
+use super::approximate_c_stability;
 
 #[cfg(test)]
 mod test;
@@ -70,13 +71,7 @@ where
     let scale = match scale {
         Some(scale) => scale,
         None => {
-            // when scale is unknown, set it relative to the sensitivity of the query
-            let margin = input_domain.active_margin().cloned().unwrap_or_default();
-            let d_in = match margin.public_info {
-                Some(MarginPub::Lengths) => 2,
-                _ => 1,
-            };
-            let (l_0, l_inf) = t_prior.map(&(margin.l_0(d_in), d_in, margin.l_inf(d_in)))?;
+            let (l_0, l_inf) = approximate_c_stability(&t_prior)?;
             f64::inf_cast(l_0)?.inf_mul(&l_inf)?
         }
     };

--- a/rust/src/measurements/make_private_expr/expr_report_noisy_max/mod.rs
+++ b/rust/src/measurements/make_private_expr/expr_report_noisy_max/mod.rs
@@ -1,4 +1,5 @@
 use crate::core::{MetricSpace, PrivacyMap};
+use crate::domains::MarginPub;
 use crate::measurements::{report_noisy_max_gumbel_map, select_score, Optimize};
 use crate::metrics::{IntDistance, LInfDistance, Parallel, PartitionDistance};
 use crate::polars::{apply_plugin, literal_value_of, match_plugin, ExprFunction, OpenDPPlugin};
@@ -71,7 +72,11 @@ where
         None => {
             // when scale is unknown, set it relative to the sensitivity of the query
             let margin = input_domain.active_margin().cloned().unwrap_or_default();
-            let (l_0, l_inf) = t_prior.map(&(margin.l_0(1), 1, margin.l_inf(1)))?;
+            let d_in = match margin.public_info {
+                Some(MarginPub::Lengths) => 2,
+                _ => 1,
+            };
+            let (l_0, l_inf) = t_prior.map(&(margin.l_0(d_in), d_in, margin.l_inf(d_in)))?;
             f64::inf_cast(l_0)?.inf_mul(&l_inf)?
         }
     };

--- a/rust/src/measurements/make_private_expr/test.rs
+++ b/rust/src/measurements/make_private_expr/test.rs
@@ -1,0 +1,48 @@
+use polars::prelude::{col, lit};
+
+use crate::{
+    domains::{AtomDomain, LazyFrameDomain, Margin, SeriesDomain},
+    metrics::{InsertDeleteDistance, L2Distance},
+    transformations::StableExpr,
+};
+
+use super::*;
+
+#[test]
+fn test_approximate_c_stability_unbounded() -> Fallible<()> {
+    let lf_domain =
+        LazyFrameDomain::new(vec![SeriesDomain::new("A", AtomDomain::<i32>::default())])?
+            .with_margin::<&str>(&[], Margin::new().with_max_partition_length(100))?;
+    let expr_domain = lf_domain.select();
+
+    // Get resulting sum (expression result)
+    let t_sum: Transformation<_, _, _, L2Distance<f64>> = col("A")
+        .clip(lit(0), lit(2))
+        .sum()
+        .make_stable(expr_domain, PartitionDistance(InsertDeleteDistance))?;
+
+    assert_eq!(approximate_c_stability(&t_sum)?, 2.0);
+    Ok(())
+}
+
+#[test]
+fn test_approximate_c_stability_bounded() -> Fallible<()> {
+    let lf_domain =
+        LazyFrameDomain::new(vec![SeriesDomain::new("A", AtomDomain::<i32>::default())])?
+            .with_margin::<&str>(
+                &[],
+                Margin::new()
+                    .with_max_partition_length(100)
+                    .with_public_lengths(),
+            )?;
+    let expr_domain = lf_domain.select();
+
+    // Get resulting sum (expression result)
+    let t_sum: Transformation<_, _, _, L2Distance<f64>> = col("A")
+        .clip(lit(4), lit(7))
+        .sum()
+        .make_stable(expr_domain, PartitionDistance(InsertDeleteDistance))?;
+
+    assert_eq!(approximate_c_stability(&t_sum)?, 3.0);
+    Ok(())
+}


### PR DESCRIPTION
Closes #1941
This makes it possible to run the Docs notebook at the tip of the stack.