### PR TITLE
fix: replace _dependencies with lifelines

### DIFF
--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -229,10 +229,6 @@ class Measurement(ctypes.POINTER(AnyMeasurement)): # type: ignore[misc]
         from opendp.typing import RuntimeType
         return RuntimeType.parse(measurement_input_carrier_type(self))
 
-    def _depends_on(self, *args):
-        """Extends the memory lifetime of args to the lifetime of self."""
-        setattr(self, "_dependencies", args)
-
     def __del__(self):
         try:
             from opendp.core import _measurement_free
@@ -471,10 +467,6 @@ class Transformation(ctypes.POINTER(AnyTransformation)): # type: ignore[misc]
         from opendp.typing import RuntimeType
         return RuntimeType.parse(transformation_input_carrier_type(self))
 
-    def _depends_on(self, *args):
-        """Extends the memory lifetime of args to the lifetime of self."""
-        setattr(self, "_dependencies", args)
-
     def __del__(self):
         try:
             from opendp.core import _transformation_free
@@ -513,10 +505,6 @@ class Queryable(object):
     def __repr__(self) -> str:
         return f"Queryable(Q={self.query_type})"
 
-    def _depends_on(self, *args):
-        """Extends the memory lifetime of args to the lifetime of self."""
-        setattr(self, "_dependencies", args)
-        
 
 class Function(ctypes.POINTER(AnyFunction)): # type: ignore[misc]
     '''
@@ -528,10 +516,6 @@ class Function(ctypes.POINTER(AnyFunction)): # type: ignore[misc]
     def __call__(self, arg):
         from opendp.core import function_eval
         return function_eval(self, arg)
-    
-    def _depends_on(self, *args):
-        """Extends the memory lifetime of args to the lifetime of self."""
-        setattr(self, "_dependencies", args)
     
     def __del__(self):
         try:
@@ -610,10 +594,6 @@ class Domain(ctypes.POINTER(AnyDomain)): # type: ignore[misc]
     def __hash__(self) -> int:
         return hash(str(self))
     
-    def _depends_on(self, *args):
-        """Extends the memory lifetime of args to the lifetime of self."""
-        setattr(self, "_dependencies", args)
-
     def __iter__(self):
         raise ValueError("Domain does not support iteration")
 
@@ -755,10 +735,6 @@ class PrivacyProfile(object):
         from opendp._data import privacy_profile_epsilon
         return privacy_profile_epsilon(self.curve, delta)
     
-    def _depends_on(self, *args):
-        """Extends the memory lifetime of args to the lifetime of self."""
-        setattr(self, "_dependencies", args)
-
 
 class _PartialConstructor(object):
     '''

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -20,7 +20,7 @@ from typing import Optional, Union, Any, Type, Sequence, _GenericAlias # type: i
 from types import GenericAlias
 import re
 
-from opendp.mod import Function, UnknownTypeException, Measurement, Transformation, Domain, Metric, Measure
+from opendp.mod import UnknownTypeException, Measurement, Transformation, Domain, Metric, Measure
 from opendp._lib import ATOM_EQUIVALENCE_CLASSES, import_optional_dependency
 
 
@@ -520,23 +520,6 @@ def pass_through(value: Any) -> Any:
     :param value: Value to pass through
     '''
     return value
-
-def get_dependencies(opendp_obj: Union[Measurement, Transformation, Function]) -> Any:
-    '''
-    Returns the dependencies of ``opendp_obj``.
-    Used extensively by combinators.
-
-    :param opendp_obj: Return the dependencies for this object
-    '''
-    return getattr(opendp_obj, "_dependencies", None)
-
-def get_dependencies_iterable(opendp_objs: Sequence[Union[Measurement, Transformation, Function]]) -> Sequence[Any]:
-    '''
-    Returns a list with the dependencies of each item in ``value``.
-
-    :param opendp_objs: Return the dependencies for all of these objects
-    '''
-    return list(map(get_dependencies, opendp_objs))
 
 def get_carrier_type(domain: Domain) -> Union[RuntimeType, str]:
     '''

--- a/python/test/test_comb.py
+++ b/python/test/test_comb.py
@@ -101,6 +101,7 @@ def test_cast_azcdp_approxdp():
     m_adp = dp.c.make_fix_delta(m_asdp, delta=1e-6)
     assert m_adp.map(1.) == (curve.epsilon(1e-6 - 1e-7), 1e-6)
 
