### PR TITLE
Make sure default `cargo test` also passes

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -122,7 +122,10 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-
 
-      - name: Test
+      - name: Test (default)
+        run: cargo test --verbose
+
+      - name: Test (all-features)
         run: cargo test --verbose --all-features
 
       - name: Run docs example

--- a/rust/src/accuracy/tail_bounds/mod.rs
+++ b/rust/src/accuracy/tail_bounds/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     traits::{InfAdd, InfCast, InfDiv, InfExp, NextFloat},
 };
 
-#[cfg(test)]
+#[cfg(all(test, feature = "contrib"))]
 mod test;
 
 /// Computes the probability of sampling a value greater than `t` from the discrete laplace distribution.


### PR DESCRIPTION
If this isn't something we would expect to pass, it would be good for me to understand that, too.

- Fix #2272