### PR TITLE
Add an `xfail` test of mistakenly using a string for a margin key.

### DIFF
--- a/python/test/test_context_usability.py
+++ b/python/test/test_context_usability.py
@@ -85,10 +85,7 @@ def test_query_dir():
     assert 'count' in query_dir
     assert 'laplace' in query_dir
 
-@pytest.mark.xfail(
-    raises=dp.OpenDPException,
-    match=re.escape('The key-set of {"a_column"} private and cannot be released without filtering')
-)
+@pytest.mark.xfail(raises=dp.OpenDPException)
 def test_string_instead_of_tuple_for_margin_key():
     pl = pytest.importorskip("polars")
 
@@ -105,7 +102,8 @@ def test_string_instead_of_tuple_for_margin_key():
         margins={
             # To reproduce failure, the column name must be multiple characters.
             # TODO: We want to fail earlier because the key is not a tuple.
-            ("a_column"): dp.polars.Margin(public_info="keys", max_partition_length=5),
+            # (mypy does catch this, so we need "type: ignore", but we can't rely on users running mypy.)
+            ("a_column"): dp.polars.Margin(public_info="keys", max_partition_length=5), # type: ignore
         },
     )
 

--- a/python/test/test_context_usability.py
+++ b/python/test/test_context_usability.py
@@ -1,6 +1,5 @@
 import pytest
 import opendp.prelude as dp
-import re
 
 
 @pytest.mark.xfail(raises=dp.UnknownTypeException)

--- a/python/test/test_context_usability.py
+++ b/python/test/test_context_usability.py
@@ -1,5 +1,6 @@
 import pytest
 import opendp.prelude as dp
+import re
 
 
 @pytest.mark.xfail(raises=dp.UnknownTypeException)
@@ -83,3 +84,35 @@ def test_query_dir():
     query_dir = dir(context.query())
     assert 'count' in query_dir
     assert 'laplace' in query_dir
+
+@pytest.mark.xfail(
+    raises=dp.OpenDPException,
+    match=re.escape('The key-set of {"a_column"} private and cannot be released without filtering')
+)
+def test_string_instead_of_tuple_for_margin_key():
+    pl = pytest.importorskip("polars")
+
+    lf = pl.LazyFrame(
+        {"a_column": [1, 2, 3, 4]},
+        schema={"a_column": pl.Int32},
+    )
+
+    context = dp.Context.compositor(
+        data=lf,
+        privacy_unit=dp.unit_of(contributions=1),
+        privacy_loss=dp.loss_of(epsilon=1.0),
+        split_evenly_over=1,
+        margins={
+            # To reproduce failure, the column name must be multiple characters.
+            # TODO: We want to fail earlier because the key is not a tuple.
+            ("a_column"): dp.polars.Margin(public_info="keys", max_partition_length=5),
+        },
+    )
+
+    counts = (
+        context.query()
+        .group_by("a_column")
+        .agg(pl.len().dp.noise())
+    )
+    counts.summarize()
+    # counts.release().collect()


### PR DESCRIPTION
- Towards #1977

(For fix, leaning towards failing early if the key is not a tuple.)