### PR TITLE
fix: openssl compilation in smoke-test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -284,7 +284,7 @@ jobs:
 
   python-sdist:
     needs: bindings
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   rust-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: rust
@@ -90,8 +90,6 @@ jobs:
 
   rust-test:
     needs: rust-build
-    # TODO: Upgrade to ubuntu-latest.
-    # https://github.com/opendp/opendp/issues/2305
     runs-on: ubuntu-22.04
     defaults:
       run:
@@ -135,7 +133,7 @@ jobs:
 
   python-test:
     needs: rust-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: python
@@ -217,7 +215,7 @@ jobs:
 
   confirm-coverage:
     needs: python-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Download coverage
         # No additional action needed: We just need to confirm that at least one test produced a coverage report.
@@ -227,7 +225,7 @@ jobs:
 
   docs-links:
     needs: rust-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: docs
@@ -250,7 +248,9 @@ jobs:
         run: sudo apt-get install -y pandoc
 
       - name: Install dependencies
-        run: python -m pip install -r requirements.txt
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
 
       - name: Build docs
         run: make html
@@ -260,7 +260,7 @@ jobs:
 
   python-notebooks:
     needs: rust-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: docs
@@ -312,7 +312,7 @@ jobs:
 
   r-test:
     needs: rust-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       OPENDP_LIB_DIR: ${{ github.workspace }}/libs
       LINTR_ERROR_ON_LINT: true

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -39,11 +39,7 @@ num = "0.3.1"
 thiserror = "1.0.24"
 statrs = "0.13.0"
 dashu = { version = "0.4.0", features = ["num-traits_v02"] }
-openssl = { version = "0.10.64", features = ["vendored"], optional = true }
-
-# Temporary fix until OpenSSL is updated to 3.4.
-# See https://github.com/openssl/openssl/issues/25366
-openssl-src = "=300.3.1"
+openssl = { version = "0.10.71", features = ["vendored"], optional = true }
 
 opendp_tooling = { path = "opendp_tooling", optional = true, version = "0.12.1-dev" }
 readonly = "0.2"


### PR DESCRIPTION
Related to #2305

Ubuntu 24.04 updated glibc beyond 0.39, where glibc changed header functions to add `cstd23` aliases for various functions. Our GitHub actions speeds up the build by reusing/caching rlib files from parent actions, which use Ubuntu 24.04. Therefore the openssl-sys rlib from the cache contains references to glibc `cstd23` functions that are only valid on Ubuntu 24.04, which don't yet exist in the glibc of Ubuntu 22.xx.

This PR standardizes CI to ubuntu-22.04, and updates pip to fix a packaging.licenses docs CI failure.