### PR TITLE
feat: `member` is true or false, with a warning; Expand serialization tests

### DIFF
--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -559,6 +559,7 @@ class Domain(ctypes.POINTER(AnyDomain)): # type: ignore[misc]
         '''
         try:
             # TODO: Should we rename the import to "_member"?
+            # https://github.com/opendp/opendp/issues/2268
             from opendp.domains import member
             return member(self, val)
         except Exception as e:

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -557,8 +557,15 @@ class Domain(ctypes.POINTER(AnyDomain)): # type: ignore[misc]
         
         :param val: a value to be checked for membership in `self`
         '''
-        from opendp.domains import member
-        return member(self, val)
+        try:
+            # TODO: Should we rename the import to "_member"?
+            from opendp.domains import member
+            return member(self, val)
+        except Exception as e:
+            from warnings import warn
+            warn(str(e))
+            return False
+
 
     @property
     def type(self) -> Union["RuntimeType", str]:

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -551,7 +551,7 @@ class Domain(ctypes.POINTER(AnyDomain)): # type: ignore[misc]
     '''
     _type_ = AnyDomain
 
-    def member(self, val):
+    def member(self, val) -> bool:
         '''
         Check if ``val`` is a member of the domain.
         
@@ -563,7 +563,7 @@ class Domain(ctypes.POINTER(AnyDomain)): # type: ignore[misc]
             return member(self, val)
         except Exception as e:
             from warnings import warn
-            warn(str(e))
+            warn(f'Value ({val}) does not belong to carrier type of {type(self)}. Details: {e}')
             return False
 
 

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -563,7 +563,7 @@ class Domain(ctypes.POINTER(AnyDomain)): # type: ignore[misc]
             return member(self, val)
         except Exception as e:
             from warnings import warn
-            warn(f'Value ({val}) does not belong to carrier type of {type(self)}. Details: {e}')
+            warn(f'Value ({val}) does not belong to carrier type of {self}. Details: {e}')
             return False
 
 

--- a/python/test/extras/test_ext_domains.py
+++ b/python/test/extras/test_ext_domains.py
@@ -50,7 +50,7 @@ def test_sscp_domain():
     domain = _sscp_domain(num_features=4, T=dp.f32)
     domain.member(np.random.normal(size=(4, 4)).astype(np.float32))
 
-    with pytest.raises(dp.OpenDPException):
+    with pytest.warns(UserWarning, match=r'does not belong to carrier type'):
         domain.member(np.random.normal(size=(4, 4)))
 
     with pytest.raises(ValueError):

--- a/python/test/extras/test_ext_domains.py
+++ b/python/test/extras/test_ext_domains.py
@@ -41,14 +41,13 @@ def test_array2_domain():
 
 
 def test_sscp_domain():
-    with optional_dependency('numpy'):
-        domain = _sscp_domain(num_features=4, T=float)
-
     np = pytest.importorskip('numpy')
-    domain.member(np.random.normal(size=(4, 4)))
+
+    domain = _sscp_domain(num_features=4, T=float)
+    assert domain.member(np.random.normal(size=(4, 4)))
 
     domain = _sscp_domain(num_features=4, T=dp.f32)
-    domain.member(np.random.normal(size=(4, 4)).astype(np.float32))
+    assert domain.member(np.random.normal(size=(4, 4)).astype(np.float32))
 
     with pytest.warns(UserWarning, match=r'does not belong to carrier type'):
         domain.member(np.random.normal(size=(4, 4)))

--- a/python/test/test_core.py
+++ b/python/test/test_core.py
@@ -152,6 +152,14 @@ def test_member():
     from opendp.domains import atom_domain, vector_domain
     from opendp.metrics import symmetric_distance
 
+    int_10_domain = atom_domain(T=int, bounds=(0, 10))
+    assert int_10_domain.member(0)
+    assert not int_10_domain.member(100)
+    with pytest.warns(UserWarning, match=r'inferred type is f64, expected i32'):
+        assert not int_10_domain.member(0.0)
+    with pytest.warns(UserWarning, match=r'inferred type is f64, expected i32'):
+        assert not int_10_domain.member(100.0)
+
     input_domain = vector_domain(atom_domain(T=int))
     input_metric = symmetric_distance()
 

