### PR TITLE
docs: Add AST checks on the formatting of the docstring

### DIFF
--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -152,7 +152,6 @@ def domain_of(T, infer: bool = False) -> Domain:
 
     >>> dp.domain_of('Option<int>')  # Python's `Optional` is not supported.
     OptionDomain(AtomDomain(T=i32))
-    
     >>> dp.domain_of(dp.i32)
     AtomDomain(T=i32)
 

--- a/python/src/opendp/extras/polars/__init__.py
+++ b/python/src/opendp/extras/polars/__init__.py
@@ -907,7 +907,7 @@ class LazyFrameQuery():
 
         >>> import polars as pl
         >>> data = pl.LazyFrame([pl.Series("convicted", [0, 1, 1, 0, 1] * 50, dtype=pl.Int32)])
-
+        >>>
         >>> context = dp.Context.compositor(
         ...     data=data,
         ...     privacy_unit=dp.unit_of(contributions=1),
@@ -915,12 +915,12 @@ class LazyFrameQuery():
         ...     split_evenly_over=1,
         ...     margins={(): dp.polars.Margin(max_partition_length=1000)},
         ... )
-
+        >>>
         >>> query = context.query().select(
         ...     dp.len(),
         ...     pl.col("convicted").fill_null(0).dp.sum((0, 1))
         ... )
-
+        >>>
         >>> query.summarize(alpha=.05)  # type: ignore[union-attr]
         shape: (2, 5)
         ┌───────────┬──────────────┬─────────────────┬───────┬──────────┐

