### PR TITLE
docs: Check for doctrings on classes

### DIFF
--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -487,7 +487,18 @@ Chain = Union[tuple[Domain, Metric], Transformation, Measurement, "PartialChain"
 
 
 class Query(object):
-    """A helper API to build a measurement."""
+    """Initializes the query with the given chain and output measure.
+
+    It is more convenient to use the ``context.query()`` constructor than this one.
+    However, this can be used stand-alone to help build a transformation/measurement that is not part of a context.
+
+    :param chain: an initial metric space (tuple of domain and metric) or transformation
+    :param output_measure: how privacy will be measured on the output of the query
+    :param d_in: an upper bound on the distance between adjacent datasets
+    :param d_out: an upper bound on the overall privacy loss
+    :param context: if specified, then when the query is released, the chain will be submitted to this context
+    :param _wrap_release: for internal use only
+    """
 
     _chain: Chain
     """The current chain of transformations and measurements."""
@@ -508,18 +519,6 @@ class Query(object):
         context: "Context" = None, # type: ignore[assignment]
         _wrap_release=None,
     ) -> None:
-        """Initializes the query with the given chain and output measure.
-
-        It is more convenient to use the ``context.query()`` constructor than this one.
-        However, this can be used stand-alone to help build a transformation/measurement that is not part of a context.
-
-        :param chain: an initial metric space (tuple of domain and metric) or transformation
-        :param output_measure: how privacy will be measured on the output of the query
-        :param d_in: an upper bound on the distance between adjacent datasets
-        :param d_out: an upper bound on the overall privacy loss
-        :param context: if specified, then when the query is released, the chain will be submitted to this context
-        :param _wrap_release: for internal use only
-        """
         self._chain = chain
         self._output_measure = output_measure
         self._d_in = d_in

--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -44,7 +44,7 @@ from opendp.mod import (
     Domain,
     Measurement,
     Metric,
-    PartialConstructor,
+    _PartialConstructor,
     Queryable,
     Transformation,
     Measure,
@@ -739,9 +739,9 @@ class PartialChain(object):
         chain.param = param
         return chain
 
-    def __rshift__(self, other: Union[Transformation, Measurement, PartialConstructor]):
+    def __rshift__(self, other: Union[Transformation, Measurement, _PartialConstructor]):
         # partials may be chained with other transformations or measurements to form a new partial
-        if isinstance(other, (Transformation, Measurement, PartialConstructor)):
+        if isinstance(other, (Transformation, Measurement, _PartialConstructor)):
             return PartialChain(lambda x: self(x) >> other)
 
         raise ValueError("At most one parameter may be missing at a time")  # pragma: no cover

--- a/python/src/opendp/extras/_utilities.py
+++ b/python/src/opendp/extras/_utilities.py
@@ -1,12 +1,12 @@
 from typing import Callable, Union
-from opendp.mod import Domain, Metric, PartialConstructor, Measurement, Transformation
+from opendp.mod import Domain, Metric, _PartialConstructor, Measurement, Transformation
 
 
-def to_then(constructor) -> Callable[..., PartialConstructor]:
+def to_then(constructor) -> Callable[..., _PartialConstructor]:
     """Convert any `make_` constructor to a `then_` constructor"""
 
     def then_func(*args, **kwargs):
-        return PartialConstructor(
+        return _PartialConstructor(
             lambda input_domain, input_metric: constructor(
                 input_domain, input_metric, *args, **kwargs
             )
@@ -17,7 +17,7 @@ def to_then(constructor) -> Callable[..., PartialConstructor]:
     return then_func
 
 
-def _register(module_name, constructor) -> Callable[..., PartialConstructor]:  # type: ignore[return]
+def _register(module_name, constructor) -> Callable[..., _PartialConstructor]:  # type: ignore[return]
     import importlib
     import inspect
 
@@ -37,19 +37,19 @@ def _register(module_name, constructor) -> Callable[..., PartialConstructor]:  #
 
 def register_transformation(
     constructor: Callable[..., Transformation]
-) -> Callable[..., PartialConstructor]:
+) -> Callable[..., _PartialConstructor]:
     return _register("transformations", constructor)
 
 
 def register_measurement(
     constructor: Callable[..., Measurement]
-) -> Callable[..., PartialConstructor]:
+) -> Callable[..., _PartialConstructor]:
     return _register("measurements", constructor)
 
 
 def register_combinator(
     constructor: Callable[..., Union[Transformation, Measurement]],
-) -> Callable[..., PartialConstructor]:
+) -> Callable[..., _PartialConstructor]:
     return _register("combinators", constructor)  # pragma: no cover
 
 