+
 def test_renyidp():
     m_rdp = dp.m.make_user_measurement(
         dp.atom_domain(T=bool), dp.absolute_distance(T=float),

--- a/python/test/test_comb.py
+++ b/python/test/test_comb.py
@@ -103,6 +103,7 @@ def test_cast_azcdp_approxdp():
 
 
 def test_renyidp():
+    import gc
     m_rdp = dp.m.make_user_measurement(
         dp.atom_domain(T=bool), dp.absolute_distance(T=float),
         dp.renyi_divergence(),
@@ -110,6 +111,9 @@ def test_renyidp():
         lambda d_in: (lambda alpha: d_in * alpha / 2.0)
     )
     rdp_curve = m_rdp.map(1.0)
+    # this used to cause a use-after free, 
+    # as the ε(α) curve created by the map would not be kept alive
+    gc.collect()
     assert rdp_curve(4.) == 2.0
 
 

--- a/rust/opendp_tooling/src/bootstrap/arguments.rs
+++ b/rust/opendp_tooling/src/bootstrap/arguments.rs
@@ -25,8 +25,6 @@ pub struct BootstrapArguments {
     pub arguments: BootTypeHashMap,
     pub derived_types: Option<DerivedTypes>,
     pub returns: Option<BootType>,
-    #[darling(default)]
-    pub dependencies: Dependencies,
 }
 
 impl BootstrapArguments {
@@ -207,18 +205,5 @@ impl FromMeta for DefaultGenerics {
         } else {
             Err(Error::custom("expected string").with_span(lit))
         }
-    }
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct Dependencies(pub Vec<TypeRecipe>);
-
-impl FromMeta for Dependencies {
-    fn from_list(items: &[NestedMeta]) -> Result<Self> {
-        items
-            .iter()
-            .map(TypeRecipe::from_nested_meta)
-            .collect::<Result<Vec<_>>>()
-            .map(Dependencies)
     }
 }

--- a/rust/opendp_tooling/src/bootstrap/mod.rs
+++ b/rust/opendp_tooling/src/bootstrap/mod.rs
@@ -85,7 +85,6 @@ pub fn reconcile_function(
             signature.output_c_type,
         )?,
         derived_types: reconcile_derived_types(bootstrap.derived_types),
-        dependencies: bootstrap.dependencies.0,
         supports_partial: signature.supports_partial,
         has_ffi: bootstrap.has_ffi.unwrap_or(true),
         deprecation: doc_comments.deprecated,

--- a/rust/opendp_tooling/src/codegen/python.rs
+++ b/rust/opendp_tooling/src/codegen/python.rs
@@ -409,14 +409,12 @@ fn generate_body(module_name: &str, func: &Function, typemap: &HashMap<String, S
         r#"{flag_checker}{type_arg_formatter}
 {data_converter}
 {make_call}
-{set_dependencies}
 {serialization}
 return output"#,
         serialization = generate_serialization(module_name, func),
         flag_checker = generate_flag_check(&func.features),
         type_arg_formatter = generate_type_arg_formatter(func),
         data_converter = generate_data_converter(func, typemap),
-        set_dependencies = set_dependencies(&func.dependencies),
         make_call = generate_call(module_name, func, typemap)
     )
 }
@@ -609,19 +607,6 @@ output = {call}"#,
         ctype_restype = ctype_restype,
         call = call
     )
-}
-
-fn set_dependencies(dependencies: &Vec<TypeRecipe>) -> String {
-    if dependencies.is_empty() {
-        String::new()
-    } else {
-        let dependencies = dependencies
-            .iter()
-            .map(|dep| dep.to_python())
-            .collect::<Vec<String>>()
-            .join(", ");
-        format!("output._depends_on({dependencies})")
-    }
 }
 
 fn generate_serialization(module_name: &str, func: &Function) -> String {

--- a/rust/opendp_tooling/src/codegen/python_typemap.json
+++ b/rust/opendp_tooling/src/codegen/python_typemap.json
@@ -47,5 +47,5 @@
     "ExtrinsicObject *": "ExtrinsicObjectPtr",
     "FfiResult": "FfiResult",
     "CallbackFn": "CallbackFnPtr",
-    "TransitionFn": "TransitionFn"
+    "TransitionFn": "TransitionFnPtr"
 }

