### PR TITLE
list -> Sequence

### DIFF
--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -418,7 +418,7 @@ def _vector_to_slice(val: Sequence[Any], type_name: RuntimeType) -> FfiSlicePtr:
     return _wrap_in_slice(array, len(val))
 
 
-def _slice_to_vector(raw: FfiSlicePtr, type_name: RuntimeType) -> list[Any]:
+def _slice_to_vector(raw: FfiSlicePtr, type_name: RuntimeType) -> Sequence[Any]:
     if type_name.origin != 'Vec' or len(type_name.args) != 1:
         raise ValueError("type_name must be a Vec<_>")
     

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -1,5 +1,5 @@
 import ctypes
-from typing import MutableMapping
+from typing import MutableMapping, Sequence
 import os
 from pathlib import Path
 import re
@@ -8,7 +8,7 @@ import importlib
 
 
 # list all acceptable alternative types for each default type
-ATOM_EQUIVALENCE_CLASSES: MutableMapping[str, list[str]] = {
+ATOM_EQUIVALENCE_CLASSES: MutableMapping[str, Sequence[str]] = {
     'i32': ['u8', 'u16', 'u32', 'u64', 'i8', 'i16', 'i32', 'i64', 'usize'],
     'f64': ['f32', 'f64'],
     'bool': ['bool'],

--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -12,7 +12,7 @@ We suggest importing under the conventional name ``dp``:
 '''
 
 import logging
-from typing import Any, Callable, Optional, Union, MutableMapping
+from typing import Any, Callable, Optional, Union, MutableMapping, Sequence
 import importlib
 from inspect import signature
 from functools import partial
@@ -357,7 +357,7 @@ class Context(object):
         accountant: Measurement,
         queryable: Queryable,
         d_in: float,
-        d_mids: Optional[list[float]] = None,
+        d_mids: Optional[Sequence[float]] = None,
         d_out: Optional[float] = None,
         space_override: Optional[tuple[Domain, Metric]] = None, # TODO: Document or add leading underscore and explain that is is for internal use only.
     ):
@@ -381,7 +381,7 @@ class Context(object):
         privacy_unit: tuple[Metric, float],
         privacy_loss: tuple[Measure, Any],
         split_evenly_over: Optional[int] = None,
-        split_by_weights: Optional[list[float]] = None,
+        split_by_weights: Optional[Sequence[float]] = None,
         domain: Optional[Domain] = None,
         margins: Optional[MutableMapping[tuple[str, ...], Margin]] = None,
     ) -> "Context":
@@ -433,7 +433,7 @@ class Context(object):
         """Executes the given query on the context."""
         answer = self.queryable(query)
         if self.d_mids is not None:
-            self.d_mids.pop(0)
+            self.d_mids = self.d_mids[1:]
         return answer
 
     def query(self, **kwargs) -> Union["Query", LazyFrameQuery]:
@@ -616,7 +616,7 @@ class Query(object):
     def compositor(
         self,
         split_evenly_over: Optional[int] = None,
-        split_by_weights: Optional[list[float]] = None,
+        split_by_weights: Optional[Sequence[float]] = None,
         d_out: Optional[float] = None,
         output_measure: Optional[Measure] = None,
         alpha: Optional[float] = None,
@@ -752,8 +752,8 @@ def _sequential_composition_by_weights(
     privacy_unit: tuple[Metric, float],
     privacy_loss: tuple[Measure, float],
     split_evenly_over: Optional[int] = None,
-    split_by_weights: Optional[list[float]] = None,
-) -> tuple[Measurement, list[Any]]:
+    split_by_weights: Optional[Sequence[float]] = None,
+) -> tuple[Measurement, Sequence[Any]]:
     """Constructs a sequential composition measurement
     where the ``d_mids`` are proportional to the weights.
 

--- a/python/src/opendp/extras/sklearn/_make_eigendecomposition/__init__.py
+++ b/python/src/opendp/extras/sklearn/_make_eigendecomposition/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Sequence
 
 from opendp.extras._utilities import register_measurement
 from opendp.extras.sklearn._make_eigenvector import then_private_eigenvectors
@@ -12,7 +13,7 @@ def make_private_np_eigendecomposition(
     input_domain: Domain,
     input_metric: Metric,
     eigvals_epsilon: float,
-    eigvecs_epsilons: list[float],
+    eigvecs_epsilons: Sequence[float],
     num_components: int | None = None,
 ) -> Measurement:
     """Construct a Measurement that releases eigenvalues and eigenvectors.

--- a/python/src/opendp/extras/sklearn/_make_eigenvector/__init__.py
+++ b/python/src/opendp/extras/sklearn/_make_eigenvector/__init__.py
@@ -1,3 +1,5 @@
+from typing import Sequence
+
 from opendp.extras.numpy import _sscp_domain
 from opendp.extras._utilities import to_then
 from opendp._lib import get_np_csprng, import_optional_dependency
@@ -136,7 +138,7 @@ then_np_sscp_projection = to_then(make_np_sscp_projection)
 
 
 def make_private_eigenvectors(
-    input_domain: Domain, input_metric: Metric, unit_epsilons: list[float]
+    input_domain: Domain, input_metric: Metric, unit_epsilons: Sequence[float]
 ) -> Measurement:
     np = import_optional_dependency('numpy')
     import opendp.prelude as dp

--- a/python/src/opendp/extras/sklearn/decomposition/__init__.py
+++ b/python/src/opendp/extras/sklearn/decomposition/__init__.py
@@ -14,7 +14,7 @@ See also our :ref:`tutorial on diffentially private PCA <dp-pca>`.
 '''
 
 from __future__ import annotations
-from typing import NamedTuple, Optional, TYPE_CHECKING
+from typing import NamedTuple, Optional, TYPE_CHECKING, Sequence
 from opendp.extras.numpy import then_np_clamp
 from opendp.extras._utilities import register_measurement, to_then
 from opendp.extras.numpy._make_np_mean import make_private_np_mean
@@ -47,7 +47,7 @@ else: # pragma: no cover
 
 class PCAEpsilons(NamedTuple):
     eigvals: float
-    eigvecs: list[float]
+    eigvecs: Sequence[float]
     mean: Optional[float]
 
 

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -16,7 +16,7 @@ We suggest importing under the conventional name ``dp``:
 from __future__ import annotations
 import typing
 from collections.abc import Hashable
-from typing import Optional, Union, Any, Type, _GenericAlias # type: ignore[attr-defined]
+from typing import Optional, Union, Any, Type, Sequence, _GenericAlias # type: ignore[attr-defined]
 from types import GenericAlias
 import re
 
@@ -68,10 +68,10 @@ PRIMITIVE_TYPES = NUMERIC_TYPES | {"bool", "String"}
 RuntimeTypeDescriptor = Union[
     "RuntimeType",  # as the normalized type -- ChangeOneDistance; RuntimeType.parse("i32")
     str,  # plaintext string in terms of Rust types -- "Vec<i32>"
-    Type[Union[list[Any], tuple[Any, Any], float, str, bool]],  # using the Python type class itself -- int, float
-    tuple["RuntimeTypeDescriptor", ...],  # shorthand for tuples -- (float, "f64"); (ChangeOneDistance, list[int])
-    _GenericAlias, # a Python type hint from the std typing module -- List[int]
-    GenericAlias, # a Python type hint from the std types module -- list[int]
+    Type[Union[Sequence[Any], tuple[Any, Any], float, str, bool]],  # using the Python type class itself -- int, float
+    tuple["RuntimeTypeDescriptor", ...],  # shorthand for tuples -- (float, "f64"); (ChangeOneDistance, Sequence[int])
+    _GenericAlias, # a Python type hint from the std typing module -- Sequence[int]
+    GenericAlias, # a Python type hint from the std types module -- Sequence[int]
 ]
 
 
@@ -116,7 +116,7 @@ class RuntimeType(object):
     """Utility for validating, manipulating, inferring and parsing/normalizing type information.
     """
     origin: str
-    args: list[Union["RuntimeType", str]]
+    args: Sequence[Union["RuntimeType", str]]
 
     def __init__(self, origin, args=None):
         if not isinstance(origin, str):
@@ -143,7 +143,7 @@ class RuntimeType(object):
         return hash(str(self))
 
     @classmethod
-    def parse(cls, type_name: RuntimeTypeDescriptor, generics: Optional[list[str]] = None) -> Union["RuntimeType", str]:
+    def parse(cls, type_name: RuntimeTypeDescriptor, generics: Optional[Sequence[str]] = None) -> Union["RuntimeType", str]:
         """Parse type descriptor into a normalized Rust type.
 
         Type descriptor may be expressed as:
@@ -155,7 +155,7 @@ class RuntimeType(object):
 
         :param type_name: type specifier
         :param generics: For internal use. List of type names to consider generic when parsing.
-        :type: list[str]
+        :type: Sequence[str]
         :return: Normalized type. If the type has subtypes, returns a RuntimeType, else a str.
         :rtype: Union["RuntimeType", str]
         :raises UnknownTypeException: if `type_name` fails to parse
@@ -194,7 +194,7 @@ class RuntimeType(object):
             
             return RuntimeType(RuntimeType.parse(origin, generics=generics), args)
 
-        # parse a tuple of types-- (int, "f64"); (list[int], (int, bool))
+        # parse a tuple of types-- (int, "f64"); (Sequence[int], (int, bool))
         if isinstance(type_name, tuple):
             return RuntimeType('Tuple', list(cls.parse(v, generics=generics) for v in type_name))
 
@@ -248,7 +248,7 @@ class RuntimeType(object):
         raise UnknownTypeException(f"unable to parse type: {type_name}")
 
     @classmethod
-    def _parse_args(cls, args, generics: Optional[list[str]] = None):
+    def _parse_args(cls, args, generics: Optional[Sequence[str]] = None):
         import re
         return [cls.parse(v, generics=generics) for v in re.split(r",\s*(?![^()<>]*\))", args)]
 
@@ -348,7 +348,7 @@ class RuntimeType(object):
             cls,
             type_name: RuntimeTypeDescriptor | None = None,
             public_example: Any = None,
-            generics: Optional[list[str]] = None
+            generics: Optional[Sequence[str]] = None
     ) -> Union["RuntimeType", str]:
         """If type_name is supplied, normalize it. Otherwise, infer the normalized type from a public example.
 
@@ -357,7 +357,7 @@ class RuntimeType(object):
         :return: Normalized type. If the type has subtypes, returns a RuntimeType, else a str.
         :rtype: Union["RuntimeType", str]
         :param generics: For internal use. List of type names to consider generic when parsing.
-        :type: list[str]
+        :type: Sequence[str]
         :raises ValueError: if `type_name` fails to parse
         :raises UnknownTypeException: if inference fails on `public_example` or no args are supplied
         """
@@ -493,7 +493,7 @@ def pass_through(value: Any) -> Any:
 def get_dependencies(value: Union[Measurement, Transformation, Function]) -> Any:
     return getattr(value, "_dependencies", None)
 
-def get_dependencies_iterable(value: list[Union[Measurement, Transformation, Function]]) -> list[Any]:
+def get_dependencies_iterable(value: Sequence[Union[Measurement, Transformation, Function]]) -> Sequence[Any]:
     return list(map(get_dependencies, value))
 
 def get_carrier_type(value: Domain) -> Union[RuntimeType, str]:


### PR DESCRIPTION
This isn't a high priority, and this isn't a global replacement, but it does tweak the signatures on many public methods. The advantage is that users could supply values that aren't exactly `list`s but are good enough, and with this change they should get fewer spurious typing errors.

- Towards #2164