--- a/python/test/test_serialization.py
+++ b/python/test/test_serialization.py
@@ -108,11 +108,10 @@ if pl is not None:
     # but that behavior is tested elsewhere, and can be ignored here.
     @pytest.mark.filterwarnings("ignore::UserWarning")
     @pytest.mark.parametrize(
-        "_readable_name,dp_obj,in_value,out_value",
+        "_readable_name,dp_domain,in_value,out_value",
         [
-            (str(obj), obj, in_value, out_value)
-            for obj, in_value, out_value in [
-                # Domains:
+            (str(dp_domain), dp_domain, in_value, out_value)
+            for dp_domain, in_value, out_value in [
                 (atom, 10, 100),
                 # TODO: Might not be specifying categorical values correctly, 
                 # but shouldn't error, regardless.
@@ -134,15 +133,45 @@ if pl is not None:
             ]
         ],
     )
-    def test_serializable_domain(_readable_name, dp_obj, in_value, out_value):
-        assert dp_obj.member(in_value)
-        assert not dp_obj.member(out_value)
+    def test_serializable_domain(_readable_name, dp_domain, in_value, out_value):
+        assert dp_domain.member(in_value)
+        assert not dp_domain.member(out_value)
 
-        serialized = dp.serialize(dp_obj)
+        serialized = dp.serialize(dp_domain)
         deserialized = dp.deserialize(serialized)
 
         assert deserialized.member(in_value)
         assert not deserialized.member(out_value)
+
+    # @pytest.mark.parametrize(
+    #     "_readable_name,dp_metric,a,b,dist",
+    #     [
+    #         (str(dp_metric), dp_metric, a, b, dist)
+    #         for dp_metric, a, b, dist in [
+    #             (dp.absolute_distance('int'), 0, 1, 1),
+    #         ]
+    #     ],
+    # )
+    # def test_serializable_metric(_readable_name, dp_metric, a, b, dist):
+    #     assert dp_metric(a, b) == dist
+
+    #     serialized = dp.serialize(dp_metric)
+    #     deserialized = dp.deserialize(serialized)
+
+    #     assert deserialized(a, b) == dist
+
+    @pytest.mark.parametrize(
+        "_readable_name,dp_measurement,value,output_type",
+        [
+            (str(dp_measurement), dp_measurement, value, output_type)
+            for dp_measurement, value, output_type in [
+                (dp.m.make_gaussian(atom, dp.absolute_distance(float), 1), 0, float),
+            ]
+        ],
+    )
+    def test_serializable_measurement(_readable_name, dp_measurement, value, output_type):
+        assert isinstance(dp_measurement(value), output_type)
+        
 
 
     lf = pl.LazyFrame(schema={"A": pl.Int32, "B": pl.String})

--- a/python/test/test_serialization.py
+++ b/python/test/test_serialization.py
@@ -143,23 +143,6 @@ if pl is not None:
         assert deserialized.member(in_value)
         assert not deserialized.member(out_value)
 
-    # @pytest.mark.parametrize(
-    #     "_readable_name,dp_metric,a,b,dist",
-    #     [
-    #         (str(dp_metric), dp_metric, a, b, dist)
-    #         for dp_metric, a, b, dist in [
-    #             (dp.absolute_distance('int'), 0, 1, 1),
-    #         ]
-    #     ],
-    # )
-    # def test_serializable_metric(_readable_name, dp_metric, a, b, dist):
-    #     assert dp_metric(a, b) == dist
-
-    #     serialized = dp.serialize(dp_metric)
-    #     deserialized = dp.deserialize(serialized)
-
-    #     assert deserialized(a, b) == dist
-
     @pytest.mark.parametrize(
         "_readable_name,dp_measurement,value,output_type",
         [

--- a/python/test/test_serialization.py
+++ b/python/test/test_serialization.py
@@ -121,7 +121,16 @@ if pl is not None:
                 #  pl.lit("A", dtype=pl.Categorical),
                 #  pl.lit("Z", dtype=pl.Categorical)
                 # ),
-                (dp.series_domain('name', atom),  pl.Series("name", [1.0, 2.0, 3.0]), pl.Series("name", ['a', 'b', 'c'], dtype=pl.String))
+                (
+                    dp.series_domain('name', atom),
+                    pl.Series("name", [1.0, 2.0, 3.0]),
+                    pl.Series("name", ['a', 'b', 'c'])
+                ),
+                (
+                    dp.lazyframe_domain([dp.series_domain('A', atom)]),
+                    pl.LazyFrame({'A': [1.0, 2.0, 3.0]}),
+                    pl.LazyFrame({'A': ['a', 'b', 'c']})
+                )
             ]
         ],
     )

