### PR TITLE
Fix: controlled rounding for sub-sub-normals

### DIFF
--- a/rust/src/measurements/alp/mod.rs
+++ b/rust/src/measurements/alp/mod.rs
@@ -14,7 +14,7 @@ use crate::interactive::Queryable;
 use crate::measures::MaxDivergence;
 use crate::metrics::L1Distance;
 use crate::traits::samplers::{fill_bytes, sample_bernoulli_float};
-use crate::traits::{Float, Hashable, InfCast, Integer};
+use crate::traits::{Float, Hashable, InfCast, Integer, ToFloatRounded};
 use std::collections::hash_map::DefaultHasher;
 
 #[cfg(feature = "ffi")]
@@ -104,8 +104,7 @@ where
         .with_precision(
             (f64::MANTISSA_DIGITS as i32 - scale.exp())
                 .max(FBig::ONE)
-                .to_f64()
-                .value() as usize,
+                .to_f64_rounded() as usize,
         )
         .value();
 

--- a/rust/src/traits/cast/mod.rs
+++ b/rust/src/traits/cast/mod.rs
@@ -247,9 +247,11 @@ impl NextFloat for f64 {
     /// Returns the least number greater than `self`.
     ///
     /// Taken from the unstable Rust compiler implementation.
+    /// https://github.com/rust-lang/rust/blob/eb33b43bab08223fa6b46abacc1e95e859fe375d/library/core/src/num/f64.rs#L763-L810
     fn next_up_(self) -> Self {
-        // We must use strictly integer arithmetic to prevent denormals from
-        // flushing to zero after an arithmetic operation on some platforms.
+        // Some targets violate Rust's assumption of IEEE semantics, e.g. by flushing
+        // denormals to zero. This is in general unsound and unsupported, but here
+        // we do our best to still produce the correct result on such targets.
         const TINY_BITS: u64 = 0x1; // Smallest positive f64.
         const CLEAR_SIGN_MASK: u64 = 0x7fff_ffff_ffff_ffff;
 
@@ -272,9 +274,11 @@ impl NextFloat for f64 {
     /// Returns the greatest number less than `self`.
     ///
     /// Taken from the unstable Rust compiler implementation.
+    /// https://github.com/rust-lang/rust/blob/eb33b43bab08223fa6b46abacc1e95e859fe375d/library/core/src/num/f64.rs#L812-L859
     fn next_down_(self) -> Self {
-        // We must use strictly integer arithmetic to prevent denormals from
-        // flushing to zero after an arithmetic operation on some platforms.
+        // Some targets violate Rust's assumption of IEEE semantics, e.g. by flushing
+        // denormals to zero. This is in general unsound and unsupported, but here
+        // we do our best to still produce the correct result on such targets.
         const NEG_TINY_BITS: u64 = 0x8000_0000_0000_0001; // Smallest (in magnitude) negative f64.
         const CLEAR_SIGN_MASK: u64 = 0x7fff_ffff_ffff_ffff;
 
@@ -298,9 +302,11 @@ impl NextFloat for f32 {
     /// Returns the least number greater than `self`.
     ///
     /// Taken from the unstable Rust compiler implementation.
+    /// https://github.com/rust-lang/rust/blob/eb33b43bab08223fa6b46abacc1e95e859fe375d/library/core/src/num/f32.rs#L750-L797
     fn next_up_(self) -> Self {
-        // We must use strictly integer arithmetic to prevent denormals from
-        // flushing to zero after an arithmetic operation on some platforms.
+        // Some targets violate Rust's assumption of IEEE semantics, e.g. by flushing
+        // denormals to zero. This is in general unsound and unsupported, but here
+        // we do our best to still produce the correct result on such targets.
         const TINY_BITS: u32 = 0x1; // Smallest positive f32.
         const CLEAR_SIGN_MASK: u32 = 0x7fff_ffff;
 
@@ -323,9 +329,11 @@ impl NextFloat for f32 {
     /// Returns the greatest number less than `self`.
     ///
     /// Taken from the unstable Rust compiler implementation.
+    /// https://github.com/rust-lang/rust/blob/eb33b43bab08223fa6b46abacc1e95e859fe375d/library/core/src/num/f32.rs#L799-L846
     fn next_down_(self) -> Self {
-        // We must use strictly integer arithmetic to prevent denormals from
-        // flushing to zero after an arithmetic operation on some platforms.
+        // Some targets violate Rust's assumption of IEEE semantics, e.g. by flushing
+        // denormals to zero. This is in general unsound and unsupported, but here
+        // we do our best to still produce the correct result on such targets.
         const NEG_TINY_BITS: u32 = 0x8000_0001; // Smallest (in magnitude) negative f32.
         const CLEAR_SIGN_MASK: u32 = 0x7fff_ffff;
 

--- a/rust/src/traits/cast/mod.rs
+++ b/rust/src/traits/cast/mod.rs
@@ -1,10 +1,11 @@
 use std::convert::TryFrom;
 
 use dashu::{
+    base::Approximation,
     float::{
         round::{
             mode::{Down, Up},
-            Round,
+            Round, Rounding,
         },
         FBig,
     },
@@ -236,20 +237,177 @@ impl ExactIntBounds for f32 {
     const MIN_CONSECUTIVE: Self = -16_777_216.0;
 }
 
+trait NextFloat {
+    // naming has a trailing underscore so as not to conflict with stabilization of the corresponding methods in Rust STD
+    fn next_up_(self) -> Self;
+    fn next_down_(self) -> Self;
+}
+
+impl NextFloat for f64 {
+    /// Returns the least number greater than `self`.
+    ///
+    /// Taken from the unstable Rust compiler implementation.
+    fn next_up_(self) -> Self {
+        // We must use strictly integer arithmetic to prevent denormals from
+        // flushing to zero after an arithmetic operation on some platforms.
+        const TINY_BITS: u64 = 0x1; // Smallest positive f64.
+        const CLEAR_SIGN_MASK: u64 = 0x7fff_ffff_ffff_ffff;
+
+        let bits = self.to_bits();
+        if self.is_nan() || bits == Self::INFINITY.to_bits() {
+            return self;
+        }
+
+        let abs = bits & CLEAR_SIGN_MASK;
+        let next_bits = if abs == 0 {
+            TINY_BITS
+        } else if bits == abs {
+            bits + 1
+        } else {
+            bits - 1
+        };
+        Self::from_bits(next_bits)
+    }
+
+    /// Returns the greatest number less than `self`.
+    ///
+    /// Taken from the unstable Rust compiler implementation.
+    fn next_down_(self) -> Self {
+        // We must use strictly integer arithmetic to prevent denormals from
+        // flushing to zero after an arithmetic operation on some platforms.
+        const NEG_TINY_BITS: u64 = 0x8000_0000_0000_0001; // Smallest (in magnitude) negative f64.
+        const CLEAR_SIGN_MASK: u64 = 0x7fff_ffff_ffff_ffff;
+
+        let bits = self.to_bits();
+        if self.is_nan() || bits == Self::NEG_INFINITY.to_bits() {
+            return self;
+        }
+
+        let abs = bits & CLEAR_SIGN_MASK;
+        let next_bits = if abs == 0 {
+            NEG_TINY_BITS
+        } else if bits == abs {
+            bits - 1
+        } else {
+            bits + 1
+        };
+        Self::from_bits(next_bits)
+    }
+}
+impl NextFloat for f32 {
+    /// Returns the least number greater than `self`.
+    ///
+    /// Taken from the unstable Rust compiler implementation.
+    fn next_up_(self) -> Self {
+        // We must use strictly integer arithmetic to prevent denormals from
+        // flushing to zero after an arithmetic operation on some platforms.
+        const TINY_BITS: u32 = 0x1; // Smallest positive f32.
+        const CLEAR_SIGN_MASK: u32 = 0x7fff_ffff;
+
+        let bits = self.to_bits();
+        if self.is_nan() || bits == Self::INFINITY.to_bits() {
+            return self;
+        }
+
+        let abs = bits & CLEAR_SIGN_MASK;
+        let next_bits = if abs == 0 {
+            TINY_BITS
+        } else if bits == abs {
+            bits + 1
+        } else {
+            bits - 1
+        };
+        Self::from_bits(next_bits)
+    }
+
+    /// Returns the greatest number less than `self`.
+    ///
+    /// Taken from the unstable Rust compiler implementation.
+    fn next_down_(self) -> Self {
+        // We must use strictly integer arithmetic to prevent denormals from
+        // flushing to zero after an arithmetic operation on some platforms.
+        const NEG_TINY_BITS: u32 = 0x8000_0001; // Smallest (in magnitude) negative f32.
+        const CLEAR_SIGN_MASK: u32 = 0x7fff_ffff;
+
+        let bits = self.to_bits();
+        if self.is_nan() || bits == Self::NEG_INFINITY.to_bits() {
+            return self;
+        }
+
+        let abs = bits & CLEAR_SIGN_MASK;
+        let next_bits = if abs == 0 {
+            NEG_TINY_BITS
+        } else if bits == abs {
+            bits - 1
+        } else {
+            bits + 1
+        };
+        Self::from_bits(next_bits)
+    }
+}
+
+/// Wrapper around Dashu's FBig::to_f32 and FBig::to_f32 that guarantees correct rounding, even in edge cases
+pub trait ToFloatRounded {
+    fn to_f32_rounded(self) -> f32;
+    fn to_f64_rounded(self) -> f64;
+}
+
+impl ToFloatRounded for FBig<Up> {
+    fn to_f32_rounded(self) -> f32 {
+        match self.to_f32() {
+            Approximation::Exact(v) | Approximation::Inexact(v, Rounding::AddOne) => v,
+            Approximation::Inexact(v, Rounding::SubOne)
+            | Approximation::Inexact(v, Rounding::NoOp) => v.next_up_(),
+        }
+    }
+
+    fn to_f64_rounded(self) -> f64 {
+        match self.to_f64() {
+            Approximation::Exact(v) | Approximation::Inexact(v, Rounding::AddOne) => v,
+            Approximation::Inexact(v, Rounding::SubOne)
+            | Approximation::Inexact(v, Rounding::NoOp) => v.next_up_(),
+        }
+    }
+}
+
+impl ToFloatRounded for FBig<Down> {
+    fn to_f32_rounded(self) -> f32 {
+        match self.to_f32() {
+            Approximation::Exact(v) | Approximation::Inexact(v, Rounding::SubOne) => v,
+            Approximation::Inexact(v, Rounding::AddOne)
+            | Approximation::Inexact(v, Rounding::NoOp) => v.next_down_(),
+        }
+    }
+
+    fn to_f64_rounded(self) -> f64 {
+        match self.to_f64() {
+            Approximation::Exact(v) | Approximation::Inexact(v, Rounding::SubOne) => v,
+            Approximation::Inexact(v, Rounding::AddOne)
+            | Approximation::Inexact(v, Rounding::NoOp) => v.next_down_(),
+        }
+    }
+}
+
 /// Convert from an FBig to a native type `Self` with controlled rounding
 trait FromFBig<R: Round> {
     fn from_fbig(value: FBig<R>) -> Self;
 }
 
-impl<R: Round> FromFBig<R> for f32 {
+impl<R: Round> FromFBig<R> for f32
+where
+    FBig<R>: ToFloatRounded,
+{
     fn from_fbig(value: FBig<R>) -> Self {
-        value.to_f32().value()
+        value.to_f32_rounded()
     }
 }
 
-impl<R: Round> FromFBig<R> for f64 {
+impl<R: Round> FromFBig<R> for f64
+where
+    FBig<R>: ToFloatRounded,
+{
     fn from_fbig(value: FBig<R>) -> Self {
-        value.to_f64().value()
+        value.to_f64_rounded()
     }
 }
 
@@ -442,21 +600,21 @@ impl<R: Round> InfCast<f64> for FBig<R> {
 
 impl<R: Round> InfCast<FBig<R>> for f32 {
     fn inf_cast(v: FBig<R>) -> Fallible<Self> {
-        Ok(v.with_rounding::<Up>().to_f32().value())
+        Ok(v.with_rounding::<Up>().to_f32_rounded())
     }
 
     fn neg_inf_cast(v: FBig<R>) -> Fallible<Self> {
-        Ok(v.with_rounding::<Down>().to_f32().value())
+        Ok(v.with_rounding::<Down>().to_f32_rounded())
     }
 }
 
 impl<R: Round> InfCast<FBig<R>> for f64 {
     fn inf_cast(v: FBig<R>) -> Fallible<Self> {
-        Ok(v.with_rounding::<Up>().to_f64().value())
+        Ok(v.with_rounding::<Up>().to_f64_rounded())
     }
 
     fn neg_inf_cast(v: FBig<R>) -> Fallible<Self> {
-        Ok(v.with_rounding::<Down>().to_f64().value())
+        Ok(v.with_rounding::<Down>().to_f64_rounded())
     }
 }
 

--- a/rust/src/traits/cast/test.rs
+++ b/rust/src/traits/cast/test.rs
@@ -72,8 +72,12 @@ fn test_subnormal_fail() -> Fallible<()> {
     let min = FBig::<Up>::try_from(f32::from_bits(1))?;
     let half: FBig<Up> = min / 2;
     // this behavior is wrong. The conversion should be conducted with rounding up, but is not
-    // if this test fails, then check to see if the bug has been fixed in dashu:
+    // If this test fails, then check to see if the bug has been fixed in dashu:
     // https://github.com/cmpute/dashu/issues/53
+
+    // When Dashu is fixed, you should be able to replace `to_fxx_rounded()` with `to_fxx().value()`.
+    // This PR introduced these changes:
+    // https://github.com/opendp/opendp/pull/1998
     assert_eq!(half.to_f32().value(), 0.);
 
     // valid subnormals still convert exactly, as expected


### PR DESCRIPTION
Fixes #1997

I'd consider this more of a patch than a fix. At some point when Dashu is updated, one of our tests will start to fail, and we can try to remove the patch.

https://github.com/cmpute/dashu/issues/53