### PR TITLE
Add warning on docs for older versions

### DIFF
--- a/docs/source/_templates/old-version-warning.html
+++ b/docs/source/_templates/old-version-warning.html
@@ -1,17 +1,9 @@
-{% if current_version and latest_version and current_version != latest_version %}
-<p>
-  <strong>
-    {% if current_version.is_released %}
-    You're reading an old version of this documentation.
-    If you want up-to-date information, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name}}</a>.
-    {% else %}
-    You're reading the documentation for a development version.
-    For the latest released version, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name}}</a>.
-    {% endif %}
-  </strong>
-</p>
+{% if current_version.name != latest_version_name %}
+<div class="admonition warning" style="position: relative;">
+  <!--
+   Without the style, the region for the article title overlaps, and the link is unclickable.
+  -->
+  <p class="admonition-title">This documention is for an old version.</p>
+  <p>The latest version of OpenDP is <a href="https://docs.opendp.org">{{ latest_version_name }}</a>.</p>
+</div>
 {% endif %}
-<pre>
-  current_version: {{ current_version }}
-  latest_version: {{ latest_version }}
-</pre>

--- a/docs/source/_templates/old-version-warning.html
+++ b/docs/source/_templates/old-version-warning.html
@@ -3,7 +3,13 @@
   <!--
    Without the style, the region for the article title overlaps, and the link is unclickable.
   -->
-  <p class="admonition-title">This is not the latest documentation.</p>
+  <p class="admonition-title">
+  {% if current_version.name in ['nightly', 'beta'] %}
+  This documentation is for a development version of OpenDP.
+  {% else %}
+  This documentation is for an old version of OpenDP.
+  {% endif %}
+  </p>
   <p>The current release of OpenDP is <a href="https://docs.opendp.org">{{ latest_version_name }}</a>.</p>
 </div>
 {% endif %}

--- a/docs/source/_templates/old-version-warning.html
+++ b/docs/source/_templates/old-version-warning.html
@@ -1,9 +1,9 @@
-{% if current_version.name != latest_version_name %}
+{% if current_version.name not in [latest_version_name, 'stable'] %}
 <div class="admonition warning" style="position: relative;">
   <!--
    Without the style, the region for the article title overlaps, and the link is unclickable.
   -->
-  <p class="admonition-title">This documention is for an old version.</p>
-  <p>The latest version of OpenDP is <a href="https://docs.opendp.org">{{ latest_version_name }}</a>.</p>
+  <p class="admonition-title">This is not the latest documentation.</p>
+  <p>The latest release of OpenDP is <a href="https://docs.opendp.org">{{ latest_version_name }}</a>.</p>
 </div>
 {% endif %}

--- a/docs/source/_templates/old-version-warning.html
+++ b/docs/source/_templates/old-version-warning.html
@@ -1,0 +1,17 @@
+{% if current_version and latest_version and current_version != latest_version %}
+<p>
+  <strong>
+    {% if current_version.is_released %}
+    You're reading an old version of this documentation.
+    If you want up-to-date information, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name}}</a>.
+    {% else %}
+    You're reading the documentation for a development version.
+    For the latest released version, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name}}</a>.
+    {% endif %}
+  </strong>
+</p>
+{% endif %}
+<pre>
+  current_version: {{ current_version }}
+  latest_version: {{ latest_version }}
+</pre>

--- a/docs/source/_templates/old-version-warning.html
+++ b/docs/source/_templates/old-version-warning.html
@@ -4,6 +4,6 @@
    Without the style, the region for the article title overlaps, and the link is unclickable.
   -->
   <p class="admonition-title">This is not the latest documentation.</p>
-  <p>The latest release of OpenDP is <a href="https://docs.opendp.org">{{ latest_version_name }}</a>.</p>
+  <p>The current release of OpenDP is <a href="https://docs.opendp.org">{{ latest_version_name }}</a>.</p>
 </div>
 {% endif %}

