### PR TITLE
make rust error messages more explicit

### DIFF
--- a/python/test/test_binary_search.py
+++ b/python/test/test_binary_search.py
@@ -6,7 +6,7 @@ def test_binary_search_fail():
     with pytest.raises(ZeroDivisionError) as e:
         dp.binary_search(lambda _: bool(1 / 0), T=float)
     if hasattr(e.value, "add_note"):
-        assert e.value.__notes__[0] == "Predicate in binary search always raises an exception. This exception is raised when the predicate is evaluated at 0.0."
+        assert e.value.__notes__[0] == "Predicate in binary search always raises an exception. This exception is raised when the predicate is evaluated at 0.0." # type: ignore[attr-defined]
 
 def test_binary_search_overflow():
 

--- a/rust/src/accuracy/mod.rs
+++ b/rust/src/accuracy/mod.rs
@@ -30,7 +30,7 @@ pub fn laplacian_scale_to_accuracy<T: Float + Zero + One + Debug>(
     alpha: T,
 ) -> Fallible<T> {
     if scale.is_sign_negative() {
-        return fallible!(InvalidDistance, "scale may not be negative");
+        return fallible!(InvalidDistance, "scale ({:?}) may not be negative", scale);
     }
     if alpha <= T::zero() || T::one() < alpha {
         return fallible!(InvalidDistance, "alpha ({:?}) must be in (0, 1]", alpha);
@@ -58,7 +58,7 @@ pub fn discrete_laplacian_scale_to_accuracy<T: Float + Zero + One + Debug>(
     alpha: T,
 ) -> Fallible<T> {
     if scale.is_sign_negative() {
-        return fallible!(InvalidDistance, "scale may not be negative");
+        return fallible!(InvalidDistance, "scale ({:?}) may not be negative", scale);
     }
     if alpha <= T::zero() || T::one() < alpha {
         return fallible!(InvalidDistance, "alpha ({:?}) must be in (0, 1]", alpha);
@@ -92,7 +92,11 @@ pub fn accuracy_to_laplacian_scale<T: Float + Zero + One + Debug>(
     alpha: T,
 ) -> Fallible<T> {
     if accuracy.is_sign_negative() {
-        return fallible!(InvalidDistance, "accuracy may not be negative");
+        return fallible!(
+            InvalidDistance,
+            "accuracy ({:?}) may not be negative",
+            accuracy
+        );
     }
     if alpha <= T::zero() || T::one() <= alpha {
         return fallible!(InvalidDistance, "alpha ({:?}) must be in (0, 1)", alpha);
@@ -179,7 +183,7 @@ where
     let scale = f64::inf_cast(scale)?;
     let alpha = f64::inf_cast(alpha)?;
     if scale.is_sign_negative() {
-        return fallible!(InvalidDistance, "scale may not be negative");
+        return fallible!(InvalidDistance, "scale ({:?}) may not be negative", scale);
     }
     if alpha <= 0. || 1. < alpha {
         return fallible!(InvalidDistance, "alpha ({:?}) must be in (0, 1]", alpha);
@@ -235,7 +239,11 @@ where
     let accuracy = f64::inf_cast(accuracy)?;
     let alpha = f64::inf_cast(alpha)?;
     if accuracy.is_sign_negative() {
-        return fallible!(InvalidDistance, "accuracy may not be negative");
+        return fallible!(
+            InvalidDistance,
+            "accuracy ({:?}) may not be negative",
+            accuracy
+        );
     }
     if alpha <= 0. || 1. <= alpha {
         return fallible!(InvalidDistance, "alpha ({:?}) must be in (0, 1)", alpha);

--- a/rust/src/combinators/amplify/mod.rs
+++ b/rust/src/combinators/amplify/mod.rs
@@ -96,7 +96,9 @@ where
     if population_size < sample_size {
         return fallible!(
             MakeMeasurement,
-            "population size cannot be less than sample size"
+            "population size ({:?}) cannot be less than sample size ({:?})",
+            population_size,
+            sample_size
         );
     }
 

--- a/rust/src/combinators/sequential_compositor/interactive/mod.rs
+++ b/rust/src/combinators/sequential_compositor/interactive/mod.rs
@@ -69,7 +69,7 @@ where
     (DI, MI): MetricSpace,
 {
     if d_mids.len() == 0 {
-        return fallible!(MakeMeasurement, "must be at least one d_mid");
+        return fallible!(MakeMeasurement, "d_mids must have at least one element");
     }
 
     // we'll iteratively pop from the end
@@ -172,7 +172,7 @@ where
                             if *id != d_mids.len() {
                                 return fallible!(
                                     FailedFunction,
-                                    "sequential compositor has received a new query"
+                                    "Adaptive compositor has received a new query. To satisfy the sequentiality constraint of adaptive composition, only the most recent release from the parent compositor may be interacted with."
                                 );
                             }
                             // otherwise, return Ok to approve the change
@@ -180,7 +180,7 @@ where
                         }
                     }
 
-                    fallible!(FailedFunction, "unrecognized query!")
+                    fallible!(FailedFunction, "unrecognized query: {:?}", query)
                 })
             }
         )),

--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 use crate::error::*;
 use crate::traits::{DistanceConstant, InfCast, InfMul, ProductOrd};
 use num::Zero;
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 
 /// A set which constrains the input or output of a [`Function`].
 ///
@@ -153,11 +153,11 @@ impl<MI: Metric, MO: Measure> PrivacyMap<MI, MO> {
     pub fn new_from_constant(c: MO::Distance) -> Self
     where
         MI::Distance: Clone,
-        MO::Distance: DistanceConstant<MI::Distance>,
+        MO::Distance: DistanceConstant<MI::Distance> + Display,
     {
         PrivacyMap::new_fallible(move |d_in: &MI::Distance| {
             if c < MO::Distance::zero() {
-                return fallible!(FailedMap, "constant must be non-negative");
+                return fallible!(FailedMap, "constant ({}) must be non-negative", c);
             }
             MO::Distance::inf_cast(d_in.clone())?.inf_mul(&c)
         })
@@ -204,11 +204,11 @@ impl<MI: Metric, MO: Metric> StabilityMap<MI, MO> {
     pub fn new_from_constant(c: MO::Distance) -> Self
     where
         MI::Distance: Clone,
-        MO::Distance: DistanceConstant<MI::Distance>,
+        MO::Distance: DistanceConstant<MI::Distance> + Display,
     {
         StabilityMap::new_fallible(move |d_in: &MI::Distance| {
             if c < MO::Distance::zero() {
-                return fallible!(FailedMap, "constant must be non-negative");
+                return fallible!(FailedMap, "constant ({}) must be non-negative", c);
             }
             MO::Distance::inf_cast(d_in.clone())?.inf_mul(&c)
         })
@@ -321,6 +321,16 @@ impl<DI: Domain, TO, MI: Metric, MO: Measure> Measurement<DI, TO, MI, MO> {
     }
 }
 
+impl<DI: Domain, TO, MI: Metric, MO: Measure> Debug for Measurement<DI, TO, MI, MO> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Measurement")
+            .field("input_domain", &self.input_domain)
+            .field("input_metric", &self.input_metric)
+            .field("output_measure", &self.output_measure)
+            .finish()
+    }
+}
+
 pub trait MetricSpace {
     fn check_space(&self) -> Fallible<()>;
 }
@@ -414,6 +424,17 @@ impl<DI: Domain, DO: Domain, MI: Metric, MO: Metric> Transformation<DI, DO, MI, 
         MO::Distance: ProductOrd,
     {
         d_out.total_ge(&self.map(d_in)?)
+    }
+}
+
+impl<DI: Domain, DO: Domain, MI: Metric, MO: Metric> Debug for Transformation<DI, DO, MI, MO> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Transformation")
+            .field("input_domain", &self.input_domain)
+            .field("input_metric", &self.input_metric)
+            .field("output_domain", &self.output_domain)
+            .field("output_metric", &self.output_metric)
+            .finish()
     }
 }
 

