### PR TITLE
Exclude code snips from indexing

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -160,7 +160,7 @@ nitpick_ignore = [
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = []
+exclude_patterns = ['**/code/*.rst']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'


### PR DESCRIPTION
- Fix #1934
- Replace #1940: This is a much better solution.

Confirmed locally that this works.