### PR TITLE
Updating quotes on pip install 'opendp[polars]' and others

### DIFF
--- a/docs/source/getting-started/tabular-data/index.rst
+++ b/docs/source/getting-started/tabular-data/index.rst
@@ -15,7 +15,7 @@ This functionality is not enabled by default.
 
         .. prompt:: bash
 
-            pip install opendp[polars]
+            pip install 'opendp[polars]'
 
         This installs the specific version of the Python Polars package that is compatible with the OpenDP Library.
 

--- a/python/src/opendp/extras/numpy/__init__.py
+++ b/python/src/opendp/extras/numpy/__init__.py
@@ -1,5 +1,5 @@
 '''
-This module requires extra installs: ``pip install opendp[numpy]``
+This module requires extra installs: ``pip install 'opendp[numpy]'``
 
 For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
 We suggest importing under the conventional name ``dp``:

--- a/python/src/opendp/extras/polars/__init__.py
+++ b/python/src/opendp/extras/polars/__init__.py
@@ -1,5 +1,5 @@
 '''
-This module requires extra installs: ``pip install opendp[polars]``
+This module requires extra installs: ``pip install 'opendp[polars]'``
 
 The ``opendp.extras.polars`` module adds differential privacy to the
 `Polars DataFrame library <https://docs.pola.rs>`_.

--- a/python/src/opendp/extras/sklearn/__init__.py
+++ b/python/src/opendp/extras/sklearn/__init__.py
@@ -1,5 +1,5 @@
 '''
-This module requires extra installs: ``pip install opendp[scikit-learn]``
+This module requires extra installs: ``pip install 'opendp[scikit-learn]'``
 
 For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
 We suggest importing under the conventional name ``dp``:

--- a/python/src/opendp/extras/sklearn/decomposition/__init__.py
+++ b/python/src/opendp/extras/sklearn/decomposition/__init__.py
@@ -1,5 +1,5 @@
 '''
-This module requires extra installs: ``pip install opendp[scikit-learn]``
+This module requires extra installs: ``pip install 'opendp[scikit-learn]'``
 
 For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
 We suggest importing under the conventional name ``dp``:


### PR DESCRIPTION
Just updated the documentation and some instances on comments that were referring to pip install opendp[XXX] without quotes.
These instances were found by just using grep
`grep -Ril "'opendp\[" ./`

Closes #2136 