--- a/python/src/opendp/extras/polars/__init__.py
+++ b/python/src/opendp/extras/polars/__init__.py
@@ -895,13 +895,13 @@ class LazyFrameQuery():
     def summarize(self, alpha: float | None = None):
         """Summarize the statistics released by this query.
 
-        :param alpha: optional. A value in [0, 1] denoting the statistical significance. For the corresponding confidence level, subtract from from 1: for 95% confidence, use 0.05 for alpha.
-
         If ``alpha`` is passed, the resulting data frame includes an ``accuracy`` column.
 
         If a threshold is configured for censoring small/sensitive partitions,
         a threshold column will be included,
         containing the cutoff for the respective count query being thresholded.
+
+        :param alpha: optional. A value in [0, 1] denoting the statistical significance. For the corresponding confidence level, subtract from from 1: for 95% confidence, use 0.05 for alpha.
 
         :example:
 

--- a/python/src/opendp/extras/polars/__init__.py
+++ b/python/src/opendp/extras/polars/__init__.py
@@ -586,10 +586,12 @@ class OnceFrame(object):
         To remain DP at the advertised privacy level, only collect the ``LazyFrame`` once.
 
         Requires "honest-but-curious" because the privacy guarantees only apply if:
+
         1. The LazyFrame (compute plan) is only ever executed once.
         2. The analyst does not observe ordering of rows in the output. 
         
         To ensure that row ordering is not observed:
+        
         1. Do not extend the compute plan with order-sensitive computations.
         2. Shuffle the output once collected `(in Polars sample all, with shuffle enabled) <https://docs.pola.rs/api/python/stable/reference/dataframe/api/polars.DataFrame.sample.html>`_.
         """

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -1047,7 +1047,7 @@ def binary_search(
     5.0
     >>> dp.binary_search(lambda x: x <= 5.)
     5.0
-
+    >>>
     >>> dp.binary_search(lambda x: x > 5, T=int)
     6
     >>> dp.binary_search(lambda x: x < 5, T=int)

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -272,7 +272,7 @@ class RuntimeType(object):
         Vec<String>
         >>> dp.RuntimeType.infer((12., True, "A"))
         (f64, bool, String)
-        
+        >>>
         >>> dp.RuntimeType.infer([])
         Traceback (most recent call last):
         ...

--- a/python/test/test_ast.py
+++ b/python/test/test_ast.py
@@ -164,13 +164,26 @@ def check_list_space(docstring):
     ...     1. but this should not!
     ... """)
     'Add a blank line above list that begins with: 1. but this should not!'
+
+    >>> check_list_space("""
+    ...     * This
+    ...     * is fine,
+    ...
+    ...     but this is
+    ...     * not ok!
+    ... """)
+    'Add a blank line above list that begins with: * not ok!'
     '''
     prev_is_text = False
     for line in docstring.split('\n'):
         line = line.strip()
-        if prev_is_text and line.startswith('1.'):
+        if prev_is_text and (line.startswith('1.') or line.startswith('* ')):
             return f'Add a blank line above list that begins with: {line}'
-        prev_is_text = line and not line.startswith('>>>') and not line.startswith('...')
+        prev_is_text = line and not (
+            line.startswith('>>>')
+            or line.startswith('...')
+            or line.startswith('* ')
+        )
 
 
 class Checker():

--- a/python/test/test_ast.py
+++ b/python/test/test_ast.py
@@ -61,7 +61,7 @@ def check_directive_order(docstring):
     directives = re.findall(r'^\s*(\:\w+:?)', docstring, re.MULTILINE)
     unknown_directives = set(directives) - {':param', ':rtype:', ':type', ':raises', ':example:', ':return:'}
     if unknown_directives:
-        return(f'Unknown directives: {", ".join(unknown_directives)}')
+        return f'Unknown directives: {", ".join(unknown_directives)}'
     
     order = ''.join(re.sub(r':$', '', d) for d in directives)
     # TODO: Has 169 failures if we require ":return" and ":rtype" together:
@@ -77,7 +77,7 @@ def check_directive_order(docstring):
     canonical_order = r'^(:param(:type)?)*(:return)?(:rtype)?(:raises)*(:example)?$'
     if not re.search(canonical_order, order):
         short_order = re.sub(r'[:$^]', '', canonical_order)
-        return(f'Directives {order} are not in canonical order: {short_order}')
+        return f'Directives {order} are not in canonical order: {short_order}'
 
 
 def check_directive_continuity(docstring):

--- a/python/test/test_ast.py
+++ b/python/test/test_ast.py
@@ -92,6 +92,21 @@ class Checker():
             self.errors.append(
                 f'Directives {order} are not in canonical order: {short_order}'
             )
+        
+        directives_started = False
+        directives_ended = False
+        for line in self.docstring.split('\n'):
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith(':'):
+                if directives_ended:
+                    self.errors.append(f'Found another directive after non-directive: {line}')
+                    break
+                directives_started = True
+            elif directives_started:
+                directives_ended = True
+
 
     def _check_params(self):
         doc_param_dict = dict(re.findall(r':param (\w+): *(.*)', self.docstring))

--- a/python/test/test_ast.py
+++ b/python/test/test_ast.py
@@ -103,9 +103,9 @@ def check_directive_continuity(docstring):
             directives_ended = True
 
 
-def check_doctest_continutity(docstring):
+def check_doctest_continuity(docstring):
     '''
-    >>> check_doctest_continutity("""
+    >>> check_doctest_continuity("""
     ...     >>> 1 + 1
     ...     2
     ...     
@@ -113,21 +113,37 @@ def check_doctest_continutity(docstring):
     ...     4
     ... """)
     'Doctest should not be split by empty line above: >>> 2 + 2'
+
+    >>> check_doctest_continuity("""
+    ...     >>> assert True
+    ...     
+    ...     And then:
+    ...     >>> print('hello!')
+    ...     hello!
+    ... """)
+    "Doctest should have blank line above: >>> print('hello!')"
     '''
     in_code = False
     after_code = False
+    in_text = False
     for line in docstring.split('\n'):
         line = line.strip()
         if line.startswith('>>>'):
             if after_code:
                 return f'Doctest should not be split by empty line above: {line}'
+            if in_text:
+                return f'Doctest should have blank line above: {line}'
             in_code = True
+            in_text = False
         elif in_code:
             if not line:
                 in_code = False
                 after_code = True
         elif line:
             after_code = False
+            in_text = True
+        else:
+            in_text = False
 
 
 class Checker():
@@ -155,7 +171,7 @@ class Checker():
             self.all_ast_args.pop(0)
 
     def _check_docstring(self):
-        for check in [check_directive_order, check_directive_continuity, check_doctest_continutity]:
+        for check in [check_directive_order, check_directive_continuity, check_doctest_continuity]:
             error = check(self.docstring)
             if error:
                 self.errors.append(error)

--- a/python/test/test_ast.py
+++ b/python/test/test_ast.py
@@ -106,6 +106,23 @@ class Checker():
                 directives_started = True
             elif directives_started:
                 directives_ended = True
+        
+        in_code = False
+        after_code = False
+        for line in self.docstring.split('\n'):
+            line = line.strip()
+            if line.startswith('>>>'):
+                if after_code:
+                    self.errors.append(f'Code sample should not be split by empty line above: {line}')
+                    break
+                in_code = True
+            elif in_code:
+                if not line:
+                    in_code = False
+                    after_code = True
+            elif line:
+                after_code = False
+
 
 
     def _check_params(self):

--- a/rust/opendp_tooling/src/bootstrap/docstring.rs
+++ b/rust/opendp_tooling/src/bootstrap/docstring.rs
@@ -446,6 +446,7 @@ pub fn make_rustdoc_link(module: &str, name: &str) -> Result<String> {
     };
 
     Ok(format!(
-        "[`{name}` in Rust documentation.]({proof_uri}/opendp/{module}/fn.{name}.html)"
+        // RST does not support nested markup, so do not try `{name}`!
+        "[{name} in Rust documentation.]({proof_uri}/opendp/{module}/fn.{name}.html)"
     ))
 }

--- a/rust/src/accuracy/code/summarize_polars_measurement.rst
+++ b/rust/src/accuracy/code/summarize_polars_measurement.rst
@@ -1,4 +1,5 @@
 First, create a measurement with the Polars API:
+
 >>> import opendp.prelude as dp
 >>> import polars as pl
 >>> dp.enable_features("contrib")
@@ -18,6 +19,7 @@ First, create a measurement with the Polars API:
 ... )
 
 This function extracts utility information about each aggregate in the resulting data frame:
+
 >>> dp.summarize_polars_measurement(meas)
 shape: (2, 4)
 ┌────────┬──────────────┬─────────────────┬───────┐
@@ -30,6 +32,7 @@ shape: (2, 4)
 └────────┴──────────────┴─────────────────┴───────┘
 
 If you pass an alpha argument, then you also get accuracy estimates:
+
 >>> dp.summarize_polars_measurement(meas, alpha=.05)
 shape: (2, 5)
 ┌────────┬──────────────┬─────────────────┬───────┬──────────┐

--- a/rust/src/data/ffi/mod.rs
+++ b/rust/src/data/ffi/mod.rs
@@ -50,8 +50,7 @@ use opendp_derive::bootstrap;
 /// * `T` - The type of the data in the slice.
 /// 
 /// # Returns
-/// An AnyObject that contains the data in `slice`.
-/// The AnyObject also captures rust type information.
+/// An AnyObject that contains the data in `slice`. The AnyObject also captures rust type information.
 #[no_mangle]
 #[rustfmt::skip]
 pub extern "C" fn opendp_data__slice_as_object(

--- a/rust/src/data/ffi/polars.rs
+++ b/rust/src/data/ffi/polars.rs
@@ -44,10 +44,12 @@ pub extern "C" fn opendp_data__onceframe_collect(
 ///
 /// # Why honest-but-curious?
 /// The privacy guarantees only apply if:
+///
 /// 1. The LazyFrame (compute plan) is only ever executed once.
 /// 2. The analyst does not observe ordering of rows in the output.
 ///    
 /// To ensure that row ordering is not observed:
+///
 /// 1. Do not extend the compute plan with order-sensitive computations.
 /// 2. Shuffle the output once collected ([in Polars sample all, with shuffling enabled](https://docs.pola.rs/api/python/stable/reference/dataframe/api/polars.DataFrame.sample.html)).
 #[no_mangle]

--- a/rust/src/domains/ffi.rs
+++ b/rust/src/domains/ffi.rs
@@ -489,6 +489,7 @@ impl Domain for ExtrinsicDomain {
 /// which can violate transformation stability.
 ///
 /// In addition, the member function must:
+///
 /// 1. be a pure function
 /// 2. be sound (only return true if its input is a member of the domain).
 #[no_mangle]

--- a/rust/src/measurements/code/make_randomized_response_bitvec.rst
+++ b/rust/src/measurements/code/make_randomized_response_bitvec.rst
@@ -1,29 +1,29 @@
 >>> import numpy as np
 >>> import opendp.prelude as dp
-
+>>>
 >>> dp.enable_features("contrib")
-
+>>>
 >>> # Create the randomized response mechanism
 >>> m_rr = dp.m.make_randomized_response_bitvec(
 ...     dp.bitvector_domain(max_weight=4), dp.discrete_distance(), f=0.95
 ... )
-
+>>>
 >>> # compute privacy loss
 >>> m_rr.map(1)
 0.8006676684558611
-
+>>>
 >>> # formula is 2 * m * ln((2 - f) / f)
 >>> # where m = 4 (the weight) and f = .95 (the flipping probability)
-
+>>>
 >>> # prepare a dataset to release, by encoding a bit vector as a numpy byte array
 >>> data = np.packbits(
 ...     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0]
 ... )
 >>> assert np.array_equal(data, np.array([0, 8, 12], dtype=np.uint8))
-
+>>>
 >>> # roundtrip: numpy -> bytes -> mech -> bytes -> numpy
 >>> release = np.frombuffer(m_rr(data.tobytes()), dtype=np.uint8)
-
+>>>
 >>> # compare the two bit vectors:
 >>> [int(bit) for bit in np.unpackbits(data)]
 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0]

--- a/rust/src/measurements/randomized_response_bitvec/mod.rs
+++ b/rust/src/measurements/randomized_response_bitvec/mod.rs
@@ -80,14 +80,13 @@ pub fn make_randomized_response_bitvec(
 #[bootstrap(features("contrib"))]
 /// Convert a vector of randomized response bitvec responses to a frequency estimate
 ///
+/// Computes the sum of the answers into a $k$-length vector $Y$ and returns
+/// $Y\frac{Y-\frac{f}{2}}{1-f}$
+///
 /// # Arguments
 /// * `answers` - A vector of BitVectors with consistent size
 /// * `f` - The per bit flipping probability used to encode `answers`
 ///
-/// Computes the sum of the answers into a $k$-length vector $Y$ and returns
-/// ```math
-/// Y\frac{Y-\frac{f}{2}}{1-f}
-/// ```
 pub fn debias_randomized_response_bitvec(answers: Vec<BitVector>, f: f64) -> Fallible<Vec<f64>> {
     if answers.len() == 0 {
         return fallible!(FailedFunction, "No answers provided");

--- a/rust/src/measures/ffi.rs
+++ b/rust/src/measures/ffi.rs
@@ -384,6 +384,7 @@ impl<Q> Measure for TypedMeasure<Q> {
 ///
 /// # Why honest-but-curious?
 /// The privacy profile should implement a well-defined $\delta(\epsilon)$ curve:
+///
 /// * monotonically decreasing
 /// * rejects epsilon values that are less than zero or nan
 /// * returns delta values only within [0, 1]

--- a/rust/src/metrics/ffi.rs
+++ b/rust/src/metrics/ffi.rs
@@ -264,6 +264,7 @@ impl Metric for ExtrinsicDistance {
 ///
 /// # Why honest-but-curious?
 /// Your definition of `d` must satisfy the requirements of a pseudo-metric:
+///
 /// 1. for any $x$, $d(x, x) = 0$
 /// 2. for any $x, y$, $d(x, y) \ge 0$ (non-negativity)
 /// 3. for any $x, y$, $d(x, y) = d(y, x)$ (symmetry)

--- a/rust/src/polars/mod.rs
+++ b/rust/src/polars/mod.rs
@@ -533,10 +533,12 @@ impl OnceFrame {
     /// Extract the compute plan with the private data.
     ///
     /// Requires "honest-but-curious" because the privacy guarantees only apply if:
+    ///
     /// 1. The LazyFrame (compute plan) is only ever executed once.
     /// 2. The analyst does not observe ordering of rows in the output.
     ///    
     /// To ensure that row ordering is not observed:
+    ///
     /// 1. Do not extend the compute plan with order-sensitive computations.
     /// 2. Shuffle the output once collected ([in Polars sample all, with shuffling enabled](https://docs.rs/polars/latest/polars/frame/struct.DataFrame.html#method.sample_n_literal)).
     #[cfg(feature = "honest-but-curious")]


### PR DESCRIPTION
Left is local docs build; Right is nightly
<img width="1031" alt="Screenshot 2025-02-06 at 6 32 11 PM" src="https://github.com/user-attachments/assets/d712e260-d968-42b6-8dbc-cdc3e92455b8" />

- If we require all the directives to be in a contiguous block, `Example` comes in the right place.
- Also require doctests to be contiguous, so they don't get split into little boxes.
- Fix #1396

<img width="1061" alt="Screenshot 2025-02-06 at 6 36 05 PM" src="https://github.com/user-attachments/assets/67d6cef4-491e-4da2-a8d7-0ef18d3982d1" />

- The math looks better, and the `Raises` is formatted correctly.
- The formatting of the rust link is also fixed with a later commit, after this screenshot was taken.
- Fix #1967

<img width="1063" alt="Screenshot 2025-02-06 at 8 59 31 PM" src="https://github.com/user-attachments/assets/503040e9-8c23-4c63-8ea4-50ff8d4eb036" />

- Not filed separately, but this is last bullet point, so fix #2188 

Also:
- No issue filed, but fix the rendering of numbered lists and bullet lists.
- Fix formatting of links to rust docs...
  - RST does not support nested inline markup
  - There is a [package](https://silverrainz.me/blog/sphinxnotes-comboroles.html) that may add support for this, but I don't think it's worth the complexity.
  - But these links are often (usually?) not working. #1025. Maybe we just drop these links?

