### PR TITLE
Polars: simplify SeriesDomain

### DIFF
--- a/python/src/opendp/extras/polars/__init__.py
+++ b/python/src/opendp/extras/polars/__init__.py
@@ -420,7 +420,7 @@ class DPExpr(object):
         │ ---    │
         │ f64    │
         ╞════════╡
-        │ ...    │
+        │ ...... │
         └────────┘
 
         Privately estimates the numerator and denominator separately, and then returns their ratio.

--- a/rust/src/domains/polars/expr/mod.rs
+++ b/rust/src/domains/polars/expr/mod.rs
@@ -116,7 +116,7 @@ impl LazyFrameDomain {
 
     pub fn aggregate<S: AsRef<str>, const P: usize>(self, by: [S; P]) -> WildExprDomain {
         let by: BTreeSet<_> = by.iter().map(|s| s.as_ref().into()).collect();
-        let margin = self.get_margin(by.clone());
+        let margin = self.get_margin(&by);
         WildExprDomain {
             columns: self.series_domains,
             context: Context::Grouping { by, margin },
@@ -144,7 +144,7 @@ impl Domain for ExprDomain {
         }
         .collect()?;
 
-        if !(self.column).member(frame.column(self.column.field.name.as_str())?)? {
+        if !(self.column).member(frame.column(self.column.name.as_str())?)? {
             return Ok(false);
         }
 

--- a/rust/src/domains/polars/frame/test.rs
+++ b/rust/src/domains/polars/frame/test.rs
@@ -46,7 +46,7 @@ fn assert_row_descriptors<F: Frame>(
     max_partition_length: Option<u32>,
     max_partition_contributions: Option<u32>,
 ) {
-    let margin = domain.get_margin(by.iter().map(|s| s.to_string().into()).collect());
+    let margin = domain.get_margin(&by.iter().map(|s| (*s).into()).collect());
     assert_eq!(margin.max_partition_length, max_partition_length);
     assert_eq!(
         margin.max_partition_contributions,
@@ -78,7 +78,7 @@ fn assert_partition_descriptors<F: Frame>(
     max_num_partitions: Option<u32>,
     max_influenced_partitions: Option<u32>,
 ) {
-    let margin = domain.get_margin(by.iter().map(|s| s.to_string().into()).collect());
+    let margin = domain.get_margin(&by.iter().map(|s| (*s).into()).collect());
     assert_eq!(margin.max_num_partitions, max_num_partitions);
     assert_eq!(margin.max_influenced_partitions, max_influenced_partitions);
 }
@@ -140,15 +140,15 @@ fn test_get_margin_public_info() -> Fallible<()> {
     .with_margin(&["A", "B"], Margin::default().with_public_lengths())?;
 
     // nothing is known when grouping not in margins
-    let margin_abc = lf_domain.get_margin(BTreeSet::from(["A".into(), "B".into(), "C".into()]));
+    let margin_abc = lf_domain.get_margin(&BTreeSet::from(["A".into(), "B".into(), "C".into()]));
     assert_eq!(margin_abc.public_info, None);
 
     // retrieving info directly from the margin as-is
-    let margin_ab = lf_domain.get_margin(BTreeSet::from(["A".into(), "B".into()]));
+    let margin_ab = lf_domain.get_margin(&BTreeSet::from(["A".into(), "B".into()]));
     assert_eq!(margin_ab.public_info, Some(MarginPub::Lengths));
 
     // keys and lengths are known on coarser partitions
-    let margin_a = lf_domain.get_margin(BTreeSet::from(["A".into()]));
+    let margin_a = lf_domain.get_margin(&BTreeSet::from(["A".into()]));
     assert_eq!(margin_a.public_info, Some(MarginPub::Lengths));
     Ok(())
 }

--- a/rust/src/measurements/make_private_expr/expr_noise/mod.rs
+++ b/rust/src/measurements/make_private_expr/expr_noise/mod.rs
@@ -205,7 +205,7 @@ where
         }
     };
 
-    let support = match &middle_domain.column.field.dtype {
+    let support = match &middle_domain.column.dtype() {
         dt if dt.is_integer() => Support::Integer,
         dt if dt.is_float() => Support::Float,
         dt => {

--- a/rust/src/measurements/make_private_lazyframe/group_by/mod.rs
+++ b/rust/src/measurements/make_private_lazyframe/group_by/mod.rs
@@ -68,7 +68,7 @@ where
     let (middle_domain, middle_metric) = t_prior.output_space();
 
     let by = match_grouping_columns(keys.clone())?;
-    let margin = middle_domain.get_margin(by.clone());
+    let margin = middle_domain.get_margin(&by);
     let expr_domain = WildExprDomain {
         columns: middle_domain.series_domains.clone(),
         context: Context::Grouping {

--- a/rust/src/measurements/make_private_lazyframe/select/mod.rs
+++ b/rust/src/measurements/make_private_lazyframe/select/mod.rs
@@ -49,7 +49,7 @@ where
         .make_stable(input_domain, input_metric)?;
     let (middle_domain, middle_metric) = t_prior.output_space();
 
-    let margin = middle_domain.get_margin(BTreeSet::new());
+    let margin = middle_domain.get_margin(&BTreeSet::new());
 
     let expr_domain = WildExprDomain {
         columns: middle_domain.series_domains.clone(),

--- a/rust/src/transformations/make_stable_expr/expr_alias/mod.rs
+++ b/rust/src/transformations/make_stable_expr/expr_alias/mod.rs
@@ -38,7 +38,7 @@ where
     let (middle_domain, middle_metric) = t_prior.output_space();
 
     let mut output_domain = middle_domain.clone();
-    output_domain.column.field.name = name.as_ref().into();
+    output_domain.column.name = name.as_ref().into();
 
     let t_alias = Transformation::new(
         middle_domain.clone(),

--- a/rust/src/transformations/make_stable_expr/expr_binary/test.rs
+++ b/rust/src/transformations/make_stable_expr/expr_binary/test.rs
@@ -66,7 +66,7 @@ macro_rules! test_binary {
             .$op(col("R"))
             .make_stable(expr_domain.clone(), SymmetricDistance)?;
         let output_series = &t_op.output_domain.column;
-        assert_eq!(&*output_series.field.name, "L");
+        assert_eq!(&*output_series.name, "L");
 
         let out = lf
             .select([col("L").$op(col("R")).alias("out").null_count()])

--- a/rust/src/transformations/make_stable_expr/expr_boolean_function/mod.rs
+++ b/rust/src/transformations/make_stable_expr/expr_boolean_function/mod.rs
@@ -82,13 +82,12 @@ where
         data_column.nullable = false;
     }
 
-    if matches!(bool_function, Not) && data_column.field.dtype != DataType::Boolean {
+    if matches!(bool_function, Not) && data_column.dtype() != DataType::Boolean {
         // under these conditions, the expression performs a bitwise negation
         data_column.drop_bounds()?;
     } else {
         // otherwise, the output data will be a bool
-        data_column.element_domain = Arc::new(AtomDomain::<bool>::default());
-        data_column.field.dtype = DataType::Boolean;
+        data_column.set_element_domain(AtomDomain::<bool>::default());
     }
 
     t_prior

--- a/rust/src/transformations/make_stable_expr/expr_cast/mod.rs
+++ b/rust/src/transformations/make_stable_expr/expr_cast/mod.rs
@@ -55,7 +55,7 @@ where
 
     let mut output_domain = middle_domain.clone();
     let data_column = &mut output_domain.column;
-    let name = data_column.field.name.as_ref();
+    let name = data_column.name.as_ref();
 
     // it is possible to tighten this:
     // in cases where casting will never fail, the nullable and/or nan bits can be left false

--- a/rust/src/transformations/make_stable_expr/expr_clip/mod.rs
+++ b/rust/src/transformations/make_stable_expr/expr_clip/mod.rs
@@ -62,7 +62,7 @@ where
         let data_column = &mut output_domain.column;
 
         use DataType::*;
-        match &data_column.field.dtype {
+        match data_column.dtype() {
             UInt32 => extract_bounds::<u32>(lower, upper, data_column)?,
             UInt64 => extract_bounds::<u64>(lower, upper, data_column)?,
             Int8 => extract_bounds::<i8>(lower, upper, data_column)?,
@@ -117,7 +117,7 @@ fn extract_bounds<T: Number + NumericDataType + Literal>(
 
     let mut atom_domain = domain.atom_domain::<T>()?.clone();
     atom_domain.bounds = Some(Bounds::new_closed(bounds)?);
-    domain.element_domain = Arc::new(atom_domain);
+    domain.set_element_domain(atom_domain);
 
     Ok((bounds.0.lit(), bounds.1.lit()))
 }

--- a/rust/src/transformations/make_stable_expr/expr_clip/test.rs
+++ b/rust/src/transformations/make_stable_expr/expr_clip/test.rs
@@ -22,9 +22,9 @@ fn test_make_expr_clip() -> Fallible<()> {
     let mut series_domain = lf_domain
         .series_domains
         .into_iter()
-        .find(|s| s.field.name.as_str() == "const_1f64")
+        .find(|s| s.name.as_str() == "const_1f64")
         .unwrap();
-    series_domain.element_domain = Arc::new(AtomDomain::<f64>::new_closed((0.0, 0.5))?);
+    series_domain.set_element_domain(AtomDomain::<f64>::new_closed((0.0, 0.5))?);
 
     let lf_domain_exp = ExprDomain {
         column: series_domain,

--- a/rust/src/transformations/make_stable_expr/expr_col/mod.rs
+++ b/rust/src/transformations/make_stable_expr/expr_col/mod.rs
@@ -29,7 +29,7 @@ where
 
     let output_domain = ExprDomain {
         column: (input_domain.columns.iter())
-            .find(|s| s.field.name.as_str() == col_name.as_ref())
+            .find(|s| s.name.as_str() == col_name.as_ref())
             .ok_or_else(|| err!(MakeTransformation, "unrecognized column: {}", col_name))?
             .clone(),
         context: input_domain.context.clone(),

--- a/rust/src/transformations/make_stable_expr/expr_count/mod.rs
+++ b/rust/src/transformations/make_stable_expr/expr_count/mod.rs
@@ -85,7 +85,7 @@ where
 
     let output_domain = ExprDomain {
         column: SeriesDomain::new(
-            middle_domain.column.field.name.as_str(),
+            middle_domain.column.name.as_str(),
             AtomDomain::<u32>::default(),
         ),
         context: Context::Grouping {

--- a/rust/src/transformations/make_stable_expr/expr_cut/mod.rs
+++ b/rust/src/transformations/make_stable_expr/expr_cut/mod.rs
@@ -80,9 +80,9 @@ where
     } else {
         compute_labels(&breaks, left_closed)?
     };
-    let series_domain = &mut output_domain.column;
-    series_domain.element_domain = Arc::new(CategoricalDomain::new_with_encoding(categories)?);
-    series_domain.field.dtype = DataType::Categorical(None, Default::default());
+
+    let element_domain = CategoricalDomain::new_with_encoding(categories)?;
+    output_domain.column.set_element_domain(element_domain);
 
     t_prior
         >> Transformation::new(

--- a/rust/src/transformations/make_stable_expr/expr_cut/test.rs
+++ b/rust/src/transformations/make_stable_expr/expr_cut/test.rs
@@ -23,8 +23,7 @@ fn test_expr_cut() -> Fallible<()> {
 
     // check domain output
     let encoding = compute_labels(&[-1.0, 1.0], false)?;
-    series_domain.element_domain = Arc::new(CategoricalDomain::new_with_encoding(encoding)?);
-    series_domain.field.dtype = DataType::Categorical(None, Default::default());
+    series_domain.set_element_domain(CategoricalDomain::new_with_encoding(encoding)?);
     let lf_domain_exp = LazyFrameDomain::new(vec![series_domain])?;
 
     assert_eq!(t_cut.output_domain, lf_domain_exp);

--- a/rust/src/transformations/make_stable_expr/expr_discrete_quantile_score/mod.rs
+++ b/rust/src/transformations/make_stable_expr/expr_discrete_quantile_score/mod.rs
@@ -58,9 +58,9 @@ where
             "Quantile estimation requires non-null inputs"
         );
     }
-    let candidates = candidates.strict_cast(&active_series.field.dtype)?;
+    let candidates = candidates.strict_cast(&active_series.dtype())?;
 
-    match &active_series.field.dtype {
+    match active_series.dtype() {
         UInt32 => validate::<UInt32Type>(&candidates),
         UInt64 => validate::<UInt64Type>(&candidates),
         Int8 => validate::<Int8Type>(&candidates),

--- a/rust/src/transformations/make_stable_expr/expr_fill_nan/mod.rs
+++ b/rust/src/transformations/make_stable_expr/expr_fill_nan/mod.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use polars::datatypes::DataType;
 use polars_plan::dsl::Expr;
 
@@ -55,7 +53,7 @@ where
     }
 
     let fill_series = &fill_domain.column;
-    let fill_can_be_nan = match &fill_series.field.dtype {
+    let fill_can_be_nan = match fill_series.dtype() {
         // from the perspective of atom domain, null refers to existence of any missing value.
         // For float types, this is NaN.
         // Therefore if the float domain may be nullable, then the domain includes NaN
@@ -82,9 +80,9 @@ where
     let series_domain = &mut output_domain.column;
     series_domain.drop_bounds().ok();
 
-    series_domain.element_domain = match &series_domain.field.dtype {
-        DataType::Float32 => Arc::new(AtomDomain::<f32>::default()),
-        DataType::Float64 => Arc::new(AtomDomain::<f64>::default()),
+    match series_domain.dtype() {
+        DataType::Float32 => series_domain.set_element_domain(AtomDomain::<f32>::default()),
+        DataType::Float64 => series_domain.set_element_domain(AtomDomain::<f64>::default()),
         _ => {
             return fallible!(
                 MakeTransformation,

--- a/rust/src/transformations/make_stable_expr/expr_fill_null/mod.rs
+++ b/rust/src/transformations/make_stable_expr/expr_fill_null/mod.rs
@@ -61,7 +61,7 @@ where
         );
     }
 
-    if matches!(data_domain.column.field.dtype, DataType::Categorical(_, _)) {
+    if matches!(data_domain.column.dtype(), DataType::Categorical(_, _)) {
         return fallible!(MakeTransformation, "fill_null cannot be applied to categorical data, because it may trigger a data-dependent CategoricalRemappingWarning in Polars");
     }
 

--- a/rust/src/transformations/make_stable_expr/expr_sum/mod.rs
+++ b/rust/src/transformations/make_stable_expr/expr_sum/mod.rs
@@ -48,7 +48,7 @@ where
         .make_stable(input_domain, input_metric)?;
     let (middle_domain, middle_metric) = t_prior.output_space();
 
-    let dtype = &middle_domain.column.field.dtype;
+    let dtype = middle_domain.column.dtype();
 
     let (by, input_margin) = middle_domain.context.grouping("sum")?;
 

--- a/rust/src/transformations/make_stable_expr/expr_to_physical/mod.rs
+++ b/rust/src/transformations/make_stable_expr/expr_to_physical/mod.rs
@@ -62,34 +62,25 @@ where
     let active_series = &mut output_domain.column;
 
     use DataType::*;
-    let in_dtype = &active_series.field.dtype;
+    let in_dtype = active_series.dtype();
 
     // this code is written intentionally to fail or change if polars behavior changes
     match (in_dtype.clone(), in_dtype.to_physical()) {
         (in_dtype, out_dtype) if in_dtype == out_dtype => (),
         (Categorical(_, _), UInt32) => {
-            let cat_domain = active_series
-                .element_domain
-                .as_any()
-                .downcast_ref::<CategoricalDomain>()
-                .ok_or_else(|| {
-                    err!(
-                        MakeTransformation,
-                        "to_physical: expected categorical series domain"
-                    )
-                })?;
+            let cat_domain = active_series.element_domain::<CategoricalDomain>()?;
 
             if cat_domain.encoding().is_none() {
                 return fallible!(MakeTransformation, "to_physical: to prevent potentially revealing information about row ordering, category ordering must be statically known. Convert to String first.");
             }
 
-            active_series.element_domain = Arc::new(AtomDomain::<u32>::default());
+            active_series.set_element_domain(AtomDomain::<u32>::default());
         }
         (Date, UInt32) => {
-            active_series.element_domain = Arc::new(AtomDomain::<u32>::default());
+            active_series.set_element_domain(AtomDomain::<u32>::default());
         }
         (Datetime(_, _) | Time | Duration(_), Int64) => {
-            active_series.element_domain = Arc::new(AtomDomain::<i64>::default());
+            active_series.set_element_domain(AtomDomain::<i64>::default());
         }
         (in_dtype, _) => {
             return fallible!(
@@ -99,7 +90,6 @@ where
             )
         }
     };
-    active_series.field.dtype = in_dtype.to_physical();
 
     t_prior
         >> Transformation::new(

--- a/rust/src/transformations/make_stable_expr/expr_to_physical/test.rs
+++ b/rust/src/transformations/make_stable_expr/expr_to_physical/test.rs
@@ -11,7 +11,7 @@ fn assert_expr_to_physical<DI: 'static + SeriesElementDomain, DO: 'static + Seri
     out_series: Series,
 ) -> Fallible<()> {
     let name = in_series.name().to_string();
-    let in_series_domain = SeriesDomain::new(&name, in_elem_domain);
+    let in_series_domain = SeriesDomain::new(name.clone(), in_elem_domain);
     let lf_domain = LazyFrameDomain::new(vec![in_series_domain.clone()])?;
     let lf = DataFrame::new(vec![in_series])?.lazy();
 
@@ -27,7 +27,7 @@ fn assert_expr_to_physical<DI: 'static + SeriesElementDomain, DO: 'static + Seri
     assert_eq!(expected, actual);
 
     // check that domain is transformed as expected
-    let out_series_domain = SeriesDomain::new(&name, out_elem_domain);
+    let out_series_domain = SeriesDomain::new(name, out_elem_domain);
     let expected_lf_domain = LazyFrameDomain::new(vec![out_series_domain])?;
 
     assert_eq!(t_binned.output_domain, expected_lf_domain);

--- a/rust/src/transformations/make_stable_expr/namespace_str/expr_strptime/test.rs
+++ b/rust/src/transformations/make_stable_expr/namespace_str/expr_strptime/test.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use chrono::NaiveTime;
 
-use crate::domains::{AtomDomain, LazyFrameDomain};
+use crate::domains::{AtomDomain, LazyFrameDomain, SeriesDomain};
 use crate::metrics::SymmetricDistance;
 use crate::transformations::make_stable_lazyframe;
 

--- a/rust/src/transformations/make_stable_lazyframe/filter/mod.rs
+++ b/rust/src/transformations/make_stable_lazyframe/filter/mod.rs
@@ -46,7 +46,7 @@ where
         .clone()
         .make_stable(expr_domain, middle_metric.clone())?;
 
-    let pred_dtype = t_pred.output_domain.column.field.dtype.clone();
+    let pred_dtype = t_pred.output_domain.column.dtype();
 
     if !pred_dtype.is_bool() {
         return fallible!(

--- a/rust/src/transformations/make_stable_lazyframe/h_stack/mod.rs
+++ b/rust/src/transformations/make_stable_lazyframe/h_stack/mod.rs
@@ -65,7 +65,7 @@ where
         .chain(new_series.clone())
         .for_each(|series_domain| {
             lookup
-                .entry(series_domain.field.name.to_string())
+                .entry(series_domain.name.to_string())
                 .and_modify(|i| {
                     series_domains[*i] = series_domain.clone();
                 })
@@ -77,7 +77,7 @@ where
 
     // only keep margins for series that have not changed
     let new_series_names = new_series
-        .map(|series_domain| series_domain.field.name.clone())
+        .map(|series_domain| series_domain.name.clone())
         .collect();
     let margins = (middle_domain.margins.iter())
         .filter(|(k, _)| k.is_disjoint(&new_series_names))

--- a/rust/src/transformations/make_stable_lazyframe/h_stack/test.rs
+++ b/rust/src/transformations/make_stable_lazyframe/h_stack/test.rs
@@ -46,10 +46,8 @@ fn test_with_column() -> Fallible<()> {
 fn test_fill_nan() -> Fallible<()> {
     let lf = df!("f64" => [1f64, f64::NAN])?.lazy();
 
-    let lf_domain = LazyFrameDomain::new(vec![SeriesDomain::new(
-        "f64",
-        AtomDomain::<f64>::new_nullable(),
-    )])?;
+    let series_domain = SeriesDomain::new("f64", AtomDomain::<f64>::new_nullable());
+    let lf_domain = LazyFrameDomain::new(vec![series_domain])?;
 
     let t_with_column = make_stable_lazyframe(
         lf_domain.clone(),

--- a/rust/src/transformations/make_stable_lazyframe/source/mod.rs
+++ b/rust/src/transformations/make_stable_lazyframe/source/mod.rs
@@ -41,13 +41,7 @@ where
         );
     }
 
-    let domain_schema = input_domain
-        .series_domains
-        .iter()
-        .map(|s| s.field.clone())
-        .collect::<Schema>();
-
-    if &domain_schema != schema.as_ref() {
+    if &input_domain.schema() != schema.as_ref() {
         return fallible!(
             MakeTransformation,
             "Schema mismatch. LazyFrame schema must match the schema from the input domain."


### PR DESCRIPTION
SeriesDomain had a drawback where you could update the element domain and forget to update the dtype, or vice-versa.

The refactored code retrieves the dtype from the element domain, and eliminates the dtype descriptor. This also eliminates the use of the Polars Field struct, shortening attribute access. I also added some useful helpers for setting the dtype or element domain that better reuses existing code.

The code also fixes a bug in the implementation of PartialEq for SeriesDomain-- two series domains that differ in their nullity bit would still be considered equal. This doesn't result in any potential exploits though, since our idiom is to set the input space to the previous domain's output space.