### PR TITLE
feat: constructor registration in Context API

### DIFF
--- a/docs/source/api/user-guide/plugins/context-api-plugins.rst
+++ b/docs/source/api/user-guide/plugins/context-api-plugins.rst
@@ -1,0 +1,66 @@
+Context API Plugins
+===================
+
+Constructor functions built from plugins can be registered in the Context API.
+
+We'll start by briefly copying over the constructor from the :ref:`measurement-plugin` and registering it.
+The constructor function may now be called from the Context API.
+
+.. tab-set::
+
+  .. tab-item:: Python
+
+    .. code:: python
+
+        >>> def make_int_constant(constant):
+        ...     return dp.m.make_user_measurement(
+        ...         input_domain=dp.atom_domain(T=int),
+        ...         input_metric=dp.absolute_distance(T=int),
+        ...         output_measure=dp.max_divergence(),
+        ...         function=lambda _: constant,
+        ...         privacy_map=lambda _: 0.0,
+        ...     )
+        ...
+        >>> dp.register(make_int_constant)
+        ...
+        >>> context = dp.Context.compositor(
+        ...     data=[1, 2, 3],
+        ...     privacy_unit=dp.unit_of(contributions=36),
+        ...     privacy_loss=dp.loss_of(epsilon=1.0),
+        ...     split_evenly_over=2,
+        ... )
+        >>> context.query().clamp((0, 5)).sum().int_constant("denied").release()
+        'denied'
+
+A drawback of this approach is that the constructor function is not very flexible.
+The input domain and metric are hard-coded, only accepting integers, 
+and can't take into account the output domain and output metric of the previous transformation.
+
+If the first two arguments to the constructor function are the ``input_domain`` and ``input_metric``,
+then they can be omitted when you call the function from the context API, and will be passed up from the previous transformation.
+
+.. tab-set::
+
+  .. tab-item:: Python
+
+    .. code:: python
+
+        >>> def make_anything_constant(input_domain, input_metric, constant):
+        ...     return dp.m.make_user_measurement(
+        ...         input_domain=input_domain,
+        ...         input_metric=input_metric,
+        ...         output_measure=dp.max_divergence(),
+        ...         function=lambda _: constant,
+        ...         privacy_map=lambda _: 0.0,
+        ...     )
+        ...
+        >>> dp.register(make_anything_constant)
+        >>> context.query().anything_constant("denied").release()
+        'denied'
+
+This modified constructor function doesn't care what the input domain and metric are,
+and will happily build a measurement that will always conform with the previous transformation.
+In practice, the constructor function usually contains checks to ensure that the input domain and metric are meaningful for your function.
+
+Constructors in the OpenDP Library almost always accept the input domain and metric as the first two arguments,
+and we recommend it when building your own plugins.

--- a/docs/source/api/user-guide/plugins/context-api-plugins.rst
+++ b/docs/source/api/user-guide/plugins/context-api-plugins.rst
@@ -2,9 +2,47 @@ Context API Plugins
 ===================
 
 Constructor functions built from plugins can be registered in the Context API.
+This follows up on the :ref:`measurement-plugin` example,
+where we built a measurement that always returns a constant value.
 
-We'll start by briefly copying over the constructor from the :ref:`measurement-plugin` and registering it.
-The constructor function may now be called from the Context API.
+Constructors in the OpenDP Library almost always accept the input domain and metric as the first two arguments,
+and we recommend it when building your own plugins.
+When the first two arguments of the constructor function are the ``input_domain`` and ``input_metric``,
+then they can be omitted when you call the function from the Context API. 
+The Context API will fill them in from the compositor's input space or from the output space of the previous transformation.
+
+.. tab-set::
+
+  .. tab-item:: Python
+
+    .. code:: python
+
+        >>> def make_anything_constant(input_domain, input_metric, constant):
+        ...     return dp.m.make_user_measurement(
+        ...         input_domain=input_domain,
+        ...         input_metric=input_metric,
+        ...         output_measure=dp.max_divergence(),
+        ...         function=lambda _: constant,
+        ...         privacy_map=lambda _: 0.0,
+        ...     )
+        ...
+        >>> dp.register(make_anything_constant)
+        ...
+        >>> context = dp.Context.compositor(
+        ...     data=[1, 2, 3],
+        ...     privacy_unit=dp.unit_of(contributions=36),
+        ...     privacy_loss=dp.loss_of(epsilon=1.0),
+        ...     split_evenly_over=2,
+        ... )
+        >>> context.query().anything_constant("denied").release()
+        'denied'
+
+This plugin constructor doesn't care what the input domain and input metric are,
+and will happily build a measurement that always conforms with the previous transformation.
+In practice, the constructor should contain checks to ensure that the input domain and input metric are meaningful for your function.
+
+While we recommend writing constructors in this convention, 
+you can still register functions that don't follow this convention.
 
 .. tab-set::
 
