### PR TITLE
chore: Update Ubuntu in CI

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -90,7 +90,7 @@ jobs:
 
   rust-test:
     needs: rust-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: rust

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -90,6 +90,8 @@ jobs:
 
   rust-test:
     needs: rust-build
+    # TODO: Upgrade to ubuntu-latest.
+    # https://github.com/opendp/opendp/issues/2305
     runs-on: ubuntu-22.04
     defaults:
       run:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -225,7 +225,7 @@ jobs:
 
   docs-links:
     needs: rust-build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: docs

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   rust-build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: rust
@@ -90,7 +90,7 @@ jobs:
 
   rust-test:
     needs: rust-build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: rust
@@ -133,7 +133,7 @@ jobs:
 
   python-test:
     needs: rust-build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: python
@@ -215,7 +215,7 @@ jobs:
 
   confirm-coverage:
     needs: python-test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Download coverage
         # No additional action needed: We just need to confirm that at least one test produced a coverage report.
@@ -225,7 +225,7 @@ jobs:
 
   docs-links:
     needs: rust-build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: docs
@@ -258,7 +258,7 @@ jobs:
 
   python-notebooks:
     needs: rust-build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: docs
@@ -310,7 +310,7 @@ jobs:
 
   r-test:
     needs: rust-build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       OPENDP_LIB_DIR: ${{ github.workspace }}/libs
       LINTR_ERROR_ON_LINT: true


### PR DESCRIPTION
- Fix #2301 by using `ubunutu-latest` for all but `rust-test`.
- Fix #2276
- Filed a follow-up issue: #2305