### PR TITLE
docs: Feedback links

### DIFF
--- a/docs/source/_templates/questions-feedback.html
+++ b/docs/source/_templates/questions-feedback.html
@@ -4,6 +4,12 @@
     -->
     <details>
         <summary>Questions or feedback?</summary>
-        iframe goes here
+        <iframe
+            src="https://docs.google.com/forms/d/e/1FAIpQLSe65Pu58WubBORSEpzlXS2ZlXGr88AjXAwd3MNRAb2PMew2_w/viewform?embedded=true"
+            width="640" height="570"
+            frameborder="0"
+            marginheight="0"
+            marginwidth="0"
+        >Loading…</iframe>
     </details>
 </div>

--- a/docs/source/_templates/questions-feedback.html
+++ b/docs/source/_templates/questions-feedback.html
@@ -1,0 +1,9 @@
+<div class="admonition warning" style="position: relative;">
+    <!--
+     Without the style, the region for the article title overlaps, and the link is unclickable.
+    -->
+    <details>
+        <summary>Questions or feedback?</summary>
+        iframe goes here
+    </details>
+</div>

--- a/docs/source/_templates/questions-feedback.html
+++ b/docs/source/_templates/questions-feedback.html
@@ -4,12 +4,14 @@
     -->
     <details>
         <summary>Questions or feedback?</summary>
-        <iframe
-            src="https://docs.google.com/forms/d/e/1FAIpQLSeL-KZ_K1Yz5SOjGo0wYOLUEVbtOwBU1Ty6WeoRJbFWeEmD5w/viewform?entry.1628573312={{ pagename }}.html"
-            width="640" height="713"
-            frameborder="0"
-            marginheight="0"
-            marginwidth="0"
-        >Loading…</iframe>
+        <div>
+            If you're having problems using OpenDP, or want to submit feedback, please reach out! Here are some ways to contact us:
+            <ul>
+                <li>Ask questions on our <a href="https://github.com/opendp/opendp/discussions">discussions forum</a>.</li>
+                <li>Open issues on our <a href="https://github.com/opendp/opendp/issues">issue tracker</a>.</li>
+                <li>Join our <a href="https://join.slack.com/t/opendp/shared_invite/zt-zw7o1k2s-dHg8NQE8WTfAGFnN_cwomA">Slack</a>.</li>
+                <li>Send general queries to <a href="mailto:info@opendp.org">info@opendp.org</a>.</li>
+            </ul>
+        </div>
     </details>
 </div>

--- a/docs/source/_templates/questions-feedback.html
+++ b/docs/source/_templates/questions-feedback.html
@@ -5,8 +5,8 @@
     <details>
         <summary>Questions or feedback?</summary>
         <iframe
-            src="https://docs.google.com/forms/d/e/1FAIpQLSe65Pu58WubBORSEpzlXS2ZlXGr88AjXAwd3MNRAb2PMew2_w/viewform?embedded=true"
-            width="640" height="570"
+            src="https://docs.google.com/forms/d/e/1FAIpQLSeL-KZ_K1Yz5SOjGo0wYOLUEVbtOwBU1Ty6WeoRJbFWeEmD5w/viewform?entry.1628573312={{ pagename }}.html"
+            width="640" height="713"
             frameborder="0"
             marginheight="0"
             marginwidth="0"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -184,7 +184,7 @@ html_last_updated_fmt = '%b %d, %Y'
 # Full list of options at https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/layout.html#references
 html_theme_options = {
     "github_url": "https://github.com/opendp",
-    "article_header_end": ["old-version-warning"]
+    "article_header_end": ["questions-feedback", "old-version-warning"]
 }
 
 html_theme = 'pydata_sphinx_theme'


### PR DESCRIPTION
- Fix #2127. Surveyed other options, but this seems good enough. 

(If it's not good enough, then that's also good to know! I don't have any hard requirements right now to constrain the search.)

If you're working on this branch note that the iframe is a 403 if you're just loading it from `file:///`: It needs to be served by http.

Looks like this:

<img width="644" alt="Screenshot 2024-11-20 at 9 08 46 AM" src="https://github.com/user-attachments/assets/120d7f5c-b0a7-497c-9311-a296cc192afa">
<img width="642" alt="Screenshot 2024-11-20 at 9 09 08 AM" src="https://github.com/user-attachments/assets/c42f16da-c6f7-4474-b1c6-2781122a2024">

I've changed the font and text color to match our site, but it's still obviously a google form.

Questions to consider:
- Privacy wise, are we ok with a google form? One alternative would be to write out the html for the iframe only after the user clicks... but I think that would be a bit for work for not much gain.
- Are these questions the questions we want to ask?
- Whose responsibility is it to look at the responses?