### PR TITLE
docs: Check for docstrings that are out of sync

### DIFF
--- a/python/test/test_ast.py
+++ b/python/test/test_ast.py
@@ -18,6 +18,8 @@ public_functions = []
 
 src_dir_path = Path(__file__).parent.parent / 'src'
 for code_path in src_dir_path.glob('**/*.py'):
+    if code_path.name.startswith('_') and code_path.name != '__init__.py':
+        continue
     code = code_path.read_text()
     tree = ast.parse(code)
     for node in ast.walk(tree):
@@ -26,8 +28,10 @@ for code_path in src_dir_path.glob('**/*.py'):
                 rel_path = re.sub(r'.*/src/', '', str(code_path))
                 public_functions.append(Function(file=rel_path, node=node))
 
-@pytest.mark.parametrize("file,name,node", [(f.file, f.node.name, f.node) for f in public_functions])
-def test_function_docs(file, name, node):
+
+# _file and _name are included to make the test output more readable.
+@pytest.mark.parametrize("_file,_name,node", [(f.file, f.node.name, f.node) for f in public_functions])
+def test_function_docs(_file, _name, node):
     docstring = ast.get_docstring(node) or ''
     param_names = set(re.findall(r':param (\w+):', docstring))
     args = (

--- a/python/test/test_ast.py
+++ b/python/test/test_ast.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import ast
+import re
+from typing import NamedTuple
+
+import pytest
+
+
+class Function(NamedTuple):
+    file: str
+    node: ast.AST
+
+    def __repr__(self):
+        return f'{self.file} [line {self.node.lineno}]: {self.node.name}()'
+
+
+public_functions = []
+
+src_dir_path = Path(__file__).parent.parent / 'src'
+for code_path in src_dir_path.glob('**/*.py'):
+    code = code_path.read_text()
+    tree = ast.parse(code)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            if not node.name.startswith('_'):
+                rel_path = re.sub(r'.*/src/', '', str(code_path))
+                public_functions.append(Function(file=rel_path, node=node))
+
+@pytest.mark.parametrize("file,name,node", [(f.file, f.node.name, f.node) for f in public_functions])
+def test_function_docs(file, name, node):
+    docstring = ast.get_docstring(node) or ''
+    param_names = set(re.findall(r':param (\w+):', docstring))
+    args = (
+        node.args.posonlyargs
+        + node.args.args
+        + node.args.kwonlyargs
+    )
+    arg_names = {arg.arg for arg in args} - {'self'}
+
+    assert param_names == arg_names
+
+ 

--- a/python/test/test_ast.py
+++ b/python/test/test_ast.py
@@ -16,7 +16,6 @@ def get_params_from_node_docstring(node):
     return set(re.findall(r':param (\w+):', docstring))  # type: ignore[arg-type]
 
 
-
 public_functions = []
 
 src_dir_path = Path(__file__).parent.parent / 'src'


### PR DESCRIPTION
- Fix #1395

After looking for a library that would handle this, and coming back empty-handed, decided just to wrap my own, and it didn't turn out to be too complicated.

Can imagine expanding this to check that we do have the parameters in the docstring, and that we have some description for each parameter, and maybe check for return and typing info.

Going to branch from here and strengthen the tests, and start filling in some gaps in the docs.