### PR TITLE
feat: Simplify Polars OO code

### DIFF
--- a/python/src/opendp/extras/polars/__init__.py
+++ b/python/src/opendp/extras/polars/__init__.py
@@ -658,7 +658,7 @@ class LazyFrameQuery():
 
     # Keep this docstring in sync with the docstring below for the dummy class.
 
-    def __init__(self, lf_plan: _LazyFrame, query):
+    def __init__(self, lf_plan, query):
         self._lf_plan = lf_plan
         self._query = query
         # do not initialize super() because inheritance is only used to mimic the API surface
@@ -706,8 +706,8 @@ class LazyFrameQuery():
 
     def sort(  # type: ignore[empty-body]
         self,
-        by: IntoExpr | Iterable[IntoExpr],
-        *more_by: IntoExpr,
+        by,
+        *more_by,
         descending: bool | Sequence[bool] = False,
         nulls_last: bool | Sequence[bool] = False,
         maintain_order: bool = False,
@@ -718,13 +718,7 @@ class LazyFrameQuery():
 
     def filter(  # type: ignore[empty-body]
         self,
-        *predicates: (
-            IntoExprColumn
-            | Iterable[IntoExprColumn]
-            | bool
-            | list[bool]
-            | np.ndarray[Any, Any]
-        ),
+        *predicates,
         **constraints: Any,
     ) -> LazyFrameQuery:
         """
@@ -735,7 +729,7 @@ class LazyFrameQuery():
         ...
 
     def select(  # type: ignore[empty-body]
-        self, *exprs: IntoExpr | Iterable[IntoExpr], **named_exprs: IntoExpr
+        self, *exprs, **named_exprs
     ) -> LazyFrameQuery:
         """
         Select columns from this ``LazyFrame``.
@@ -745,7 +739,7 @@ class LazyFrameQuery():
         ...
 
     def select_seq(  # type: ignore[empty-body]
-        self, *exprs: IntoExpr | Iterable[IntoExpr], **named_exprs: IntoExpr
+        self, *exprs, **named_exprs
     ) -> LazyFrameQuery:
         """
         Select columns from this ``LazyFrame``.
@@ -756,7 +750,7 @@ class LazyFrameQuery():
 
     def group_by(  # type: ignore[empty-body]
         self,
-        *by: IntoExpr | Iterable[IntoExpr],
+        *by,
         maintain_order: bool = False,
         **named_by: IntoExpr,
     ) -> LazyGroupByQuery:
@@ -769,8 +763,8 @@ class LazyFrameQuery():
 
     def with_columns(  # type: ignore[empty-body]
         self,
-        *exprs: IntoExpr | Iterable[IntoExpr],
-        **named_exprs: IntoExpr,
+        *exprs,
+        **named_exprs,
     ) -> LazyFrameQuery:
         """
         Add columns to this ``LazyFrame``.
@@ -782,8 +776,8 @@ class LazyFrameQuery():
 
     def with_columns_seq(  # type: ignore[empty-body]
         self,
-        *exprs: IntoExpr | Iterable[IntoExpr],
-        **named_exprs: IntoExpr,
+        *exprs,
+        **named_exprs,
     ) -> LazyFrameQuery:
         """
         Add columns to this ``LazyFrame``.
@@ -795,14 +789,14 @@ class LazyFrameQuery():
 
     def join(  # type: ignore[empty-body]
         self,
-        other: _LazyFrame,
-        on: str | _Expr | Sequence[str | _Expr] | None = None,
-        how: JoinStrategy = "inner",
+        other,
+        on = None,
+        how = "inner",
         *,
-        left_on: str | _Expr | Sequence[str | _Expr] | None = None,
-        right_on: str | _Expr | Sequence[str | _Expr] | None = None,
+        left_on = None,
+        right_on = None,
         suffix: str = "_right",
-        validate: JoinValidation = "m:m",
+        validate = "m:m",
         join_nulls: bool = False,
         coalesce: bool | None = None,
         allow_parallel: bool = True,
@@ -815,7 +809,7 @@ class LazyFrameQuery():
 
     def with_keys(
         self,
-        keys: _LazyFrame,
+        keys,
         on: list[str] | None = None,
     ) -> LazyFrameQuery:
         """
@@ -952,20 +946,20 @@ class LazyFrameQuery():
 
         return summarize_polars_measurement(self.resolve(), alpha)
 
-class LazyGroupByQuery(_LazyGroupBy):
+class LazyGroupByQuery():
     """
     A ``LazyGroupByQuery`` is returned by :py:func:`opendp.extras.polars.LazyFrameQuery.group_by`.
     It mimics a `Polars LazyGroupBy <https://docs.pola.rs/api/python/stable/reference/lazyframe/group_by.html>`_,
     but only supports APIs documented below."""
 
-    def __init__(self, lgb_plan: _LazyGroupBy, query):
+    def __init__(self, lgb_plan, query):
         self._lgb_plan = lgb_plan
         self._query = query
 
     def agg(
         self,
-        *aggs: IntoExpr | Iterable[IntoExpr],
-        **named_aggs: IntoExpr,
+        *aggs,
+        **named_aggs,
     ) -> LazyFrameQuery:
         """
         Compute aggregations for each group of a group by operation.

--- a/python/src/opendp/extras/polars/__init__.py
+++ b/python/src/opendp/extras/polars/__init__.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import os
 from typing import Any, Iterable, Literal, Sequence
-from opendp._lib import lib_path
+from opendp._lib import lib_path, import_optional_dependency
 from opendp.mod import (
     Domain,
     Measurement,
@@ -522,12 +522,9 @@ class DPExpr(object):
         return self.expr.dp.quantile(0.5, candidates, scale)
 
 
-try:
-    from polars.api import register_expr_namespace  # type: ignore[import-not-found]
-
-    register_expr_namespace("dp")(DPExpr)
-except ImportError:  # pragma: no cover
-    pass
+pl = import_optional_dependency('polars', raise_error=False)
+if pl is not None:
+    pl.api.register_expr_namespace("dp")(DPExpr)
 
 
 def dp_len(scale: float | None = None):

--- a/python/src/opendp/extras/polars/__init__.py
+++ b/python/src/opendp/extras/polars/__init__.py
@@ -650,388 +650,331 @@ _LAZY_EXECUTION_METHODS = {
 }
 
 
-# In our DataFrame APIs, we only need to make a few small adjustments to Polars LazyFrames.
-# Therefore if Polars is installed, LazyFrameQuery subclasses LazyFrame.
-#
-# # Compatibility with MyPy
-# If Polars is not installed, then a dummy LazyFrameQuery class is declared.
-# This way other modules can import and include LazyFrameQuery in static type annotations.
-# MyPy type-checks based on the first definition of a class,
-# so the code is written such that the first definition of the class is the real thing.
-#
-# # Compatibility with Pylance
-# If declared in branching code, Pylance may only provide code analysis based on the dummy class.
-# Therefore preference is given to the real class via a try-except block.
-#
-# # Compatibility with Sphinx
-# Even when Polars is installed, Sphinx fails to find the reference to the Polars LazyFrame class.
-# I think this is because Polars is not a direct dependency.
-# Therefore the following code uses OPENDP_HEADLESS to get Sphinx to document the dummy class instead.
-# This may also be preferred behavior:
-#     only the changes we make to the Polars LazyFrame API are documented, not the entire LazyFrame API.
-try:
-    if os.environ.get("OPENDP_HEADLESS"):
-        raise ImportError(
-            "Sphinx always fails to find a reference to LazyFrame. Falling back to dummy class."
-        )
-    from polars.lazyframe.frame import LazyFrame as _LazyFrame  # type: ignore[import-not-found]
-    from polars.dataframe.frame import DataFrame as _DataFrame  # type: ignore[import-not-found]
-    from polars.expr.expr import Expr as _Expr  # type: ignore[import-not-found]
-    from polars.lazyframe.group_by import LazyGroupBy as _LazyGroupBy  # type: ignore[import-not-found]
-    from polars._typing import IntoExpr, IntoExprColumn, JoinStrategy, JoinValidation  # type: ignore[import-not-found]
-    import numpy as np  # type: ignore[import-not-found]
+class LazyFrameQuery():
+    """
+    A ``LazyFrameQuery`` may be returned by :py:func:`opendp.context.Context.query`.
+    It mimics a `Polars LazyFrame <https://docs.pola.rs/api/python/stable/reference/lazyframe/index.html>`_,
+    but makes a few additions and changes as documented below."""
 
-    class LazyFrameQuery(_LazyFrame):
+    # Keep this docstring in sync with the docstring below for the dummy class.
+
+    def __init__(self, lf_plan: _LazyFrame, query):
+        self._lf_plan = lf_plan
+        self._query = query
+        # do not initialize super() because inheritance is only used to mimic the API surface
+
+    def __getattribute__(self, name):
+        # Re-route all possible attribute access to self._lf_plan.
+        # __getattribute__ is necessary because __getattr__ cannot intercept calls to inherited methods
+
+        # We keep the query plan void of data anyways,
+        # so running the computation doesn't affect privacy.
+        # This doesn't have to cover all possible APIs that may execute the query,
+        #    but it does give a simple sanity check for the obvious cases.
+        if name in _LAZY_EXECUTION_METHODS:
+            raise ValueError("You must call `.release()` before executing a query.")
+
+        lf_plan = object.__getattribute__(self, "_lf_plan")
+        query = object.__getattribute__(self, "_query")
+        attr = getattr(lf_plan, name, None)
+
+        # If not a valid attribute on self._lf_plan, then don't re-route
+        if attr is None:
+            return object.__getattribute__(self, name)
+
+        # any callable attributes (like .with_columns or .select) will now also wrap their outputs in a LazyFrameQuery
+        if callable(attr):
+
+            def _wrap(*args, **kwargs):
+                out = attr(*args, **kwargs)
+
+                # re-wrap any lazy outputs to keep the conveniences afforded by this class
+                if isinstance(out, _LazyFrame):
+                    return LazyFrameQuery(out, query)
+
+                if isinstance(out, _LazyGroupBy):
+                    return LazyGroupByQuery(out, query)
+
+                return out
+
+            return _wrap
+        return attr
+
+    # These definitions are primarily for mypy:
+    # Without them, a "# type: ignore[union-attr]" is needed on every line where these methods are used.
+    # The docstrings are not seen by Sphinx, but aren't doing any harm either.
+
+    def sort(  # type: ignore[empty-body]
+        self,
+        by: IntoExpr | Iterable[IntoExpr],
+        *more_by: IntoExpr,
+        descending: bool | Sequence[bool] = False,
+        nulls_last: bool | Sequence[bool] = False,
+        maintain_order: bool = False,
+        multithreaded: bool = True,
+    ) -> LazyFrameQuery:
+        """Sort the ``LazyFrame`` by the given columns."""
+        ...
+
+    def filter(  # type: ignore[empty-body]
+        self,
+        *predicates: (
+            IntoExprColumn
+            | Iterable[IntoExprColumn]
+            | bool
+            | list[bool]
+            | np.ndarray[Any, Any]
+        ),
+        **constraints: Any,
+    ) -> LazyFrameQuery:
         """
-        A ``LazyFrameQuery`` may be returned by :py:func:`opendp.context.Context.query`.
-        It mimics a `Polars LazyFrame <https://docs.pola.rs/api/python/stable/reference/lazyframe/index.html>`_,
-        but makes a few additions and changes as documented below."""
+        Filter the rows in the ``LazyFrame`` based on a predicate expression.
 
-        # Keep this docstring in sync with the docstring below for the dummy class.
+        OpenDP discards relevant margin descriptors in the domain when filtering.
+        """
+        ...
 
-        def __init__(self, lf_plan: _LazyFrame, query):
-            self._lf_plan = lf_plan
-            self._query = query
-            # do not initialize super() because inheritance is only used to mimic the API surface
+    def select(  # type: ignore[empty-body]
+        self, *exprs: IntoExpr | Iterable[IntoExpr], **named_exprs: IntoExpr
+    ) -> LazyFrameQuery:
+        """
+        Select columns from this ``LazyFrame``.
 
-        def __getattribute__(self, name):
-            # Re-route all possible attribute access to self._lf_plan.
-            # __getattribute__ is necessary because __getattr__ cannot intercept calls to inherited methods
+        OpenDP expects expressions in select statements that don't aggregate to be row-by-row.
+        """
+        ...
 
-            # We keep the query plan void of data anyways,
-            # so running the computation doesn't affect privacy.
-            # This doesn't have to cover all possible APIs that may execute the query,
-            #    but it does give a simple sanity check for the obvious cases.
-            if name in _LAZY_EXECUTION_METHODS:
-                raise ValueError("You must call `.release()` before executing a query.")
+    def select_seq(  # type: ignore[empty-body]
+        self, *exprs: IntoExpr | Iterable[IntoExpr], **named_exprs: IntoExpr
+    ) -> LazyFrameQuery:
+        """
+        Select columns from this ``LazyFrame``.
 
-            lf_plan = object.__getattribute__(self, "_lf_plan")
-            query = object.__getattribute__(self, "_query")
-            attr = getattr(lf_plan, name, None)
+        OpenDP allows expressions in select statements that aggregate to not be row-by-row.
+        """
+        ...
 
-            # If not a valid attribute on self._lf_plan, then don't re-route
-            if attr is None:
-                return object.__getattribute__(self, name)
+    def group_by(  # type: ignore[empty-body]
+        self,
+        *by: IntoExpr | Iterable[IntoExpr],
+        maintain_order: bool = False,
+        **named_by: IntoExpr,
+    ) -> LazyGroupByQuery:
+        """
+        Start a group by operation.
 
-            # any callable attributes (like .with_columns or .select) will now also wrap their outputs in a LazyFrameQuery
-            if callable(attr):
+        OpenDP currently requires that grouping keys be simple column expressions.
+        """
+        ...
 
-                def _wrap(*args, **kwargs):
-                    out = attr(*args, **kwargs)
+    def with_columns(  # type: ignore[empty-body]
+        self,
+        *exprs: IntoExpr | Iterable[IntoExpr],
+        **named_exprs: IntoExpr,
+    ) -> LazyFrameQuery:
+        """
+        Add columns to this ``LazyFrame``.
 
-                    # re-wrap any lazy outputs to keep the conveniences afforded by this class
-                    if isinstance(out, _LazyFrame):
-                        return LazyFrameQuery(out, query)
+        OpenDP requires that expressions in with_columns are row-by-row:
+        expressions may not change the number or order of records
+        """
+        ...
 
-                    if isinstance(out, _LazyGroupBy):
-                        return LazyGroupByQuery(out, query)
+    def with_columns_seq(  # type: ignore[empty-body]
+        self,
+        *exprs: IntoExpr | Iterable[IntoExpr],
+        **named_exprs: IntoExpr,
+    ) -> LazyFrameQuery:
+        """
+        Add columns to this ``LazyFrame``.
 
-                    return out
+        OpenDP requires that expressions in with_columns are row-by-row:
+        expressions may not change the number or order of records
+        """
+        ...
 
-                return _wrap
-            return attr
+    def join(  # type: ignore[empty-body]
+        self,
+        other: _LazyFrame,
+        on: str | _Expr | Sequence[str | _Expr] | None = None,
+        how: JoinStrategy = "inner",
+        *,
+        left_on: str | _Expr | Sequence[str | _Expr] | None = None,
+        right_on: str | _Expr | Sequence[str | _Expr] | None = None,
+        suffix: str = "_right",
+        validate: JoinValidation = "m:m",
+        join_nulls: bool = False,
+        coalesce: bool | None = None,
+        allow_parallel: bool = True,
+        force_parallel: bool = False,
+    ) -> LazyFrameQuery:
+        """
+        Add a join operation to the Logical Plan.
+        """
+        ...
 
-        # These definitions are primarily for mypy:
-        # Without them, a "# type: ignore[union-attr]" is needed on every line where these methods are used.
-        # The docstrings are not seen by Sphinx, but aren't doing any harm either.
+    def with_keys(
+        self,
+        keys: _LazyFrame,
+        on: list[str] | None = None,
+    ) -> LazyFrameQuery:
+        """
+        Shorthand to join with an explicit key-set.
 
-        def sort(  # type: ignore[empty-body]
-            self,
-            by: IntoExpr | Iterable[IntoExpr],
-            *more_by: IntoExpr,
-            descending: bool | Sequence[bool] = False,
-            nulls_last: bool | Sequence[bool] = False,
-            maintain_order: bool = False,
-            multithreaded: bool = True,
-        ) -> LazyFrameQuery:
-            """Sort the ``LazyFrame`` by the given columns."""
-            ...
+        :param keys: lazyframe containing a key-set whose columns correspond to the grouping keys
+        :param on: optional, the names of columns to join on. Useful if the key dataframe contains extra columns
+        """
+        # Motivation for adding this new API:
+        # 1. Writing a left join is more difficult in the context API: 
+        #   see the complexity of this implementation, where you have to go under the hood. 
+        #   This gives an easier shorthand to write a left join.
+        # 2. Left joins are more likely to be supported by database backends.
+        # 3. Easier to use; with the Polars API the key set needs to be lazy, user must specify they want a right join and the join keys.
 
-        def filter(  # type: ignore[empty-body]
-            self,
-            *predicates: (
-                IntoExprColumn
-                | Iterable[IntoExprColumn]
-                | bool
-                | list[bool]
-                | np.ndarray[Any, Any]
-            ),
-            **constraints: Any,
-        ) -> LazyFrameQuery:
-            """
-            Filter the rows in the ``LazyFrame`` based on a predicate expression.
+        if isinstance(keys, _DataFrame):
+            keys = keys.lazy()
+        
+        if on is None:
+            on = keys.collect_schema().names()
 
-            OpenDP discards relevant margin descriptors in the domain when filtering.
-            """
-            ...
+        return LazyFrameQuery(
+            keys.join(self._lf_plan, how="left", on=on),
+            self._query,
+        )
 
-        def select(  # type: ignore[empty-body]
-            self, *exprs: IntoExpr | Iterable[IntoExpr], **named_exprs: IntoExpr
-        ) -> LazyFrameQuery:
-            """
-            Select columns from this ``LazyFrame``.
+    def resolve(self) -> Measurement:
+        """Resolve the query into a measurement."""
 
-            OpenDP expects expressions in select statements that don't aggregate to be row-by-row.
-            """
-            ...
+        # access attributes of self without getting intercepted by Self.__getattribute__
+        lf_plan = object.__getattribute__(self, "_lf_plan")
+        query = object.__getattribute__(self, "_query")
+        input_domain, input_metric = query._chain
+        d_in, d_out = query._d_in, query._d_out
 
-        def select_seq(  # type: ignore[empty-body]
-            self, *exprs: IntoExpr | Iterable[IntoExpr], **named_exprs: IntoExpr
-        ) -> LazyFrameQuery:
-            """
-            Select columns from this ``LazyFrame``.
-
-            OpenDP allows expressions in select statements that aggregate to not be row-by-row.
-            """
-            ...
-
-        def group_by(  # type: ignore[empty-body]
-            self,
-            *by: IntoExpr | Iterable[IntoExpr],
-            maintain_order: bool = False,
-            **named_by: IntoExpr,
-        ) -> LazyGroupByQuery:
-            """
-            Start a group by operation.
-
-            OpenDP currently requires that grouping keys be simple column expressions.
-            """
-            ...
-
-        def with_columns(  # type: ignore[empty-body]
-            self,
-            *exprs: IntoExpr | Iterable[IntoExpr],
-            **named_exprs: IntoExpr,
-        ) -> LazyFrameQuery:
-            """
-            Add columns to this ``LazyFrame``.
-
-            OpenDP requires that expressions in with_columns are row-by-row:
-            expressions may not change the number or order of records
-            """
-            ...
-
-        def with_columns_seq(  # type: ignore[empty-body]
-            self,
-            *exprs: IntoExpr | Iterable[IntoExpr],
-            **named_exprs: IntoExpr,
-        ) -> LazyFrameQuery:
-            """
-            Add columns to this ``LazyFrame``.
-
-            OpenDP requires that expressions in with_columns are row-by-row:
-            expressions may not change the number or order of records
-            """
-            ...
-
-        def join(  # type: ignore[empty-body]
-            self,
-            other: _LazyFrame,
-            on: str | _Expr | Sequence[str | _Expr] | None = None,
-            how: JoinStrategy = "inner",
-            *,
-            left_on: str | _Expr | Sequence[str | _Expr] | None = None,
-            right_on: str | _Expr | Sequence[str | _Expr] | None = None,
-            suffix: str = "_right",
-            validate: JoinValidation = "m:m",
-            join_nulls: bool = False,
-            coalesce: bool | None = None,
-            allow_parallel: bool = True,
-            force_parallel: bool = False,
-        ) -> LazyFrameQuery:
-            """
-            Add a join operation to the Logical Plan.
-            """
-            ...
-
-        def with_keys(
-            self,
-            keys: _LazyFrame,
-            on: list[str] | None = None,
-        ) -> LazyFrameQuery:
-            """
-            Shorthand to join with an explicit key-set.
-
-            :param keys: lazyframe containing a key-set whose columns correspond to the grouping keys
-            :param on: optional, the names of columns to join on. Useful if the key dataframe contains extra columns
-            """
-            # Motivation for adding this new API:
-            # 1. Writing a left join is more difficult in the context API: 
-            #   see the complexity of this implementation, where you have to go under the hood. 
-            #   This gives an easier shorthand to write a left join.
-            # 2. Left joins are more likely to be supported by database backends.
-            # 3. Easier to use; with the Polars API the key set needs to be lazy, user must specify they want a right join and the join keys.
-
-            if isinstance(keys, _DataFrame):
-                keys = keys.lazy()
-            
-            if on is None:
-                on = keys.collect_schema().names()
-
-            return LazyFrameQuery(
-                keys.join(self._lf_plan, how="left", on=on),
-                self._query,
+        def _make(scale, threshold=None):
+            return make_private_lazyframe(
+                input_domain=input_domain,
+                input_metric=input_metric,
+                output_measure=query._output_measure,
+                lazyframe=lf_plan,
+                global_scale=scale,
+                threshold=threshold,
             )
 
-        def resolve(self) -> Measurement:
-            """Resolve the query into a measurement."""
+        # when the output measure is δ-approximate, then there are two free parameters to tune
+        if getattr(query._output_measure.type, "origin", None) == "Approximate":
 
-            # access attributes of self without getting intercepted by Self.__getattribute__
-            lf_plan = object.__getattribute__(self, "_lf_plan")
-            query = object.__getattribute__(self, "_query")
-            input_domain, input_metric = query._chain
-            d_in, d_out = query._d_in, query._d_out
+            # search for a scale parameter. Solve for epsilon first,
+            # setting threshold to u32::MAX so as not to interfere with the search for a suitable scale parameter
+            scale = binary_search(
+                lambda s: _make(s, threshold=2**32 - 1).map(d_in)[0] < d_out[0],  # type: ignore[index]
+                T=float,
+            )
 
-            def _make(scale, threshold=None):
-                return make_private_lazyframe(
-                    input_domain=input_domain,
-                    input_metric=input_metric,
-                    output_measure=query._output_measure,
-                    lazyframe=lf_plan,
-                    global_scale=scale,
-                    threshold=threshold,
-                )
+            # attempt to return without setting a threshold
+            try:
+                return _make(scale, threshold=None)
+            except OpenDPException:
+                pass
 
-            # when the output measure is δ-approximate, then there are two free parameters to tune
-            if getattr(query._output_measure.type, "origin", None) == "Approximate":
+            # now that scale has been solved, find a suitable threshold
+            threshold = binary_search(
+                lambda t: _make(scale, t).map(d_in)[1] < d_out[1],  # type: ignore[index]
+                T=int,
+            )
 
-                # search for a scale parameter. Solve for epsilon first,
-                # setting threshold to u32::MAX so as not to interfere with the search for a suitable scale parameter
-                scale = binary_search(
-                    lambda s: _make(s, threshold=2**32 - 1).map(d_in)[0] < d_out[0],  # type: ignore[index]
-                    T=float,
-                )
+            # return a measurement with the discovered scale and threshold
+            return _make(scale, threshold)
 
-                # attempt to return without setting a threshold
-                try:
-                    return _make(scale, threshold=None)
-                except OpenDPException:
-                    pass
+        # when no delta parameter is involved,
+        # finding a suitable measurement just comes down to finding scale
+        return binary_search_chain(_make, d_in, d_out, T=float)
 
-                # now that scale has been solved, find a suitable threshold
-                threshold = binary_search(
-                    lambda t: _make(scale, t).map(d_in)[1] < d_out[1],  # type: ignore[index]
-                    T=int,
-                )
+    def release(self) -> OnceFrame:
+        """Release the query. The query must be part of a context."""
+        query = object.__getattribute__(self, "_query")
+        resolve = object.__getattribute__(self, "resolve")
+        return query._context(resolve())  # type: ignore[misc]
 
-                # return a measurement with the discovered scale and threshold
-                return _make(scale, threshold)
+    def summarize(self, alpha: float | None = None):
+        """Summarize the statistics released by this query.
 
-            # when no delta parameter is involved,
-            # finding a suitable measurement just comes down to finding scale
-            return binary_search_chain(_make, d_in, d_out, T=float)
+        :param alpha: optional. A value in [0, 1] denoting the statistical significance. For the corresponding confidence level, subtract from from 1: for 95% confidence, use 0.05 for alpha.
 
-        def release(self) -> OnceFrame:
-            """Release the query. The query must be part of a context."""
-            query = object.__getattribute__(self, "_query")
-            resolve = object.__getattribute__(self, "resolve")
-            return query._context(resolve())  # type: ignore[misc]
+        If ``alpha`` is passed, the resulting data frame includes an ``accuracy`` column.
 
-        def summarize(self, alpha: float | None = None):
-            """Summarize the statistics released by this query.
+        If a threshold is configured for censoring small/sensitive partitions,
+        a threshold column will be included,
+        containing the cutoff for the respective count query being thresholded.
 
-            :param alpha: optional. A value in [0, 1] denoting the statistical significance. For the corresponding confidence level, subtract from from 1: for 95% confidence, use 0.05 for alpha.
+        :example:
 
-            If ``alpha`` is passed, the resulting data frame includes an ``accuracy`` column.
+        >>> import polars as pl
+        >>> data = pl.LazyFrame([pl.Series("convicted", [0, 1, 1, 0, 1] * 50, dtype=pl.Int32)])
 
-            If a threshold is configured for censoring small/sensitive partitions,
-            a threshold column will be included,
-            containing the cutoff for the respective count query being thresholded.
+        >>> context = dp.Context.compositor(
+        ...     data=data,
+        ...     privacy_unit=dp.unit_of(contributions=1),
+        ...     privacy_loss=dp.loss_of(epsilon=1.0),
+        ...     split_evenly_over=1,
+        ...     margins={(): dp.polars.Margin(max_partition_length=1000)},
+        ... )
 
-            :example:
+        >>> query = context.query().select(
+        ...     dp.len(),
+        ...     pl.col("convicted").fill_null(0).dp.sum((0, 1))
+        ... )
 
-            >>> import polars as pl
-            >>> data = pl.LazyFrame([pl.Series("convicted", [0, 1, 1, 0, 1] * 50, dtype=pl.Int32)])
+        >>> query.summarize(alpha=.05)  # type: ignore[union-attr]
+        shape: (2, 5)
+        ┌───────────┬──────────────┬─────────────────┬───────┬──────────┐
+        │ column    ┆ aggregate    ┆ distribution    ┆ scale ┆ accuracy │
+        │ ---       ┆ ---          ┆ ---             ┆ ---   ┆ ---      │
+        │ str       ┆ str          ┆ str             ┆ f64   ┆ f64      │
+        ╞═══════════╪══════════════╪═════════════════╪═══════╪══════════╡
+        │ len       ┆ Frame Length ┆ Integer Laplace ┆ 2.0   ┆ 6.429605 │
+        │ convicted ┆ Sum          ┆ Integer Laplace ┆ 2.0   ┆ 6.429605 │
+        └───────────┴──────────────┴─────────────────┴───────┴──────────┘
 
-            >>> context = dp.Context.compositor(
-            ...     data=data,
-            ...     privacy_unit=dp.unit_of(contributions=1),
-            ...     privacy_loss=dp.loss_of(epsilon=1.0),
-            ...     split_evenly_over=1,
-            ...     margins={(): dp.polars.Margin(max_partition_length=1000)},
-            ... )
+        The accuracy in any given row can be interpreted with:
 
-            >>> query = context.query().select(
-            ...     dp.len(),
-            ...     pl.col("convicted").fill_null(0).dp.sum((0, 1))
-            ... )
-
-            >>> query.summarize(alpha=.05)  # type: ignore[union-attr]
-            shape: (2, 5)
-            ┌───────────┬──────────────┬─────────────────┬───────┬──────────┐
-            │ column    ┆ aggregate    ┆ distribution    ┆ scale ┆ accuracy │
-            │ ---       ┆ ---          ┆ ---             ┆ ---   ┆ ---      │
-            │ str       ┆ str          ┆ str             ┆ f64   ┆ f64      │
-            ╞═══════════╪══════════════╪═════════════════╪═══════╪══════════╡
-            │ len       ┆ Frame Length ┆ Integer Laplace ┆ 2.0   ┆ 6.429605 │
-            │ convicted ┆ Sum          ┆ Integer Laplace ┆ 2.0   ┆ 6.429605 │
-            └───────────┴──────────────┴─────────────────┴───────┴──────────┘
-
-            The accuracy in any given row can be interpreted with:
-
-            >>> def interpret_accuracy(distribution, scale, accuracy, alpha):
-            ...     return (
-            ...         f"When the {distribution} scale is {scale}, "
-            ...         f"the DP estimate differs from the true value by no more than {accuracy} "
-            ...         f"at a statistical significance level alpha of {alpha}, "
-            ...         f"or with (1 - {alpha})100% = {(1 - alpha) * 100}% confidence."
-            ...     )
-            ...
-            >>> interpret_accuracy("Integer Laplace", 2.0, 6.429605, alpha=.05) # doctest:+SKIP
-            """
-            from opendp.accuracy import summarize_polars_measurement
-
-            return summarize_polars_measurement(self.resolve(), alpha)
-
-    class LazyGroupByQuery(_LazyGroupBy):
+        >>> def interpret_accuracy(distribution, scale, accuracy, alpha):
+        ...     return (
+        ...         f"When the {distribution} scale is {scale}, "
+        ...         f"the DP estimate differs from the true value by no more than {accuracy} "
+        ...         f"at a statistical significance level alpha of {alpha}, "
+        ...         f"or with (1 - {alpha})100% = {(1 - alpha) * 100}% confidence."
+        ...     )
+        ...
+        >>> interpret_accuracy("Integer Laplace", 2.0, 6.429605, alpha=.05) # doctest:+SKIP
         """
-        A ``LazyGroupByQuery`` is returned by :py:func:`opendp.extras.polars.LazyFrameQuery.group_by`.
-        It mimics a `Polars LazyGroupBy <https://docs.pola.rs/api/python/stable/reference/lazyframe/group_by.html>`_,
-        but only supports APIs documented below."""
+        from opendp.accuracy import summarize_polars_measurement
 
-        def __init__(self, lgb_plan: _LazyGroupBy, query):
-            self._lgb_plan = lgb_plan
-            self._query = query
+        return summarize_polars_measurement(self.resolve(), alpha)
 
-        def agg(
-            self,
-            *aggs: IntoExpr | Iterable[IntoExpr],
-            **named_aggs: IntoExpr,
-        ) -> LazyFrameQuery:
-            """
-            Compute aggregations for each group of a group by operation.
+class LazyGroupByQuery(_LazyGroupBy):
+    """
+    A ``LazyGroupByQuery`` is returned by :py:func:`opendp.extras.polars.LazyFrameQuery.group_by`.
+    It mimics a `Polars LazyGroupBy <https://docs.pola.rs/api/python/stable/reference/lazyframe/group_by.html>`_,
+    but only supports APIs documented below."""
 
-            :param aggs: expressions to apply in the aggregation context
-            :param named_aggs: named/aliased expressions to apply in the aggregation context
-            """
-            lf_plan = self._lgb_plan.agg(*aggs, **named_aggs)
-            return LazyFrameQuery(lf_plan, self._query)
+    def __init__(self, lgb_plan: _LazyGroupBy, query):
+        self._lgb_plan = lgb_plan
+        self._query = query
 
-except ImportError:  # pragma: no cover
-    ERR_MSG = "LazyFrameQuery depends on Polars: `pip install 'opendp[polars]'`."
-
-    class LazyFrameQuery(object):  # type: ignore[no-redef]
+    def agg(
+        self,
+        *aggs: IntoExpr | Iterable[IntoExpr],
+        **named_aggs: IntoExpr,
+    ) -> LazyFrameQuery:
         """
-        A ``LazyFrameQuery`` may be returned by :py:func:`opendp.context.Context.query`.
-        It mimics a `Polars LazyFrame <https://docs.pola.rs/api/python/stable/reference/lazyframe/index.html>`_,
-        but makes a few additions as documented below."""
+        Compute aggregations for each group of a group by operation.
 
-        # Keep this docstring in sync with the docstring above for the real class.
-
-        def resolve(self) -> Measurement:
-            """Resolve the query into a measurement."""
-            raise ImportError(ERR_MSG)
-
-        def release(self) -> OnceFrame:
-            """Release the query. The query must be part of a context."""
-            raise ImportError(ERR_MSG)
-
-        def summarize(self, alpha: float | None = None):
-            """Summarize the statistics released by this query.
-            
-            :param alpha: optional. A value in [0, 1] denoting the statistical significance. For the corresponding confidence level, subtract from from 1: for 95% confidence, use 0.05 for alpha.
-            """
-            raise ImportError(ERR_MSG)
+        :param aggs: expressions to apply in the aggregation context
+        :param named_aggs: named/aliased expressions to apply in the aggregation context
+        """
+        lf_plan = self._lgb_plan.agg(*aggs, **named_aggs)
+        return LazyFrameQuery(lf_plan, self._query)
 
 
 @dataclass


### PR DESCRIPTION
- Inspired by #2218
- Fix #2231
- Replaces #2236 (new branch from main easier than sorting out conflicts)

In this case it looks like we don't actually need anything from the superclass, so we could just drop it, and we don't need to update the type hierarchy or anything like this.

We do lose type annotations, because the types may not actually be available, but those weren't showing up in the docs in any case, so I don't think it's a big loss.