--- a/rust/opendp_tooling/src/codegen/r/c.rs
+++ b/rust/opendp_tooling/src/codegen/r/c.rs
@@ -270,17 +270,6 @@ fn generate_c_call(module_name: &str, func: &Function) -> String {
     )
 }
 
-// fn set_dependencies(
-//     dependencies: &Vec<TypeRecipe>
-// ) -> String {
-//     if dependencies.is_empty() {
-//         String::new()
-//     } else {
-//         let dependencies = dependencies.iter().map(|dep| dep.to_r()).collect::<Vec<String>>().join(", ");
-//         format!("output._depends_on({dependencies})")
-//     }
-// }
-
 /// Generate code to convert an SEXP to OpenDP Library C FFI representation.
 ///
 /// Reads the type information in `arg` to know which hand-written C function to call to perform the data conversion.

--- a/rust/opendp_tooling/src/codegen/test.rs
+++ b/rust/opendp_tooling/src/codegen/test.rs
@@ -28,7 +28,6 @@ fn make_function(parameter_argument: Argument, return_argument: Argument) -> Fun
         args: vec![parameter_argument],
         derived_types: vec![],
         ret: return_argument,
-        dependencies: vec![],
         supports_partial: false,
         has_ffi: true,
         deprecation: Some(Deprecation {
@@ -72,7 +71,6 @@ def fake_function(
     lib_function.restype = ctypes.c_double
 
     output = c_to_py(lib_function(c_fake_argument))
-
     try:
         output.__opendp_dict__ = {
             '__function__': 'fake_function',

--- a/rust/opendp_tooling/src/lib.rs
+++ b/rust/opendp_tooling/src/lib.rs
@@ -27,8 +27,6 @@ pub struct Function {
     pub derived_types: Vec<Argument>,
     // metadata for return type
     pub ret: Argument,
-    // references to values that should share the same lifetime
-    pub dependencies: Vec<TypeRecipe>,
     // set to true if the first two arguments are input domain and input metric
     pub supports_partial: bool,
     // whether to generate FFI

--- a/rust/src/combinators/amplify/ffi.rs
+++ b/rust/src/combinators/amplify/ffi.rs
@@ -75,10 +75,7 @@ impl IsSizedDomain for AnyDomain {
     }
 }
 
-#[bootstrap(
-    features("contrib", "honest-but-curious"),
-    dependencies("$get_dependencies(measurement)")
-)]
+#[bootstrap(features("contrib", "honest-but-curious"))]
 /// Construct an amplified measurement from a `measurement` with privacy amplification by subsampling.
 /// This measurement does not perform any sampling.
 /// It is useful when you have a dataset on-hand that is a simple random sample from a larger population.

--- a/rust/src/combinators/chain/ffi.rs
+++ b/rust/src/combinators/chain/ffi.rs
@@ -10,10 +10,6 @@ use crate::ffi::any::{AnyFunction, AnyMeasurement, AnyTransformation};
     arguments(
         measurement1(rust_type = b"null"),
         transformation0(rust_type = b"null")
-    ),
-    dependencies(
-        "$get_dependencies(measurement1)",
-        "$get_dependencies(transformation0)"
     )
 )]
 /// Construct the functional composition (`measurement1` ○ `transformation0`).
@@ -44,10 +40,6 @@ pub extern "C" fn opendp_combinators__make_chain_mt(
     arguments(
         transformation1(rust_type = b"null"),
         transformation0(rust_type = b"null")
-    ),
-    dependencies(
-        "$get_dependencies(transformation1)",
-        "$get_dependencies(transformation0)"
     )
 )]
 /// Construct the functional composition (`transformation1` ○ `transformation0`).
@@ -74,8 +66,7 @@ pub extern "C" fn opendp_combinators__make_chain_tt(
 
 #[bootstrap(
     features("contrib"),
-    arguments(postprocess1(rust_type = b"null"), measurement0(rust_type = b"null")),
-    dependencies("$get_dependencies(postprocess1)", "$get_dependencies(measurement0)")
+    arguments(postprocess1(rust_type = b"null"), measurement0(rust_type = b"null"))
 )]
 /// Construct the functional composition (`postprocess1` ○ `measurement0`).
 /// Returns a Measurement that when invoked, computes `postprocess1(measurement0(x))`.