--- a/python/test/test_serialization.py
+++ b/python/test/test_serialization.py
@@ -108,32 +108,30 @@ if pl is not None:
     # but that behavior is tested elsewhere, and can be ignored here.
     @pytest.mark.filterwarnings("ignore::UserWarning")
     @pytest.mark.parametrize(
-        "_readable_name,dp_domain,in_value,out_value",
+        "dp_domain,in_value,out_value",
         [
-            (str(dp_domain), dp_domain, in_value, out_value)
-            for dp_domain, in_value, out_value in [
-                (atom, 10, 100),
-                # TODO: Might not be specifying categorical values correctly, 
-                # but shouldn't error, regardless.
-                # https://github.com/opendp/opendp/issues/2264
-                # (dp.categorical_domain(['A', 'B', 'C']),
-                #  pl.lit("A", dtype=pl.Categorical),
-                #  pl.lit("Z", dtype=pl.Categorical)
-                # ),
-                (
-                    dp.series_domain('name', atom),
-                    pl.Series("name", [1.0, 2.0, 3.0]),
-                    pl.Series("name", ['a', 'b', 'c'])
-                ),
-                (
-                    dp.lazyframe_domain([dp.series_domain('A', atom)]),
-                    pl.LazyFrame({'A': [1.0, 2.0, 3.0]}),
-                    pl.LazyFrame({'A': ['a', 'b', 'c']})
-                )
-            ]
+            (atom, 10, 100),
+            # TODO: Might not be specifying categorical values correctly, 
+            # but shouldn't error, regardless.
+            # https://github.com/opendp/opendp/issues/2264
+            # (dp.categorical_domain(['A', 'B', 'C']),
+            #  pl.lit("A", dtype=pl.Categorical),
+            #  pl.lit("Z", dtype=pl.Categorical)
+            # ),
+            (
+                dp.series_domain('name', atom),
+                pl.Series("name", [1.0, 2.0, 3.0]),
+                pl.Series("name", ['a', 'b', 'c'])
+            ),
+            (
+                dp.lazyframe_domain([dp.series_domain('A', atom)]),
+                pl.LazyFrame({'A': [1.0, 2.0, 3.0]}),
+                pl.LazyFrame({'A': ['a', 'b', 'c']})
+            )
         ],
+        ids=lambda arg: str(arg)
     )
-    def test_serializable_domain(_readable_name, dp_domain, in_value, out_value):
+    def test_serializable_domain(dp_domain, in_value, out_value):
         assert dp_domain.member(in_value)
         assert not dp_domain.member(out_value)
 

--- a/python/test/test_serialization.py
+++ b/python/test/test_serialization.py
@@ -12,39 +12,37 @@ chained = input_space >> dp.t.then_mean() >> dp.m.then_laplace(scale=0.5)
 
 
 @pytest.mark.parametrize(
-    "_readable_name,dp_obj",
+    "dp_obj",
     [
-        (str(obj), obj)
-        for obj in [
-            # Python objects:
-            ('nested', ('tuple', ('containing', ('domain', (atom,))))),
-            {'dict key': atom},
-            input_space,
-            # Domains:
-            atom,
-            dp.categorical_domain(['A', 'B', 'C']),
-            dp.series_domain('A', atom),
-            dp.lazyframe_domain([dp.series_domain('A', atom)]),
-            dp.wild_expr_domain([]),
-            # Metrics:
-            dp.absolute_distance("int"),
-            dp.change_one_distance(),
-            dp.linf_distance("float", True),
-            dp.user_distance("user_distance"),
-            # Measures:
-            dp.m.max_divergence(),
-            dp.m.approximate(dp.m.max_divergence()),
-            dp.m.user_divergence("user_divergence"),
-            # Measurements:
-            dp.m.make_gaussian(atom, dp.absolute_distance(float), 1),
-            dp.m.then_gaussian(1),
-            # Compositions:
-            chained,
-            dp.c.make_population_amplification(chained, population_size=100),
-        ]
+        # Python objects:
+        ('nested', ('tuple', ('containing', ('domain', (atom,))))),
+        {'dict key': atom},
+        input_space,
+        # Domains:
+        atom,
+        dp.categorical_domain(['A', 'B', 'C']),
+        dp.series_domain('A', atom),
+        dp.lazyframe_domain([dp.series_domain('A', atom)]),
+        dp.wild_expr_domain([]),
+        # Metrics:
+        dp.absolute_distance("int"),
+        dp.change_one_distance(),
+        dp.linf_distance("float", True),
+        dp.user_distance("user_distance"),
+        # Measures:
+        dp.m.max_divergence(),
+        dp.m.approximate(dp.m.max_divergence()),
+        dp.m.user_divergence("user_divergence"),
+        # Measurements:
+        dp.m.make_gaussian(atom, dp.absolute_distance(float), 1),
+        dp.m.then_gaussian(1),
+        # Compositions:
+        chained,
+        dp.c.make_population_amplification(chained, population_size=100),
     ],
+    ids=lambda arg: str(arg)
 )
-def test_serializable_equal(_readable_name, dp_obj):
+def test_serializable_equal(dp_obj):
     serialized = dp.serialize(dp_obj)
     deserialized = dp.deserialize(serialized)
     # We don't want to define __eq__ just for the sake of testing,
