### PR TITLE
Un-pin numpy dependency

### DIFF
--- a/docs/requirements_notebooks.txt
+++ b/docs/requirements_notebooks.txt
@@ -1,5 +1,4 @@
 matplotlib
-numpy<2.0 # v2.0 incompatible with randomgen: https://github.com/bashtage/randomgen/issues/360
 randomgen
 pandas
 seaborn

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -37,7 +37,7 @@ opendp =
 [options.extras_require]
 # If this changes, update the smoke-test matrix.
 numpy = 
-	numpy>=1.17,<2.0
+	numpy
 	randomgen
 scikit-learn = 
 	scikit-learn


### PR DESCRIPTION
Close #2055
Randomgen 2.x exists now: https://pypi.org/project/randomgen/2.0.1/


requirements-dev.txt already has Numpy-2.0