### PR TITLE
testing: Fuzzy doctests

### DIFF
--- a/python/conftest.py
+++ b/python/conftest.py
@@ -11,16 +11,40 @@ def add_dp(doctest_namespace):
 
 
 FUZZY = doctest.register_optionflag('FUZZY')
+FUZZY_DF = doctest.register_optionflag('FUZZY_DF')
+IGNORE = doctest.register_optionflag('IGNORE')
+
+# Related doctest flags:
+# - NUMBER (https://docs.pytest.org/en/7.1.x/how-to/doctest.html?highlight=NUMBER#using-doctest-options)
+#   Floating-point numbers only need to match as far as the precision you have written in the expected doctest output
+# - SKIP (https://docs.python.org/3/library/doctest.html#doctest.SKIP)
+#   Do not run the example at all
+
+def _norm_df(df):
+    df = re.sub(r'╞.*', '', df, flags=re.DOTALL)
+    df = re.sub(r'\s+', ' ', df)
+    df = re.sub(r'shape: \(\d+,', 'shape: (#', df)
+    return df
 
 class CustomOutputChecker(doctest.OutputChecker):
     def check_output(self, want, got, optionflags):
         if FUZZY & optionflags:
+            if optionflags - FUZZY:
+                raise Exception('FUZZY can not be used with other flags')
             # A replacement string has special behavior with backslashes,
             # but the value returned by a lambda does not.
             number_re = lambda _: r'-?\d+(\.\d*)?'
             # Replace each tilde-number with a regex representing any possible number.
             want_re = re.sub(r'\\~(\\-)?\d+(\\\.\d*)?', number_re, re.escape(want.strip()))
             return bool(re.search(want_re, got))
+        if FUZZY_DF & optionflags:
+            if optionflags - FUZZY_DF:
+                raise Exception('FUZZY_DF can not be used with other flags')
+            return _norm_df(want) == _norm_df(got)
+        if IGNORE & optionflags:
+            if optionflags - IGNORE:
+                raise Exception('IGNORE can not be used with other flags')
+            return 'Traceback' not in got
         return super().check_output(want, got, optionflags)
 
 doctest.OutputChecker = CustomOutputChecker  # type: ignore

--- a/python/conftest.py
+++ b/python/conftest.py
@@ -18,9 +18,9 @@ class CustomOutputChecker(doctest.OutputChecker):
             # A replacement string has special behavior with backslashes,
             # but the value returned by a lambda does not.
             number_re = lambda _: r'-?\d+(\.\d*)?'
-            # Replace each number with a regex representing any possible number.
+            # Replace each tilde-number with a regex representing any possible number.
             want_re = re.sub(r'\\~(\\-)?\d+(\\\.\d*)?', number_re, re.escape(want.strip()))
             return bool(re.search(want_re, got))
         return super().check_output(want, got, optionflags)
 
-doctest.OutputChecker = CustomOutputChecker
+doctest.OutputChecker = CustomOutputChecker  # type: ignore

--- a/python/conftest.py
+++ b/python/conftest.py
@@ -1,6 +1,26 @@
 import pytest
+import doctest
+import re
+
 import opendp.prelude as dp
+
 
 @pytest.fixture(autouse=True)
 def add_dp(doctest_namespace):
     doctest_namespace['dp'] = dp
+
+
+FUZZY = doctest.register_optionflag('FUZZY')
+
+class CustomOutputChecker(doctest.OutputChecker):
+    def check_output(self, want, got, optionflags):
+        if FUZZY & optionflags:
+            # A replacement string has special behavior with backslashes,
+            # but the value returned by a lambda does not.
+            number_re = lambda _: r'-?\d+(\.\d*)?'
+            # Replace each number with a regex representing any possible number.
+            want_re = re.sub(r'\\~(\\-)?\d+(\\\.\d*)?', number_re, re.escape(want.strip()))
+            return bool(re.search(want_re, got))
+        return super().check_output(want, got, optionflags)
+
+doctest.OutputChecker = CustomOutputChecker

--- a/python/conftest.py
+++ b/python/conftest.py
@@ -37,7 +37,7 @@ class CustomOutputChecker(doctest.OutputChecker):
         if IGNORE & optionflags:
             if optionflags - IGNORE:
                 raise Exception('IGNORE can not be used with other flags')
-            return 'Traceback' not in got
+            return 'Traceback' not in got and bool(len(want)) == bool(len(got))
         return super().check_output(want, got, optionflags)
 
 doctest.OutputChecker = CustomOutputChecker  # type: ignore

--- a/python/conftest.py
+++ b/python/conftest.py
@@ -23,6 +23,7 @@ IGNORE = doctest.register_optionflag('IGNORE')
 def _norm_df(df):
     df = re.sub(r'╞.*', '', df, flags=re.DOTALL)
     df = re.sub(r'\s+', ' ', df)
