### PR TITLE
Link in paper is still 404, but the redirect after 5 seconds will now work

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -27,6 +27,7 @@
 
                     '/user/utilities/accuracy/accuracy-pitfalls.html': '/theory/accuracy-pitfalls.html',
                     '/user/getting-started.html': '/getting-started/index.html',
+                    '/user/measurements/pca.html': '/getting-started/statistical-modeling/pca.html',
                     '/user/': '/api/user-guide/',
 
                     '/contact.html': '/contributing/contact.html',


### PR DESCRIPTION
- Fix #2054