### PR TITLE
docs: Consistent lists of communication channels

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,10 @@
 blank_issues_enabled: true
 contact_links:
+  # All of these lists should be in sync:
+  # - README.md
+  # - docs/source/contributing/contact.rst
+  # - docs/source/_templates/questions-feedback.html
+  # - .github/ISSUE_TEMPLATE/config.yml
   - name: Blank issue
     url: https://github.com/opendp/opendp/issues/new
   - name: Email

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,10 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Discussions
-    url: https://github.com/opendp/opendp/discussions/new
-    about: Ask questions, make feature requests, and discuss with other OpenDP community members
   - name: Blank issue
     url: https://github.com/opendp/opendp/issues/new
-    about: Just let me make an issue!
+  - name: Email
+    url: mailto:info@opendp.org
+  - name: Slack
+    url: https://join.slack.com/t/opendp/shared_invite/zt-zw7o1k2s-dHg8NQE8WTfAGFnN_cwomA
+  - name: Mailing list
+    url: https://groups.google.com/a/g.harvard.edu/g/opendp-community

--- a/.github/ISSUE_TEMPLATE/new-contribution.md
+++ b/.github/ISSUE_TEMPLATE/new-contribution.md
@@ -8,6 +8,5 @@ How exciting!
 Please review [the information to include in your issue](https://docs.opendp.org/en/stable/contributing/getting-involved.html#code-and-proof-contributions),
 and we will try to get back with you shortly.
 
-In the meantime, you might want to [review the contribution process](https://docs.opendp.org/en/stable/contributing/contribution-process.html),
-[join the discussion on Slack](https://join.slack.com/t/opendp/shared_invite/zt-zw7o1k2s-dHg8NQE8WTfAGFnN_cwomA),
+In the meantime, you might want to [review the contribution process](https://docs.opendp.org/en/stable/contributing/contribution-process.html)
 and start getting your development environment set up.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ The full documentation for OpenDP is located at https://docs.opendp.org. Here ar
 
 If you're having problems using OpenDP, or want to submit feedback, please reach out! Here are some ways to contact us:
 
+<!--
+    All of these lists should be in sync:
+    - README.md
+    - docs/source/contributing/contact.rst
+    - docs/source/_templates/questions-feedback.html
+    - .github/ISSUE_TEMPLATE/config.yml
+
+    (although office hours are only listed here.)
+-->
+
 * Report a bug or request a feature on [Github](https://github.com/opendp/opendp/issues).
 * Send general queries to [info@opendp.org](mailto:info@opendp.org), or email [security@opendp.org](mailto:security@opendp.org) if it is related to security.
 * Join the conversation on [Slack](https://join.slack.com/t/opendp/shared_invite/zt-zw7o1k2s-dHg8NQE8WTfAGFnN_cwomA), or the [mailing list](https://groups.google.com/a/g.harvard.edu/g/opendp-community).

--- a/README.md
+++ b/README.md
@@ -59,11 +59,10 @@ The full documentation for OpenDP is located at https://docs.opendp.org. Here ar
 
 If you're having problems using OpenDP, or want to submit feedback, please reach out! Here are some ways to contact us:
 
-* Ask questions on our [discussions forum](https://github.com/opendp/opendp/discussions)
-* Open issues on our [issue tracker](https://github.com/opendp/opendp/issues)
-* Join our [Slack](https://join.slack.com/t/opendp/shared_invite/zt-zw7o1k2s-dHg8NQE8WTfAGFnN_cwomA)
-* Send general queries to [info@opendp.org](mailto:info@opendp.org)
-* Reach us on Twitter at [@opendp_org](https://twitter.com/opendp_org)
+* Report a bug or request a feature on [Github](https://github.com/opendp/opendp/issues).
+* Send general queries to [info@opendp.org](mailto:info@opendp.org), or email [security@opendp.org](mailto:security@opendp.org) if it is related to security.
+* Join the conversation on [Slack](https://join.slack.com/t/opendp/shared_invite/zt-zw7o1k2s-dHg8NQE8WTfAGFnN_cwomA), or the [mailing list](https://groups.google.com/a/g.harvard.edu/g/opendp-community).
+* Office hours are M/T/Th at 11am Eastern on [Zoom](https://harvard.zoom.us/j/98058847683).
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ If you believe you have found a security vulnerability in any OpenDP repository,
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-Instead, please report them to us via email at info@opendp.org.
+Instead, please report them to us via email at security@opendp.org.
 
 You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,7 +96,3 @@ Otherwise, you will get an error that includes:
 
     /docs/source/api/index.rst:4:toctree contains reference to nonexisting document 'api/python/index'
 
-
-## Join the Discussion
-
-You are very welcome to join us on [GitHub Discussions](https://github.com/opendp/opendp/discussions)!

--- a/docs/source/_templates/questions-feedback.html
+++ b/docs/source/_templates/questions-feedback.html
@@ -4,14 +4,10 @@
     -->
     <details>
         <summary>Questions or feedback?</summary>
-        <div>
-            If you're having problems using OpenDP, or want to submit feedback, please reach out! Here are some ways to contact us:
-            <ul>
-                <li>Ask questions on our <a href="https://github.com/opendp/opendp/discussions">discussions forum</a>.</li>
-                <li>Open issues on our <a href="https://github.com/opendp/opendp/issues">issue tracker</a>.</li>
-                <li>Join our <a href="https://join.slack.com/t/opendp/shared_invite/zt-zw7o1k2s-dHg8NQE8WTfAGFnN_cwomA">Slack</a>.</li>
-                <li>Send general queries to <a href="mailto:info@opendp.org">info@opendp.org</a>.</li>
-            </ul>
-        </div>
+        <ul>
+            <li>Report a bug or request a feature on <a href="https://github.com/opendp/opendp/issues">Github</a>.</li>
+            <li>Send general queries to <a href="mailto:info@opendp.org">info@opendp.org</a>, or email <a href="mailto:security@opendp.org">security@opendp.org</a> if it is related to security.</li>
+            <li>Join the conversation on <a href="https://join.slack.com/t/opendp/shared_invite/zt-zw7o1k2s-dHg8NQE8WTfAGFnN_cwomA">Slack</a>, or the <a href="https://groups.google.com/a/g.harvard.edu/g/opendp-community">mailing list</a>.</li>
+        </ul>
     </details>
 </div>

--- a/docs/source/_templates/questions-feedback.html
+++ b/docs/source/_templates/questions-feedback.html
@@ -4,6 +4,13 @@
     -->
     <details>
         <summary>Questions or feedback?</summary>
+        <!--
+            All of these lists should be in sync:
+            - README.md
+            - docs/source/contributing/contact.rst
+            - docs/source/_templates/questions-feedback.html
+            - .github/ISSUE_TEMPLATE/config.yml
+        -->
         <ul>
             <li>Report a bug or request a feature on <a href="https://github.com/opendp/opendp/issues">Github</a>.</li>
             <li>Send general queries to <a href="mailto:info@opendp.org">info@opendp.org</a>, or email <a href="mailto:security@opendp.org">security@opendp.org</a> if it is related to security.</li>

--- a/docs/source/contributing/contact.rst
+++ b/docs/source/contributing/contact.rst
@@ -3,6 +3,12 @@
 Contact
 =======
 
+.. All of these lists should be in sync:
+.. - README.md
+.. - docs/source/contributing/contact.rst
+.. - docs/source/_templates/questions-feedback.html
+.. - .github/ISSUE_TEMPLATE/config.yml
+
 * Report a bug or request a feature on `Github <https://github.com/opendp/opendp/issues>`_.
 * Send general queries to `info@opendp.org <mailto:info@opendp.org>`_, or email `security@opendp.org <mailto:security@opendp.org>`_ if it is related to security.
 * Join the conversation on `Slack <https://join.slack.com/t/opendp/shared_invite/zt-zw7o1k2s-dHg8NQE8WTfAGFnN_cwomA>`_, or the `mailing list <https://groups.google.com/a/g.harvard.edu/g/opendp-community>`_.

--- a/docs/source/contributing/contact.rst
+++ b/docs/source/contributing/contact.rst
@@ -3,28 +3,6 @@
 Contact
 =======
 
-A great way to get in contact with the OpenDP community is `GitHub Discussions`_.
-
-.. _GitHub Discussions: https://github.com/opendp/opendp/discussions
-
-To subscribe to the `mailing list`_, please use the `sign up form`_.
-
-.. _mailing list: https://groups.google.com/a/g.harvard.edu/g/opendp-community
-
-.. _sign up form: https://harvard.az1.qualtrics.com/jfe/form/SV_3yCVtAEzVsadAfX
-
-Feel free to join our `Slack`_.
-
-.. _Slack: https://join.slack.com/t/opendp/shared_invite/zt-zw7o1k2s-dHg8NQE8WTfAGFnN_cwomA
-
-You can reach OpenDP on Twitter at `@opendp_org`_.
-
-.. _@opendp_org: https://twitter.com/opendp_org
-
-To report bugs, please use the `issue tracker`_.
-
-.. _issue tracker: https://github.com/opendp/opendp/issues
-
-Guidelines for reporting security issues are `here <https://github.com/opendp/opendp/blob/main/SECURITY.md>`_.
-
-For general inquiries, please email info@opendp.org.
+* Report a bug or request a feature on `Github <https://github.com/opendp/opendp/issues>`_.
+* Send general queries to `info@opendp.org <mailto:info@opendp.org>`_, or email `security@opendp.org <mailto:security@opendp.org>`_ if it is related to security.
+* Join the conversation on `Slack <https://join.slack.com/t/opendp/shared_invite/zt-zw7o1k2s-dHg8NQE8WTfAGFnN_cwomA>`_, or the `mailing list <https://groups.google.com/a/g.harvard.edu/g/opendp-community>`_.

--- a/docs/source/contributing/getting-involved.rst
+++ b/docs/source/contributing/getting-involved.rst
@@ -3,8 +3,10 @@
 Getting Involved
 ================
 
+
 OpenDP is a community effort and we welcome your contributions!
 OpenDP development takes place on GitHub, so you will need to create a GitHub account to get started.
+
 
 Bug Reports
 -----------
@@ -13,6 +15,7 @@ Guidelines for reporting security issues are `here <https://github.com/opendp/op
 Please `open a new issue <https://github.com/opendp/opendp/issues/new?template=bug-report.md>`__ for any other bug report.
 We also welcome new issues for usability problems!
 We want to know if you've encountered, say, a missing piece of documentation, or a particularly confusing interface.
+
 
 Code and Proof Contributions
 ----------------------------
@@ -75,8 +78,3 @@ Review Pull Requests
 --------------------
 It always helps to have another set of eyes reviewing code.
 This can also be a great way to familiarize yourself with the library internals and development process.
-
-Respond to Discussion Posts
----------------------------
-We want to develop `discussions into a useful community forum <https://github.com/opendp/opendp/discussions>`_.
-Sharing your experience on this public forum would, of course, help make differential privacy more accessible!


### PR DESCRIPTION
We have several places where we list communication channels:
- new issue page in github
- readme
- contact page in docs
- questions-feedback (new!)

This makes them all consistent, and drops a couple channels:
- twitter
- github discussions

I think there are enough other options and we'll benefit from being more focussed, but the more important thing here is consistency: Talk about this at a Monday meeting?

It adds office hours (but only on the readme: soft launch).

- Fix #2057 
- Fix #2226 (won't worry about prefilling subject lines)