--- a/docs/source/_templates/old-version-warning.html
+++ b/docs/source/_templates/old-version-warning.html
@@ -1,4 +1,4 @@
-{% if current_version.name not in [latest_version_name, 'stable'] %}
+{% if current_version and current_version.name not in [latest_version_name, 'stable'] %}
 <div class="admonition warning" style="position: relative;">
   <!--
    Without the style, the region for the article title overlaps, and the link is unclickable.

--- a/docs/source/_templates/versioning.html
+++ b/docs/source/_templates/versioning.html
@@ -16,9 +16,13 @@
   {%- for tag in versions.tags %}
     {%- set extended_name = tag.name if "-rc" in tag.name else tag.name + "-rc.~" %}
     {%- set weight = "bold" if current_version.name == tag.name else "normal" %}
-    {%- set ns.items = ns.items + [{"extended_name": extended_name, "tag": tag, "weight": weight}] %}
+    {%- set ns.items = ns.items + [{
+            "tag": tag,
+            "weight": weight,
+            "sort_key": '{:0>3}.{:0>3}.{:0>3}'.format(*extended_name.split("."))
+    }] %}
   {%- endfor %}
-  {%- for item in ns.items|sort(attribute="extended_name", reverse=True) %}
+  {%- for item in ns.items | sort(attribute="sort_key", reverse=True) %}
     <li><a href="{{ item.tag.url }}" style="font-weight: {{ item.weight }}">{{ item.tag.name }}</a></li>
   {%- endfor %}
 </ul>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -182,7 +182,8 @@ html_last_updated_fmt = '%b %d, %Y'
 
 # Custom sidebar templates, maps document names to template names.
 html_theme_options = {
-    "github_url": "https://github.com/opendp"
+    "github_url": "https://github.com/opendp",
+    "article_header_start": ["breadcrumbs", "old-version-warning"]
 }
 
 html_theme = 'pydata_sphinx_theme'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -181,9 +181,10 @@ html_static_path = ['_static']
 html_last_updated_fmt = '%b %d, %Y'
 
 # Custom sidebar templates, maps document names to template names.
+# Full list of options at https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/layout.html#references
 html_theme_options = {
     "github_url": "https://github.com/opendp",
-    "article_header_start": ["breadcrumbs", "old-version-warning"]
+    "article_header_end": ["old-version-warning"]
 }
 
 html_theme = 'pydata_sphinx_theme'
@@ -195,6 +196,10 @@ html_css_files = [
 # Note: Overridden in the Makefile for local builds. Be sure to update both places.
 html_sidebars = {
    '**': ['sidebar-nav-bs.html', 'versioning.html'],
+}
+html_context = {
+    # Expected sphinx-multiversion to set "latest_version", but it was None, so set it manually.
+    'latest_version_name': f'v{version}'
 }
 
 # SPHINX-MULTIVERSION STUFF


### PR DESCRIPTION
- Fix #946
- Fix #1712 (we talked, and decided that it is good to keep this sidebar, once it's sorted.)

The template path suggested by sphinx-multiversion wasn't being read, perhaps because the pydata theme uses a different set of templates.

In the pydata theme, there didn't seem to be a template that is included above the article text, but in the same div; That said, the end result wasn't my initial goal, but I think it looks fine.

Sphinx-multiversion failed to set `latest_version` in the context. Seems easy enough to set by hand, even if that's not ideal.

The same warning is used on the nightly docs: I think that's ok. If we want to add more conditions, I should find a way to skip some versions so I can experiment more quickly.

`announcement` is verbatim text, rather than a template name.

The pydata theme also has [version warning banners](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/announcements.html#version-warning-banners)... but that relies on version info maintained in JSON: Might be the right thing to do in the long run, but didn't want to get distracted.

v0.6.0:
<img width="440" alt="Screenshot 2024-08-26 at 6 01 06 PM" src="https://github.com/user-attachments/assets/18b33ffc-cf1e-4461-9de0-20991435f3f9">


