### PR TITLE
Polars: simplify ExprDomain

### DIFF
--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -274,7 +274,7 @@ def _py_to_slice(value: Any, type_name: Union[RuntimeType, str]) -> FfiSlicePtr:
         if type_name == "Series":
             return _series_to_slice(value)
         
-        if type_name == "LazyFrame":
+        if type_name in {"LazyFrame", "DslPlan"}:
             return _lazyframe_to_slice(value)
         
         if type_name == "DataFrame":
@@ -453,14 +453,6 @@ def _tuple_to_slice(val: tuple[Any, ...], type_name: Union[RuntimeType, str]) ->
     if len(inner_type_names) != len(val):
         raise TypeError("type_name members must have same length as tuple")
 
-    if inner_type_names == ['DslPlan', 'Expr']:
-        lf_slice = _lazyframe_to_slice(val[0])
-        expr_slice = _expr_to_slice(val[1])
-        array = (ctypes.c_void_p * len(val))(ctypes.cast(lf_slice, ctypes.c_void_p), ctypes.cast(expr_slice, ctypes.c_void_p))
-        out = _wrap_in_slice(ctypes.pointer(array), 2)
-        out.depends_on(lf_slice, expr_slice)
-        return out
-    
     if inner_type_names == ['f64', 'ExtrinsicObject']:
         score_ptr = ctypes.pointer(ctypes.c_double(val[0]))
         ext_obj = ctypes.pointer(ExtrinsicObject(ctypes.py_object(val[1]), c_counter))
@@ -498,11 +490,6 @@ def _slice_to_tuple(raw: FfiSlicePtr, type_name: RuntimeType) -> tuple[Any, ...]
     # list of void*
     ptr_data = void_array_ptr[0:raw.contents.len]
 
-    if inner_type_names == ['DslPlan', 'Expr']:
-        lp_slice = ctypes.cast(ptr_data[0], FfiSlicePtr)
-        expr_slice = ctypes.cast(ptr_data[1], FfiSlicePtr)
-        return _slice_to_lazyframe(lp_slice), _slice_to_expr(expr_slice)
-    
     if inner_type_names == ['PrivacyProfile', 'f64']:
         curve = ctypes.cast(ptr_data[0], AnyObjectPtr)
         delta = ctypes.cast(ptr_data[1], ctypes.POINTER(ctypes.c_double))

--- a/python/test/test_polars.py
+++ b/python/test/test_polars.py
@@ -229,7 +229,7 @@ def test_filter(measure):
 
     lf_domain, lf = example_lf(margin=[], public_info="keys", max_partition_length=50)
 
-    plan = lf.filter(pl.col("B") < 2).select(pl.len().dp.noise(scale=0.0))
+    plan = lf.filter(pl.col("B") < 2).select(dp.len(scale=0.0))
 
     m_lf = dp.m.make_private_lazyframe(
         lf_domain, dp.symmetric_distance(), measure, plan
@@ -240,10 +240,8 @@ def test_filter(measure):
 
 
 def test_onceframe_multi_collect():
-    pl = pytest.importorskip("polars")
-
     lf_domain, lf = example_lf()
-    plan = seed(lf.collect_schema()).select(pl.len().dp.noise(0.0))
+    plan = seed(lf.collect_schema()).select(dp.len(0.0))
     m_lf = dp.m.make_private_lazyframe(
         lf_domain, dp.symmetric_distance(), dp.max_divergence(), plan
     )
@@ -258,7 +256,7 @@ def test_onceframe_lazy():
     pl = pytest.importorskip("polars")
 
     lf_domain, lf = example_lf()
-    plan = seed(lf.collect_schema()).select(pl.len().dp.noise(0.0))
+    plan = seed(lf.collect_schema()).select(dp.len(0.0))
     m_lf = dp.m.make_private_lazyframe(
         lf_domain, dp.symmetric_distance(), dp.max_divergence(), plan
     )

--- a/python/test/test_usability.py
+++ b/python/test/test_usability.py
@@ -121,10 +121,10 @@ def test_polars_data_loader_error_is_human_readable(domain):
 
 def test_polars_expr_loader_error_is_human_readable():
     pl = pytest.importorskip("polars")
-    overall_pipeline = dp.c.make_sequential_composition(
-        dp.expr_domain(dp.lazyframe_domain([])), 
-        dp.symmetric_distance(), 
-        dp.max_divergence(), 
-        d_in=1, d_mids=[1.])
     with pytest.raises(ValueError, match="expected Polars Expr"):
-        overall_pipeline((pl.LazyFrame({}), "I'm not the right type!"))
+        dp.m.make_private_expr(
+            dp.wild_expr_domain([]),
+            dp.symmetric_distance(),
+            dp.max_divergence(),
+            pl.LazyFrame({}),
+        )

--- a/rust/opendp_tooling/src/codegen/r/mod.rs
+++ b/rust/opendp_tooling/src/codegen/r/mod.rs
@@ -57,7 +57,7 @@ const BLACKLIST: &'static [&'static str] = &[
     "lazyframe_domain",
     "_lazyframe_from_domain",
     "with_margin",
-    "expr_domain",
+    "wild_expr_domain",
     "make_stable_lazyframe",
     "make_stable_expr",
     "make_private_lazyframe",

--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -381,6 +381,7 @@ where
         })
     }
 