@@ -55,30 +53,26 @@ def test_serializable_equal(_readable_name, dp_obj):
 
 
 @pytest.mark.parametrize(
-    "_readable_name,dp_obj",
+    "dp_obj",
     [
-        (str(obj), obj)
-        for obj in [
-            dp.user_domain("trivial_user_domain", lambda: True),
-            dp.m.new_privacy_profile(lambda x: x),
-        ]
+        dp.user_domain("trivial_user_domain", lambda: True),
+        dp.m.new_privacy_profile(lambda x: x),
     ],
+    ids=lambda arg: str(arg)
 )
-def test_not_ever_serializable(_readable_name, dp_obj):
+def test_not_ever_serializable(dp_obj):
     with pytest.raises(Exception, match=r"OpenDP JSON Encoder does not handle"):
         dp.serialize(dp_obj)
 
 
 @pytest.mark.parametrize(
-    "_readable_name,dp_obj",
+    "dp_obj",
     [
-        (str(obj), obj)
-        for obj in [
-            {('tuple', 'key'): 'value'},
-        ]
+        {('tuple', 'key'): 'value'},
     ],
+    ids=lambda arg: str(arg)
 )
-def test_not_json_serializable(_readable_name, dp_obj):
+def test_not_json_serializable(dp_obj):
     with pytest.raises(Exception, match=r"keys must be str, int, float, bool or None, not tuple"):
         dp.serialize(dp_obj)
 
@@ -142,15 +136,13 @@ if pl is not None:
         assert not deserialized.member(out_value)
 
     @pytest.mark.parametrize(
-        "_readable_name,dp_measurement,value,output_type",
+        "dp_measurement,value,output_type",
         [
-            (str(dp_measurement), dp_measurement, value, output_type)
-            for dp_measurement, value, output_type in [
-                (dp.m.make_gaussian(atom, dp.absolute_distance(float), 1), 0, float),
-            ]
+            (dp.m.make_gaussian(atom, dp.absolute_distance(float), 1), 0, float),
         ],
+        ids=lambda arg: str(arg)
     )
-    def test_serializable_measurement(_readable_name, dp_measurement, value, output_type):
+    def test_serializable_measurement(dp_measurement, value, output_type):
         assert isinstance(dp_measurement(value), output_type)
         
 
@@ -171,45 +163,41 @@ if pl is not None:
     query = context.query().select(dp.len())
 
     @pytest.mark.parametrize(
-        "_readable_name,dp_obj",
+        "dp_obj",
         [
-            (str(obj), obj)
-            for obj in [
-                lf_domain,
+            lf_domain,
+            lf_domain_with_margin,
+            dp.m.make_private_lazyframe(
                 lf_domain_with_margin,
-                dp.m.make_private_lazyframe(
-                    lf_domain_with_margin,
-                    dp.symmetric_distance(),
-                    dp.max_divergence(),
-                    lf.select([dp.len(), pl.col("A").dp.sum((0, 1))]),
-                    global_scale=1.0
-                ),
-                dp.m.make_private_expr(
-                    dp.wild_expr_domain([], by=[]),
-                    dp.partition_distance(dp.symmetric_distance()),
-                    dp.max_divergence(),
-                    dp.len(scale=1.0)
-                ),
-            ]
+                dp.symmetric_distance(),
+                dp.max_divergence(),
+                lf.select([dp.len(), pl.col("A").dp.sum((0, 1))]),
+                global_scale=1.0
+            ),
+            dp.m.make_private_expr(
+                dp.wild_expr_domain([], by=[]),
+                dp.partition_distance(dp.symmetric_distance()),
+                dp.max_divergence(),
+                dp.len(scale=1.0)
+            ),
         ],
+        ids=lambda arg: str(arg)
     )
-    def test_serializable_polars(_readable_name, dp_obj):
+    def test_serializable_polars(dp_obj):
         serialized = dp.serialize(dp_obj)
         deserialized = dp.deserialize(serialized)
         assert serialized == dp.serialize(deserialized)
 
 
     @pytest.mark.parametrize(
-        "_readable_name,dp_obj",
+        "dp_obj",
         [
-            (str(obj), obj)
-            for obj in [
-                context,
-                dp.Queryable('value', 'query_type'),
-                query
-            ]
+            context,
+            dp.Queryable('value', 'query_type'),
+            query
         ],
+        ids=lambda arg: str(arg)
     )
-    def test_not_currently_serializable(_readable_name, dp_obj):
+    def test_not_currently_serializable(dp_obj):
         with pytest.raises(Exception, match=r"OpenDP JSON Encoder currently does not handle"):
             dp.serialize(dp_obj)


### PR DESCRIPTION
- fix #1007
- Fix #2262

Python is less rigorous than Rust, and I think most users are just going to expect `member` to return a bool. But we do have a side channel to pass more information, if the user wants more information: warnings.

(This is motivated by wanting to write stronger tests of serialization, but its not strictly necessary for that: I could just have `with pytest.warns()` blocks.)