### PR TITLE
fix coverage check in CI, RDP function FFI

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -199,7 +199,9 @@ jobs:
         # We only expect test coverage with all extra dependencies.
         # "polars" implies "scikit-learn": see setup.cfg.
         if: ${{ contains(matrix.extra-install, 'polars') && contains(matrix.python-version, '3.12') }}
-        run: coverage report | tee /tmp/coverage.txt
+        run: |
+          set -o pipefail
+          coverage report | tee /tmp/coverage.txt
 
       - name: Upload coverage
         if: ${{ contains(matrix.extra-install, 'polars') && contains(matrix.python-version, '3.12') }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -200,8 +200,8 @@ jobs:
         # "polars" implies "scikit-learn": see setup.cfg.
         if: ${{ contains(matrix.extra-install, 'polars') && contains(matrix.python-version, '3.12') }}
         run: |
-          set -o pipefail
-          coverage report | tee /tmp/coverage.txt
+          coverage report
+          touch /tmp/coverage.txt
 
       - name: Upload coverage
         if: ${{ contains(matrix.extra-install, 'polars') && contains(matrix.python-version, '3.12') }}

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -223,6 +223,21 @@ class ExtrinsicObjectPtr(ctypes.POINTER(ExtrinsicObject)): # type: ignore[misc]
             #   ImportError: sys.meta_path is None, Python is likely shutting down
             pass
 
+
+# The output type cannot be an `ctypes.POINTER(FfiResult)` due to:
+#   https://bugs.python.org/issue5710#msg85731
+#                                 (output         , input       )
+CallbackFnValue = ctypes.CFUNCTYPE(ctypes.c_void_p, AnyObjectPtr)
+
+class CallbackFn(ctypes.Structure):
+    _fields_ = [
+        ("callback", CallbackFnValue),
+        ("lifeline", ExtrinsicObject)
+    ]
+
+class CallbackFnPtr(ctypes.POINTER(CallbackFn)): # type: ignore[misc]
+    _type_ = CallbackFn
+
 # def _str_to_c_char_p(s: Optional[str]) -> Optional[bytes]:
 #     return s and s.encode("utf-8")
 def _c_char_p_to_str(s: Optional[bytes]) -> Optional[str]:

--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -716,7 +716,7 @@ class PartialChain(object):
                 meas = _cast_measure(self(param), output_measure, d_out)
                 return meas.check(d_in, d_out)
         
-        param = binary_search(predicate, T=T)
+        param = binary_search(predicate)
         chain = self.partial(param)
         chain.param = param
         return chain
@@ -726,7 +726,6 @@ class PartialChain(object):
         if isinstance(other, (Transformation, Measurement, PartialConstructor)):
             return PartialChain(lambda x: self(x) >> other)
 
-        print(self, other)
         raise ValueError("At most one parameter may be missing at a time")
     
     def __rrshift__(self, other: Union[tuple[Domain, Metric], Transformation, Measurement]):

--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -44,6 +44,7 @@ from opendp.mod import (
     Domain,
     Measurement,
     Metric,
+    PartialConstructor,
     Queryable,
     Transformation,
     Measure,
@@ -697,7 +698,7 @@ class PartialChain(object):
 
     def __call__(self, v):
         """Returns the transformation or measurement with the given parameter."""
-        return self.partial(v) # pragma: no cover
+        return self.partial(v)
 
     def fix(self, d_in: float, d_out: float, output_measure: Optional[Measure] = None, T=None):
         """Returns the closest transformation or measurement that satisfies the given stability or privacy constraint.
@@ -720,11 +721,12 @@ class PartialChain(object):
         chain.param = param
         return chain
 
-    def __rshift__(self, other: Union[Transformation, Measurement]):
+    def __rshift__(self, other: Union[Transformation, Measurement, PartialConstructor]):
         # partials may be chained with other transformations or measurements to form a new partial
-        if isinstance(other, (Transformation, Measurement)): # pragma: no cover
+        if isinstance(other, (Transformation, Measurement, PartialConstructor)):
             return PartialChain(lambda x: self(x) >> other)
 
+        print(self, other)
         raise ValueError("At most one parameter may be missing at a time")
     
     def __rrshift__(self, other: Union[tuple[Domain, Metric], Transformation, Measurement]):

--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -697,7 +697,6 @@ class PartialChain(object):
 
     def __call__(self, v):
         """Returns the transformation or measurement with the given parameter."""
-        # TODO: Can we exercise this?
         return self.partial(v) # pragma: no cover
 
     def fix(self, d_in: float, d_out: float, output_measure: Optional[Measure] = None, T=None):
@@ -709,11 +708,11 @@ class PartialChain(object):
         # The delta parameter should be fixed in _cast_measure, and if not, then the search will be impossible here anyways.
         if output_measure == fixed_smoothed_max_divergence():
             def predicate(param):
-                meas = _cast_measure(self.partial(param), output_measure, d_out)
+                meas = _cast_measure(self(param), output_measure, d_out)
                 return meas.map(d_in)[0] <= d_out[0] # type: ignore[index] 
         else:
             def predicate(param):
-                meas = _cast_measure(self.partial(param), output_measure, d_out)
+                meas = _cast_measure(self(param), output_measure, d_out)
                 return meas.check(d_in, d_out)
         
         param = binary_search(predicate, T=T)
@@ -723,10 +722,15 @@ class PartialChain(object):
 
     def __rshift__(self, other: Union[Transformation, Measurement]):
         # partials may be chained with other transformations or measurements to form a new partial
-        # TODO: Can we exercise this?
         if isinstance(other, (Transformation, Measurement)): # pragma: no cover
-            return PartialChain(lambda x: self.partial(x) >> other)
+            return PartialChain(lambda x: self(x) >> other)
 
+        raise ValueError("At most one parameter may be missing at a time")
+    
+    def __rrshift__(self, other: Union[tuple[Domain, Metric], Transformation, Measurement]):
+        if isinstance(other, (tuple, Transformation, Measurement)):
+            return PartialChain(lambda x: other >> self(x))
+        
         raise ValueError("At most one parameter may be missing at a time")
 
     @classmethod

--- a/python/test/context/test_context.py
+++ b/python/test/context/test_context.py
@@ -265,6 +265,18 @@ def test_approx_to_approx_zCDP():
     assert release == [1, 2, 3]
 
 
+def test_agg_input():
+    dp.enable_features("contrib")
+    context = dp.Context.compositor(
+        data=0,
+        privacy_unit=dp.unit_of(absolute=1),
+        privacy_loss=dp.loss_of(rho=0.5, delta=0.0),
+        split_evenly_over=1,
+    )
+
+    assert isinstance(context.query().gaussian().release(), int)
+
+
 def test_transformation_release_error():
     privacy_unit = dp.unit_of(contributions=2)
     privacy_loss = dp.loss_of(epsilon=1.0)

--- a/python/test/context/test_context.py
+++ b/python/test/context/test_context.py
@@ -127,6 +127,18 @@ def test_context_zCDP():
     print(dp_sum.release())
 
 
+def test_middle_param():
+    context = dp.Context.compositor(
+        data=[1.0, 2.0, 3.0],
+        privacy_unit=dp.unit_of(contributions=1),
+        privacy_loss=dp.loss_of(epsilon=3.0),
+        split_evenly_over=1,
+    )
+
+    dp_sum = context.query().resize(constant=2.0).clamp((1.0, 10.0)).mean().laplace(1.0)  # type: ignore
+    print(dp_sum.release())
+
+
 def test_query_repr():
     context = dp.Context.compositor(
         data=[1, 2, 3],
@@ -266,7 +278,6 @@ def test_approx_to_approx_zCDP():
 
 
 def test_agg_input():
-    dp.enable_features("contrib")
     context = dp.Context.compositor(
         data=0,
         privacy_unit=dp.unit_of(absolute=1),

--- a/python/test/context/test_context.py
+++ b/python/test/context/test_context.py
@@ -288,6 +288,16 @@ def test_agg_input():
     assert isinstance(context.query().gaussian().release(), int)
 
 
+def test_rshift_multi_partial():
+    context = dp.Context.compositor(
+        data=[1, 2, 3],
+        privacy_unit=dp.unit_of(l1=1),
+        privacy_loss=dp.loss_of(epsilon=0.5),
+        split_evenly_over=1,
+    )
+    with pytest.raises(ValueError, match="laplace is missing"):
+        context.query().b_ary_tree(leaf_count=3).laplace()
+
 def test_transformation_release_error():
     privacy_unit = dp.unit_of(contributions=2)
     privacy_loss = dp.loss_of(epsilon=1.0)

--- a/python/test/test_comb.py
+++ b/python/test/test_comb.py
@@ -115,15 +115,19 @@ def test_renyidp():
 def test_make_approximate():
     input_space = dp.atom_domain(T=float), dp.absolute_distance(T=float)
 
-    meas = dp.c.make_basic_composition([
-        dp.c.make_approximate(dp.m.make_laplace(*input_space, 10.)),
-        dp.c.make_fix_delta(dp.c.make_zCDP_to_approxDP(dp.m.make_gaussian(*input_space, 10.)), delta=1e-6)
-    ])
+    # spot check that mechanisms get delta terms
+    m_gauss = dp.c.make_approximate(dp.m.make_gaussian(*input_space, 1.0))
+    assert m_gauss.map(1.) == (0.5, 0.0)
 
-    assert meas.map(1.) == (0.5299414688369495, 1e-06)
-    
-    meas = dp.c.make_approximate(dp.m.make_gaussian(*input_space, 1.0))
-    assert meas.map(1.) == (0.5, 0.0)
+    m_lap = dp.c.make_approximate(dp.m.make_laplace(*input_space, 1.0))
+    assert m_lap.map(1.) == (1.0, 0.0)
+
+    # composition works properly
+    m_comp = dp.c.make_basic_composition([
+        m_lap,
+        dp.c.make_fix_delta(dp.c.make_zCDP_to_approxDP(dp.m.make_gaussian(*input_space, 1.)), delta=1e-6)
+    ])
+    assert isinstance(m_comp.map(1.), tuple)
 
 
 def test_make_pureDP_to_zCDP():
@@ -133,6 +137,7 @@ def test_make_pureDP_to_zCDP():
         dp.m.make_gaussian(*input_space, 10.)
     ])
 
+    # (1/10)^2 / 2 + 1 / 10^2 / 2
     assert meas.map(1.) == 0.010000000000000002
 
 if __name__ == "__main__":

--- a/python/test/test_comb.py
+++ b/python/test/test_comb.py
@@ -101,6 +101,16 @@ def test_cast_azcdp_approxdp():
     m_adp = dp.c.make_fix_delta(m_asdp, delta=1e-6)
     assert m_adp.map(1.) == (curve.epsilon(1e-6 - 1e-7), 1e-6)
 
+def test_renyidp():
+    m_rdp = dp.m.make_user_measurement(
+        dp.atom_domain(T=bool), dp.absolute_distance(T=float),
+        dp.renyi_divergence(),
+        lambda x: x,
+        lambda d_in: (lambda alpha: d_in * alpha / 2.0)
+    )
+    rdp_curve = m_rdp.map(1.0)
+    assert rdp_curve(4.) == 2.0
+
 
 def test_make_approximate():
     input_space = dp.atom_domain(T=float), dp.absolute_distance(T=float)
@@ -110,7 +120,10 @@ def test_make_approximate():
         dp.c.make_fix_delta(dp.c.make_zCDP_to_approxDP(dp.m.make_gaussian(*input_space, 10.)), delta=1e-6)
     ])
 
-    print(meas.map(1.))
+    assert meas.map(1.) == (0.5299414688369495, 1e-06)
+    
+    meas = dp.c.make_approximate(dp.m.make_gaussian(*input_space, 1.0))
+    assert meas.map(1.) == (0.5, 0.0)
 
 
 def test_make_pureDP_to_zCDP():
@@ -120,7 +133,7 @@ def test_make_pureDP_to_zCDP():
         dp.m.make_gaussian(*input_space, 10.)
     ])
 
-    print(meas.map(1.))
+    assert meas.map(1.) == 0.010000000000000002
 
 if __name__ == "__main__":
     test_make_approximate()

--- a/python/test/test_core.py
+++ b/python/test/test_core.py
@@ -328,4 +328,8 @@ def test_pointer_classes_dont_iter():
     # We override __iter__ so as to make this infinite loop/lock impossible to accidentally trigger
     with pytest.raises(ValueError):
         [*dp.atom_domain(T=bool)]
-    
+
+
+def test_erfc():
+    from opendp._data import erfc
+    assert erfc(0.5) == 0.4795001222363462

--- a/python/test/test_core.py
+++ b/python/test/test_core.py
@@ -251,6 +251,11 @@ def test_user_domain():
 
 def test_extrinsic_free():
     space = dp.user_domain("anything", lambda _: True), dp.symmetric_distance()
+    query = space >> dp.m.then_user_measurement(
+        dp.max_divergence(),
+        lambda x: x,
+        lambda _: 0.0,
+    )
 
     sc_meas = space >> dp.c.then_sequential_composition(
         dp.max_divergence(),
@@ -262,12 +267,6 @@ def test_extrinsic_free():
     qbl = sc_meas([])
     # at this point []'s refcount is zero, but has not been freed yet, because the gc has not run
     # however, a pointer to [] is stored inside qbl
-
-    query = space >> dp.m.then_user_measurement(
-        dp.max_divergence(),
-        lambda x: x,
-        lambda _: 0.0,
-    )
 
     import gc
 

--- a/python/test/test_meas.py
+++ b/python/test/test_meas.py
@@ -246,7 +246,7 @@ def test_randomized_response_bitvec():
     assert np.array_equal(data, np.array([0, 8, 12], dtype=np.uint8))
 
     # roundtrip: bytes -> mech -> numpy
-    release = np.frombuffer(m_rr(data.tobytes()), dtype=np.uint8)
+    release = np.frombuffer(m_rr(data), dtype=np.uint8)
 
     print(np.unpackbits(data), np.unpackbits(release))
     # epsilon is 2 * m * ln((2 - f) / f)

--- a/rust/opendp_tooling/src/codegen/python_typemap.json
+++ b/rust/opendp_tooling/src/codegen/python_typemap.json
@@ -46,6 +46,6 @@
     "const FfiError *": "ctypes.POINTER(FfiError)",
     "ExtrinsicObject *": "ExtrinsicObjectPtr",
     "FfiResult": "FfiResult",
-    "CallbackFn": "CallbackFn",
+    "CallbackFn": "CallbackFnPtr",
     "TransitionFn": "TransitionFn"
 }

--- a/rust/src/core/ffi.rs
+++ b/rust/src/core/ffi.rs
@@ -687,16 +687,17 @@ pub extern "C" fn opendp_core__measurement_output_distance_type(
 /// # Generics
 /// * `TO` - Output Type
 #[allow(dead_code)]
-fn new_function<TO>(function: CallbackFn) -> Fallible<AnyFunction> {
+fn new_function<TO>(function: *const CallbackFn) -> Fallible<AnyFunction> {
     let _ = function;
     panic!("this signature only exists for code generation")
 }
 
 #[no_mangle]
 pub extern "C" fn opendp_core__new_function(
-    function: CallbackFn,
+    function: *const CallbackFn,
     TO: *const c_char,
 ) -> FfiResult<*mut AnyFunction> {
+    let function = try_as_ref!(function).clone();
     let _TO = TO;
     FfiResult::Ok(util::into_raw(Function::new_fallible(wrap_func(function))))
 }

--- a/rust/src/domains/ffi.rs
+++ b/rust/src/domains/ffi.rs
@@ -470,14 +470,15 @@ impl Domain for UserDomain {
 #[no_mangle]
 pub extern "C" fn opendp_domains__user_domain(
     identifier: *mut c_char,
-    member: CallbackFn,
+    member: *const CallbackFn,
     descriptor: *mut ExtrinsicObject,
 ) -> FfiResult<*mut AnyDomain> {
     let identifier = try_!(to_str(identifier)).to_string();
     let descriptor = try_as_ref!(descriptor).clone();
     let element = ExtrinsicElement::new(identifier, descriptor);
+    let member = try_as_ref!(member).clone();
     let member = Function::new_fallible(move |arg: &ExtrinsicObject| -> Fallible<bool> {
-        let c_res = member(AnyObject::new_raw(arg.clone()));
+        let c_res = (member.callback)(AnyObject::new_raw(arg.clone()));
         Fallible::from(util::into_owned(c_res)?)?.downcast::<bool>()
     });
 

--- a/rust/src/measurements/make_user_measurement/mod.rs
+++ b/rust/src/measurements/make_user_measurement/mod.rs
@@ -55,8 +55,8 @@ fn make_user_measurement<TO>(
     input_domain: AnyDomain,
     input_metric: AnyMetric,
     output_measure: AnyMeasure,
-    function: CallbackFn,
-    privacy_map: CallbackFn,
+    function: *const CallbackFn,
+    privacy_map: *const CallbackFn,
 ) -> Fallible<Measurement<AnyDomain, AnyObject, AnyMetric, AnyMeasure>> {
     let _ = (
         input_domain,
@@ -73,17 +73,17 @@ pub extern "C" fn opendp_measurements__make_user_measurement(
     input_domain: *const AnyDomain,
     input_metric: *const AnyMetric,
     output_measure: *const AnyMeasure,
-    function: CallbackFn,
-    privacy_map: CallbackFn,
+    function: *const CallbackFn,
+    privacy_map: *const CallbackFn,
     TO: *const c_char,
 ) -> FfiResult<*mut AnyMeasurement> {
     let _TO = TO;
     Measurement::new(
         try_as_ref!(input_domain).clone(),
-        Function::new_fallible(wrap_func(function)),
+        Function::new_fallible(wrap_func(try_as_ref!(function).clone())),
         try_as_ref!(input_metric).clone(),
         try_as_ref!(output_measure).clone(),
-        PrivacyMap::new_fallible(wrap_func(privacy_map)),
+        PrivacyMap::new_fallible(wrap_func(try_as_ref!(privacy_map).clone())),
     )
     .into()
 }

--- a/rust/src/measures/ffi.rs
+++ b/rust/src/measures/ffi.rs
@@ -388,16 +388,16 @@ impl<Q> Measure for TypedMeasure<Q> {
 /// * rejects epsilon values that are less than zero or nan
 /// * returns delta values only within [0, 1]
 #[allow(dead_code)]
-fn new_privacy_profile(curve: CallbackFn) -> Fallible<AnyObject> {
+fn new_privacy_profile(curve: *const CallbackFn) -> Fallible<AnyObject> {
     let _ = curve;
     panic!("this signature only exists for code generation")
 }
 
 #[no_mangle]
 pub extern "C" fn opendp_measures__new_privacy_profile(
-    curve: CallbackFn,
+    curve: *const CallbackFn,
 ) -> FfiResult<*mut AnyObject> {
-    let curve = wrap_func(curve);
+    let curve = wrap_func(try_as_ref!(curve).clone());
     FfiResult::Ok(AnyObject::new_raw(PrivacyProfile::new(
         move |epsilon: f64| curve(&AnyObject::new(epsilon))?.downcast::<f64>(),
     )))

--- a/rust/src/transformations/make_user_transformation/mod.rs
+++ b/rust/src/transformations/make_user_transformation/mod.rs
@@ -53,16 +53,16 @@ pub extern "C" fn opendp_transformations__make_user_transformation(
     input_metric: *const AnyMetric,
     output_domain: *const AnyDomain,
     output_metric: *const AnyMetric,
-    function: CallbackFn,
-    stability_map: CallbackFn,
+    function: *const CallbackFn,
+    stability_map: *const CallbackFn,
 ) -> FfiResult<*mut AnyTransformation> {
     Transformation::new(
         try_as_ref!(input_domain).clone(),
         try_as_ref!(output_domain).clone(),
-        Function::new_fallible(wrap_func(function)),
+        Function::new_fallible(wrap_func(try_as_ref!(function).clone())),
         try_as_ref!(input_metric).clone(),
         try_as_ref!(output_metric).clone(),
-        StabilityMap::new_fallible(wrap_func(stability_map)),
+        StabilityMap::new_fallible(wrap_func(try_as_ref!(stability_map).clone())),
     )
     .into()
 }


### PR DESCRIPTION
Closes #2149

The following changes were made in the process of fixing coverage:
Drive-by: FFI for creating RDP privacy curves from Python.
Drive-by: Allow partial chain to be the first element of the query.

Two commits, the first shows that CI fails if coverage is not complete, and the second expands coverage.