+    #[allow(dead_code)]
     pub(crate) fn with_map<MI2: Metric, MO2: Metric>(
         &self,
         input_metric: MI2,

--- a/rust/src/data/ffi/mod.rs
+++ b/rust/src/data/ffi/mod.rs
@@ -259,6 +259,10 @@ pub extern "C" fn opendp_data__slice_as_object(
         Ok(AnyObject::new(LazyFrame::from(deserialize_raw::<DslPlan>(raw, "LazyFrame")?)))
     }
     #[cfg(feature = "polars")]
+    fn raw_to_dslplan(raw: &FfiSlice) -> Fallible<AnyObject> {
+        Ok(AnyObject::new(LazyFrame::from(deserialize_raw::<DslPlan>(raw, "LazyFrame")?).logical_plan))
+    }
+    #[cfg(feature = "polars")]
     fn raw_to_tuple_lf_expr(
         raw: &FfiSlice,
     ) -> Fallible<AnyObject> {
@@ -285,6 +289,8 @@ pub extern "C" fn opendp_data__slice_as_object(
 
         #[cfg(feature = "polars")]
         TypeContents::PLAIN("LazyFrame") => raw_to_lazyframe(raw),
+        #[cfg(feature = "polars")]
+        TypeContents::PLAIN("DslPlan") => raw_to_dslplan(raw),
         #[cfg(feature = "polars")]
         TypeContents::PLAIN("Expr") => raw_to_expr(raw),
         #[cfg(feature = "polars")]

--- a/rust/src/domains/polars/expr/ffi.rs
+++ b/rust/src/domains/polars/expr/ffi.rs
@@ -1,60 +1,83 @@
+use std::{ffi::c_char, os::raw::c_void};
+
 use opendp_derive::bootstrap;
 
 use crate::{
     core::{FfiResult, Metric, MetricSpace},
-    domains::LazyFrameDomain,
+    domains::{polars::ffi::unpack_series_domains, Margin, MarginPub},
     error::Fallible,
     ffi::{
         any::{AnyDomain, AnyMetric, AnyObject, Downcast},
-        util::as_ref,
+        util,
     },
     metrics::{InsertDeleteDistance, SymmetricDistance},
 };
 
-use super::{ExprContext, ExprDomain};
+use super::{Context, ExprDomain, WildExprDomain};
 
 #[no_mangle]
 #[bootstrap(
-    name = "expr_domain",
+    name = "wild_expr_domain",
     features("contrib"),
     arguments(
-        lazyframe_domain(c_type = "AnyDomain *", rust_type = b"null"),
-        context(default = b"null", rust_type = b"null"),
-        grouping_columns(
+        columns(rust_type = "Vec<SeriesDomain>"),
+        by(
             rust_type = "Option<Vec<String>>",
             default = b"null",
             hint = "list[str]"
         ),
-        active_column(
-            c_type = "AnyObject *",
-            rust_type = "Option<String>",
+        max_partition_length(c_type = "void *", rust_type = "Option<u32>", default = b"null"),
+        max_num_partitions(c_type = "void *", rust_type = "Option<u32>", default = b"null"),
+        max_partition_contributions(
+            c_type = "void *",
+            rust_type = "Option<u32>",
             default = b"null"
-        )
+        ),
+        max_influenced_partitions(c_type = "void *", rust_type = "Option<u32>", default = b"null"),
+        public_info(rust_type = "Option<String>", default = b"null")
     )
 )]
-/// Construct an ExprDomain from a LazyFrameDomain.
-///
-/// Must pass either `context` or `grouping_columns`.
+/// Construct a WildExprDomain.
 ///
 /// # Arguments
-/// * `lazyframe_domain` - the domain of the LazyFrame to be constructed
-/// * `grouping_columns` - set when creating an expression that aggregates
-pub extern "C" fn opendp_domains__expr_domain(
-    lazyframe_domain: *const AnyDomain,
-    grouping_columns: *const AnyObject,
+/// * `columns` - descriptors for each column in the data
+/// * `by` - optional. Set if expression is applied to grouped data
+/// * `margin` - descriptors for grouped data
+pub extern "C" fn opendp_domains__wild_expr_domain(
+    columns: *const AnyObject,
+    by: *const AnyObject,
+    max_partition_length: *const c_void,
+    max_num_partitions: *const c_void,
+    max_partition_contributions: *const c_void,
+    max_influenced_partitions: *const c_void,
+    public_info: *const c_char,
 ) -> FfiResult<*mut AnyDomain> {
-    let lf_domain = try_!(try_as_ref!(lazyframe_domain).downcast_ref::<LazyFrameDomain>()).clone();
+    let columns = try_!(unpack_series_domains(columns));
 
-    let context = if let Some(object) = as_ref(grouping_columns) {
-        let grouping_columns = try_!(object.downcast_ref::<Vec<String>>()).clone();
-        ExprContext::Aggregate {
-            grouping_columns: grouping_columns.into_iter().collect(),
-        }
+    let context = if let Some(by) = util::as_ref(by) {
+        let by = try_!(by.downcast_ref::<Vec<String>>()).clone();
+        let by = by.into_iter().map(|s| s.into()).collect();
+
+        let margin = Margin {
+            max_partition_length: util::as_ref(max_partition_length as *const u32).cloned(),
+            max_num_partitions: util::as_ref(max_num_partitions as *const u32).cloned(),
+            max_partition_contributions: util::as_ref(max_partition_contributions as *const u32)
+                .cloned(),
+            max_influenced_partitions: util::as_ref(max_influenced_partitions as *const u32)
+                .cloned(),
+            public_info: match try_!(util::to_option_str(public_info)) {
+                Some("keys") => Some(MarginPub::Keys),
+                Some("lengths") => Some(MarginPub::Lengths),
+                None => None,
+                _ => return err!(FFI, "public_info must be one of 'keys' or 'lengths'").into(),
+            },
+        };
+        Context::Grouping { by, margin }
     } else {
-        ExprContext::RowByRow
+        Context::RowByRow
     };
 
-    Ok(AnyDomain::new(ExprDomain::new(lf_domain, context))).into()
+    Ok(AnyDomain::new(WildExprDomain { columns, context })).into()
 }
 
 impl MetricSpace for (ExprDomain, AnyMetric) {

--- a/rust/src/domains/polars/frame/test.rs
+++ b/rust/src/domains/polars/frame/test.rs
@@ -46,7 +46,7 @@ fn assert_row_descriptors<F: Frame>(
     max_partition_length: Option<u32>,
     max_partition_contributions: Option<u32>,
 ) {
-    let margin = domain.get_margin(by.iter().map(ToString::to_string).collect());
+    let margin = domain.get_margin(by.iter().map(|s| s.to_string().into()).collect());
     assert_eq!(margin.max_partition_length, max_partition_length);
     assert_eq!(
         margin.max_partition_contributions,
@@ -78,7 +78,7 @@ fn assert_partition_descriptors<F: Frame>(
     max_num_partitions: Option<u32>,
     max_influenced_partitions: Option<u32>,
 ) {
-    let margin = domain.get_margin(by.iter().map(ToString::to_string).collect());
+    let margin = domain.get_margin(by.iter().map(|s| s.to_string().into()).collect());
     assert_eq!(margin.max_num_partitions, max_num_partitions);
     assert_eq!(margin.max_influenced_partitions, max_influenced_partitions);
 }
@@ -140,19 +140,15 @@ fn test_get_margin_public_info() -> Fallible<()> {
     .with_margin(&["A", "B"], Margin::default().with_public_lengths())?;
 
     // nothing is known when grouping not in margins
-    let margin_abc = lf_domain.get_margin(BTreeSet::from([
-        "A".to_string(),
-        "B".to_string(),
-        "C".to_string(),
-    ]));
+    let margin_abc = lf_domain.get_margin(BTreeSet::from(["A".into(), "B".into(), "C".into()]));
     assert_eq!(margin_abc.public_info, None);
 
     // retrieving info directly from the margin as-is
-    let margin_ab = lf_domain.get_margin(BTreeSet::from(["A".to_string(), "B".to_string()]));
+    let margin_ab = lf_domain.get_margin(BTreeSet::from(["A".into(), "B".into()]));
     assert_eq!(margin_ab.public_info, Some(MarginPub::Lengths));
 
     // keys and lengths are known on coarser partitions
-    let margin_a = lf_domain.get_margin(BTreeSet::from(["A".to_string()]));
+    let margin_a = lf_domain.get_margin(BTreeSet::from(["A".into()]));
     assert_eq!(margin_a.public_info, Some(MarginPub::Lengths));
     Ok(())
 }

--- a/rust/src/measurements/make_private_expr/expr_len/mod.rs
+++ b/rust/src/measurements/make_private_expr/expr_len/mod.rs
@@ -1,11 +1,9 @@
-use crate::core::{Measure, MetricSpace, PrivacyMap};
-use crate::domains::MarginPub;
+use crate::core::{Measure, PrivacyMap};
+use crate::domains::{MarginPub, WildExprDomain};
 use crate::metrics::PartitionDistance;
-use crate::polars::ExprFunction;
 use crate::transformations::traits::UnboundedMetric;
 use crate::{
     core::{Function, Measurement},
-    domains::ExprDomain,
     error::Fallible,
 };
 
@@ -34,25 +32,19 @@ mod test;
 /// * `output_measure` - how to measure privacy loss
 /// * `expr` - count expression
 pub fn make_expr_private_len<MI: 'static + UnboundedMetric, MO: 'static + Measure>(
-    input_domain: ExprDomain,
+    input_domain: WildExprDomain,
     input_metric: PartitionDistance<MI>,
     output_measure: MO,
     expr: Expr,
-) -> Fallible<Measurement<ExprDomain, Expr, PartitionDistance<MI>, MO>>
+) -> Fallible<Measurement<WildExprDomain, Expr, PartitionDistance<MI>, MO>>
 where
     MO::Distance: Zero,
-    (ExprDomain, PartitionDistance<MI>): MetricSpace,
 {
     let Expr::Len = expr else {
         return fallible!(MakeMeasurement, "Expected len() expression");
     };
 
-    let by = input_domain.context.grouping_columns()?;
-    let margin = input_domain
-        .frame_domain
-        .margins
-        .get(&by)
-        .ok_or_else(|| err!(MakeMeasurement, "Unknown margin for {:?}", by))?;
+    let (by, margin) = input_domain.context.grouping("len")?;
 
     if Some(MarginPub::Lengths) != margin.public_info {
         return fallible!(
@@ -64,7 +56,7 @@ where
 
     Measurement::new(
         input_domain,
-        Function::from_expr(len()),
+        Function::new(|_| len()),
         input_metric,
         output_measure,
         PrivacyMap::new(move |_| MO::Distance::zero()),

--- a/rust/src/measurements/make_private_expr/expr_len/test.rs
+++ b/rust/src/measurements/make_private_expr/expr_len/test.rs
@@ -22,7 +22,7 @@ fn test_make_count_expr_grouped() -> Fallible<()> {
         None,
     )?;
 
-    let meas_res = m_lap.invoke(&(lf.logical_plan.clone(), all()))?;
+    let meas_res = m_lap.invoke(&lf.logical_plan)?;
 
     let df_actual = lf
         .clone()

--- a/rust/src/measurements/make_private_expr/expr_literal/mod.rs
+++ b/rust/src/measurements/make_private_expr/expr_literal/mod.rs
@@ -1,9 +1,8 @@
 use crate::core::{Measure, Metric, MetricSpace, PrivacyMap};
+use crate::domains::WildExprDomain;
 use crate::metrics::PartitionDistance;
-use crate::polars::ExprFunction;
 use crate::{
     core::{Function, Measurement},
-    domains::ExprDomain,
     error::Fallible,
 };
 
@@ -22,13 +21,13 @@ mod test;
 /// * `input_metric` - valid selections shown in table above
 /// * `expr` - literal expression
 pub fn make_expr_private_lit<MI: 'static + Metric, MO: 'static + Measure>(
-    input_domain: ExprDomain,
+    input_domain: WildExprDomain,
     input_metric: PartitionDistance<MI>,
     expr: Expr,
-) -> Fallible<Measurement<ExprDomain, Expr, PartitionDistance<MI>, MO>>
+) -> Fallible<Measurement<WildExprDomain, Expr, PartitionDistance<MI>, MO>>
 where
     MO::Distance: Zero,
-    (ExprDomain, PartitionDistance<MI>): MetricSpace,
+    (WildExprDomain, PartitionDistance<MI>): MetricSpace,
 {
     let Expr::Literal(_) = &expr else {
         return fallible!(MakeMeasurement, "Expected Literal expression");
@@ -36,9 +35,9 @@ where
 
     Measurement::new(
         input_domain,
-        Function::from_expr(expr),
+        Function::new(move |_| expr.clone()),
         input_metric,
         MO::default(),
-        PrivacyMap::new(move |_| MO::Distance::zero()),
+        PrivacyMap::new(|_| MO::Distance::zero()),
     )
 }

--- a/rust/src/measurements/make_private_expr/expr_literal/test.rs
+++ b/rust/src/measurements/make_private_expr/expr_literal/test.rs
@@ -1,5 +1,5 @@
 use polars::df;
-use polars_plan::dsl::{all, lit};
+use polars_plan::dsl::lit;
 
 use crate::{
     measurements::{make_private_lazyframe, PrivateExpr},
@@ -22,7 +22,7 @@ fn test_make_expr_private_lit() -> Fallible<()> {
         None,
     )?;
 
-    let actual = m_lit.invoke(&(lf.logical_plan.clone(), all()))?;
+    let actual = m_lit.invoke(&lf.logical_plan)?;
     assert_eq!(actual, lit(1));
     Ok(())
 }

--- a/rust/src/measurements/make_private_expr/expr_noise/test.rs
+++ b/rust/src/measurements/make_private_expr/expr_noise/test.rs
@@ -13,18 +13,17 @@ use crate::{
 #[test]
 fn test_make_expr_puredp() -> Fallible<()> {
     let (lf_domain, lf) = get_test_data()?;
-    let expr_domain = lf_domain.select();
     let scale: f64 = 0.0;
 
     let m_quant = make_private_expr(
-        expr_domain,
+        lf_domain.select(),
         PartitionDistance(InsertDeleteDistance),
         MaxDivergence::default(),
         col("const_1f64").dp().sum((0., 1.), Some(scale)),
         None,
     )?;
 
-    let dp_expr = m_quant.invoke(&(lf.logical_plan.clone(), all()))?;
+    let dp_expr = m_quant.invoke(&lf.logical_plan)?;
     let df_actual = lf.select([dp_expr]).collect()?;
 
     assert_eq!(df_actual, df!("const_1f64" => [1000.0])?);
@@ -35,18 +34,17 @@ fn test_make_expr_puredp() -> Fallible<()> {
 #[test]
 fn test_make_expr_zcdp() -> Fallible<()> {
     let (lf_domain, lf) = get_test_data()?;
-    let expr_domain = lf_domain.select();
     let scale: f64 = 0.0;
 
     let m_quant = make_private_expr(
-        expr_domain,
+        lf_domain.select(),
         PartitionDistance(InsertDeleteDistance),
         ZeroConcentratedDivergence::default(),
         col("const_1f64").dp().sum((0., 1.), Some(scale)),
         None,
     )?;
 
-    let dp_expr = m_quant.invoke(&(lf.logical_plan.clone(), all()))?;
+    let dp_expr = m_quant.invoke(&lf.logical_plan)?;
     let df_actual = lf.select([dp_expr]).collect()?;
 
     assert_eq!(df_actual, df!("const_1f64" => [1000.0])?);
@@ -57,11 +55,10 @@ fn test_make_expr_zcdp() -> Fallible<()> {
 #[test]
 fn test_fail_make_expr_wrong_distribution() -> Fallible<()> {
     let (lf_domain, _) = get_test_data()?;
-    let expr_domain = lf_domain.select();
     let scale: f64 = 0.0;
 
     let variant = make_private_expr(
-        expr_domain,
+        lf_domain.select(),
         PartitionDistance(InsertDeleteDistance),
         MaxDivergence::default(),
         col("const_1f64")
@@ -83,18 +80,17 @@ fn test_fail_make_expr_wrong_distribution() -> Fallible<()> {
 #[test]
 fn test_make_expr_gaussian() -> Fallible<()> {
     let (lf_domain, lf) = get_test_data()?;
-    let expr_domain = lf_domain.select();
     let scale: f64 = 0.0;
 
     let m_quant = make_private_expr(
-        expr_domain,
+        lf_domain.select(),
         PartitionDistance(InsertDeleteDistance),
         ZeroConcentratedDivergence::default(),
         col("const_1f64").dp().sum((0., 1.), Some(scale)),
         None,
     )?;
 
-    let dp_expr = m_quant.invoke(&(lf.logical_plan.clone(), all()))?;
+    let dp_expr = m_quant.invoke(&lf.logical_plan)?;
     let df_actual = lf.select([dp_expr]).collect()?;
 
     assert_eq!(df_actual, df!("const_1f64" => [1000.0])?);

--- a/rust/src/measurements/make_private_expr/expr_postprocess/mod.rs
+++ b/rust/src/measurements/make_private_expr/expr_postprocess/mod.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use crate::combinators::{make_basic_composition, BasicCompositionMeasure};
 use crate::core::{Metric, MetricSpace};
+use crate::domains::WildExprDomain;
 use crate::{
     core::{Function, Measurement},
-    domains::ExprDomain,
     error::Fallible,
 };
 
@@ -25,16 +25,16 @@ mod test;
 /// * `postprocessor` - function that applies post-processing to the expressions
 /// * `param` - global noise (re)scale parameter
 pub fn make_expr_postprocess<MI: 'static + Metric, MO: 'static + BasicCompositionMeasure>(
-    input_domain: ExprDomain,
+    input_domain: WildExprDomain,
     input_metric: MI,
     output_measure: MO,
     input_exprs: Vec<Expr>,
     postprocessor: impl Fn(Vec<Expr>) -> Fallible<Expr> + 'static + Send + Sync,
     param: Option<f64>,
-) -> Fallible<Measurement<ExprDomain, Expr, MI, MO>>
+) -> Fallible<Measurement<WildExprDomain, Expr, MI, MO>>
 where
     Expr: PrivateExpr<MI, MO>,
-    (ExprDomain, MI): MetricSpace,
+    (WildExprDomain, MI): MetricSpace,
 {
     let m_exprs = input_exprs
         .into_iter()
@@ -61,15 +61,15 @@ where
 }
 
 pub fn match_postprocess<MI: 'static + Metric, MO: 'static + BasicCompositionMeasure>(
-    input_domain: ExprDomain,
+    input_domain: WildExprDomain,
     input_metric: MI,
     output_measure: MO,
     expr: Expr,
     global_scale: Option<f64>,
-) -> Fallible<Option<Measurement<ExprDomain, Expr, MI, MO>>>
+) -> Fallible<Option<Measurement<WildExprDomain, Expr, MI, MO>>>
 where
     Expr: PrivateExpr<MI, MO>,
-    (ExprDomain, MI): MetricSpace,
+    (WildExprDomain, MI): MetricSpace,
 {
     match expr {
         #[cfg(feature = "contrib")]

--- a/rust/src/measurements/make_private_expr/expr_postprocess/test.rs
+++ b/rust/src/measurements/make_private_expr/expr_postprocess/test.rs
@@ -1,5 +1,5 @@
 use polars::df;
-use polars_plan::dsl::{all, col, len, lit};
+use polars_plan::dsl::{col, len, lit};
 
 use crate::{
     measures::MaxDivergence,
@@ -12,18 +12,17 @@ use super::*;
 #[test]
 fn test_postprocess_alias() -> Fallible<()> {
     let (lf_domain, lf) = get_test_data()?;
-    let expr_domain = lf_domain.aggregate(["chunk_2_bool"]);
 
     let expr = len().alias("new name");
 
     let m_expr = expr.clone().make_private(
-        expr_domain,
+        lf_domain.aggregate(["chunk_2_bool"]),
         PartitionDistance(SymmetricDistance),
         MaxDivergence::default(),
         Some(0.),
     )?;
 
-    let expr_p = m_expr.invoke(&(lf.logical_plan.clone(), all()))?;
+    let expr_p = m_expr.invoke(&lf.logical_plan)?;
     let actual = lf.group_by([col("chunk_2_bool")]).agg([expr_p]).collect()?;
     let expected = df!("chunk_2_bool" => [false, true], "new name" => [500u32, 500])?;
 
@@ -37,19 +36,18 @@ fn test_postprocess_alias() -> Fallible<()> {
 #[test]
 fn test_postprocess_binary() -> Fallible<()> {
     let (lf_domain, lf) = get_test_data()?;
-    let expr_domain = lf_domain.aggregate(["chunk_2_bool"]);
 
     // any binary expression is fine
     let expr = (len() / lit(2)).eq(lit(23)).or(lit(false));
 
     let m_expr = expr.clone().make_private(
-        expr_domain,
+        lf_domain.aggregate(["chunk_2_bool"]),
         PartitionDistance(SymmetricDistance),
         MaxDivergence::default(),
         Some(0.),
     )?;
 
-    let expr_p = m_expr.invoke(&(lf.logical_plan.clone(), all()))?;
+    let expr_p = m_expr.invoke(&lf.logical_plan)?;
     let actual = lf.group_by([col("chunk_2_bool")]).agg([expr_p]).collect()?;
     let expected = df!("chunk_2_bool" => [false, true], "len" => [false, false])?;
 

--- a/rust/src/measurements/make_private_expr/expr_report_noisy_max/test.rs
+++ b/rust/src/measurements/make_private_expr/expr_report_noisy_max/test.rs
@@ -44,12 +44,11 @@ fn test_report_noisy_max_gumbel_udf() -> Fallible<()> {
 #[test]
 fn test_report_noisy_max_gumbel_expr() -> Fallible<()> {
     let (lf_domain, lf) = get_quantile_test_data()?;
-    let expr_domain = lf_domain.select();
     let scale: f64 = 1e-8;
     let candidates = Series::new("", [0., 10., 20., 30., 40., 50., 60., 70., 80., 90., 100.]);
 
     let m_quant = make_private_expr(
-        expr_domain,
+        lf_domain.select(),
         PartitionDistance(SymmetricDistance),
         MaxDivergence::default(),
         col("cycle_(..101f64)")
@@ -60,7 +59,7 @@ fn test_report_noisy_max_gumbel_expr() -> Fallible<()> {
         None,
     )?;
 
-    let dp_expr = m_quant.invoke(&(lf.logical_plan.clone(), all()))?;
+    let dp_expr = m_quant.invoke(&lf.logical_plan)?;
     let df = lf.select([dp_expr]).collect()?;
     let actual = df.column("cycle_(..101f64)")?.u32()?.get(0).unwrap();
     assert_eq!(actual, 5);
@@ -71,12 +70,11 @@ fn test_report_noisy_max_gumbel_expr() -> Fallible<()> {
 #[test]
 fn test_fail_report_noisy_max_gumbel_expr_nan_scale() -> Fallible<()> {
     let (lf_domain, _) = get_quantile_test_data()?;
-    let expr_domain = lf_domain.select();
     let scale: f64 = f64::NAN;
     let candidates = Series::new("", [0., 10., 20., 30., 40., 50., 60., 70., 80., 90., 100.]);
 
     let err_variant = make_private_expr(
-        expr_domain,
+        lf_domain.select(),
         PartitionDistance(SymmetricDistance),
         MaxDivergence::default(),
         col("cycle_(..101f64)").dp().median(candidates, Some(scale)),

--- a/rust/src/measurements/make_private_expr/ffi.rs
+++ b/rust/src/measurements/make_private_expr/ffi.rs
@@ -2,7 +2,7 @@ use polars_plan::dsl::Expr;
 
 use crate::{
     core::{FfiResult, IntoAnyMeasurementFfiResultExt, Measure},
-    domains::ExprDomain,
+    domains::WildExprDomain,
     error::Fallible,
     ffi::{
         any::{AnyDomain, AnyMeasure, AnyMeasurement, AnyMetric, AnyObject, Downcast},
@@ -23,7 +23,7 @@ pub extern "C" fn opendp_measurements__make_private_expr(
     expr: *const AnyObject,
     global_scale: *const AnyObject,
 ) -> FfiResult<*mut AnyMeasurement> {
-    let input_domain = try_!(try_as_ref!(input_domain).downcast_ref::<ExprDomain>()).clone();
+    let input_domain = try_!(try_as_ref!(input_domain).downcast_ref::<WildExprDomain>()).clone();
     let input_metric =
         try_!(try_as_ref!(input_metric).downcast_ref::<PartitionDistance<SymmetricDistance>>())
             .clone();
@@ -40,7 +40,7 @@ pub extern "C" fn opendp_measurements__make_private_expr(
     };
 
     fn monomorphize<MO: 'static + Measure>(
-        input_domain: ExprDomain,
+        input_domain: WildExprDomain,
         input_metric: PartitionDistance<SymmetricDistance>,
         output_measure: &AnyMeasure,
         expr: Expr,

--- a/rust/src/measurements/make_private_expr/mod.rs
+++ b/rust/src/measurements/make_private_expr/mod.rs
@@ -4,7 +4,7 @@ use polars_plan::dsl::Expr;
 use crate::{
     combinators::{make_approximate, BasicCompositionMeasure},
     core::{Measure, Measurement, Metric, MetricSpace, Transformation},
-    domains::{ExprDomain, MarginPub},
+    domains::{Context, ExprDomain, MarginPub, WildExprDomain},
     error::Fallible,
     measures::{Approximate, MaxDivergence, ZeroConcentratedDivergence},
     metrics::PartitionDistance,
@@ -56,15 +56,15 @@ pub(crate) mod expr_report_noisy_max;
 /// # Why honest-but-curious?
 /// The privacy guarantee governs only at most one evaluation of the released expression.
 pub fn make_private_expr<MI: 'static + Metric, MO: 'static + Measure>(
-    input_domain: ExprDomain,
+    input_domain: WildExprDomain,
     input_metric: MI,
     output_measure: MO,
     expr: Expr,
     global_scale: Option<f64>,
-) -> Fallible<Measurement<ExprDomain, Expr, MI, MO>>
+) -> Fallible<Measurement<WildExprDomain, Expr, MI, MO>>
 where
     Expr: PrivateExpr<MI, MO>,
-    (ExprDomain, MI): MetricSpace,
+    (WildExprDomain, MI): MetricSpace,
 {
     expr.make_private(input_domain, input_metric, output_measure, global_scale)
 }
@@ -72,21 +72,21 @@ where
 pub trait PrivateExpr<MI: Metric, MO: Measure> {
     fn make_private(
         self,
-        input_domain: ExprDomain,
+        input_domain: WildExprDomain,
         input_metric: MI,
         output_metric: MO,
         global_scale: Option<f64>,
-    ) -> Fallible<Measurement<ExprDomain, Expr, MI, MO>>;
+    ) -> Fallible<Measurement<WildExprDomain, Expr, MI, MO>>;
 }
 
 impl<M: 'static + UnboundedMetric> PrivateExpr<PartitionDistance<M>, MaxDivergence> for Expr {
     fn make_private(
         self,
-        input_domain: ExprDomain,
+        input_domain: WildExprDomain,
         input_metric: PartitionDistance<M>,
         output_measure: MaxDivergence,
         global_scale: Option<f64>,
-    ) -> Fallible<Measurement<ExprDomain, Expr, PartitionDistance<M>, MaxDivergence>> {
+    ) -> Fallible<Measurement<WildExprDomain, Expr, PartitionDistance<M>, MaxDivergence>> {
         if expr_noise::match_noise_shim(&self)?.is_some() {
             return expr_noise::make_expr_noise(input_domain, input_metric, self, global_scale);
         }
@@ -115,11 +115,11 @@ impl<M: 'static + UnboundedMetric> PrivateExpr<PartitionDistance<M>, ZeroConcent
 {
     fn make_private(
         self,
-        input_domain: ExprDomain,
+        input_domain: WildExprDomain,
         input_metric: PartitionDistance<M>,
         output_measure: ZeroConcentratedDivergence,
         global_scale: Option<f64>,
-    ) -> Fallible<Measurement<ExprDomain, Expr, PartitionDistance<M>, ZeroConcentratedDivergence>>
+    ) -> Fallible<Measurement<WildExprDomain, Expr, PartitionDistance<M>, ZeroConcentratedDivergence>>
     {
         if expr_noise::match_noise_shim(&self)?.is_some() {
             return expr_noise::make_expr_noise(input_domain, input_metric, self, global_scale);
@@ -142,11 +142,11 @@ where
 {
     fn make_private(
         self,
-        input_domain: ExprDomain,
+        input_domain: WildExprDomain,
         input_metric: PartitionDistance<MI>,
         output_measure: Approximate<MO>,
         global_scale: Option<f64>,
-    ) -> Fallible<Measurement<ExprDomain, Expr, PartitionDistance<MI>, Approximate<MO>>> {
+    ) -> Fallible<Measurement<WildExprDomain, Expr, PartitionDistance<MI>, Approximate<MO>>> {
         make_approximate(self.make_private(
             input_domain,
             input_metric,
@@ -160,15 +160,14 @@ fn make_private_measure_agnostic<
     MI: 'static + UnboundedMetric,
     MO: 'static + BasicCompositionMeasure<Distance = f64>,
 >(
-    input_domain: ExprDomain,
+    input_domain: WildExprDomain,
     input_metric: PartitionDistance<MI>,
     output_measure: MO,
     expr: Expr,
     global_scale: Option<f64>,
-) -> Fallible<Measurement<ExprDomain, Expr, PartitionDistance<MI>, MO>>
+) -> Fallible<Measurement<WildExprDomain, Expr, PartitionDistance<MI>, MO>>
 where
     Expr: PrivateExpr<PartitionDistance<MI>, MO>,
-    (ExprDomain, MI): MetricSpace,
 {
     if expr_index_candidates::match_index_candidates(&expr)?.is_some() {
         return expr_index_candidates::make_expr_index_candidates::<PartitionDistance<MI>, _>(
@@ -219,9 +218,17 @@ where
 /// * one row is added/removed in unbounded-DP
 /// * one row is changed in bounded-DP
 pub(crate) fn approximate_c_stability<MI: UnboundedMetric, MO: Metric>(
-    trans: &Transformation<ExprDomain, ExprDomain, PartitionDistance<MI>, MO>,
+    trans: &Transformation<WildExprDomain, ExprDomain, PartitionDistance<MI>, MO>,
 ) -> Fallible<MO::Distance> {
-    let margin = trans.input_domain.active_margin()?;
+    let margin = match &trans.input_domain.context {
+        Context::RowByRow { .. } => {
+            return fallible!(
+                MakeTransformation,
+                "c-stability approximation may only be conducted under aggregation"
+            )
+        }
+        Context::Grouping { margin, .. } => margin,
+    };
 
     let d_in = match margin.public_info {
         // smallest valid dataset distance is 2 in bounded-DP

--- a/rust/src/measurements/make_private_lazyframe/group_by/matching.rs
+++ b/rust/src/measurements/make_private_lazyframe/group_by/matching.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeSet, sync::Arc};
 
+use polars::prelude::SmartString;
 use polars_plan::{
     dsl::{Expr, Operator},
     plans::DslPlan,
@@ -58,13 +59,13 @@ pub(crate) fn match_group_by(mut plan: DslPlan) -> Fallible<Option<MatchGroupBy>
     }))
 }
 
-pub fn match_grouping_columns(keys: Vec<Expr>) -> Fallible<BTreeSet<String>> {
+pub fn match_grouping_columns(keys: Vec<Expr>) -> Fallible<BTreeSet<SmartString>> {
     Ok(keys
         .iter()
         .map(|e| {
             Ok(match e {
-                Expr::Column(name) => vec![(*name).to_string()],
-                Expr::Columns(names) => names.iter().map(|s| s.to_string()).collect(),
+                Expr::Column(name) => vec![name.as_ref().into()],
+                Expr::Columns(names) => names.iter().map(|s| s.as_ref().into()).collect(),
                 e => {
                     return fallible!(
                         MakeMeasurement,

--- a/rust/src/measurements/make_private_lazyframe/mod.rs
+++ b/rust/src/measurements/make_private_lazyframe/mod.rs
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 use crate::{
     combinators::{make_approximate, BasicCompositionMeasure},
     core::{Function, Measure, Measurement, Metric, MetricSpace},
-    domains::{DslPlanDomain, ExprDomain, LazyFrameDomain},
+    domains::{DslPlanDomain, LazyFrameDomain},
     error::Fallible,
     measures::{Approximate, MaxDivergence, ZeroConcentratedDivergence},
     metrics::PartitionDistance,
@@ -43,8 +43,6 @@ where
     MO::Distance: Debug,
     Expr: PrivateExpr<PartitionDistance<MS>, MO>,
     DslPlan: StableDslPlan<MS, MS>,
-    (DslPlanDomain, MS): MetricSpace,
-    (ExprDomain, MS): MetricSpace,
 {
     #[cfg(feature = "contrib")]
     if group_by::match_group_by(plan.clone())?.is_some() {
@@ -147,11 +145,8 @@ const SORT_ERR_MSG: &'static str = "Found sort in query plan. To conceal row ord
 
 impl<MS> PrivateDslPlan<MS, MaxDivergence> for DslPlan
 where
-    MS: 'static + UnboundedMetric + DatasetMetric,
-    Expr: PrivateExpr<PartitionDistance<MS>, MaxDivergence>,
+    MS: 'static + UnboundedMetric,
     DslPlan: StableDslPlan<MS, MS>,
-    (DslPlanDomain, MS): MetricSpace,
-    (ExprDomain, MS): MetricSpace,
 {
     fn make_private(
         self,
@@ -178,11 +173,8 @@ where
 
 impl<MS> PrivateDslPlan<MS, ZeroConcentratedDivergence> for DslPlan
 where
-    MS: 'static + UnboundedMetric + DatasetMetric,
-    Expr: PrivateExpr<PartitionDistance<MS>, ZeroConcentratedDivergence>,
+    MS: 'static + UnboundedMetric,
     DslPlan: StableDslPlan<MS, MS>,
-    (DslPlanDomain, MS): MetricSpace,
-    (ExprDomain, MS): MetricSpace,
 {
     fn make_private(
         self,
@@ -209,15 +201,12 @@ where
 
 impl<MS, MO> PrivateDslPlan<MS, Approximate<MO>> for DslPlan
 where
-    MS: 'static + UnboundedMetric + DatasetMetric,
+    MS: 'static + UnboundedMetric,
     MO: 'static + BasicCompositionMeasure,
     Approximate<MO>: 'static + ApproximateMeasure,
     <Approximate<MO> as Measure>::Distance: Debug,
-    Expr: PrivateExpr<PartitionDistance<MS>, MO>
-        + PrivateExpr<PartitionDistance<MS>, Approximate<MO>>,
+    Expr: PrivateExpr<PartitionDistance<MS>, Approximate<MO>>,
     DslPlan: StableDslPlan<MS, MS> + PrivateDslPlan<MS, MO>,
-    (DslPlanDomain, MS): MetricSpace,
-    (ExprDomain, MS): MetricSpace,
 {
     fn make_private(
         self,

--- a/rust/src/traits/operations/mod.rs
+++ b/rust/src/traits/operations/mod.rs
@@ -316,14 +316,14 @@ macro_rules! impl_inherent_null_float {
 impl_inherent_null_float!(f64, f32);
 
 // TRAIT ProductOrd
-macro_rules! impl_total_ord_for_ord {
+macro_rules! impl_ProductOrd_for_ord {
     ($($ty:ty),*) => {$(impl ProductOrd for $ty {
         fn total_cmp(&self, other: &Self) -> Fallible<Ordering> {Ok(Ord::cmp(self, other))}
     })*}
 }
-impl_total_ord_for_ord!(u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
+impl_ProductOrd_for_ord!(u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
 
-impl_total_ord_for_ord!(RBig, IBig);
+impl_ProductOrd_for_ord!(RBig, IBig);
 
 macro_rules! impl_total_ord_for_float {
     ($($ty:ty),*) => {

--- a/rust/src/transformations/make_stable_expr/expr_alias/mod.rs
+++ b/rust/src/transformations/make_stable_expr/expr_alias/mod.rs
@@ -1,13 +1,9 @@
-use std::collections::BTreeSet;
-use std::mem::replace;
-
 use polars_plan::dsl::Expr;
 
 use crate::core::{Function, MetricSpace, StabilityMap, Transformation};
-use crate::domains::{ExprDomain, OuterMetric};
+use crate::domains::{ExprDomain, OuterMetric, WildExprDomain};
 use crate::error::*;
 use crate::polars::ExprFunction;
-use crate::transformations::DatasetMetric;
 
 use super::StableExpr;
 
@@ -21,13 +17,13 @@ mod test;
 /// * `input_metric` - The metric under which neighboring LazyFrames are compared
 /// * `expr` - The alias expression
 pub fn make_expr_alias<M: OuterMetric>(
-    input_domain: ExprDomain,
+    input_domain: WildExprDomain,
     input_metric: M,
     expr: Expr,
-) -> Fallible<Transformation<ExprDomain, ExprDomain, M, M>>
+) -> Fallible<Transformation<WildExprDomain, ExprDomain, M, M>>
 where
-    M::InnerMetric: DatasetMetric,
     M::Distance: Clone,
+    (WildExprDomain, M): MetricSpace,
     (ExprDomain, M): MetricSpace,
     Expr: StableExpr<M, M>,
 {
@@ -42,30 +38,7 @@ where
     let (middle_domain, middle_metric) = t_prior.output_space();
 
     let mut output_domain = middle_domain.clone();
-    let old_name = replace(
-        &mut output_domain.active_series_mut()?.field.name,
-        name.as_ref().into(),
-    );
-
-    // only keep margins with as many unique grouping keys as there were before
-    // if the number of unique grouping keys drops after aliasing,
-    //    then one of the grouping keys is shadowing another grouping key
-    output_domain.frame_domain.margins = (output_domain.frame_domain.margins)
-        .into_iter()
-        .filter_map(|(k, v)| {
-            let old_len = k.len();
-            let new_k: BTreeSet<_> = (k.into_iter())
-                .map(|col| {
-                    if col == old_name {
-                        name.to_string()
-                    } else {
-                        col
-                    }
-                })
-                .collect();
-            (new_k.len() == old_len).then_some((new_k, v))
-        })
-        .collect();
+    output_domain.column.field.name = name.as_ref().into();
 
     let t_alias = Transformation::new(
         middle_domain.clone(),

--- a/rust/src/transformations/make_stable_expr/expr_alias/test.rs
+++ b/rust/src/transformations/make_stable_expr/expr_alias/test.rs
@@ -2,7 +2,7 @@ use polars::{
     df,
     lazy::frame::{IntoLazy, LazyFrame},
 };
-use polars_plan::dsl::{all, col};
+use polars_plan::dsl::col;
 
 use crate::{
     domains::{AtomDomain, LazyFrameDomain, SeriesDomain},
@@ -77,8 +77,8 @@ fn test_alias() -> Fallible<()> {
         .alias("C")
         .make_stable(expr_domain, SymmetricDistance)?;
 
-    let expr_ab = t_ab.invoke(&(lf.clone().logical_plan, all()))?.1;
-    let expr_bc = t_bc.invoke(&(lf.clone().logical_plan, all()))?.1;
+    let expr_ab = t_ab.invoke(&lf.logical_plan)?.1;
+    let expr_bc = t_bc.invoke(&lf.logical_plan)?.1;
 
     let actual = lf.with_columns([expr_ab, expr_bc]).collect()?;
     let expect = df!("A" => ints, "B" => ints, "C" => bools)?;

--- a/rust/src/transformations/make_stable_expr/expr_binary/mod.rs
+++ b/rust/src/transformations/make_stable_expr/expr_binary/mod.rs
@@ -3,9 +3,7 @@ use polars_plan::dsl::Expr;
 use polars_plan::utils::expr_output_name;
 
 use crate::core::{Function, MetricSpace, StabilityMap, Transformation};
-use crate::domains::{
-    AtomDomain, DslPlanDomain, ExprContext, ExprDomain, OuterMetric, SeriesDomain,
-};
+use crate::domains::{AtomDomain, ExprDomain, OuterMetric, SeriesDomain, WildExprDomain};
 use crate::error::*;
 use crate::transformations::DatasetMetric;
 
@@ -20,14 +18,16 @@ mod test;
 /// * `input_domain` - Expr domain
 /// * `input_metric` - The metric under which neighboring LazyFrames are compared
 /// * `expr` - The clipping expression
-pub fn make_expr_binary<M: OuterMetric>(
-    input_domain: ExprDomain,
+pub fn make_expr_binary<M>(
+    input_domain: WildExprDomain,
     input_metric: M,
     expr: Expr,
-) -> Fallible<Transformation<ExprDomain, ExprDomain, M, M>>
+) -> Fallible<Transformation<WildExprDomain, ExprDomain, M, M>>
 where
+    M: OuterMetric,
     M::InnerMetric: DatasetMetric,
     M::Distance: Clone,
+    (WildExprDomain, M): MetricSpace,
     (ExprDomain, M): MetricSpace,
     Expr: StableExpr<M, M>,
 {
@@ -35,20 +35,14 @@ where
         return fallible!(MakeTransformation, "expected binary expression");
     };
 
-    let ExprDomain {
-        frame_domain,
-        context,
-    } = input_domain.clone();
-
-    let expr_domain = ExprDomain::new(frame_domain, ExprContext::RowByRow);
     let t_left = left
         .as_ref()
         .clone()
-        .make_stable(expr_domain.clone(), input_metric.clone())?;
+        .make_stable(input_domain.as_row_by_row(), input_metric.clone())?;
     let t_right = right
         .as_ref()
         .clone()
-        .make_stable(expr_domain.clone(), input_metric.clone())?;
+        .make_stable(input_domain.as_row_by_row(), input_metric.clone())?;
 
     use polars_plan::dsl::Operator::*;
     if !matches!(
@@ -58,20 +52,23 @@ where
         return fallible!(MakeTransformation, "unsupported operator: {:?}. Only binary operations that emit booleans are currently supported.", op);
     }
 
-    let mut series_domain =
+    let mut data_column =
         SeriesDomain::new(&*expr_output_name(&expr)?, AtomDomain::<bool>::default());
 
-    let left_nullable = t_left.output_domain.active_series()?.nullable;
-    let right_nullable = t_right.output_domain.active_series()?.nullable;
+    let left_nullable = t_left.output_domain.column.nullable;
+    let right_nullable = t_right.output_domain.column.nullable;
 
-    series_domain.nullable = left_nullable || right_nullable;
+    data_column.nullable = left_nullable || right_nullable;
 
-    let output_domain = ExprDomain::new(DslPlanDomain::new(vec![series_domain])?, context);
+    let output_domain = ExprDomain {
+        column: data_column,
+        context: input_domain.context.clone(),
+    };
 
     Transformation::new(
         input_domain,
         output_domain,
-        Function::new_fallible(move |arg: &(DslPlan, Expr)| {
+        Function::new_fallible(move |arg: &DslPlan| {
             let left = t_left.invoke(arg)?.1;
             let right = t_right.invoke(arg)?.1;
 
@@ -80,7 +77,7 @@ where
                 right: Arc::new(right),
                 op: op.clone(),
             };
-            Ok((arg.0.clone(), binary))
+            Ok((arg.clone(), binary))
         }),
         input_metric.clone(),
         input_metric,

--- a/rust/src/transformations/make_stable_expr/expr_binary/test.rs
+++ b/rust/src/transformations/make_stable_expr/expr_binary/test.rs
@@ -65,7 +65,7 @@ macro_rules! test_binary {
         let t_op = col("L")
             .$op(col("R"))
             .make_stable(expr_domain.clone(), SymmetricDistance)?;
-        let output_series = t_op.output_domain.active_series()?;
+        let output_series = &t_op.output_domain.column;
         assert_eq!(&*output_series.field.name, "L");
 
         let out = lf

--- a/rust/src/transformations/make_stable_expr/expr_boolean_function/test.rs
+++ b/rust/src/transformations/make_stable_expr/expr_boolean_function/test.rs
@@ -29,7 +29,7 @@ macro_rules! is_nullable {
         $col.$op()
             .make_stable($domain.clone(), SymmetricDistance)?
             .output_domain
-            .active_series()?
+            .column
             .nullable
     };
 }

--- a/rust/src/transformations/make_stable_expr/expr_clip/test.rs
+++ b/rust/src/transformations/make_stable_expr/expr_clip/test.rs
@@ -1,5 +1,5 @@
-use crate::domains::{AtomDomain, DslPlanDomain};
-use crate::metrics::SymmetricDistance;
+use crate::domains::AtomDomain;
+use crate::metrics::{PartitionDistance, SymmetricDistance};
 use crate::transformations::test_helper::get_test_data;
 
 use super::*;
@@ -7,15 +7,15 @@ use super::*;
 #[test]
 fn test_make_expr_clip() -> Fallible<()> {
     let (lf_domain, lf) = get_test_data()?;
-    let lp = lf.logical_plan;
-    let expr_domain = lf_domain.clone().select();
 
     let expected = col("const_1f64").clip(lit(0.), lit(0.5));
 
-    let t_clip = expected
-        .clone()
-        .make_stable(expr_domain, SymmetricDistance)?;
-    let actual = t_clip.invoke(&(lp, all()))?.1;
+    let t_clip: Transformation<_, _, _, PartitionDistance<SymmetricDistance>> =
+        expected.clone().make_stable(
+            lf_domain.clone().select(),
+            PartitionDistance(SymmetricDistance),
+        )?;
+    let actual = t_clip.invoke(&lf.logical_plan)?.1;
 
     assert_eq!(expected, actual);
 
@@ -26,10 +26,12 @@ fn test_make_expr_clip() -> Fallible<()> {
         .unwrap();
     series_domain.element_domain = Arc::new(AtomDomain::<f64>::new_closed((0.0, 0.5))?);
 
-    let mut lf_domain_exp = DslPlanDomain::new(vec![series_domain])?;
-    lf_domain_exp.margins = t_clip.output_domain.frame_domain.margins.clone();
+    let lf_domain_exp = ExprDomain {
+        column: series_domain,
+        context: t_clip.output_domain.context.clone(),
+    };
 
-    assert_eq!(t_clip.output_domain, lf_domain_exp.select());
+    assert_eq!(t_clip.output_domain, lf_domain_exp);
 
     Ok(())
 }

--- a/rust/src/transformations/make_stable_expr/expr_col/test.rs
+++ b/rust/src/transformations/make_stable_expr/expr_col/test.rs
@@ -1,3 +1,4 @@
+use crate::error::ErrorVariant;
 use crate::metrics::SymmetricDistance;
 use crate::transformations::make_stable_expr::test_helper::get_test_data;
 use crate::transformations::StableExpr;
@@ -12,25 +13,9 @@ fn test_make_col_expr() -> Fallible<()> {
     let t_col = expected
         .clone()
         .make_stable(expr_domain.clone(), SymmetricDistance)?;
-    let actual = t_col.invoke(&(lf.logical_plan, all()))?.1;
+    let actual = t_col.invoke(&lf.logical_plan)?.1;
 
     assert_eq!(actual, expected);
-
-    Ok(())
-}
-
-#[test]
-fn test_make_col_expr_no_wildcard() -> Fallible<()> {
-    let (lf_domain, lf) = get_test_data()?;
-    let expr_domain = lf_domain.row_by_row();
-
-    let t_col = col("const_1f64").make_stable(expr_domain.clone(), SymmetricDistance)?;
-    let error_res = t_col
-        .invoke(&(lf.logical_plan, col("not wildcard")))
-        .map(|v| v.1)
-        .unwrap_err()
-        .variant;
-    assert_eq!(error_res, ErrorVariant::FailedFunction);
 
     Ok(())
 }

--- a/rust/src/transformations/make_stable_expr/expr_count/test.rs
+++ b/rust/src/transformations/make_stable_expr/expr_count/test.rs
@@ -9,7 +9,6 @@ use polars::{
     df,
     prelude::{col, IntoLazy},
 };
-use polars_plan::dsl::all;
 
 #[test]
 fn test_select_make_expr_counting() -> Fallible<()> {
@@ -31,7 +30,7 @@ fn test_select_make_expr_counting() -> Fallible<()> {
         let t_sum: Transformation<_, _, _, L1Distance<f64>> = expr
             .clone()
             .make_stable(expr_domain.clone(), PartitionDistance(SymmetricDistance))?;
-        let expr_res = t_sum.invoke(&(lf.logical_plan.clone(), all()))?.1;
+        let expr_res = t_sum.invoke(&lf.logical_plan)?.1;
         assert_eq!(expr_res, expr);
 
         let sensitivity = t_sum.map(&(1, 2, 2))?;
@@ -69,7 +68,7 @@ fn test_grouped_make_len_expr() -> Fallible<()> {
         let t_sum: Transformation<_, _, _, L2Distance<f64>> = expr
             .clone()
             .make_stable(expr_domain.clone(), PartitionDistance(SymmetricDistance))?;
-        let expr_res = t_sum.invoke(&(lf.logical_plan.clone(), all()))?.1;
+        let expr_res = t_sum.invoke(&lf.logical_plan)?.1;
         assert_eq!(expr_res, expr);
 
         // assume we're in a grouping context.

--- a/rust/src/transformations/make_stable_expr/expr_cut/mod.rs
+++ b/rust/src/transformations/make_stable_expr/expr_cut/mod.rs
@@ -2,7 +2,7 @@ use polars::prelude::*;
 use polars_plan::dsl::{Expr, FunctionExpr};
 
 use crate::core::{Function, MetricSpace, StabilityMap, Transformation};
-use crate::domains::{CategoricalDomain, ExprDomain, OuterMetric};
+use crate::domains::{CategoricalDomain, ExprDomain, OuterMetric, WildExprDomain};
 use crate::error::*;
 use crate::polars::ExprFunction;
 use crate::transformations::DatasetMetric;
@@ -19,13 +19,14 @@ mod test;
 /// * `input_metric` - The metric under which neighboring LazyFrames are compared
 /// * `expr` - The clipping expression
 pub fn make_expr_cut<M: OuterMetric>(
-    input_domain: ExprDomain,
+    input_domain: WildExprDomain,
     input_metric: M,
     expr: Expr,
-) -> Fallible<Transformation<ExprDomain, ExprDomain, M, M>>
+) -> Fallible<Transformation<WildExprDomain, ExprDomain, M, M>>
 where
     M::InnerMetric: DatasetMetric,
     M::Distance: Clone,
+    (WildExprDomain, M): MetricSpace,
     (ExprDomain, M): MetricSpace,
     Expr: StableExpr<M, M>,
 {
@@ -79,7 +80,7 @@ where
     } else {
         compute_labels(&breaks, left_closed)?
     };
-    let series_domain = output_domain.active_series_mut()?;
+    let series_domain = &mut output_domain.column;
     series_domain.element_domain = Arc::new(CategoricalDomain::new_with_encoding(categories)?);
     series_domain.field.dtype = DataType::Categorical(None, Default::default());
 

--- a/rust/src/transformations/make_stable_expr/expr_discrete_quantile_score/plugin_dq_score.rs
+++ b/rust/src/transformations/make_stable_expr/expr_discrete_quantile_score/plugin_dq_score.rs
@@ -28,7 +28,8 @@ use crate::{polars::OpenDPPlugin, traits::RoundCast};
 
 use super::series_to_vec;
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "ffi", derive(Serialize, Deserialize))]
 pub(crate) struct DiscreteQuantileScoreShim;
 impl SeriesUdf for DiscreteQuantileScoreShim {
     // makes it possible to downcast the AnonymousFunction trait object back to Self

--- a/rust/src/transformations/make_stable_expr/expr_discrete_quantile_score/test.rs
+++ b/rust/src/transformations/make_stable_expr/expr_discrete_quantile_score/test.rs
@@ -30,15 +30,14 @@ pub fn get_quantile_test_data() -> Fallible<(LazyFrameDomain, LazyFrame)> {
 #[test]
 fn test_expr_discrete_quantile_score_float() -> Fallible<()> {
     let (lf_domain, lf) = get_quantile_test_data()?;
-    let expr_domain = lf_domain.select();
     let candidates = Series::new("", [0., 10., 20., 30., 40., 50., 60., 70., 80., 90., 100.]);
 
     let m_quant: Transformation<_, _, _, Parallel<LInfDistance<f64>>> = col("cycle_(..101f64)")
         .dp()
         .quantile_score(0.5, candidates)
-        .make_stable(expr_domain, PartitionDistance(SymmetricDistance))?;
+        .make_stable(lf_domain.select(), PartitionDistance(SymmetricDistance))?;
 
-    let dp_expr = m_quant.invoke(&(lf.logical_plan.clone(), all()))?.1;
+    let dp_expr = m_quant.invoke(&lf.logical_plan)?.1;
 
     let df_actual = lf.clone().select([dp_expr]).collect()?;
     let AnyValue::Array(series, _) = df_actual.column("cycle_(..101f64)")?.get(0)? else {
@@ -68,7 +67,7 @@ fn test_expr_discrete_quantile_score_int() -> Fallible<()> {
         .quantile_score(0.5, candidates)
         .make_stable(expr_domain, PartitionDistance(SymmetricDistance))?;
 
-    let dp_expr = m_quant.invoke(&(lf.logical_plan.clone(), all()))?.1;
+    let dp_expr = m_quant.invoke(&lf.logical_plan)?.1;
 
     let df_actual = lf.clone().select([dp_expr]).collect()?;
     let AnyValue::Array(series, _) = df_actual.column("cycle_(..10i32)")?.get(0)? else {

--- a/rust/src/transformations/make_stable_expr/expr_fill_nan/test.rs
+++ b/rust/src/transformations/make_stable_expr/expr_fill_nan/test.rs
@@ -1,6 +1,6 @@
 use polars::df;
 use polars::lazy::frame::IntoLazy;
-use polars_plan::dsl::{all, col};
+use polars_plan::dsl::col;
 
 use crate::domains::{AtomDomain, LazyFrameDomain, OptionDomain, SeriesDomain};
 use crate::metrics::SymmetricDistance;
@@ -19,14 +19,14 @@ fn test_make_expr_fill_nan() -> Fallible<()> {
     let t_fill_nan = col("f64")
         .fill_nan(0.0)
         .make_stable(lf_domain.clone().row_by_row(), SymmetricDistance)?;
-    let expr_fill_nan = t_fill_nan.invoke(&(lf.logical_plan.clone(), all()))?.1;
+    let expr_fill_nan = t_fill_nan.invoke(&lf.logical_plan)?.1;
     let actual = lf.with_column(expr_fill_nan).collect()?;
 
     assert_eq!(actual, df!("f64" => [None, Some(1.), Some(0.)])?);
 
     assert!(!t_fill_nan
         .output_domain
-        .active_series()?
+        .column
         .atom_domain::<f64>()?
         .nullable());
 

--- a/rust/src/transformations/make_stable_expr/expr_fill_null/mod.rs
+++ b/rust/src/transformations/make_stable_expr/expr_fill_null/mod.rs
@@ -2,7 +2,7 @@ use polars::prelude::DataType;
 use polars_plan::dsl::{Expr, FunctionExpr};
 
 use crate::core::{Function, MetricSpace, StabilityMap, Transformation};
-use crate::domains::{ExprContext, ExprDomain, OuterMetric};
+use crate::domains::{ExprDomain, OuterMetric, WildExprDomain};
 use crate::error::*;
 use crate::transformations::DatasetMetric;
 
@@ -18,13 +18,14 @@ mod test;
 /// * `input_metric` - The metric under which neighboring LazyFrames are compared
 /// * `expr` - The fill_null expression
 pub fn make_expr_fill_null<M: OuterMetric>(
-    input_domain: ExprDomain,
+    input_domain: WildExprDomain,
     input_metric: M,
     expr: Expr,
-) -> Fallible<Transformation<ExprDomain, ExprDomain, M, M>>
+) -> Fallible<Transformation<WildExprDomain, ExprDomain, M, M>>
 where
     M::InnerMetric: DatasetMetric,
     M::Distance: Clone,
+    (WildExprDomain, M): MetricSpace,
     (ExprDomain, M): MetricSpace,
     Expr: StableExpr<M, M>,
 {
@@ -41,18 +42,12 @@ where
         return fallible!(MakeTransformation, "fill_null expects 2 arguments");
     };
 
-    let ExprDomain {
-        frame_domain,
-        context,
-    } = input_domain.clone();
-    let rr_domain = ExprDomain::new(frame_domain, ExprContext::RowByRow);
-
     let t_data = data
         .clone()
-        .make_stable(rr_domain.clone(), input_metric.clone())?;
+        .make_stable(input_domain.as_row_by_row(), input_metric.clone())?;
     let t_fill = fill
         .clone()
-        .make_stable(rr_domain.clone(), input_metric.clone())?;
+        .make_stable(input_domain.as_row_by_row(), input_metric.clone())?;
 
     let (data_domain, data_metric) = t_data.output_space();
     let (fill_domain, fill_metric) = t_fill.output_space();
@@ -66,24 +61,18 @@ where
         );
     }
 
-    if matches!(
-        data_domain.active_series()?.field.dtype,
-        DataType::Categorical(_, _)
-    ) {
+    if matches!(data_domain.column.field.dtype, DataType::Categorical(_, _)) {
         return fallible!(MakeTransformation, "fill_null cannot be applied to categorical data, because it may trigger a data-dependent CategoricalRemappingWarning in Polars");
     }
 
-    if fill_domain.active_series()?.nullable {
+    if fill_domain.column.nullable {
         return fallible!(MakeTransformation, "fill expression must not be nullable");
     }
 
     let mut output_domain = data_domain.clone();
-    // fill_null should not change the output context-- just require that its input is row-by-row
-    output_domain.context = context;
-
-    let series_domain = output_domain.active_series_mut()?;
-    series_domain.drop_bounds().ok();
-    series_domain.nullable = false;
+    output_domain.column.drop_bounds().ok();
+    output_domain.column.nullable = false;
+    output_domain.context = input_domain.context.clone();
 
     Transformation::new(
         input_domain,
@@ -94,7 +83,7 @@ where
 
             let expr_impute = expr_data.fill_null(expr_fill);
 
-            Ok((arg.0.clone(), expr_impute))
+            Ok((arg.clone(), expr_impute))
         }),
         input_metric.clone(),
         input_metric,

--- a/rust/src/transformations/make_stable_expr/expr_fill_null/test.rs
+++ b/rust/src/transformations/make_stable_expr/expr_fill_null/test.rs
@@ -1,6 +1,6 @@
 use polars::df;
 use polars::lazy::frame::IntoLazy;
-use polars_plan::dsl::{all, col};
+use polars_plan::dsl::col;
 
 use crate::domains::{AtomDomain, LazyFrameDomain, OptionDomain, SeriesDomain};
 use crate::metrics::SymmetricDistance;
@@ -19,13 +19,13 @@ fn test_make_expr_fill_null() -> Fallible<()> {
     let t_fill_null = col("i32")
         .fill_null(0)
         .make_stable(lf_domain.clone().row_by_row(), SymmetricDistance)?;
-    let expr_fill_null = t_fill_null.invoke(&(lf.logical_plan.clone(), all()))?.1;
+    let expr_fill_null = t_fill_null.invoke(&lf.logical_plan)?.1;
     println!("{:?}", expr_fill_null);
     let actual = lf.with_column(expr_fill_null).collect()?;
 
     assert_eq!(actual, df!("i32" => [0, 1])?);
 
-    assert!(!t_fill_null.output_domain.active_series()?.nullable);
+    assert!(!t_fill_null.output_domain.column.nullable);
 
     Ok(())
 }

--- a/rust/src/transformations/make_stable_expr/expr_len/mod.rs
+++ b/rust/src/transformations/make_stable_expr/expr_len/mod.rs
@@ -1,9 +1,9 @@
 use crate::core::{Function, MetricSpace, Transformation};
-use crate::domains::{AtomDomain, DslPlanDomain, ExprDomain, SeriesDomain};
+use crate::domains::{AtomDomain, Context, ExprDomain, Margin, SeriesDomain, WildExprDomain};
 use crate::error::*;
 use crate::metrics::{LpDistance, PartitionDistance};
-use crate::polars::ExprFunction;
 use crate::transformations::traits::UnboundedMetric;
+use polars::prelude::DslPlan;
 use polars_plan::dsl::{len, Expr};
 
 use super::expr_count::counting_query_stability_map;
@@ -23,37 +23,43 @@ mod test;
 /// * `input_metric` - valid selections shown in table above
 /// * `expr` - a length expression
 pub fn make_expr_len<MI, const P: usize>(
-    input_domain: ExprDomain,
+    input_domain: WildExprDomain,
     input_metric: PartitionDistance<MI>,
     expr: Expr,
-) -> Fallible<Transformation<ExprDomain, ExprDomain, PartitionDistance<MI>, LpDistance<P, f64>>>
+) -> Fallible<Transformation<WildExprDomain, ExprDomain, PartitionDistance<MI>, LpDistance<P, f64>>>
 where
     MI: 'static + UnboundedMetric,
-    (ExprDomain, PartitionDistance<MI>): MetricSpace,
+    (WildExprDomain, PartitionDistance<MI>): MetricSpace,
     (ExprDomain, LpDistance<P, f64>): MetricSpace,
 {
     let Expr::Len = expr else {
         return fallible!(MakeTransformation, "expected len expression");
     };
 
-    // check that we are in a context where it is ok to break row-alignment
-    input_domain.context.check_alignment_can_be_broken()?;
+    let (by, old_margin) = input_domain.context.grouping("len")?;
+    let margin = Margin {
+        max_partition_length: Some(1),
+        max_num_partitions: Some(1),
+        max_partition_contributions: old_margin.max_partition_contributions,
+        max_influenced_partitions: old_margin.max_influenced_partitions,
+        public_info: old_margin.public_info,
+    };
 
     // build output domain
-    let output_domain = ExprDomain::new(
-        DslPlanDomain::new(vec![SeriesDomain::new("len", AtomDomain::<u32>::default())])?,
-        input_domain.context.clone(),
-    );
-
-    // we only care about the margin that matches the current grouping columns
-    let public_info = input_domain.active_margin()?.public_info;
+    let output_domain = ExprDomain {
+        column: SeriesDomain::new("len", AtomDomain::<u32>::default()),
+        context: Context::Grouping {
+            margin: margin.clone(),
+            by,
+        },
+    };
 
     Transformation::new(
         input_domain,
         output_domain,
-        Function::from_expr(len()),
+        Function::new(|lp: &DslPlan| (lp.clone(), len())),
         input_metric,
         LpDistance::default(),
-        counting_query_stability_map(public_info),
+        counting_query_stability_map(margin.public_info),
     )
 }

--- a/rust/src/transformations/make_stable_expr/expr_len/test.rs
+++ b/rust/src/transformations/make_stable_expr/expr_len/test.rs
@@ -1,5 +1,5 @@
 use polars::df;
-use polars_plan::dsl::{all, len};
+use polars_plan::dsl::len;
 
 use crate::{
     core::Transformation,
@@ -16,7 +16,7 @@ fn test_select_make_expr_len() -> Fallible<()> {
 
     let t_sum: Transformation<_, _, _, L2Distance<f64>> =
         len().make_stable(expr_domain, PartitionDistance(InsertDeleteDistance))?;
-    let expr_res = t_sum.invoke(&(lf.logical_plan.clone(), all()))?.1;
+    let expr_res = t_sum.invoke(&lf.logical_plan)?.1;
     assert_eq!(expr_res, len());
 
     let sensitivity = t_sum.map(&(4, 4, 1))?;
@@ -33,7 +33,7 @@ fn test_grouped_make_len_expr() -> Fallible<()> {
     // Get resulting sum (expression result)
     let t_sum: Transformation<_, _, _, L2Distance<f64>> =
         len().make_stable(expr_domain, PartitionDistance(InsertDeleteDistance))?;
-    let expr_res = t_sum.invoke(&(lf.logical_plan.clone(), all()))?.1;
+    let expr_res = t_sum.invoke(&lf.logical_plan)?.1;
 
     let df_actual = lf
         .group_by(["chunk_(..10u32)"])

--- a/rust/src/transformations/make_stable_expr/expr_lit/test.rs
+++ b/rust/src/transformations/make_stable_expr/expr_lit/test.rs
@@ -1,5 +1,5 @@
 use polars::{df, lazy::frame::IntoLazy};
-use polars_plan::dsl::{all, lit};
+use polars_plan::dsl::lit;
 
 use crate::{
     domains::{AtomDomain, LazyFrameDomain},
@@ -18,14 +18,14 @@ fn test_lit() -> Fallible<()> {
     let lf = df!("bool" => [true; 3])?.lazy();
 
     let t_const = lit(1.0).make_stable(lf_domain.row_by_row(), SymmetricDistance)?;
-    let expr_const = t_const.invoke(&(lf.logical_plan.clone(), all()))?.1;
+    let expr_const = t_const.invoke(&lf.logical_plan)?.1;
     assert_eq!(expr_const, lit(1.0));
 
     let actual = lf.with_column(expr_const).collect()?;
     let expect = df!("bool" => [true; 3], "literal" => [1.0; 3])?;
     assert_eq!(actual, expect);
 
-    let series_domain = t_const.output_domain.active_series()?;
+    let series_domain = &t_const.output_domain.column;
     assert_eq!(series_domain.atom_domain::<f64>()?.nullable(), false);
     assert_eq!(series_domain.nullable, false);
 

--- a/rust/src/transformations/make_stable_expr/expr_sum/test.rs
+++ b/rust/src/transformations/make_stable_expr/expr_sum/test.rs
@@ -15,7 +15,7 @@ fn test_select_make_sum_expr() -> Fallible<()> {
         .clip(lit(0), lit(1))
         .sum()
         .make_stable(expr_domain, PartitionDistance(InsertDeleteDistance))?;
-    let expr_res = t_sum.invoke(&(lf.logical_plan.clone(), all()))?.1;
+    let expr_res = t_sum.invoke(&lf.logical_plan)?.1;
     // dtype in clip changes
     assert_eq!(expr_res, col("const_1f64").clip(lit(0.), lit(1.)).sum());
 
@@ -37,7 +37,7 @@ fn test_grouped_make_sum_expr() -> Fallible<()> {
         .sum()
         .clone()
         .make_stable(expr_domain, PartitionDistance(InsertDeleteDistance))?;
-    let expr_res = t_sum.invoke(&(lf.logical_plan.clone(), all()))?.1;
+    let expr_res = t_sum.invoke(&lf.logical_plan)?.1;
 
     let df_actual = lf
         .group_by(["chunk_(..10u32)"])

--- a/rust/src/transformations/make_stable_expr/ffi.rs
+++ b/rust/src/transformations/make_stable_expr/ffi.rs
@@ -2,7 +2,7 @@ use polars_plan::dsl::Expr;
 
 use crate::{
     core::{FfiResult, IntoAnyTransformationFfiResultExt},
-    domains::ExprDomain,
+    domains::WildExprDomain,
     ffi::any::{AnyDomain, AnyMetric, AnyObject, AnyTransformation, Downcast},
     metrics::{L1Distance, PartitionDistance, SymmetricDistance},
 };
@@ -15,7 +15,7 @@ pub extern "C" fn opendp_transformations__make_stable_expr(
     input_metric: *const AnyMetric,
     expr: *const AnyObject,
 ) -> FfiResult<*mut AnyTransformation> {
-    let input_domain = try_!(try_as_ref!(input_domain).downcast_ref::<ExprDomain>()).clone();
+    let input_domain = try_!(try_as_ref!(input_domain).downcast_ref::<WildExprDomain>()).clone();
     let input_metric =
         try_!(try_as_ref!(input_metric).downcast_ref::<PartitionDistance<SymmetricDistance>>())
             .clone();


### PR DESCRIPTION
When writing proofs for Polars functionality, I found that there were too many descriptors carried around in ExprDomain leading to more complexity in proofs. Before this PR ExprDomain held a frame domain, with information for all columns and margins, as well as information about the context.

Since expressions always produce a single column, the refactored ExprDomain only holds a single series domain instead of all series domains.

When tracking margins in a row-by-row context, maintaining metadata about margins that is consistent with all other margins is tricky, and the descriptors quickly become extremely pessimistic to the point where they are not useful. Due to this, I've completely removed access to margin metadata when in the row-by-row context.

When tracking margins in a grouping context, only the margin about the current grouping needs to be known. Therefore in the grouping context, ExprDomains may hold one margin. This is useful for calibrating sensitivity in aggregators.

By this logic, proof for output domain correctness need only consider one series domain and how the margin might change in the grouping context (which for most transformations will not change).

This PR also adds a `WildExprDomain` used to start expression transformations/measurements when a column has not yet been selected.`WildExprDomain` carries descriptors for all the select-able series domains, and its carrier type is just a plan, which simplifies how expression transformations/measurements are called (no more tuple of a plan and `all()`)