--- a/python/src/opendp/extras/polars/__init__.py
+++ b/python/src/opendp/extras/polars/__init__.py
@@ -57,7 +57,6 @@ class DPExpr(object):
     """
 
     def __init__(self, expr):
-        """Apply a differentially private plugin to a Polars expression."""
         self.expr = expr
 
     def noise(

--- a/python/src/opendp/extras/polars/__init__.py
+++ b/python/src/opendp/extras/polars/__init__.py
@@ -562,14 +562,14 @@ def dp_len(scale: float | None = None):
 
 
 class OnceFrame(object):
+    """OnceFrame is a Polars LazyFrame that may only be collected into a DataFrame once.
+
+    The APIs on this class mimic those that can be found in Polars.
+
+    Differentially private guarantees on a given LazyFrame require the LazyFrame to be evaluated at most once.
+    The purpose of this class is to protect against repeatedly evaluating the LazyFrame.
+    """
     def __init__(self, queryable):
-        """OnceFrame is a Polars LazyFrame that may only be collected into a DataFrame once.
-
-        The APIs on this class mimic those that can be found in Polars.
-
-        Differentially private guarantees on a given LazyFrame require the LazyFrame to be evaluated at most once.
-        The purpose of this class is to protect against repeatedly evaluating the LazyFrame.
-        """
         self.queryable = queryable
 
     def collect(self):

--- a/python/src/opendp/extras/sklearn/decomposition/__init__.py
+++ b/python/src/opendp/extras/sklearn/decomposition/__init__.py
@@ -28,6 +28,9 @@ if TYPE_CHECKING: # pragma: no cover
 
 
 class PCAEpsilons(NamedTuple):
+    '''
+    Tuple used to describe the ε-expenditure per changed record in the input data
+    '''
     eigvals: float
     eigvecs: Sequence[float]
     mean: Optional[float]

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -727,6 +727,13 @@ class Measure(ctypes.POINTER(AnyMeasure)): # type: ignore[misc]
 
 
 class PrivacyProfile(object):
+    '''
+    Given a profile function provided by the user,
+    gives the epsilon corresponding to a given delta, and vice versa.
+
+    :py:func:`new_privacy_profile <opendp.measures.new_privacy_profile>`
+    should be used to create new instances.
+    '''
     def __init__(self, curve):
         self.curve = curve
 

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -29,7 +29,7 @@ __all__ = [
     'Metric',
     'Measure',
     'PrivacyProfile',
-    'PartialConstructor',
+    '_PartialConstructor',
     'UnknownTypeException',
     'OpenDPException',
     'GLOBAL_FEATURES',
@@ -360,10 +360,10 @@ class Transformation(ctypes.POINTER(AnyTransformation)): # type: ignore[misc]
         ...
 
     @overload
-    def __rshift__(self, other: "PartialConstructor") -> "PartialConstructor":
+    def __rshift__(self, other: "_PartialConstructor") -> "_PartialConstructor":
         ...
 
-    def __rshift__(self, other: Union["Measurement", "Transformation", "PartialConstructor"]) -> Union["Measurement", "Transformation", "PartialConstructor", "PartialChain"]:  # type: ignore[name-defined] # noqa F821
+    def __rshift__(self, other: Union["Measurement", "Transformation", "_PartialConstructor"]) -> Union["Measurement", "Transformation", "_PartialConstructor", "PartialChain"]:  # type: ignore[name-defined] # noqa F821
         if isinstance(other, Measurement):
             from opendp.combinators import make_chain_mt
             return make_chain_mt(other, self)
@@ -372,7 +372,7 @@ class Transformation(ctypes.POINTER(AnyTransformation)): # type: ignore[misc]
             from opendp.combinators import make_chain_tt
             return make_chain_tt(other, self)
         
-        if isinstance(other, PartialConstructor):
+        if isinstance(other, _PartialConstructor):
             return self >> other(self.output_domain, self.output_metric) # type: ignore[call-arg]
 
         from opendp.context import PartialChain
@@ -760,7 +760,10 @@ class PrivacyProfile(object):
         setattr(self, "_dependencies", args)
 
 
-class PartialConstructor(object):
+class _PartialConstructor(object):
+    '''
+
+    '''
     def __init__(self, constructor):
         self.constructor = constructor
         self.__opendp_dict__ = {}  # Not needed at runtime, but the definition prevents mypy errors.
@@ -769,7 +772,7 @@ class PartialConstructor(object):
         return self.constructor(input_domain, input_metric)
     
     def __rshift__(self, other):
-        return PartialConstructor(lambda input_domain, input_metric: self(input_domain, input_metric) >> other) # pragma: no cover
+        return _PartialConstructor(lambda input_domain, input_metric: self(input_domain, input_metric) >> other) # pragma: no cover
 
     def __rrshift__(self, other):
         if isinstance(other, tuple) and list(map(type, other)) == [Domain, Metric]:

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -498,6 +498,10 @@ class Transformation(ctypes.POINTER(AnyTransformation)): # type: ignore[misc]
 Transformation = cast(Type[Transformation], Transformation) # type: ignore[misc]
 
 class Queryable(object):
+    '''
+    See also the API docs for :py:func:`make_sequential_composition <opendp.combinators.make_sequential_composition>`
+    and :py:func:`new_queryable <opendp.core.new_queryable>`.
+    '''
     def __init__(self, value, query_type):
         self.value = value
         self.query_type = query_type

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -202,7 +202,7 @@ class RuntimeType(object):
         if isinstance(type_name, str):
             type_name = type_name.strip()
             if type_name in generics:
-                return GenericType(type_name)
+                return _GenericType(type_name)
             if type_name.startswith('(') and type_name.endswith(')'):
                 return RuntimeType('Tuple', cls._parse_args(type_name[1:-1], generics=generics))
             start, end = type_name.find('<'), type_name.rfind('>')
@@ -373,14 +373,14 @@ class RuntimeType(object):
         
         :param kwargs:
         '''
-        if isinstance(self, GenericType):
+        if isinstance(self, _GenericType):
             return kwargs.get(self.origin, self)
         if isinstance(self, RuntimeType):
             return RuntimeType(self.origin, self.args and [RuntimeType.substitute(arg, **kwargs) for arg in self.args])
         return self
     
 
-class GenericType(RuntimeType):
+class _GenericType(RuntimeType):
     def __repr__(self):
         raise UnknownTypeException(f"attempted to create a type_name with an unknown generic: {self.origin}")  # pragma: no cover
 
@@ -478,7 +478,7 @@ def get_atom(type_name):
     '''
     type_name = RuntimeType.parse(type_name)
     while isinstance(type_name, RuntimeType):
-        if isinstance(type_name, GenericType):
+        if isinstance(type_name, _GenericType):
             return
         type_name = type_name.args[0]
     return type_name

--- a/python/test/test_ast.py
+++ b/python/test/test_ast.py
@@ -68,6 +68,9 @@ class Checker():
         if len(self.all_ast_args) and self.all_ast_args[0].arg in ['self', 'cls']:
             # TODO: Confirm that this is a method in a class.
             self.all_ast_args.pop(0)
+        
+        if self.name == '__init__' and self.docstring:
+            self.errors.append('Move docstring up to class')
 
     def _check_docstring(self):
         directives = re.findall(r'^\s*(\:\w+:?)', self.docstring, re.MULTILINE)

--- a/python/test/test_ast.py
+++ b/python/test/test_ast.py
@@ -196,13 +196,14 @@ class Checker():
 PUBLIC = 'public'
 PRIVATE = 'private'
 
-class Function(NamedTuple):
+class CodeObj(NamedTuple):
     file: str
     name: str
     tree: ast.AST
     visibility: str  # str rather than bool so the pytest report is more readable.
 
 
+classes = []
 functions = []
 
 src_dir_path = Path(__file__).parent.parent / 'src'
@@ -215,21 +216,23 @@ for code_path in src_dir_path.glob('**/*.py'):
     code = code_path.read_text()
     tree = ast.parse(code)
     for node in ast.walk(tree):
-        if not isinstance(node, ast.FunctionDef):
-            # TODO: Also check class docs
+        if not isinstance(node, (ast.FunctionDef, ast.ClassDef)):
             continue
         if ast_ends_with_ellipsis(node):
             continue
         if node.name.startswith('_'):
             is_public = False
 
-        function = Function(
+        code_obj = CodeObj(
             file=f'{code_path.parent.name}/{code_path.name}',
             name=node.name,
             tree=node,
             visibility=PUBLIC if is_public else PRIVATE,
         )
-        functions.append(function)
+        if isinstance(node, ast.FunctionDef):
+            functions.append(code_obj)
+        if isinstance(node, ast.ClassDef):
+            classes.append(code_obj)
 
 # Typo check:
 assert len(functions) > 100
@@ -254,3 +257,13 @@ def test_function_docs(file, name, tree, visibility, pytestconfig):
     ).get_errors()
     if errors:
         pytest.fail(f'{where}: {errors}')
+
+@pytest.mark.parametrize("file,name,tree,visibility", classes)
+def test_class_docs(file, name, tree, visibility):
+    where = f'In {file}, line {tree.lineno}, class {name}'
+    is_public = visibility == PUBLIC
+
+    docstring = ast.get_docstring(tree)
+    if not is_public and docstring is None:
+        return
+    assert docstring is not None, f'{where}: add docstring or make private'

--- a/rust/opendp_tooling/src/codegen/python.rs
+++ b/rust/opendp_tooling/src/codegen/python.rs
@@ -200,7 +200,7 @@ def {then_name}(
 
 {doc_params}{example}
     """