@@ -23,44 +61,9 @@ The constructor function may now be called from the Context API.
         ...
         >>> dp.register(make_int_constant)
         ...
-        >>> context = dp.Context.compositor(
-        ...     data=[1, 2, 3],
-        ...     privacy_unit=dp.unit_of(contributions=36),
-        ...     privacy_loss=dp.loss_of(epsilon=1.0),
-        ...     split_evenly_over=2,
-        ... )
         >>> context.query().clamp((0, 5)).sum().int_constant("denied").release()
         'denied'
 
 A drawback of this approach is that the constructor function is not very flexible.
 The input domain and metric are hard-coded, only accepting integers, 
 and can't take into account the output domain and output metric of the previous transformation.
-
-If the first two arguments to the constructor function are the ``input_domain`` and ``input_metric``,
-then they can be omitted when you call the function from the context API, and will be passed up from the previous transformation.
-
-.. tab-set::
-
-  .. tab-item:: Python
-
-    .. code:: python
-
-        >>> def make_anything_constant(input_domain, input_metric, constant):
-        ...     return dp.m.make_user_measurement(
-        ...         input_domain=input_domain,
-        ...         input_metric=input_metric,
-        ...         output_measure=dp.max_divergence(),
-        ...         function=lambda _: constant,
-        ...         privacy_map=lambda _: 0.0,
-        ...     )
-        ...
-        >>> dp.register(make_anything_constant)
-        >>> context.query().anything_constant("denied").release()
-        'denied'
-
-This modified constructor function doesn't care what the input domain and metric are,
-and will happily build a measurement that will always conform with the previous transformation.
-In practice, the constructor function usually contains checks to ensure that the input domain and metric are meaningful for your function.
-
-Constructors in the OpenDP Library almost always accept the input domain and metric as the first two arguments,
-and we recommend it when building your own plugins.

--- a/docs/source/api/user-guide/plugins/index.rst
+++ b/docs/source/api/user-guide/plugins/index.rst
@@ -5,16 +5,16 @@ Because Differential Privacy is a wide and expanding field,
 we can't implement every mechanism for every user,
 but users can provide their own code through these methods:
 
-Domains
-    :py:func:`user_domain <opendp.domains.user_domain>`
 Measurements
-    :py:func:`make_user_measurement <opendp.measurements.make_user_measurement>` and :py:func:`then_user_measurement <opendp.measurements.then_user_measurement>`
-Measures
-    :py:func:`user_divergence <opendp.measures.user_divergence>`
-Metrics
-    :py:func:`user_distance <opendp.metrics.user_distance>`
+    :py:func:`make_user_measurement <opendp.measurements.make_user_measurement>`
 Transformations
     :py:func:`make_user_transformation <opendp.transformations.make_user_transformation>`
+Domains
+    :py:func:`user_domain <opendp.domains.user_domain>`
+Metrics
+    :py:func:`user_distance <opendp.metrics.user_distance>`
+Measures
+    :py:func:`user_divergence <opendp.measures.user_divergence>`
 Postprocessors
     :py:func:`new_function <opendp.core.new_function>`
 Privacy Profiles
@@ -36,3 +36,4 @@ Examples
   measurement
   transformation
   selecting-grouping-columns
+  context-api-plugins

--- a/docs/source/api/user-guide/plugins/measurement.rst
+++ b/docs/source/api/user-guide/plugins/measurement.rst
@@ -1,3 +1,5 @@
+.. _measurement-plugin:
+
 Measurement example
 ===================
 

