### PR TITLE
feat: Add pip upgrade to link checker

### DIFF
--- a/.github/workflows/weekly-doc-check.yml
+++ b/.github/workflows/weekly-doc-check.yml
@@ -71,8 +71,10 @@ jobs:
           name: python_bindings
           path: python/src/opendp/
 
-      - name: Install deps
-        run: python -m pip install -r requirements.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
 
       - name: Check markdown links
         run: |


### PR DESCRIPTION
- Fix #2301

The saga continues:
- We first tried upgrading ubuntu to latest everywhere
- That didn't work for Rust for some reason, so we kept that action on an older ubuntu version
- But then there was a mismatch in the opendp binary that later actions need
- So we ended up pinning all the actions to an older ubuntu, and for smoke-test added an upgrade for pip
- _but we forgot the same upgrade for the link checker!_
- so add that in this PR.