### PR TITLE
update ubuntu to 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
 
   bindings:
     needs: credential-check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@v1.3.1
@@ -203,7 +203,7 @@ jobs:
   
   python-aarch64:
     needs: bindings
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       DOCKER_IMAGE: messense/manylinux_2_24-cross:aarch64
       TARGET: aarch64-unknown-linux-gnu
@@ -311,7 +311,7 @@ jobs:
 
   r:
     needs: bindings
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,8 +56,6 @@ jobs:
     needs:
       - credential-check
       - r-docs
-    # fixed to ubuntu-22.04, which is currently newer than ubuntu-latest, because pandoc needs at least v2.6
-    # ubuntu-latest points to ubuntu-20.04, which has pandoc v2.5, which is subject to this bug: https://github.com/jgm/pandoc/issues/5128
     runs-on: ubuntu-22.04
     env:
       # don't attempt to load binaries when sourcing the library

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,7 @@ jobs:
 
   publish-python:
     needs: credential-check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       # twine doesn't support dry-runs, so if that's what we're doing, simulate it by using TestPyPI instead of PyPI
       PYPI_API_TOKEN: ${{ inputs.dry_run && secrets.TEST_PYPI_API_TOKEN || secrets.PYPI_API_TOKEN }}
@@ -100,7 +100,7 @@ jobs:
   publish-r:
     if: 
     needs: credential-check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -131,7 +131,7 @@ jobs:
 
   publish-rust:
     needs: publish-python
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       CRATES_IO_API_TOKEN: ${{ secrets.CRATES_IO_API_TOKEN }}
     steps:
@@ -154,7 +154,7 @@ jobs:
 
   publish-github:
     needs: publish-rust
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
- fix #2277

Wait for 24.02 until after the patch release, just to reduce the number of variables if something does go wrong?