--- a/rust/src/combinators/fix_delta/ffi.rs
+++ b/rust/src/combinators/fix_delta/ffi.rs
@@ -8,11 +8,7 @@ use crate::{
     measures::{Approximate, SmoothedMaxDivergence},
 };
 
-#[bootstrap(
-    features("contrib"),
-    arguments(measurement(rust_type = b"null"),),
-    dependencies("$get_dependencies(measurement)")
-)]
+#[bootstrap(features("contrib"), arguments(measurement(rust_type = b"null"),))]
 /// Fix the delta parameter in the privacy map of a `measurement` with a SmoothedMaxDivergence output measure.
 ///
 /// # Arguments

--- a/rust/src/combinators/measure_cast/zCDP_to_approxDP/ffi.rs
+++ b/rust/src/combinators/measure_cast/zCDP_to_approxDP/ffi.rs
@@ -8,7 +8,7 @@ use crate::{
     measures::{Approximate, ZeroConcentratedDivergence},
 };
 
-#[bootstrap(features("contrib"), dependencies("$get_dependencies(measurement)"))]
+#[bootstrap(features("contrib"))]
 /// Constructs a new output measurement where the output measure
 /// is casted from `ZeroConcentratedDivergence` to `SmoothedMaxDivergence`.
 ///

--- a/rust/src/combinators/select_private_candidate/mod.rs
+++ b/rust/src/combinators/select_private_candidate/mod.rs
@@ -17,8 +17,7 @@ mod test;
 #[bootstrap(
     features("contrib"),
     arguments(measurement(rust_type = "AnyMeasurement"),),
-    generics(DI(suppress), MI(suppress), TO(suppress)),
-    dependencies("$get_dependencies(measurement)")
+    generics(DI(suppress), MI(suppress), TO(suppress))
 )]
 /// Select a private candidate whose score is above a threshold.
 ///

--- a/rust/src/combinators/sequential_compositor/noninteractive/ffi.rs
+++ b/rust/src/combinators/sequential_compositor/noninteractive/ffi.rs
@@ -16,8 +16,7 @@ use super::BasicCompositionMeasure;
 
 #[bootstrap(
     features("contrib"),
-    arguments(measurements(rust_type = "Vec<AnyMeasurementPtr>")),
-    dependencies("$get_dependencies_iterable(measurements)")
+    arguments(measurements(rust_type = "Vec<AnyMeasurementPtr>"))
 )]
 /// Construct the DP composition \[`measurement0`, `measurement1`, ...\].
 /// Returns a Measurement that when invoked, computes `[measurement0(x), measurement1(x), ...]`

--- a/rust/src/domains/ffi.rs
+++ b/rust/src/domains/ffi.rs
@@ -500,12 +500,17 @@ pub extern "C" fn opendp_domains__user_domain(
     let identifier = try_!(to_str(identifier)).to_string();
     let descriptor = try_as_ref!(descriptor).clone();
     let element = ExtrinsicElement::new(identifier, descriptor);
-    let member = wrap_func(try_as_ref!(member).clone());
-    let member = Function::new_fallible(move |arg: &ExtrinsicObject| -> Fallible<bool> {
-        member(&AnyObject::new(arg.clone()))?.downcast::<bool>()
+
+    let member_closure = wrap_func(try_as_ref!(member).clone());
+    let member_function = Function::new_fallible(move |arg: &ExtrinsicObject| -> Fallible<bool> {
+        member_closure(&AnyObject::new(arg.clone()))?.downcast::<bool>()
     });
 
-    Ok(AnyDomain::new(ExtrinsicDomain { element, member })).into()
+    Ok(AnyDomain::new(ExtrinsicDomain {
+        element,
+        member: member_function,
+    }))
+    .into()
 }
 
 #[bootstrap(

--- a/rust/src/domains/ffi.rs
+++ b/rust/src/domains/ffi.rs
@@ -7,7 +7,7 @@ use crate::{
     domains::{type_name, AtomDomain, MapDomain, VectorDomain},
     error::Fallible,
     ffi::{
-        any::{AnyDomain, AnyObject, CallbackFn, Downcast},
+        any::{wrap_func, AnyDomain, AnyObject, CallbackFn, Downcast},
         util::{self, c_bool, into_c_char_p, to_str, ExtrinsicObject, Type, TypeContents},
     },
     traits::{CheckAtom, Float, Hashable, Integer, Primitive},
@@ -470,8 +470,7 @@ impl Domain for ExtrinsicDomain {
         identifier(c_type = "char *", rust_type = b"null"),
         member(rust_type = "bool"),
         descriptor(default = b"null", rust_type = "ExtrinsicObject")
-    ),
-    dependencies("c_member")
+    )
 )]
 /// Construct a new UserDomain.
 /// Any two instances of an UserDomain are equal if their string descriptors are equal.
