### PR TITLE
Add`xfail` for mis-encoded CSV loading

### DIFF
--- a/python/test/test_polars.py
+++ b/python/test/test_polars.py
@@ -2,6 +2,7 @@ import pytest
 import opendp.prelude as dp
 import os
 import warnings
+import re
 
 
 
@@ -670,13 +671,19 @@ def test_cut():
     pl_testing.assert_frame_equal(actual, expected)
 
 
+@pytest.mark.xfail(raises=AssertionError, match=re.escape("value mismatch for column 'name'"))
 def test_csv_bad_encoding_loading():
+    # See https://github.com/opendp/opendp/issues/1976
+    # If a CSV is misencoded, Polars loads an empty dataframe.
+    # Since we tell users not to look at their data,
+    # we may want to try harder to load the csv,
+    # or give more information on failure.
     pl = pytest.importorskip("polars")
     pl_testing = pytest.importorskip("polars.testing")
     import tempfile
 
     name = 'André'
-    name_b = name.encode('utf-8')
+    name_b = name.encode('iso-8859-1') # Polars only handles 'utf-8'.
 
     with tempfile.NamedTemporaryFile(delete=False) as fp:
         fp.write(b'name\n' + name_b)

--- a/python/test/test_polars.py
+++ b/python/test/test_polars.py
@@ -668,4 +668,19 @@ def test_cut():
     )
 
     pl_testing.assert_frame_equal(actual, expected)
-    
+
+
+def test_csv_bad_encoding_loading():
+    pl = pytest.importorskip("polars")
+    pl_testing = pytest.importorskip("polars.testing")
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(delete=False) as fp:
+        fp.write(b'name\nChuck')
+        fp.close()
+        df = pl.scan_csv(fp.name, ignore_errors=True)
+        expected = pl.LazyFrame(
+            {"name": ["Chuck"]},
+            schema={"name": pl.String},
+        )
+        pl_testing.assert_frame_equal(df, expected)

--- a/python/test/test_polars.py
+++ b/python/test/test_polars.py
@@ -675,12 +675,15 @@ def test_csv_bad_encoding_loading():
     pl_testing = pytest.importorskip("polars.testing")
     import tempfile
 
+    name = 'André'
+    name_b = name.encode('utf-8')
+
     with tempfile.NamedTemporaryFile(delete=False) as fp:
-        fp.write(b'name\nChuck')
+        fp.write(b'name\n' + name_b)
         fp.close()
         df = pl.scan_csv(fp.name, ignore_errors=True)
         expected = pl.LazyFrame(
-            {"name": ["Chuck"]},
+            {"name": [name]},
             schema={"name": pl.String},
         )
         pl_testing.assert_frame_equal(df, expected)

--- a/python/test/test_polars.py
+++ b/python/test/test_polars.py
@@ -686,6 +686,8 @@ def test_csv_bad_encoding_loading():
     name_b = name.encode('iso-8859-1') # Polars only handles 'utf-8'.
 
     with tempfile.NamedTemporaryFile(delete=False) as fp:
+        # By default, would delete file on "close()";
+        # With "delete=False", clean up when exiting "with" instead.
         fp.write(b'name\n' + name_b)
         fp.close()
         df = pl.scan_csv(fp.name, ignore_errors=True)


### PR DESCRIPTION
- Towards #1976

If we decide to implement a friendlier CSV loader, we can test it here.