### PR TITLE
Fix bitvec doctest

### DIFF
--- a/docs/source/_templates/old-version-warning.html
+++ b/docs/source/_templates/old-version-warning.html
@@ -10,6 +10,6 @@
   This documentation is for an old version of OpenDP.
   {% endif %}
   </p>
-  <p>The current release of OpenDP is <a href="https://docs.opendp.org">{{ latest_version_name }}</a>.</p>
+  <p>The current release of OpenDP is <a href="/">{{ latest_version_name }}</a>.</p>
 </div>
 {% endif %}

--- a/rust/src/measurements/code/make_randomized_response_bitvec.rst
+++ b/rust/src/measurements/code/make_randomized_response_bitvec.rst
@@ -25,7 +25,7 @@
 >>> release = np.frombuffer(m_rr(data.tobytes()), dtype=np.uint8)
 
 >>> # compare the two bit vectors:
->>> list(np.unpackbits(data))
+>>> [int(bit) for bit in np.unpackbits(data)]
 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0]
->>> list(np.unpackbits(release))
+>>> [int(bit) for bit in np.unpackbits(release)]
 [...]


### PR DESCRIPTION
- Fix #1989
- Not reproducing locally: May not be pulling in the same version of numpy because of #1990, but that's a guess.
- Also incorporate a fix for a [docs-links bug](https://github.com/opendp/opendp/actions/runs/10598415088/job/29371920703#step:3:5). The new not-the-latest-version warning intersects with a new CI check for references to doc.opendp.org.

(Draft until I confirm that this does fix CI.)