### PR TITLE
fix nightly build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,17 @@ jobs:
     needs: credential-check
     runs-on: ubuntu-20.04
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false     # no: will remove rust
+          android: true         # 8.7GiB
+          dotnet: true          # 1.6GiB
+          docker-images: true   # 3.2GiB
+          haskell: false        # no: little/no benefit
+          large-packages: false # no: slow
+          swap-storage: false   # no: having swap is useful
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -73,17 +84,6 @@ jobs:
             rust/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-
-
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: false     # no: will remove rust
-          android: true         # 8.7GiB
-          dotnet: true          # 1.6GiB
-          docker-images: true   # 3.2GiB
-          haskell: false        # no: little/no benefit
-          large-packages: false # no: slow
-          swap-storage: false   # no: having swap is useful
 
       - name: Create bindings
         if: ${{ !inputs.fake }}
@@ -125,6 +125,17 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-13, macos-14]
 
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false     # no: will remove rust
+          android: true         # 8.7GiB
+          dotnet: true          # 1.6GiB
+          docker-images: true   # 3.2GiB
+          haskell: false        # no: little/no benefit
+          large-packages: false # no: slow
+          swap-storage: false   # no: having swap is useful
+  
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -143,17 +154,6 @@ jobs:
         with:
           python-version: 3.9
           cache: pip
-
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: false     # no: will remove rust
-          android: true         # 8.7GiB
-          dotnet: true          # 1.6GiB
-          docker-images: true   # 3.2GiB
-          haskell: false        # no: little/no benefit
-          large-packages: false # no: slow
-          swap-storage: false   # no: having swap is useful
 
       - name: Install cibuildwheel
         run: |
@@ -189,6 +189,7 @@ jobs:
                 apk update && apk add openssl pkgconfig
             fi
           CIBW_BUILD_VERBOSITY: 1
+          CIBW_TEST_COMMAND: python -c "import opendp"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -202,6 +203,17 @@ jobs:
       DOCKER_IMAGE: messense/manylinux_2_24-cross:aarch64
       TARGET: aarch64-unknown-linux-gnu
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false     # no: will remove rust
+          android: true         # 8.7GiB
+          dotnet: true          # 1.6GiB
+          docker-images: true   # 3.2GiB
+          haskell: false        # no: little/no benefit
+          large-packages: false # no: slow
+          swap-storage: false   # no: having swap is useful
+
       - name: Checkout repository
         if: ${{ !inputs.fake }}
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,17 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-
 
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false     # no: will remove rust
+          android: true         # 8.7GiB
+          dotnet: true          # 1.6GiB
+          docker-images: true   # 3.2GiB
+          haskell: false        # no: little/no benefit
+          large-packages: false # no: slow
+          swap-storage: false   # no: having swap is useful
+
       - name: Create bindings
         if: ${{ !inputs.fake }}
         run: bash tools/rust_build.sh -r -n -f "$FEATURES,bindings"
@@ -132,6 +143,17 @@ jobs:
         with:
           python-version: 3.9
           cache: pip
+
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false     # no: will remove rust
+          android: true         # 8.7GiB
+          dotnet: true          # 1.6GiB
+          docker-images: true   # 3.2GiB
+          haskell: false        # no: little/no benefit
+          large-packages: false # no: slow
+          swap-storage: false   # no: having swap is useful
 
       - name: Install cibuildwheel
         run: |

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -26,10 +26,15 @@ def _load_library():
         lib_dir = Path(__file__).parent / ".." / ".." / ".." / 'rust' / 'target' / build_dir  # pragma: no cover
 
     if lib_dir.exists():
+        from importlib.machinery import EXTENSION_SUFFIXES
+        suffixes = EXTENSION_SUFFIXES + [".dylib"]
+
         lib_dir_file_names = [
-            p for p in lib_dir.iterdir()
-            if p.suffix in {".so", ".dylib", ".dll", ".pyd"}
-            and p.stem.replace("lib", "") == "opendp"]
+            str(p.name) for p in lib_dir.iterdir() 
+            if "opendp" in p.name and "derive" not in p.name
+            and any(p.name.endswith(suffix) for suffix in suffixes)
+        ]
+        
         if len(lib_dir_file_names) != 1:
             raise Exception(f"Expected exactly one binary to be present in {lib_dir}. Got: {lib_dir_file_names}")
         

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -40,6 +40,9 @@ thiserror = "1.0.24"
 statrs = "0.13.0"
 dashu = { version = "0.4.0", features = ["num-traits_v02"] }
 openssl = { version = "0.10.64", features = ["vendored"], optional = true }
+# Pin to older openssl version until bug is fixed.
+# https://github.com/openssl/openssl/pull/25367#issuecomment-2336747983
+openssl-src = { version = "300.3.2+3.3.2" }
 opendp_tooling = { path = "opendp_tooling", optional = true, version = "0.11.1-dev" }
 readonly = "0.2"
 bitvec = "1.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -42,7 +42,7 @@ dashu = { version = "0.4.0", features = ["num-traits_v02"] }
 openssl = { version = "0.10.64", features = ["vendored"], optional = true }
 # Pin to older openssl version until bug is fixed.
 # https://github.com/openssl/openssl/pull/25367#issuecomment-2336747983
-openssl-src = { version = "300.3.2+3.3.2" }
+openssl-src = { version = "=300.3.1+3.3.1" }
 opendp_tooling = { path = "opendp_tooling", optional = true, version = "0.11.1-dev" }
 readonly = "0.2"
 bitvec = "1.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -40,9 +40,11 @@ thiserror = "1.0.24"
 statrs = "0.13.0"
 dashu = { version = "0.4.0", features = ["num-traits_v02"] }
 openssl = { version = "0.10.64", features = ["vendored"], optional = true }
-# Pin to older openssl version until bug is fixed.
-# https://github.com/openssl/openssl/pull/25367#issuecomment-2336747983
-openssl-src = { version = "=300.3.1+3.3.1" }
+
+# Temporary fix until OpenSSL is updated to 3.4.
+# See https://github.com/openssl/openssl/issues/25366
+openssl-src = "=300.3.1"
+
 opendp_tooling = { path = "opendp_tooling", optional = true, version = "0.11.1-dev" }
 readonly = "0.2"
 bitvec = "1.0"


### PR DESCRIPTION
Close #2016

* Free unused disk space so that builds don't run out of disk space when making a release
* Relax criteria for a suitable library binary, given that cibuildwheel emits tagged binaries
* Pin the version of the OpenSSL dependency to avoid build failure on linux distributions

Successful build shown here (save for dropping old nightly pypi versions):
https://github.com/opendp/opendp/actions/runs/11239240060