### PR TITLE
Document supported polars methods

### DIFF
--- a/python/src/opendp/extras/polars/__init__.py
+++ b/python/src/opendp/extras/polars/__init__.py
@@ -70,7 +70,7 @@ class DPExpr(object):
 
     A few ``Expr`` aggregation methods are also available:
 
-    .. list-table:: Supported Polars ``Expr`` Methods
+    .. list-table:: Supported Polars ``Expr`` Aggregation Methods
         :header-rows: 1
 
         * - Method

--- a/python/src/opendp/extras/polars/__init__.py
+++ b/python/src/opendp/extras/polars/__init__.py
@@ -45,7 +45,7 @@ class DPExpr(object):
     >>> pl.len().dp
     <opendp.extras.polars.DPExpr object at ...>
 
-    In addition to the DP-specific methods documented below, many Polars ``Expr`` methods are also supported.
+    In addition to the DP-specific methods documented below, some Polars ``Expr`` methods are also supported.
     For these, the best documentation is the `official Polars documentation <https://docs.pola.rs/api/python/stable/reference/expressions/index.html>`_.
 
     .. list-table:: Supported Polars ``Expr`` Methods
@@ -77,13 +77,10 @@ class DPExpr(object):
           - Comments
         * - `len <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.len.html>`_
           - Number of rows, including nulls
-        * - `count <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.count.html>`_
+        * - `count <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.count.html>`_
           - Number of rows, not including nulls
-        * - `n_unique <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.n_unique.html>`_
+        * - `n_unique <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.n_unique.html>`_
           - Number of unique rows
-
-
-              
     '''
     def __init__(self, expr):
         """Apply a differentially private plugin to a Polars expression."""

--- a/python/src/opendp/extras/polars/__init__.py
+++ b/python/src/opendp/extras/polars/__init__.py
@@ -54,30 +54,43 @@ class DPExpr(object):
         * - Method
           - Operators
           - Use for
+          - Usage
         * - `alias <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.alias.html>`_
           -
           - Renaming the expression
+          - 
+            >>> import polars as pl
+            >>> print(pl.col('numbers').dp.noise().alias('noisy'))
+            col("numbers")...alias("noisy")
+
         * - `eq, ne, lt, le, gt, ge <https://docs.pola.rs/api/python/stable/reference/expressions/operators.html#comparison>`_
           - ``==`` ``!=`` ``<`` ``<=`` ``>`` ``>=``
           - Comparison
+          -
         * - `and, or, xor <https://docs.pola.rs/api/python/stable/reference/expressions/operators.html#conjunction>`_
           - ``&`` ``|`` ``^``
           - Bit-wise operators
+          -
         * - `is_null, is_not_null, is_finite, is_not_finite, is_nan, is_not_nan, not <https://docs.pola.rs/api/python/stable/reference/expressions/boolean.html>`_
           -
-          - Boolean information    
+          - Boolean information  
+          -  
         * - `clip <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.clip.html>`_
           -
           - Set values outside boundaries to the boundary value
+          -
         * - `fill_null <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.fill_null.html>`_, `fill_nan <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.fill_nan.html>`_
           -
           - Fill missing values
+          -
         * - `len <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.len.html>`_
           -
           - Return the number of rows
+          -
         * - `lit <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.lit.html>`_
           -
           - Return an expression representing a literal value 
+          -
     '''
     def __init__(self, expr):
         """Apply a differentially private plugin to a Polars expression."""

--- a/python/src/opendp/extras/polars/__init__.py
+++ b/python/src/opendp/extras/polars/__init__.py
@@ -44,6 +44,40 @@ class DPExpr(object):
     >>> import polars as pl
     >>> pl.len().dp
     <opendp.extras.polars.DPExpr object at ...>