+    df = re.sub(r'─+', '─', df)  # Special character used in box
     df = re.sub(r'shape: \(\d+,', 'shape: (#', df)
     return df
 

--- a/python/test/test_tests.py
+++ b/python/test/test_tests.py
@@ -1,3 +1,5 @@
+import pytest
+
 import opendp.prelude as dp
 
 
@@ -25,3 +27,14 @@ def test_TODOs():
     dp.t.then_ordered_random()
     dp.t.then_quantile_score_candidates([], 0.5)
     dp.t.then_sum_of_squared_deviations()
+
+
+def test_fuzzy_doctests():
+    '''
+    >>> 2+2 # doctest: +FUZZY
+    ~-5
+
+    >>> print(f'[{2+2}]') # doctest: +FUZZY
+    [~4.1]
+    '''
+    pass

--- a/python/test/test_tests.py
+++ b/python/test/test_tests.py
@@ -1,5 +1,3 @@
-import pytest
-
 import opendp.prelude as dp
 
 

--- a/python/test/test_tests.py
+++ b/python/test/test_tests.py
@@ -63,3 +63,27 @@ def test_doctest_fuzzy(capsys):
 
     with pytest.raises(Exception, match='FUZZY can not be used with other flags'):
         assert_doctest_pass('>>> 2+2', capsys, {'FUZZY', 'NUMBER'})
+
+
+# Include "polars" in name to filter out in smoke-test.yml.
+def test_doctest_fuzzy_polars(capsys):
+    doctest = '''
+    >>> import polars as pl
+    >>> pl.DataFrame({'col': ['value']})
+    shape: (2, 1)
+    ┌───────────┐
+    │ col       │
+    │ ---       │
+    │ str       │
+    ╞═══════════╡
+    │ value     │
+    │ surprise! │
+    └───────────┘
+    '''
+    assert_doctest_fail(doctest, capsys)
+    assert_doctest_fail(doctest, capsys, {'FUZZY'})
+    assert_doctest_pass(doctest, capsys, {'FUZZY_DF'})
+    assert_doctest_fail(doctest.replace('1)', '100)'), capsys, {'FUZZY_DF'})
+
+    with pytest.raises(Exception, match='FUZZY_DF can not be used with other flags'):
+        assert_doctest_pass(doctest, capsys, {'FUZZY_DF', 'NUMBER'})

--- a/python/test/test_tests.py
+++ b/python/test/test_tests.py
@@ -55,16 +55,6 @@ def test_doctest_ignore(capsys):
         assert_doctest_pass('>>> 2+2', capsys, {'IGNORE', 'NUMBER'})
 
 
-def test_doctest_fuzzy(capsys):
-    assert_doctest_pass('>>> 2+2\n4', capsys)
-    assert_doctest_fail('>>> 2+2\n5', capsys)
-    assert_doctest_pass('>>> 2+2\n~5', capsys, {'FUZZY'})
-    assert_doctest_fail('>>> 2+2\n~5 extra!', capsys, {'FUZZY'})
-
-    with pytest.raises(Exception, match='FUZZY can not be used with other flags'):
-        assert_doctest_pass('>>> 2+2', capsys, {'FUZZY', 'NUMBER'})
-
-
 # Include "polars" in name to filter out in smoke-test.yml.
 def test_doctest_fuzzy_polars(capsys):
     doctest = '''

--- a/python/test/test_tests.py
+++ b/python/test/test_tests.py
@@ -53,7 +53,7 @@ def test_doctest_ignore(capsys):
 
     assert_FAIL('>>> 2+2', capsys)
     assert_pass('>>> 2+2', capsys, {'SKIP'})
-    assert_pass('>>> 2+2', capsys, {'IGNORE'})
+    assert_FAIL('>>> 2+2', capsys, {'IGNORE'})
 
     assert_pass('>>> 2+2\n4', capsys)
     assert_pass('>>> 2+2\n4', capsys, {'SKIP'})


### PR DESCRIPTION
- Fix #2245
- Prereq to #2205

This might be needlessly complicated, but the idea is that instead of simply ignoring the result altogether, we can loosen it, so that if the RST has a number preceded by tilde, any number will work, but the rest of the output still needs to match.

FYI: Pytest has a related doctest extension: [NUMBER](https://docs.pytest.org/en/7.1.x/how-to/doctest.html?highlight=doctest#using-doctest-options).

> when enabled, floating-point numbers only need to match as far as the precision you have written in the expected doctest output

The [source code](https://github.com/pytest-dev/pytest/blob/2f369848ea0ead42182efc77000a5ecef629a0ba/src/_pytest/doctest.py#L654-L676) is interesting.