### PR TITLE
feat: Add more info for the user in `max_partition_length` error message 

### DIFF
--- a/python/test/test_usability.py
+++ b/python/test/test_usability.py
@@ -181,11 +181,11 @@ def test_without_max_partition_length():
     config = pl.col("A").fill_null(0).dp.mean((0, 10))
 
     plain_query = context_wo_margin.query().select(config)
-    with pytest.raises(dp.OpenDPException, match=r"must specify 'max_length' in margin with by=\[\]"):
+    with pytest.raises(dp.OpenDPException, match=r"must specify 'max_length' in a margin with by=\[\]"):
         plain_query.release()
 
     agg_query = context_wo_margin.query().group_by(["B"]).agg(config)
-    with pytest.raises(dp.OpenDPException, match=r"must specify 'max_length' in margin with by=\[\]"):
+    with pytest.raises(dp.OpenDPException, match=r"must specify 'max_length' in a margin with by=\[\]"):
         agg_query.release()
     
     

--- a/rust/src/transformations/make_stable_expr/expr_sum/mod.rs
+++ b/rust/src/transformations/make_stable_expr/expr_sum/mod.rs
@@ -151,7 +151,12 @@ where
     let invariant = margin.invariant;
 
     let max_size = usize::exact_int_cast(margin.max_length.ok_or_else(|| {
-        let margin_by = margin.by.iter().map(|expr| expr.to_string()).collect::<Vec<_>>().join(", ");
+        let margin_by = margin
+            .by
+            .iter()
+            .map(|expr| expr.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
         err!(
             MakeTransformation,
             "must specify 'max_length' in a margin with by=[{margin_by}]"

--- a/rust/src/transformations/make_stable_expr/expr_sum/mod.rs
+++ b/rust/src/transformations/make_stable_expr/expr_sum/mod.rs
@@ -150,11 +150,13 @@ where
 
     let invariant = margin.invariant;
 
-    let max_size = usize::exact_int_cast(
-        margin
-            .max_length
-            .ok_or_else(|| err!(MakeTransformation, "must specify max_length in margin"))?,
-    )?;
+    let max_size = usize::exact_int_cast(margin.max_length.ok_or_else(|| {
+        let margin_by = margin.by.iter().map(|expr| expr.to_string()).collect::<Vec<_>>().join(", ");
+        err!(
+            MakeTransformation,
+            "must specify 'max_length' in a margin with by=[{margin_by}]"
+        )
+    })?)?;
 
     let pp_relaxation = f64::inf_cast(TI::Sum::relaxation(max_size, l, u)?)?;
 


### PR DESCRIPTION
- Fix #2314 

@Shoeboxam , I realize looking at this that it doesn't test the case where `by` isn't empty. I thought the grouping might trigger that. Ideas?