+
+    In addition to the DP-specific methods documented below, many Polars ``Expr`` methods are also supported.
+    For these, the best documentation is the official Polars documentation.
+
+    .. list-table:: Supported Polars ``Expr`` Methods
+        :header-rows: 1
+
+        * - Method
+          - Operators
+          - Use for
+        * - `alias <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.alias.html>`_
+          -
+          - Renaming the expression
+        * - `eq, ne, lt, le, gt, ge <https://docs.pola.rs/api/python/stable/reference/expressions/operators.html#comparison>`_
+          - ``==`` ``!=`` ``<`` ``<=`` ``>`` ``>=``
+          - Comparison
+        * - `and, or, xor <https://docs.pola.rs/api/python/stable/reference/expressions/operators.html#conjunction>`_
+          - ``&`` ``|`` ``^``
+          - Bit-wise operators
+        * - `is_null, is_not_null, is_finite, is_not_finite, is_nan, is_not_nan, not <https://docs.pola.rs/api/python/stable/reference/expressions/boolean.html>`_
+          -
+          - Boolean information    
+        * - `clip <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.clip.html>`_
+          -
+          - Set values outside boundaries to the boundary value
+        * - `fill_null <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.fill_null.html>`_, `fill_nan <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.fill_nan.html>`_
+          -
+          - Fill missing values
+        * - `len <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.len.html>`_
+          -
+          - Return the number of rows
+        * - `lit <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.lit.html>`_
+          -
+          - Return an expression representing a literal value 
     '''
     def __init__(self, expr):
         """Apply a differentially private plugin to a Polars expression."""

--- a/python/src/opendp/extras/polars/__init__.py
+++ b/python/src/opendp/extras/polars/__init__.py
@@ -46,51 +46,44 @@ class DPExpr(object):
     <opendp.extras.polars.DPExpr object at ...>
 
     In addition to the DP-specific methods documented below, many Polars ``Expr`` methods are also supported.
-    For these, the best documentation is the official Polars documentation.
+    For these, the best documentation is the `official Polars documentation <https://docs.pola.rs/api/python/stable/reference/expressions/index.html>`_.
 
     .. list-table:: Supported Polars ``Expr`` Methods
         :header-rows: 1
 
         * - Method
-          - Operators
-          - Use for
-          - Usage
+          - Comments
         * - `alias <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.alias.html>`_
-          -
-          - Renaming the expression
-          - 
-            >>> import polars as pl
-            >>> print(pl.col('numbers').dp.noise().alias('noisy'))
-            col("numbers")...alias("noisy")
-
+          - Rename the expression
         * - `eq, ne, lt, le, gt, ge <https://docs.pola.rs/api/python/stable/reference/expressions/operators.html#comparison>`_
-          - ``==`` ``!=`` ``<`` ``<=`` ``>`` ``>=``
-          - Comparison
-          -
+          - Comparison operators may be more readable: ``==`` ``!=`` ``<`` ``<=`` ``>`` ``>=``
         * - `and, or, xor <https://docs.pola.rs/api/python/stable/reference/expressions/operators.html#conjunction>`_
-          - ``&`` ``|`` ``^``
-          - Bit-wise operators
-          -
+          - Bit-wise operators may be more readable: ``&`` ``|`` ``^``
         * - `is_null, is_not_null, is_finite, is_not_finite, is_nan, is_not_nan, not <https://docs.pola.rs/api/python/stable/reference/expressions/boolean.html>`_
-          -
-          - Boolean information  
-          -  
+          - Boolean information
         * - `clip <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.clip.html>`_
-          -
-          - Set values outside boundaries to the boundary value
-          -
+          - Set value outside bounds to boundary value
         * - `fill_null <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.fill_null.html>`_, `fill_nan <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.fill_nan.html>`_
-          -
-          - Fill missing values
-          -
-        * - `len <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.len.html>`_
-          -
-          - Return the number of rows
-          -
+          - Fill missing values with provided value
         * - `lit <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.lit.html>`_
-          -
           - Return an expression representing a literal value 
-          -
+
+    A few ``Expr`` aggregation methods are also available:
+
+    .. list-table:: Supported Polars ``Expr`` Methods
+        :header-rows: 1
+
+        * - Method
+          - Comments
+        * - `len <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.len.html>`_
+          - Number of rows, including nulls
+        * - `count <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.count.html>`_
+          - Number of rows, not including nulls
+        * - `n_unique <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.n_unique.html>`_
+          - Number of unique rows
+
+
+              
     '''
     def __init__(self, expr):
         """Apply a differentially private plugin to a Polars expression."""

--- a/python/src/opendp/extras/polars/__init__.py
+++ b/python/src/opendp/extras/polars/__init__.py
@@ -79,8 +79,8 @@ class DPExpr(object):
           - Number of rows, including nulls
         * - `count <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.count.html>`_
           - Number of rows, not including nulls
-        * - `n_unique <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.n_unique.html>`_
-          - Number of unique rows
+        * - `sum <https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.sum.html>`_
+          - Sum
     '''
     def __init__(self, expr):
         """Apply a differentially private plugin to a Polars expression."""

--- a/python/src/opendp/extras/polars/__init__.py
+++ b/python/src/opendp/extras/polars/__init__.py
@@ -57,7 +57,7 @@ class DPExpr(object):
           - Rename the expression
         * - `eq, ne, lt, le, gt, ge <https://docs.pola.rs/api/python/stable/reference/expressions/operators.html#comparison>`_
           - Comparison operators may be more readable: ``==`` ``!=`` ``<`` ``<=`` ``>`` ``>=``
-        * - `and, or, xor <https://docs.pola.rs/api/python/stable/reference/expressions/operators.html#conjunction>`_
+        * - `and_, or_, xor <https://docs.pola.rs/api/python/stable/reference/expressions/operators.html#conjunction>`_
           - Bit-wise operators may be more readable: ``&`` ``|`` ``^``
         * - `is_null, is_not_null, is_finite, is_not_finite, is_nan, is_not_nan, not <https://docs.pola.rs/api/python/stable/reference/expressions/boolean.html>`_
           - Boolean information


### PR DESCRIPTION
- Fix #2025

Draft for now:
- Is this the right place for this information? I think at one time there was an idea of adding a page in the tabular data section, but this seems more like reference material.
- Is a fourth column with doctests useful? Maybe they are useful, but cramming them in a table is a mistake.
- How should we explain where these can be used? They can't be used right after the `dp`, but they will work if `noise` or another method intervenes.
- Does it make sense to do the same thing for `LazyFrame` methods?