### PR TITLE
docs: Start error reference in User Guide

### DIFF
--- a/docs/source/api/user-guide/errors.rst
+++ b/docs/source/api/user-guide/errors.rst
@@ -1,0 +1,47 @@
+Errors
+======
+
+OpenDP is designed to prevent operations which would violate the guarantees of differential privacy.
+This means there are a lot of potential errors, some more clear than others.
+This is not a complete list, but it does describe some situations,
+and tries to provide more context than a short error message can accomodate.
+
+``Margin keys must be a sequence``
+----------------------------------
+
+Confirm that you aren't using a string for the ``by`` kwarg by mistake.
+
+.. tab-set::
+
+  .. tab-item:: Python
+
+    .. code:: python
+
+        >>> import polars as pl
+        >>> lf = pl.LazyFrame({"a_column": [1, 2, 3, 4]})
+        >>> privacy_unit = dp.unit_of(contributions=1)
+        >>> privacy_loss = dp.loss_of(epsilon=1.0)
+
+        >>> context = dp.Context.compositor(
+        ...     data=lf,
+        ...     privacy_unit=privacy_unit,
+        ...     privacy_loss=privacy_loss,
+        ...     split_evenly_over=1,
+        ...     margins=[
+        ...         dp.polars.Margin(by="a_column")
+        ...     ],
+        ... )
+        Traceback (most recent call last):
+        ...
+        ValueError: Margin keys must be a sequence; https://docs.opendp.org/.../errors.html#margin-keys-must-be-a-sequence
+        
+        >>> context = dp.Context.compositor(
+        ...     data=lf,
+        ...     privacy_unit=privacy_unit,
+        ...     privacy_loss=privacy_loss,
+        ...     split_evenly_over=1,
+        ...     margins=[
+        ...         # "by" should be a list of column names or expressions:    
+        ...         dp.polars.Margin(by=["a_column"])
+        ...     ],
+        ... )

--- a/docs/source/api/user-guide/index.rst
+++ b/docs/source/api/user-guide/index.rst
@@ -77,3 +77,4 @@ See also the :ref:`comprehensive listing of features for Rust<rust-feature-listi
    context/index
    polars/index
    plugins/index
+   errors

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -442,3 +442,20 @@ def indent(text):
     spaces = ' ' * 4
     indented_rest = [f'\n{spaces}{line}' for line in rest]
     return first + ''.join(indented_rest)
+
+
+def get_error_url(message: str) -> str:
+    '''
+    >>> import opendp.prelude as dp
+    >>> version = dp.__version__
+    >>> print(get_error_url("Don't do *that*!").replace(dp.__version__, '0.0.0'))
+    https://docs.opendp.org/en/v0.0.0/api/user-guide/errors.html#don-t-do-that
+    '''
+    import re
+    import opendp.prelude as dp
+    normed = re.sub(r'\W+', '-', message.lower())
+    normed = re.sub(r'^-+', '', normed)
+    normed = re.sub(r'-+$', '', normed)
+    return f'https://docs.opendp.org/en/v{dp.__version__}/api/user-guide/errors.html#{normed}'
+    
+    

--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -52,7 +52,7 @@ from opendp.mod import (
     binary_search_param,
 )
 from opendp.typing import RuntimeType
-from opendp._lib import indent, import_optional_dependency
+from opendp._lib import indent, import_optional_dependency, get_error_url
 from opendp.extras.polars import LazyFrameQuery, Margin
 from dataclasses import asdict, replace
 
@@ -415,7 +415,9 @@ class Context(object):
             for margin in margins:
                 by = margin.by or []
                 if not isinstance(by, Sequence) or isinstance(by, str):
-                    raise ValueError("Margin keys must be a sequence")
+                    message = "Margin keys must be a sequence"
+                    url = get_error_url(message)
+                    raise ValueError(f"{message}; {url}")
 
                 by_exprs = [col if isinstance(col, pl.Expr) else pl.col(col) for col in by]
                 domain = with_margin(domain, **asdict(replace(margin, by=by_exprs)))

--- a/python/test/test_usability.py
+++ b/python/test/test_usability.py
@@ -85,29 +85,6 @@ def test_query_dir():
     assert 'laplace' in query_dir
 
 
-def test_string_instead_of_tuple_for_margin_key():
-    pl = pytest.importorskip("polars")
-
-    lf = pl.LazyFrame(
-        {"a_column": [1, 2, 3, 4]},
-        schema={"a_column": pl.Int32},
-    )
-
-    with pytest.raises(ValueError, match="Margin keys must be a sequence"):
-        dp.Context.compositor(
-            data=lf,
-            privacy_unit=dp.unit_of(contributions=1),
-            privacy_loss=dp.loss_of(epsilon=1.0),
-            split_evenly_over=1,
-            margins=[
-                # To reproduce failure, the column name must be multiple characters.
-                # TODO: We want to fail earlier because the key is not a tuple.
-                # (mypy does catch this, so we need "type: ignore", but we can't rely on users running mypy.)
-                dp.polars.Margin(by=("a_column"), public_info="keys", max_partition_length=5), # type: ignore
-            ],
-        )
-
-
 @pytest.mark.parametrize(
     "domain", [dp.lazyframe_domain([]), dp.series_domain("A", dp.atom_domain(T=bool))])
 def test_polars_data_loader_error_is_human_readable(domain):


### PR DESCRIPTION
- Towards #2323

👉 Big question is whether a reference page for errors is good way to improve usability, compared with all the other things we could spend time on.

I think that adding an example that works will be an important complement to each failing doc test: Coming up with a passing example might take a little time in some cases.

The messages themselves might be enriched: in this case I might have added the bad margin to the error message. If we're visiting these points in the code, maybe we also want to make that update?

It's up to the user to make sure the title of their section actually matches the string used for the URL. While it would be possible for `get_error_url` to read `errors.rst` and confirm that the string matches, that feels a little weird.