### PR TITLE
Block older versions of docs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -137,6 +137,8 @@ on github, or with the `gh` command line tool. Parameters:
         git checkout -b version-changelog
         ``` 
 
+    1. Update `robots.txt`: Add the new version to the `Disallow` list.
+
     1. Update changelog
 
         ```shell

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -47,7 +47,8 @@ versions:
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 	cp redirect.html $(BUILDDIR)/html/index.html
 	cp 404.html      $(BUILDDIR)/html/
-	@echo "Redirect and 404 pages copied into $(BUILDDIR)/html."
+	cp robots.txt    $(BUILDDIR)/html/
+	@echo "Redirect, 404.html, and robots.txt copied into $(BUILDDIR)/html."
 
 latex:
 	rm -rf build/html/proofs

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -5,6 +5,9 @@
 User-agent: *
 Disallow: /en/beta/
 Disallow: /en/nightly/
+
+# Path globbing is not universally supported.
+Disallow: /en/v*
 Disallow: /en/v0.11.1/
 Disallow: /en/v0.11.0/
 Disallow: /en/v0.10.0/

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,29 @@
+# Disallow everything except for /stable.
+# The is no official "Allow", so we just need to list all the old versions.
+# With quarterly releases, automating the creation of this file is low value.
+
+User-agent: *
+Disallow: /en/beta/
+Disallow: /en/nightly/
+Disallow: /en/v0.11.1/
+Disallow: /en/v0.11.0/
+Disallow: /en/v0.10.0/
+Disallow: /en/v0.9.2/
+Disallow: /en/v0.9.1/
+Disallow: /en/v0.9.0/
+Disallow: /en/v0.8.0/
+Disallow: /en/v0.7.0/
+Disallow: /en/v0.6.2/
+Disallow: /en/v0.6.1/
+Disallow: /en/v0.6.0/
+Disallow: /en/v0.5.0/
+Disallow: /en/v0.4.0/
+Disallow: /en/v0.3.0/
+Disallow: /en/v0.2.4/
+Disallow: /en/v0.2.3/
+Disallow: /en/v0.2.2/
+Disallow: /en/v0.2.1/
+Disallow: /en/v0.2.0/
+Disallow: /en/v0.1.0/
+
+


### PR DESCRIPTION
- Towards #2145 

I'd suggest keeping the issue open until we've manually confirmed that the build has put the robots.txt in the right place at the top level.