@@ -501,10 +500,9 @@ pub extern "C" fn opendp_domains__user_domain(
     let identifier = try_!(to_str(identifier)).to_string();
     let descriptor = try_as_ref!(descriptor).clone();
     let element = ExtrinsicElement::new(identifier, descriptor);
-    let member = try_as_ref!(member).clone();
+    let member = wrap_func(try_as_ref!(member).clone());
     let member = Function::new_fallible(move |arg: &ExtrinsicObject| -> Fallible<bool> {
-        let c_res = (member.callback)(AnyObject::new_raw(arg.clone()));
-        Fallible::from(util::into_owned(c_res)?)?.downcast::<bool>()
+        member(&AnyObject::new(arg.clone()))?.downcast::<bool>()
     });
 
     Ok(AnyDomain::new(ExtrinsicDomain { element, member })).into()

--- a/rust/src/ffi/any.rs
+++ b/rust/src/ffi/any.rs
@@ -354,6 +354,9 @@ pub struct CallbackFn {
 // wrap a CallbackFn in a closure, so that it can be used in transformations and measurements
 pub fn wrap_func(func: CallbackFn) -> impl Fn(&AnyObject) -> Fallible<AnyObject> {
     move |arg: &AnyObject| -> Fallible<AnyObject> {
+        // extends the lifetime of func.callback to the lifetime of this closure
+        let _ = &func.lifeline;
+
         into_owned((func.callback)(arg as *const AnyObject))?.into()
     }
 }

--- a/rust/src/ffi/util.rs
+++ b/rust/src/ffi/util.rs
@@ -58,6 +58,9 @@ pub struct ExtrinsicObject {
     pub(crate) count: RefCountFn,
 }
 
+unsafe impl Send for ExtrinsicObject {}
+unsafe impl Sync for ExtrinsicObject {}
+
 impl Clone for ExtrinsicObject {
     fn clone(&self) -> Self {
         (self.count)(self.ptr, true);

--- a/rust/src/internal/mod.rs
+++ b/rust/src/internal/mod.rs
@@ -31,14 +31,7 @@ use self::util::to_str;
         function(rust_type = "$pass_through(TO)"),
         privacy_map(rust_type = "$measure_distance_type(output_measure)"),
     ),
-    generics(TO(default = "ExtrinsicObject")),
-    dependencies(
-        "input_domain",
-        "input_metric",
-        "output_measure",
-        "c_function",
-        "c_privacy_map"
-    )
+    generics(TO(default = "ExtrinsicObject"))
 )]
 /// Construct a Measurement from user-defined callbacks.
 /// This is meant for internal use, as it does not require "honest-but-curious",
@@ -102,14 +95,6 @@ pub extern "C" fn opendp_internal___make_measurement(
         output_metric(hint = "Metric"),
         function(rust_type = "$domain_carrier_type(output_domain)"),
         stability_map(rust_type = "$metric_distance_type(output_metric)"),
-    ),
-    dependencies(
-        "input_domain",
-        "input_metric",
-        "output_domain",
-        "output_metric",
-        "c_function",
-        "c_stability_map"
     )
 )]
 /// Construct a Transformation from user-defined callbacks.
@@ -151,8 +136,7 @@ pub extern "C" fn opendp_internal___make_transformation(
         identifier(c_type = "char *", rust_type = b"null"),
         member(rust_type = "bool"),
         descriptor(default = b"null", rust_type = "ExtrinsicObject")
-    ),
-    dependencies("c_member")
+    )
 )]
 /// Construct a new ExtrinsicDomain.
 /// This is meant for internal use, as it does not require "honest-but-curious",
