### PR TITLE
Apply black to __init__.py and _convert.py

### DIFF
--- a/python/src/opendp/__init__.py
+++ b/python/src/opendp/__init__.py
@@ -1,1 +1,6 @@
-from opendp.mod import Transformation, Measurement, OpenDPException, UnknownTypeException
+from opendp.mod import (
+    Transformation,
+    Measurement,
+    OpenDPException,
+    UnknownTypeException,
+)

--- a/rust/src/transformations/make_stable_expr/namespace_arr/mod.rs
+++ b/rust/src/transformations/make_stable_expr/namespace_arr/mod.rs
@@ -39,7 +39,7 @@ where
 
     fallible!(
         MakeTransformation,
-        "Expr is not recognized at this time: {:?}. Waiting for: https://github.com/pola-rs/polars/pull/20421", 
+        "Expr is not recognized at this time: {:?}. Waiting for: https://github.com/pola-rs/polars/pull/20421",
         array_function
     )
 }


### PR DESCRIPTION
- Towards #2274

Working on DP Wizard, I've gotten to like black formatting. Also one Rust whitespace fix.

Plus:
- Consistent python style across OpenDP projects
- Analogous to the `cargo fmt` we're already using on the Rust side
- Getting the format clean is either a pre-req or primary motivation for adding a pre-commit hook 
- If this looks good, plan to make more small PRs to avoid merge conflicts

Minus:
- Benefits are subjective
- Makes `git blame` harder to use
- Might not apply to generated code in the end, and the inconsistency might be a nuissance 