-    output = PartialConstructor(lambda {dom_met}: {name}(
+    output = _PartialConstructor(lambda {dom_met}: {name}(
 {args}))
     output.__opendp_dict__ = {{
             '__function__': '{then_name}',

--- a/rust/src/measures/ffi.rs
+++ b/rust/src/measures/ffi.rs
@@ -383,7 +383,9 @@ impl<Q> Measure for TypedMeasure<Q> {
 /// * `curve` - A privacy curve mapping epsilon to delta
 ///
 /// # Why honest-but-curious?
+/// 
 /// The privacy profile should implement a well-defined $\delta(\epsilon)$ curve:
+/// 
 /// * monotonically decreasing
 /// * rejects epsilon values that are less than zero or nan
 /// * returns delta values only within [0, 1]

--- a/rust/src/measures/ffi.rs
+++ b/rust/src/measures/ffi.rs
@@ -383,9 +383,9 @@ impl<Q> Measure for TypedMeasure<Q> {
 /// * `curve` - A privacy curve mapping epsilon to delta
 ///
 /// # Why honest-but-curious?
-/// 
+///
 /// The privacy profile should implement a well-defined $\delta(\epsilon)$ curve:
-/// 
+///
 /// * monotonically decreasing
 /// * rejects epsilon values that are less than zero or nan
 /// * returns delta values only within [0, 1]


### PR DESCRIPTION
- Prompted by #2259

Make sure we document all of our public classes. The changes here do that a few different ways.
- Fill in new documentation
- Move docstrings up from `__init__` that weren't being rendered. (This is the default, but like everything else [it could be configured](https://stackoverflow.com/questions/5599254/how-to-use-sphinxs-autodoc-to-document-a-classs-init-self-method).)
- Make classes that don't seem intended for end user use private. (Maybe more of this?)

The `__init__` docs weren't being checked, but I could imagine checking that the new class docstrings are consistent with constructor parameters.