--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -102,21 +102,22 @@ def register(
     then the input domain and input metric are omitted when called via the Context API.
 
     Constructor requirements:
-    - The constructor must return a transformation or measurement.
-    - If name is None, the constructor's name must start with ``make_``.
+    
+    * The constructor must return a transformation or measurement.
+    * If name is None, the constructor's name must start with ``make_``.
 
     :param constructor: The constructor function to register.
     :param name: The name to register the constructor under in the Context API. If None, the name will be derived from the constructor's name.
     """
     if name is None:
         if not constructor.__name__.startswith("make_"):
-            raise ValueError(  # pragma: no cover
+            raise ValueError(
                 f"constructor.__name__ must start with 'make_', found {constructor.__name__}"
             )
         name = constructor.__name__[5:]
 
     if name in constructors:
-        raise ValueError(  # pragma: no cover
+        raise ValueError(
             f"'{name}' is already registered in the Context API. Please choose a different name."
         )
 

--- a/python/src/opendp/extras/_utilities.py
+++ b/python/src/opendp/extras/_utilities.py
@@ -1,10 +1,23 @@
 from typing import Callable, Union
 from opendp.mod import Domain, Metric, _PartialConstructor, Measurement, Transformation
+import inspect
+
+
+def supports_partial(constructor: Callable[..., Union[Transformation, Measurement]]) -> bool:
+    """Check if the constructor can be written as a then_ (partial application) function.
+
+    This is true if the first two arguments are input_domain and input_metric.
+    """
+    arg_names = inspect.getfullargspec(constructor)[0]
+    return len(arg_names) > 1 and arg_names[:2] == ["input_domain", "input_metric"]
 
 
 def to_then(constructor) -> Callable[..., _PartialConstructor]:
     """Convert any `make_` constructor to a `then_` constructor"""
 
+    if not supports_partial(constructor):  # pragma: no cover
+        raise ValueError("the first two arguments of the constructor must be input_domain and input_metric")
+    
     def then_func(*args, **kwargs):
         return _PartialConstructor(
             lambda input_domain, input_metric: constructor(
@@ -13,44 +26,15 @@ def to_then(constructor) -> Callable[..., _PartialConstructor]:
         )
 
     then_func.__name__ = constructor.__name__.replace("make_", "then_", 1)
-    then_func.__doc__ = f"partial constructor of {constructor.__name__}"
+    then_func.__doc__ = f"""{constructor.__doc__}
+
+    Fixes the ``input_domain`` and ``input_metric`` of: ``{constructor.__name__}``"""
+
+    # preserve the signature, except for the first two parameters
+    original_sig = inspect.signature(constructor)
+    new_params = list(original_sig.parameters.values())[2:]
+    then_func.__signature__ = original_sig.replace(parameters=new_params) # type: ignore[attr-defined]
     return then_func
-
-
-def _register(module_name, constructor) -> Callable[..., _PartialConstructor]:  # type: ignore[return]
-    import importlib
-    import inspect
-
-    module = importlib.import_module(f"opendp.{module_name}")
-    setattr(module, constructor.__name__, constructor)
-    arg_names = inspect.getfullargspec(constructor)[0]
-
-    if len(arg_names) >= 2 and arg_names[:2] == ["input_domain", "input_metric"]:
-        then_const = to_then(constructor)
-        then_const.__doc__ = f"""{then_const.__doc__}
-
-        Fixes the `input_domain` and `input_metric` of:
-        :py:func:`opendp.{module_name}.{constructor.__name__}`"""
-        setattr(module, then_const.__name__, then_const)
-        return then_const
-
-
-def register_transformation(
-    constructor: Callable[..., Transformation]
-) -> Callable[..., _PartialConstructor]:
-    return _register("transformations", constructor)
-
-
-def register_measurement(
-    constructor: Callable[..., Measurement]
-) -> Callable[..., _PartialConstructor]:
-    return _register("measurements", constructor)
-
-
-def register_combinator(
-    constructor: Callable[..., Union[Transformation, Measurement]],
-) -> Callable[..., _PartialConstructor]:
-    return _register("combinators", constructor)  # pragma: no cover
 
 
 def with_privacy(

--- a/python/src/opendp/extras/numpy/_make_np_clamp/__init__.py
+++ b/python/src/opendp/extras/numpy/_make_np_clamp/__init__.py
@@ -1,5 +1,6 @@
+from opendp.extras._utilities import to_then
 from opendp.mod import Domain, Metric, Transformation
-from opendp.extras._utilities import register_transformation
+from opendp.context import register
 from opendp._lib import import_optional_dependency
 from opendp._internal import _make_transformation
 
@@ -77,4 +78,5 @@ def make_np_clamp(
 
 # generate then variant of the constructor
 # TODO: Show this in the API Reference?
-then_np_clamp = register_transformation(make_np_clamp)
+register(make_np_clamp)
+then_np_clamp = to_then(make_np_clamp)

--- a/python/src/opendp/extras/sklearn/_make_eigendecomposition/__init__.py
+++ b/python/src/opendp/extras/sklearn/_make_eigendecomposition/__init__.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 from typing import Sequence
 
-from opendp.extras._utilities import register_measurement
+from opendp.context import register
 from opendp.extras.sklearn._make_eigenvector import then_private_eigenvectors
 from opendp.extras.sklearn._make_eigenvalues import then_eigenvalues
 from opendp.extras.numpy._make_np_sscp import make_np_sscp
 
+from opendp.extras._utilities import to_then
 from opendp.mod import Domain, Metric, Measurement
 
 
@@ -64,6 +65,5 @@ def make_private_np_eigendecomposition(
 
 
 # generate then variant of the constructor
-then_private_np_eigendecomposition = register_measurement(
-    make_private_np_eigendecomposition
-)
+then_private_np_eigendecomposition = to_then(make_private_np_eigendecomposition)
+register(make_private_np_eigendecomposition)

--- a/python/src/opendp/extras/sklearn/decomposition/__init__.py
+++ b/python/src/opendp/extras/sklearn/decomposition/__init__.py
@@ -16,7 +16,8 @@ See also our :ref:`tutorial on diffentially private PCA <dp-pca>`.
 from __future__ import annotations
 from typing import NamedTuple, Optional, TYPE_CHECKING, Sequence
 from opendp.extras.numpy import then_np_clamp
-from opendp.extras._utilities import register_measurement, to_then
+from opendp.context import register
+from opendp.extras._utilities import to_then
 from opendp.extras.numpy._make_np_mean import make_private_np_mean
 from opendp.extras.sklearn._make_eigendecomposition import then_private_np_eigendecomposition
 from opendp.mod import Domain, Measurement, Metric
@@ -152,7 +153,8 @@ def make_private_pca(
 
 
 # generate then variant of the constructor
-then_private_pca = register_measurement(make_private_pca)
+then_private_pca = to_then(make_private_pca)
+register(make_private_pca)
 
 
 class PCA():

--- a/python/test/context/test_context.py
+++ b/python/test/context/test_context.py
@@ -351,3 +351,10 @@ def test_register():
         split_evenly_over=1
     )
     assert context.query().constant("z").release() == "z"
+
+def test_register_fail():
+    with pytest.raises(ValueError, match="must start with 'make_',"):
+        dp.register(lambda: 0) # type: ignore[arg-type, return-value]
+
+    with pytest.raises(ValueError, match="is already registered in the Context API"):
+        dp.register(dp.t.make_sum)

--- a/python/test/context/test_context.py
+++ b/python/test/context/test_context.py
@@ -329,3 +329,25 @@ def test_transformation_release_error():
     clamped = context.query().impute_constant(0.0)
     with pytest.raises(ValueError, match=r"Query is not yet a measurement"):
         clamped.release()
+
+
+def test_register():
+
+    def make_constant(input_domain, input_metric, constant):
+        return _make_measurement(
+            input_domain,
+            input_metric,
+            dp.max_divergence(),
+            lambda _: constant,
+            lambda _: 0.,
+        )
+    
+    dp.register(make_constant)
+    # now call the constructor through the context API
+    context = dp.Context.compositor(
+        data=[1, 2, 3],
+        privacy_unit=dp.unit_of(contributions=1),
+        privacy_loss=dp.loss_of(epsilon=1.0),
+        split_evenly_over=1
+    )
+    assert context.query().constant("z").release() == "z"


### PR DESCRIPTION
#1382 was not resolved
closes #2338 

This PR also stops registering constructors in the generated modules, opting instead to register them in the context API.