--- a/rust/src/domains/mod.rs
+++ b/rust/src/domains/mod.rs
@@ -134,7 +134,7 @@ impl<T: CheckAtom + InherentNull> AtomDomain<T> {
         }
     }
 }
-impl<T: CheckAtom + ProductOrd> AtomDomain<T> {
+impl<T: CheckAtom + ProductOrd + Debug> AtomDomain<T> {
     pub fn new_closed(bounds: (T, T)) -> Fallible<Self> {
         Ok(AtomDomain {
             bounds: Some(Bounds::new_closed(bounds)?),
@@ -212,7 +212,7 @@ pub struct Bounds<T> {
     lower: Bound<T>,
     upper: Bound<T>,
 }
-impl<T: ProductOrd> Bounds<T> {
+impl<T: ProductOrd + Debug> Bounds<T> {
     pub fn new_closed(bounds: (T, T)) -> Fallible<Self> {
         Self::new((Bound::Included(bounds.0), Bound::Included(bounds.1)))
     }
@@ -230,16 +230,28 @@ impl<T: ProductOrd> Bounds<T> {
             if v_lower > v_upper {
                 return fallible!(
                     MakeDomain,
-                    "lower bound may not be greater than upper bound"
+                    "lower bound ({:?}) may not be greater than upper bound ({:?})",
+                    v_lower,
+                    v_upper
                 );
             }
             if v_lower == v_upper {
                 match (&lower, &upper) {
-                    (Bound::Included(_l), Bound::Excluded(_u)) => {
-                        return fallible!(MakeDomain, "upper bound excludes inclusive lower bound")
+                    (Bound::Included(l), Bound::Excluded(u)) => {
+                        return fallible!(
+                            MakeDomain,
+                            "upper bound ({:?}) excludes inclusive lower bound ({:?})",
+                            l,
+                            u
+                        )
                     }
-                    (Bound::Excluded(_l), Bound::Included(_u)) => {
-                        return fallible!(MakeDomain, "lower bound excludes inclusive upper bound")
+                    (Bound::Excluded(l), Bound::Included(u)) => {
+                        return fallible!(
+                            MakeDomain,
+                            "lower bound ({:?}) excludes inclusive upper bound ({:?})",
+                            l,
+                            u
+                        )
                     }
                     _ => (),
                 }

--- a/rust/src/domains/polars/series/mod.rs
+++ b/rust/src/domains/polars/series/mod.rs
@@ -132,7 +132,13 @@ impl SeriesDomain {
             ($ty:ty) => {{
                 let mut element_domain = (self.element_domain.as_any())
                     .downcast_ref::<AtomDomain<$ty>>()
-                    .ok_or_else(|| err!(FailedFunction, "unrecognized element domain"))?
+                    .ok_or_else(|| {
+                        err!(
+                            FailedFunction,
+                            "unrecognized element domain. Expected AtomDomain<{}>",
+                            stringify!($ty)
+                        )
+                    })?
                     .clone();
                 element_domain.bounds = None;
                 self.element_domain = Arc::new(element_domain) as Arc<dyn DynSeriesAtomDomain>;

--- a/rust/src/ffi/mod.rs
+++ b/rust/src/ffi/mod.rs
@@ -99,15 +99,21 @@ macro_rules! try_ {
 #[macro_export]
 macro_rules! try_as_ref {
     ($value:expr) => {
-        try_!($crate::ffi::util::as_ref($value)
-            .ok_or_else(|| err!(FFI, concat!("null pointer: ", stringify!($value)))))
+        try_!($crate::ffi::util::as_ref($value).ok_or_else(|| err!(
+            FFI,
+            "null pointer: {}",
+            stringify!($value)
+        )))
     };
 }
 
 #[macro_export]
 macro_rules! try_as_mut_ref {
     ($value:expr) => {
-        try_!($crate::ffi::util::as_mut_ref($value)
-            .ok_or_else(|| err!(FFI, concat!("null pointer: ", stringify!($value)))))
+        try_!($crate::ffi::util::as_mut_ref($value).ok_or_else(|| err!(
+            FFI,
+            "null pointer: {}",
+            stringify!($value)
+        )))
     };
 }

--- a/rust/src/interactive/mod.rs
+++ b/rust/src/interactive/mod.rs
@@ -53,6 +53,7 @@ impl<Q: ?Sized, A> Queryable<Q, A> {
 }
 
 // in the Queryable struct definition, this 'a lifetime is supplied by an HRTB after `dyn`, and then elided
+#[derive(Debug)]
 pub(crate) enum Query<'a, Q: ?Sized> {
     External(&'a Q),
     Internal(&'a dyn Any),

--- a/rust/src/measurements/alp/ffi.rs
+++ b/rust/src/measurements/alp/ffi.rs
@@ -71,8 +71,8 @@ pub extern "C" fn opendp_measurements__make_alp_queryable(
     let TypeContents::GENERIC { name, args } = &input_domain.carrier_type.contents else {
         return err!(
             FFI,
-            "Expected input domain to be MapDomain, found {:?}",
-            input_domain
+            "Expected input domain to be MapDomain, found {}",
+            input_domain.type_.to_string()
         )
         .into();
     };
@@ -80,8 +80,8 @@ pub extern "C" fn opendp_measurements__make_alp_queryable(
     if name != &"HashMap" {
         return err!(
             FFI,
-            "Expected input domain to be MapDomain, found {:?}",
-            input_domain
+            "Expected input domain to be MapDomain, found {}",
+            input_domain.type_.to_string()
         )
         .into();
     }

--- a/rust/src/measurements/alp/ffi.rs
+++ b/rust/src/measurements/alp/ffi.rs
@@ -69,11 +69,21 @@ pub extern "C" fn opendp_measurements__make_alp_queryable(
     let size_factor = util::as_ref(size_factor as *const u32).cloned();
 
     let TypeContents::GENERIC { name, args } = &input_domain.carrier_type.contents else {
-        return err!(FFI, "Expected generic input domain").into();
+        return err!(
+            FFI,
+            "Expected input domain to be MapDomain, found {:?}",
+            input_domain
+        )
+        .into();
     };
 
     if name != &"HashMap" {
-        return err!(FFI, "Expected input domain to be MapDomain").into();
+        return err!(
+            FFI,
+            "Expected input domain to be MapDomain, found {:?}",
+            input_domain
+        )
+        .into();
     }
 
     let K = try_!(try_!(Type::of_id(&args[0])).get_atom());

--- a/rust/src/measurements/alp/mod.rs
+++ b/rust/src/measurements/alp/mod.rs
@@ -245,10 +245,10 @@ where
     }
 
     if scale.is_sign_negative() || scale.is_zero() {
-        return fallible!(MakeMeasurement, "scale must be positive");
+        return fallible!(MakeMeasurement, "scale ({}) must be positive", scale);
     }
     if alpha.is_sign_negative() || alpha.is_zero() {
-        return fallible!(MakeMeasurement, "alpha must be positive");
+        return fallible!(MakeMeasurement, "alpha ({}) must be positive", alpha);
     }
     if projection_size == 0 {
         return fallible!(MakeMeasurement, "projection_size must be positive");

--- a/rust/src/measurements/gaussian/float/mod.rs
+++ b/rust/src/measurements/gaussian/float/mod.rs
@@ -39,7 +39,7 @@ where
     i32: ExactIntCast<<T as FloatBits>::Bits>,
 {
     if scale.is_sign_negative() {
-        return fallible!(MakeMeasurement, "scale must not be negative");
+        return fallible!(MakeMeasurement, "scale ({:?}) must not be negative", scale);
     }
 
     let (k, relaxation) = get_discretization_consts(k)?;
@@ -80,7 +80,7 @@ where
     i32: ExactIntCast<<T as FloatBits>::Bits>,
 {
     if scale.is_sign_negative() {
-        return fallible!(MakeMeasurement, "scale must not be negative");
+        return fallible!(MakeMeasurement, "scale ({:?}) must not be negative", scale);
     }
 
     let (k, mut relaxation): (i32, T) = get_discretization_consts(k)?;

--- a/rust/src/measurements/gaussian/integer/mod.rs
+++ b/rust/src/measurements/gaussian/integer/mod.rs
@@ -38,10 +38,10 @@ where
     RBig: TryFrom<MO::Atom>,
 {
     if scale.is_sign_negative() {
-        return fallible!(MakeMeasurement, "scale must not be negative");
+        return fallible!(MakeMeasurement, "scale ({}) must not be negative", scale);
     }
-    let scale_rational =
-        RBig::try_from(scale).map_err(|_| err!(MakeMeasurement, "scale must be finite"))?;
+    let scale_rational = RBig::try_from(scale)
+        .map_err(|_| err!(MakeMeasurement, "scale ({}) must be finite", scale))?;
 
     Measurement::new(
         input_domain,
@@ -89,10 +89,10 @@ where
     RBig: TryFrom<MO::Atom>,
 {
     if scale.is_sign_negative() {
-        return fallible!(MakeMeasurement, "scale must not be negative");
+        return fallible!(MakeMeasurement, "scale ({}) must not be negative", scale);
     }
-    let scale_rational =
-        RBig::try_from(scale).map_err(|_| err!(MakeMeasurement, "scale must be finite"))?;
+    let scale_rational = RBig::try_from(scale)
+        .map_err(|_| err!(MakeMeasurement, "scale ({}) must be finite", scale))?;
 
     Measurement::new(
         input_domain,

--- a/rust/src/measurements/gaussian/integer/mod.rs
+++ b/rust/src/measurements/gaussian/integer/mod.rs
@@ -40,8 +40,13 @@ where
     if scale.is_sign_negative() {
         return fallible!(MakeMeasurement, "scale ({}) must not be negative", scale);
     }
-    let scale_rational = RBig::try_from(scale)
-        .map_err(|_| err!(MakeMeasurement, "scale ({}) must be finite", scale))?;
+    let scale_rational = RBig::try_from(scale).map_err(|_| {
+        err!(
+            MakeMeasurement,
+            "scale ({}) is not representable as a fraction",
+            scale
+        )
+    })?;
 
     Measurement::new(
         input_domain,
@@ -91,8 +96,13 @@ where
     if scale.is_sign_negative() {
         return fallible!(MakeMeasurement, "scale ({}) must not be negative", scale);
     }
-    let scale_rational = RBig::try_from(scale)
-        .map_err(|_| err!(MakeMeasurement, "scale ({}) must be finite", scale))?;
+    let scale_rational = RBig::try_from(scale).map_err(|_| {
+        err!(
+            MakeMeasurement,
+            "scale ({}) is not representable as a fraction",
+            scale
+        )
+    })?;
 
     Measurement::new(
         input_domain,

--- a/rust/src/measurements/laplace/integer/mod.rs
+++ b/rust/src/measurements/laplace/integer/mod.rs
@@ -40,8 +40,13 @@ where
     if scale.is_sign_negative() {
         return fallible!(MakeMeasurement, "scale ({}) must not be negative", scale);
     }
-    let r_scale = RBig::try_from(scale)
-        .map_err(|_| err!(MakeMeasurement, "scale ({}) must be finite", scale))?;
+    let r_scale = RBig::try_from(scale).map_err(|_| {
+        err!(
+            MakeMeasurement,
+            "scale ({}) must be representable as a fraction",
+            scale
+        )
+    })?;
 
     Measurement::new(
         input_domain,
@@ -88,8 +93,13 @@ where
     if scale.is_sign_negative() {
         return fallible!(MakeMeasurement, "scale ({}) must not be negative", scale);
     }
-    let r_scale = RBig::try_from(scale)
-        .map_err(|_| err!(MakeMeasurement, "scale ({}) must be finite", scale))?;
+    let r_scale = RBig::try_from(scale).map_err(|_| {
+        err!(
+            MakeMeasurement,
+            "scale ({}) must be representable as a fraction",
+            scale
+        )
+    })?;
 
     Measurement::new(
         input_domain,

--- a/rust/src/measurements/laplace/integer/mod.rs
+++ b/rust/src/measurements/laplace/integer/mod.rs
@@ -38,10 +38,10 @@ where
     RBig: TryFrom<QO>,
 {
     if scale.is_sign_negative() {
-        return fallible!(MakeMeasurement, "scale must not be negative");
+        return fallible!(MakeMeasurement, "scale ({}) must not be negative", scale);
     }
-    let r_scale =
-        RBig::try_from(scale).map_err(|_| err!(MakeMeasurement, "scale must be finite"))?;
+    let r_scale = RBig::try_from(scale)
+        .map_err(|_| err!(MakeMeasurement, "scale ({}) must be finite", scale))?;
 
     Measurement::new(
         input_domain,
@@ -86,10 +86,10 @@ where
     RBig: TryFrom<QO>,
 {
     if scale.is_sign_negative() {
-        return fallible!(MakeMeasurement, "scale must not be negative");
+        return fallible!(MakeMeasurement, "scale ({}) must not be negative", scale);
     }
-    let r_scale =
-        RBig::try_from(scale).map_err(|_| err!(MakeMeasurement, "scale must be finite"))?;
+    let r_scale = RBig::try_from(scale)
+        .map_err(|_| err!(MakeMeasurement, "scale ({}) must be finite", scale))?;
 
     Measurement::new(
         input_domain,

--- a/rust/src/measurements/make_private_expr/expr_noise/mod.rs
+++ b/rust/src/measurements/make_private_expr/expr_noise/mod.rs
@@ -310,7 +310,7 @@ fn noise_udf(inputs: &[Series], kwargs: NoisePlugin) -> PolarsResult<Series> {
         ChunkedArray<PT>: IntoSeries,
     {
         let Ok(scale) = RBig::try_from(scale) else {
-            polars_bail!(InvalidOperation: "scale must be finite")
+            polars_bail!(InvalidOperation: "scale ({}) must be representable as a fraction", scale)
         };
 
         Ok(series

--- a/rust/src/measurements/make_private_expr/expr_report_noisy_max/mod.rs
+++ b/rust/src/measurements/make_private_expr/expr_report_noisy_max/mod.rs
@@ -87,7 +87,8 @@ where
     if global_scale.is_nan() || global_scale.is_sign_negative() {
         return fallible!(
             MakeMeasurement,
-            "global_scale must be a non-negative number"
+            "global_scale ({}) must be a non-negative number",
+            global_scale
         );
     }
 
@@ -146,8 +147,13 @@ pub(crate) fn match_report_noisy_max(
         );
     };
 
-    let optimize = literal_value_of::<String>(optimize)?
-        .ok_or_else(|| err!(MakeMeasurement, "Optimize must be \"max\" or \"min\"."))?;
+    let optimize = literal_value_of::<String>(optimize)?.ok_or_else(|| {
+        err!(
+            MakeMeasurement,
+            "Optimize must be \"max\" or \"min\", found \"{}\".",
+            optimize
+        )
+    })?;
     let optimize = Optimize::deserialize(optimize.as_str().into_deserializer())
         .map_err(|e: serde::de::value::Error| err!(FailedFunction, "{:?}", e))?;
 

--- a/rust/src/measures/ffi.rs
+++ b/rust/src/measures/ffi.rs
@@ -197,7 +197,12 @@ pub struct TypedMeasure<Q> {
 impl<Q: 'static> TypedMeasure<Q> {
     pub fn new(measure: AnyMeasure) -> Fallible<TypedMeasure<Q>> {
         if measure.distance_type != Type::of::<Q>() {
-            return fallible!(FFI, "unexpected distance type");
+            return fallible!(
+                FFI,
+                "unexpected distance type in measure. Expected {}, got {}",
+                Type::of::<Q>().to_string(),
+                measure.distance_type.to_string()
+            );
         }
 
         Ok(TypedMeasure {

--- a/rust/src/metrics/ffi.rs
+++ b/rust/src/metrics/ffi.rs
@@ -277,7 +277,12 @@ pub struct TypedMetric<Q> {
 impl<Q: 'static> TypedMetric<Q> {
     pub fn new(metric: AnyMetric) -> Fallible<TypedMetric<Q>> {
         if metric.distance_type != Type::of::<Q>() {
-            return fallible!(FFI, "unexpected distance type");
+            return fallible!(
+                FFI,
+                "unexpected distance type in metric. Expected {}, got {}",
+                Type::of::<Q>().to_string(),
+                metric.distance_type.to_string()
+            );
         }
 
         Ok(TypedMetric {

--- a/rust/src/polars/mod.rs
+++ b/rust/src/polars/mod.rs
@@ -448,7 +448,7 @@ impl From<LazyFrame> for OnceFrame {
         let mut state = Some(value);
         Self::new_raw(move |_self: &Self, query: Query<OnceFrameQuery>| {
             let Some(lazyframe) = state.clone() else {
-                return fallible!(FailedFunction, "LazyFrame has been exhausted");
+                return fallible!(FailedFunction, "OnceFrame has been exhausted");
             };
             Ok(match query {
                 Query::External(q_external) => Answer::External(match q_external {

--- a/rust/src/traits/mod.rs
+++ b/rust/src/traits/mod.rs
@@ -82,13 +82,23 @@ impl<TI, TO> DistanceConstant<TI> for TO where
 /// test_func(1i8);
 /// ```
 pub trait Primitive:
-    'static + Clone + std::fmt::Debug + CheckNull + PartialEq + Default + CheckAtom + Send + Sync
+    'static
+    + Clone
+    + std::fmt::Debug
+    + std::fmt::Display
+    + CheckNull
+    + PartialEq
+    + Default
+    + CheckAtom
+    + Send
+    + Sync
 {
 }
 impl<T> Primitive for T where
     T: 'static
         + Clone
         + std::fmt::Debug
+        + std::fmt::Display
         + CheckNull
         + PartialEq
         + Default

--- a/rust/src/traits/samplers/discretize/mod.rs
+++ b/rust/src/traits/samplers/discretize/mod.rs
@@ -124,7 +124,13 @@ macro_rules! impl_cast_internal_rational_float {
                 v.$method().value()
             }
             fn into_rational(self) -> Fallible<RBig> {
-                RBig::try_from(self).map_err(|_| err!(FailedFunction, "shift must be finite"))
+                RBig::try_from(self).map_err(|_| {
+                    err!(
+                        FailedFunction,
+                        "{} must be representable as a fraction",
+                        self
+                    )
+                })
             }
         }
     };

--- a/rust/src/traits/samplers/uniform/mod.rs
+++ b/rust/src/traits/samplers/uniform/mod.rs
@@ -222,7 +222,11 @@ impl SampleUniformIntBelow for UBig {
 impl SampleUniformIntBelow for IBig {
     fn sample_uniform_int_below(upper: Self, trials: Option<usize>) -> Fallible<Self> {
         if upper.is_negative() {
-            return fallible!(FailedFunction, "upper bound must not be negative");
+            return fallible!(
+                FailedFunction,
+                "upper bound ({}) must not be negative",
+                upper
+            );
         }
 
         let upper = UBig::try_from(upper)?;

--- a/rust/src/transformations/covariance/mod.rs
+++ b/rust/src/transformations/covariance/mod.rs
@@ -34,10 +34,19 @@ where
     (S::Item, S::Item): CheckAtom,
 {
     if size == 0 {
-        return fallible!(MakeTransformation, "size must be greater than zero");
+        return fallible!(
+            MakeTransformation,
+            "size ({}) must be greater than zero",
+            size
+        );
     }
     if ddof >= size {
-        return fallible!(MakeTransformation, "size - ddof must be greater than zero");
+        return fallible!(
+            MakeTransformation,
+            "size - ddof must be greater than zero. Size is {}, ddof is {}",
+            size,
+            ddof
+        );
     }
     let _size = S::Item::exact_int_cast(size)?;
     let _ddof = S::Item::exact_int_cast(ddof)?;

--- a/rust/src/transformations/impute/ffi.rs
+++ b/rust/src/transformations/impute/ffi.rs
@@ -64,7 +64,12 @@ pub extern "C" fn opendp_transformations__make_impute_constant(
             "Vec must have one type argument."
         )))))
     } else {
-        return err!(FFI, "Invalid type name.").into();
+        return err!(
+            FFI,
+            "Invalid type name. Expected VectorDomain, found {}",
+            DI.to_string()
+        )
+        .into();
     };
 
     let TA = try_!(DIA.get_atom());
@@ -146,7 +151,12 @@ pub extern "C" fn opendp_transformations__make_drop_null(
             "Vec must have one type argument."
         )))))
     } else {
-        return err!(FFI, "Invalid type name.").into();
+        return err!(
+            FFI,
+            "Invalid input domain. Expected VectorDomain, found {}",
+            DI.to_string()
+        )
+        .into();
     };
 
     let TA = try_!(DIA.get_atom());

--- a/rust/src/transformations/make_stable_expr/expr_clip/mod.rs
+++ b/rust/src/transformations/make_stable_expr/expr_clip/mod.rs
@@ -42,8 +42,14 @@ where
         return fallible!(MakeTransformation, "Clip must have min and max");
     }
 
-    let [input, lower, upper] = <[Expr; 3]>::try_from(input)
-        .map_err(|_| err!(MakeTransformation, "Clip expects 3 arguments"))?;
+    let n_args = input.len();
+    let [input, lower, upper] = <[Expr; 3]>::try_from(input).map_err(|_| {
+        err!(
+            MakeTransformation,
+            "Clip expects 3 arguments, found {}",
+            n_args
+        )
+    })?;
 
     let t_prior = input.make_stable(input_domain.clone(), input_metric.clone())?;
     let (middle_domain, middle_metric) = t_prior.output_space();

--- a/rust/src/transformations/make_stable_expr/expr_discrete_quantile_score/mod.rs
+++ b/rust/src/transformations/make_stable_expr/expr_discrete_quantile_score/mod.rs
@@ -130,7 +130,8 @@ where
     if candidates.null_count() > 0 {
         return fallible!(
             MakeTransformation,
-            "Candidates must not contain null values"
+            "Candidates must not contain null values, found {} null value(s)",
+            candidates.null_count()
         );
     }
     validate_candidates(&series_to_vec::<T>(&candidates.cast(&T::get_dtype())?)?)

--- a/rust/src/transformations/manipulation/ffi.rs
+++ b/rust/src/transformations/manipulation/ffi.rs
@@ -71,10 +71,9 @@ pub extern "C" fn opendp_transformations__make_is_null(
         args,
     } = DI.contents
     {
-        try_!(Type::of_id(try_!(args.get(0).ok_or_else(|| err!(
-            FFI,
-            "Vec must have one type argument."
-        )))))
+        try_!(Type::of_id(try_!(args
+            .get(0)
+            .ok_or_else(|| err!(FFI, "Vec must have one type argument")))))
     } else {
         return err!(FFI, "Invalid type name.").into();
     };

--- a/rust/src/transformations/manipulation/ffi.rs
+++ b/rust/src/transformations/manipulation/ffi.rs
@@ -1,3 +1,5 @@
+use std::any::TypeId;
+
 use crate::core::MetricSpace;
 use crate::core::{FfiResult, IntoAnyTransformationFfiResultExt};
 use crate::domains::{AtomDomain, OptionDomain, VectorDomain};
@@ -71,9 +73,10 @@ pub extern "C" fn opendp_transformations__make_is_null(
         args,
     } = DI.contents
     {
-        try_!(Type::of_id(try_!(args
-            .get(0)
-            .ok_or_else(|| err!(FFI, "Vec must have one type argument")))))
+        let type_id =
+            try_!(<[TypeId; 1]>::try_from(args)
+                .map_err(|_| err!(FFI, "Vec must have one type argument")))[0];
+        try_!(Type::of_id(&type_id))
     } else {
         return err!(FFI, "Invalid type name.").into();
     };

--- a/rust/src/transformations/variance/mod.rs
+++ b/rust/src/transformations/variance/mod.rs
@@ -58,7 +58,12 @@ where
         .ok_or_else(|| err!(MakeTransformation, "dataset size must be known. Either specify size in the input domain or use make_resize"))?;
     let bounds = (input_domain.element_domain.get_closed_bounds())?;
     if ddof >= size {
-        return fallible!(MakeTransformation, "size - ddof must be greater than zero");
+        return fallible!(
+            MakeTransformation,
+            "size - ddof must be greater than zero. Size is {} and ddof is {}.",
+            size,
+            ddof
+        );
     }
 
     let constant = S::Item::exact_int_cast(size.alerting_sub(&ddof)?)?.recip();


### PR DESCRIPTION
Towards #1422. Doesn't resolve, but provides more info in many cases. In particular, the error message for TypedMeasure and TypedMetric would have been useful during the hackathon.