@@ -223,8 +207,7 @@ pub extern "C" fn opendp_internal___extrinsic_distance(
 
 #[bootstrap(
     features("contrib"),
-    arguments(function(rust_type = "$pass_through(TO)")),
-    dependencies("c_function")
+    arguments(function(rust_type = "$pass_through(TO)"))
 )]
 /// Construct a Function from a user-defined callback.
 /// This is meant for internal use, as it does not require "honest-but-curious",

--- a/rust/src/measurements/make_user_measurement/mod.rs
+++ b/rust/src/measurements/make_user_measurement/mod.rs
@@ -20,14 +20,7 @@ use crate::{
         function(rust_type = "$pass_through(TO)"),
         privacy_map(rust_type = "$measure_distance_type(output_measure)"),
     ),
-    generics(TO(default = "ExtrinsicObject")),
-    dependencies(
-        "input_domain",
-        "input_metric",
-        "output_measure",
-        "c_function",
-        "c_privacy_map"
-    )
+    generics(TO(default = "ExtrinsicObject"))
 )]
 /// Construct a Measurement from user-defined callbacks.
 ///

--- a/rust/src/measures/ffi.rs
+++ b/rust/src/measures/ffi.rs
@@ -374,8 +374,7 @@ impl<Q> Measure for TypedMeasure<Q> {
     name = "new_privacy_profile",
     features("contrib", "honest-but-curious"),
     arguments(curve(rust_type = "f64")),
-    returns(rust_type = "PrivacyProfile"),
-    dependencies("c_curve")
+    returns(rust_type = "PrivacyProfile")
 )]
 /// Construct a PrivacyProfile from a user-defined callback.
 ///

--- a/rust/src/transformations/make_user_transformation/mod.rs
+++ b/rust/src/transformations/make_user_transformation/mod.rs
@@ -15,14 +15,6 @@ use crate::{
         output_metric(hint = "Metric"),
         function(rust_type = "$domain_carrier_type(output_domain)"),
         stability_map(rust_type = "$metric_distance_type(output_metric)"),
-    ),
-    dependencies(
-        "input_domain",
-        "input_metric",
-        "output_domain",
-        "output_metric",
-        "c_function",
-        "c_stability_map"
     )
 )]
 /// Construct a Transformation from user-defined callbacks.


### PR DESCRIPTION
Fix #2235

The plugin APIs embed Python objects inside opaque Rust structs (transformation, measurement, queryable, function, domain, privacy profile, etc).

Imagine a user defines a custom function and uses the plugin API to embed it into a Rust struct.
When execution continues, the Rust struct holds a pointer to memory allocated in Python. 
Unfortunately, Python doesn't know the memory is still being referenced by Rust, 
and the Python refcount to that object naturally drops to zero.
The Python interpreter then frees the object upon the next garbage collection, leading to a use-after-free memory corruption when the Rust struct is used.

Previously, the generated code would add a reference to any Python objects embedded in the Rust struct, to the corresponding opaque struct on the Python side under the `_dependencies` attribute.
That is, the Rust object "depends on" the Python objects in its `_dependencies`,
extending the lifetime of any embedded Python objects to the lifetime of the Rust struct.
Two downsides to this approach:
- tracking the dependencies requires Rust structs built by combinators to inherit dependencies of its arguments, leading to complexity
- there is no natural place to attach dependencies for privacy maps that return user-defined Renyi-DP tradeoff functions

PR #2168 introduced a new approach to maintain the refcount, by adding a "lifeline" to callback functions.
The lifeline is a struct that increments the Python refcount when cloned, and decrements when dropped.
The intention of the PR was to capture a clone of the lifeline in the Rust closure,
so that the Python refcount for the object would remain non-zero until all Rust closures referencing the Python object/holding the lifeline are dropped.
Unfortunately, the lifeline wasn't being captured, leaving the refcount unprotected.

This PR ensures that the lifeline is captured, and adjusts transition functions to use the same mechanism. 
Since all Python objects are now protected via lifelines, this PR also removes the dependencies system.



Disables R linting due to #2279 