### PR TITLE
docs: fix PCA API docs

### DIFF
--- a/python/src/opendp/extras/sklearn/decomposition/__init__.py
+++ b/python/src/opendp/extras/sklearn/decomposition/__init__.py
@@ -165,11 +165,13 @@ class PCA():
         n_changes: int = 1,
         whiten: bool = False,
     ) -> None:
-        if self.__class__.__bases__ == (object,):
-            raise ImportError(
-                "The optional install scikit-learn is required for this functionality"
-            )
-        super().__init__(
+        # Error if constructor called without depency installed:
+        import_optional_dependency('sklearn.decomposition')
+        
+        # The zero-argument form of super() does not work,
+        # (I believe) because the type argument is determined lexically,
+        # and it doesn't see our redefinition.
+        super(PCA, self).__init__(
             n_components or n_features,
             whiten=whiten,
         )

--- a/python/src/opendp/extras/sklearn/decomposition/__init__.py
+++ b/python/src/opendp/extras/sklearn/decomposition/__init__.py
@@ -156,9 +156,14 @@ class PCA():
     '''
     DP wrapper for `sklearn's PCA <https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html>`_.
 
-    Trying to create an instance without sklearn installed will raise a ``ImportError``.
+    Trying to create an instance without sklearn installed will raise an ``ImportError``.
     
     See the :ref:`tutorial on diffentially private PCA <dp-pca>` for details.
+
+    :param whiten: Mirrors the corresponding sklearn parameter:
+        When ``True`` (``False`` by default) the ``components_`` vectors are multiplied
+        by the square root of n_samples and then divided by the singular values
+        to ensure uncorrelated outputs with unit component-wise variances.
     '''
     def __init__(
         self,

--- a/python/src/opendp/extras/sklearn/decomposition/__init__.py
+++ b/python/src/opendp/extras/sklearn/decomposition/__init__.py
@@ -153,7 +153,13 @@ then_private_pca = register_measurement(make_private_pca)
 
 
 class PCA():
-    '''TODO'''
+    '''
+    DP wrapper for `sklearn's PCA <https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html>`_.
+
+    Trying to create an instance without sklearn installed will raise a ``ImportError``.
+    
+    See the :ref:`tutorial on diffentially private PCA <dp-pca>` for details.
+    '''
     def __init__(
         self,
         *,

--- a/python/src/opendp/extras/sklearn/decomposition/__init__.py
+++ b/python/src/opendp/extras/sklearn/decomposition/__init__.py
@@ -186,7 +186,7 @@ class PCA():
         return self.n_features_in_
 
     # this overrides the scikit-learn method to instead use the opendp-core constructor
-    def fit(self, X):
+    def _fit(self, X):
         return self._prepare_fitter()(X)
 
     def _prepare_fitter(self) -> Measurement:


### PR DESCRIPTION
- Fix #2217

Instead of making the base class dynamic (which causes trouble for Sphinx), make it just a regular class, but update the class hierarchy if the optional install is installed.

The core is getting rid of 
```python
_decomposition = import_optional_dependency('sklearn.decomposition', False)
if _decomposition is not None:
    class _SKLPCA(_decomposition.PCA): # type: ignore[name-defined]
        ...
else: # pragma: no cover
    class _SKLPCA(object): # type: ignore[no-redef]
        ...
```
and replacing it with
```
_decomposition = import_optional_dependency('sklearn.decomposition', False)
if _decomposition is not None:
    PCA = type('PCA', (_decomposition.PCA,), dict(PCA.__dict__))  # type: ignore[assignment,misc]
```

Since it's now documented by Sphinx, fill in docstring a little: could still use more documentation on parameters, but this is a start.
