### PR TITLE
Deprecate margins dict

### DIFF
--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -407,8 +407,11 @@ class Context(object):
             domain = domain_of(data, infer=True)
 
         if margins:
+
             # allows dictionaries of {[by]: [margin]}
             if isinstance(margins, MutableMapping):
+                from warnings import warn
+                warn('Margin dicts should be replaced with lists, with the key supplied as the "by" kwarg', DeprecationWarning)
                 margins = [replace(margin, by=by) for by, margin in margins.items()]
             
             pl = import_optional_dependency("polars")

--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -407,7 +407,6 @@ class Context(object):
             domain = domain_of(data, infer=True)
 
         if margins:
-
             # allows dictionaries of {[by]: [margin]}
             if isinstance(margins, MutableMapping):
                 from warnings import warn

--- a/python/test/test_polars.py
+++ b/python/test/test_polars.py
@@ -361,9 +361,9 @@ def test_polars_describe():
         privacy_unit=dp.unit_of(contributions=1),
         privacy_loss=dp.loss_of(epsilon=1.0),
         split_evenly_over=2,
-        margins={ # type: ignore[arg-type]
-            ("B",): dp.polars.Margin(public_info="keys", max_partition_length=5),
-        },
+        margins=[
+            dp.polars.Margin(by=["B"], public_info="keys", max_partition_length=5),
+        ],
     )
 
     expected = pl.DataFrame(

--- a/python/test/test_usability.py
+++ b/python/test/test_usability.py
@@ -1,3 +1,4 @@
+import re
 import pytest
 import opendp.prelude as dp
 
@@ -116,15 +117,16 @@ def test_margins_dict_instead_of_list():
         schema={"col": pl.Int32},
     )
 
-    dp.Context.compositor(
-        data=lf,
-        privacy_unit=dp.unit_of(contributions=1),
-        privacy_loss=dp.loss_of(epsilon=1.0),
-        split_evenly_over=1,
-        margins={
-            ('col',): dp.polars.Margin(public_info="keys", max_partition_length=5),
-        }
-    )
+    with pytest.warns(DeprecationWarning, match=re.escape('Margin dicts should be replaced with lists, with the key supplied as the "by" kwarg')):
+        dp.Context.compositor(
+            data=lf,
+            privacy_unit=dp.unit_of(contributions=1),
+            privacy_loss=dp.loss_of(epsilon=1.0),
+            split_evenly_over=1,
+            margins={
+                ('col',): dp.polars.Margin(public_info="keys", max_partition_length=5),
+            }
+        )
 
 
 @pytest.mark.parametrize(

--- a/python/test/test_usability.py
+++ b/python/test/test_usability.py
@@ -123,7 +123,7 @@ def test_margins_dict_instead_of_list():
             privacy_unit=dp.unit_of(contributions=1),
             privacy_loss=dp.loss_of(epsilon=1.0),
             split_evenly_over=1,
-            margins={
+            margins={ # type: ignore[arg-type]
                 ('col',): dp.polars.Margin(public_info="keys", max_partition_length=5),
             }
         )

--- a/python/test/test_usability.py
+++ b/python/test/test_usability.py
@@ -108,6 +108,25 @@ def test_string_instead_of_tuple_for_margin_key():
         )
 
 
+def test_margins_dict_instead_of_list():
+    pl = pytest.importorskip("polars")
+
+    lf = pl.LazyFrame(
+        {"col": [1, 2, 3, 4]},
+        schema={"col": pl.Int32},
+    )
+
+    dp.Context.compositor(
+        data=lf,
+        privacy_unit=dp.unit_of(contributions=1),
+        privacy_loss=dp.loss_of(epsilon=1.0),
+        split_evenly_over=1,
+        margins={
+            ('col',): dp.polars.Margin(public_info="keys", max_partition_length=5),
+        }
+    )
+
+
 @pytest.mark.parametrize(
     "domain", [dp.lazyframe_domain([]), dp.series_domain("A", dp.atom_domain(T=bool))])
 def test_polars_data_loader_error_is_human_readable(domain):


### PR DESCRIPTION
- Fix #2297

I'd have a slight preference that there be one right way to use the library, just so the users aren't left wondering if the dict and list somehow work differently. Feel free to close if this seems too fussy.