### PR TITLE
Remove code that generates links to rust docs

### DIFF
--- a/rust/build/derive.rs
+++ b/rust/build/derive.rs
@@ -123,7 +123,7 @@ fn parse_file_tree(
 
                 let mut contents = String::new();
                 File::open(&path)?.read_to_string(&mut contents)?;
-                if let Some(funcs) = parse_file(contents, &proof_paths, module_name) {
+                if let Some(funcs) = parse_file(contents, &proof_paths) {
                     matches.extend(funcs);
                 } else {
                     return Ok(None);
@@ -137,8 +137,7 @@ fn parse_file_tree(
 /// Search a file for bootstrap macro invocations
 fn parse_file(
     text: String,
-    proof_paths: &HashMap<String, Option<String>>,
-    module_name: &str,
+    proof_paths: &HashMap<String, Option<String>>
 ) -> Option<Vec<Function>> {
     // ignore files that fail to parse so as not to break IDE tooling
     let ts = TokenStream::from_str(&text).ok()?;
@@ -187,7 +186,7 @@ fn parse_file(
             }
 
             // use the bootstrap crate to parse a Function
-            Function::from_ast(attr_args, item_fn, Some(module_name)).ok()
+            Function::from_ast(attr_args, item_fn).ok()
         })
         .collect()
 }

--- a/rust/build/derive.rs
+++ b/rust/build/derive.rs
@@ -137,7 +137,7 @@ fn parse_file_tree(
 /// Search a file for bootstrap macro invocations
 fn parse_file(
     text: String,
-    proof_paths: &HashMap<String, Option<String>>
+    proof_paths: &HashMap<String, Option<String>>,
 ) -> Option<Vec<Function>> {
     // ignore files that fail to parse so as not to break IDE tooling
     let ts = TokenStream::from_str(&text).ok()?;

--- a/rust/opendp_derive/src/full.rs
+++ b/rust/opendp_derive/src/full.rs
@@ -51,7 +51,7 @@ pub(crate) fn bootstrap(attr_args: TokenStream, input: TokenStream) -> TokenStre
     }
 
     let function = try_!(
-        Function::from_ast(attr_args, item_fn.clone(), None),
+        Function::from_ast(attr_args, item_fn.clone()),
         original_input
     );
 

--- a/rust/opendp_tooling/src/bootstrap/docstring.rs
+++ b/rust/opendp_tooling/src/bootstrap/docstring.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, env, path::PathBuf};
+use std::{collections::HashMap, path::PathBuf};
 
 use darling::{Error, FromMeta, Result};
 use proc_macro2::{Literal, Punct, Spacing, TokenStream, TokenTree};
@@ -35,7 +35,6 @@ impl BootstrapDocstring {
         name: &String,
         attrs: Vec<Attribute>,
         output: &ReturnType,
-        path: Option<(&str, &str)>,
         features: Vec<String>,
     ) -> Result<BootstrapDocstring> {
         // look for this attr:
@@ -93,12 +92,6 @@ impl BootstrapDocstring {
                 .collect::<Vec<_>>()
                 .join(", ");
             description.push(format!("\n\nRequired features: {features_list}"));
-        }
-
-        // add a link to rust documentation (with a gap line)
-        if let Some((module, name)) = &path {
-            description.push(String::new());
-            description.push(make_rustdoc_link(module, name)?)
         }
 
         let mut add_section_to_description = |section_name: &str| {
@@ -425,27 +418,4 @@ fn new_comment_attribute(comment: &str) -> Attribute {
             .into_iter(),
         ),
     }
-}
-
-pub fn make_rustdoc_link(module: &str, name: &str) -> Result<String> {
-    // link from foreign library docs to rust docs
-    let proof_uri = if let Ok(rustdoc_port) = std::env::var("OPENDP_RUSTDOC_PORT") {
-        format!("http://localhost:{rustdoc_port}")
-    } else {
-        // find the docs uri
-        let docs_uri =
-            env::var("OPENDP_REMOTE_RUSTDOC_URI").unwrap_or_else(|_| "https://docs.rs".to_string());
-
-        // find the version
-        let mut version = env!("CARGO_PKG_VERSION");
-        if version.ends_with("-dev") {
-            version = "latest";
-        };
-
-        format!("{docs_uri}/opendp/{version}")
-    };
-
-    Ok(format!(
-        "[`{name}` in Rust documentation.]({proof_uri}/opendp/{module}/fn.{name}.html)"
-    ))
 }

--- a/rust/opendp_tooling/src/bootstrap/mod.rs
+++ b/rust/opendp_tooling/src/bootstrap/mod.rs
@@ -22,10 +22,7 @@ use self::{
 mod test;
 
 impl Function {
-    pub fn from_ast(
-        attr_args: AttributeArgs,
-        item_fn: ItemFn,
-    ) -> Result<Function> {
+    pub fn from_ast(attr_args: AttributeArgs, item_fn: ItemFn) -> Result<Function> {
         // Parse the proc bootstrap macro args
         let arguments = BootstrapArguments::from_attribute_args(&attr_args)?;
 

--- a/rust/opendp_tooling/src/bootstrap/mod.rs
+++ b/rust/opendp_tooling/src/bootstrap/mod.rs
@@ -25,7 +25,6 @@ impl Function {
     pub fn from_ast(
         attr_args: AttributeArgs,
         item_fn: ItemFn,
-        module: Option<&str>,
     ) -> Result<Function> {
         // Parse the proc bootstrap macro args
         let arguments = BootstrapArguments::from_attribute_args(&attr_args)?;
@@ -33,22 +32,11 @@ impl Function {
         // Parse the signature
         let signature = BootstrapSignature::from_syn(item_fn.sig.clone())?;
 
-        // Parse the docstring
-        let path = if arguments.name.is_none() {
-            module.map(|module| {
-                let name = arguments.name.as_ref().unwrap_or(&signature.name).as_str();
-                (module, name)
-            })
-        } else {
-            None
-        };
-
         let name = arguments.name.clone().unwrap_or(signature.name.clone());
         let docstring = BootstrapDocstring::from_attrs(
             &name,
             item_fn.attrs,
             &item_fn.sig.output,
-            path,
             arguments.features.0.clone(),
         )?;
 

--- a/rust/opendp_tooling/src/bootstrap/test.rs
+++ b/rust/opendp_tooling/src/bootstrap/test.rs
@@ -8,10 +8,9 @@ fn test_docstring_description_from_attrs() {
     let name = "fake_name".to_string();
     let attrs = vec![];
     let output = ReturnType::Default;
-    let path = None;
     let features = vec!["feature_1".to_string(), "feature_2".to_string()];
 
-    let result = BootstrapDocstring::from_attrs(&name, attrs, &output, path, features);
+    let result = BootstrapDocstring::from_attrs(&name, attrs, &output, features);
 
     let docstring = result.expect("from_attrs failed");
     let description = docstring.description.unwrap();


### PR DESCRIPTION
- Fix #1025

A proposal. A separate PR (#2267) addressing the formatting, but how useful would these links be, even if the kinks were ironed out? What's the story where a Python user would want to consult the Rust docs?