### PR TITLE
feat: radius parameter on additive noise mechanisms

### DIFF
--- a/python/test/test_meas.py
+++ b/python/test/test_meas.py
@@ -67,6 +67,11 @@ def test_vector_laplace():
     print("base laplace:", meas([80., 90., 100.]))
     assert meas.check(1., 1.3)
 
+def test_laplace_radius():
+    input_space = dp.atom_domain(T=float, nan=False), dp.absolute_distance(T=float)
+    meas = dp.m.make_laplace(*input_space, 10.5, radius=10.0)
+    print("base laplace:", meas(100.))
+    print("epsilon, delta", meas.map(1.))
 
 def test_gaussian_smoothed_max_divergence():
     input_space = dp.atom_domain(T=float, nan=False), dp.absolute_distance(T=float)
@@ -97,6 +102,13 @@ def test_vector_gaussian():
     print("base gaussian:", meas([80., 90., 100.]))
     assert meas.check(1., (0.6, delta))
 
+def test_gaussian_radius():
+    input_space = dp.atom_domain(T=float, nan=False), dp.absolute_distance(T=float)
+    meas = input_space >> dp.m.then_gaussian(scale=1.5, radius=10.0)
+    print("base gaussian:", meas(100.))
+
+    rho, delta = meas.map(d_in=1.)
+    print("rho, delta:", rho, delta)
 
 def test_geometric():
     input_space = dp.atom_domain(T=int), dp.absolute_distance(T=int)

--- a/rust/src/accuracy/tail_bounds/mod.rs
+++ b/rust/src/accuracy/tail_bounds/mod.rs
@@ -1,10 +1,12 @@
-use dashu::{integer::UBig, rational::RBig};
+use dashu::{base::Inverse, integer::UBig, rational::RBig};
 use num::Zero;
 use statrs::function::erf::erfc;
 
+use dashu::integer::IBig;
+
 use crate::{
     error::Fallible,
-    traits::{InfAdd, InfCast, InfDiv, InfExp, NextFloat},
+    traits::{InfAdd, InfCast, InfDiv, InfExp, InfMul, InfPowI, InfSqrt, NextFloat},
 };
 
 #[cfg(all(test, feature = "contrib"))]
@@ -42,7 +44,7 @@ pub fn conservative_continuous_laplacian_tail_to_alpha(scale: RBig, tail: RBig) 
 /// $\mathcal{L}_\mathbb{Z}(0, scale)$ is distributed as follows:
 /// ```math
 /// \forall x \in \mathbb{Z}, \quad  
-/// P[X = x] = \frac{e^{-1/scale} - 1}{e^{-1/scale} + 1} e^{-|x|/scale}, \quad
+/// P[X = x] = \frac{1 - e^{-1/scale}}{1 + e^{-1/scale}} e^{-|x|/scale}, \quad
 /// \text{where } X \sim \mathcal{L}_\mathbb{Z}(0, scale)
 /// ```
 pub fn conservative_discrete_laplacian_tail_to_alpha(scale: RBig, tail: UBig) -> Fallible<f64> {
@@ -51,6 +53,30 @@ pub fn conservative_discrete_laplacian_tail_to_alpha(scale: RBig, tail: UBig) ->
         .neg_inf_exp()?
         .neg_inf_add(&1.)?;
     numer.inf_div(&denom)
+}
+
+/// Computes the probability of sampling a value greater than `t` from the discrete laplace distribution.
+///
+/// Arithmetic is controlled such that the resulting probability can only ever be slightly under-estimated due to numerical inaccuracy.
+///
+/// # Proof definition
+/// Returns `Ok(out)`, where `out` does not overestimate $\Pr[X > t]$
+/// for $X \sim \mathcal{L}_\mathbb{Z}(0, scale)$, assuming $t > 0$,
+/// or `Err(e)` if any numerical computation overflows.
+///
+/// $\mathcal{L}_\mathbb{Z}(0, scale)$ is distributed as follows:
+/// ```math
+/// \forall x \in \mathbb{Z}, \quad  
+/// P[X = x] = \frac{1 - e^{-1/scale}}{1 + e^{-1/scale}} e^{-|x|/scale}, \quad
+/// \text{where } X \sim \mathcal{L}_\mathbb{Z}(0, scale)
+/// ```
+pub fn conservative_discrete_laplacian_tail_to_alpha_lower(
+    scale: RBig,
+    tail: UBig,
+) -> Fallible<f64> {
+    let numer = f64::neg_inf_cast(-RBig::from(tail) / scale.clone())?.neg_inf_exp()?;
+    let denom = f64::inf_cast(RBig::ONE / scale)?.inf_exp()?.inf_add(&1.)?;
+    numer.neg_inf_div(&denom)
 }
 
 /// Computes the probability of sampling a value greater than `t` from the discrete gaussian distribution.
@@ -75,6 +101,102 @@ pub fn conservative_discrete_gaussian_tail_to_alpha(scale: RBig, tail: UBig) -> 
     // where tail = m - 1
     conservative_continuous_gaussian_tail_to_alpha(scale, RBig::from(tail))
 }
+
+/// Computes the probability of sampling a value greater than `t` from the discrete gaussian distribution.
+///
+/// Arithmetic is controlled such that the resulting probability can only ever be under-estimated due to numerical inaccuracy.
+///
+/// # Citations
+/// * Fact 20, Proposition 25: [CKS20 The Discrete Gaussian for Differential Privacy](https://arxiv.org/pdf/2004.00010.pdf)
+///
+/// # Proof definition
+/// Returns `Ok(out)`, where `out` does not overestimate $\Pr[X > t]$
+/// for $X \sim \mathcal{N}_\mathbb{Z}(0, scale)$, assuming $t > 0$,
+/// or `Err(e)` if any numerical computation overflows.
+///
+/// $\mathcal{N}_\mathbb{Z}(0, scale)$ is distributed as follows:
+/// ```math
+/// \forall x \in \mathbb{Z}, \quad  
+/// P[X = x] = \frac{e^{-\frac{x^2}{2\sigma^2}}}{\sum_{y\in\mathbb{Z}}e^{-\frac{y^2}{2\sigma^2}}}, \quad
+/// \text{where } X \sim \mathcal{N}_\mathbb{Z}(0, \sigma^2)
+/// ```
+pub fn conservative_discrete_gaussian_tail_to_alpha_lower(
+    scale: RBig,
+    tail: UBig,
+) -> Fallible<f64> {
+    // where tail = m - 1
+
+    let pi = std::f64::consts::PI;
+    let frac_1_pi = std::f64::consts::FRAC_1_PI;
+
+    let twice_scale2 = RBig::from(2) * scale.clone().pow(2);
+
+    let exp_minus_2pi2_scale2_upper = pi
+        .neg_inf_powi(IBig::from(2))?
+        .inf_mul(&f64::inf_cast(-twice_scale2.clone())?)?
+        .inf_exp()?;
+
+    let exp_minus_inverse_twice_scale2_upper = f64::inf_cast(-twice_scale2.inv())?.inf_exp()?;
+
+    let inv_scale_sqrt_tau = frac_1_pi
+        .inf_div(&f64::inf_cast(2)?)?
+        .inf_sqrt()?
+        .inf_mul(&f64::inf_cast(scale.clone().inv())?)?;
+
+    // Compute expressions of which the minimum will be the denominator
+    let denominator_a = exp_minus_2pi2_scale2_upper
+        .inf_mul(&2.0)?
+        .inf_add(&1.0)?
+        .inf_add(&exp_minus_2pi2_scale2_upper.inf_mul(&inv_scale_sqrt_tau)?)?;
+
+    let denominator_b = exp_minus_inverse_twice_scale2_upper
+        .inf_mul(&2.0)?
+        .inf_add(&1.0)?
+        .inf_mul(&inv_scale_sqrt_tau)?
+        .inf_add(&exp_minus_inverse_twice_scale2_upper)?;
+
+    let denominator_min = denominator_a.min(denominator_b);
+
+    // compute tail bound
+    let continuous_tail_bound = conservative_continuous_gaussian_tail_to_alpha_lower(
+        scale,
+        RBig::from(tail + UBig::from(1u8)),
+    )?;
+    continuous_tail_bound.neg_inf_div(&denominator_min)
+}
+
+// pub fn conservative_discrete_gaussian_tail_to_alpha_lower(scale: f64, tail: u32) -> Fallible<f64> {
+//     // where tail = m - 1
+//
+//     let pi = std::f64::consts::PI;
+//     let tau = std::f64::consts::TAU;
+//
+//     // require scale >= 1/sqrt(2*pi), since this is a requirement of Proposition 25 cited above
+//     let scale_squared = scale.neg_inf_powi(IBig::from(2))?;
+//     let tau_inverse = 1.0.neg_inf_div(&tau)?;
+//     let difference = scale_squared.neg_inf_sub(&tau_inverse)?;
+//
+//     if difference < 0.0 {
+//         return Err(err!(
+//             FailedFunction,
+//             format!("scale must be at least 1/sqrt(2*pi), got {}", scale)
+//         ));
+//     }
+//
+//     // compute tail bound
+//     let t = pi.neg_inf_mul(&scale)?;
+//     let t = t.neg_inf_powi(IBig::from(2))?;
+//     let t = t.inf_mul(&-2.0)?;
+//     let t = t.inf_exp()?;
+//     let t = t.inf_mul(&3.0)?;
+//     let denominator = t.inf_add(&1.0)?;
+//     let tail_plus_one = tail.inf_add(&1)?;
+//     let tail_bound = conservative_continuous_gaussian_tail_to_alpha_lower(
+//         scale,
+//         f64::neg_inf_cast(tail_plus_one)?,
+//     )?;
+//     tail_bound.neg_inf_div(&denominator)
+// }
 
 /// Computes the probability of sampling a value greater than or equal to `t` from the continuous gaussian distribution.
 ///
@@ -110,6 +232,36 @@ pub fn conservative_continuous_gaussian_tail_to_alpha(scale: RBig, tail: RBig) -
     //     .neg_inf_div(&2.0)?
     //     .neg()
     //     .inf_exp()
+}
+
+/// Computes the probability of sampling a value greater than or equal to `t` from the continuous gaussian distribution.
+///
+/// Arithmetic is controlled such that the resulting probability can only ever be slightly under-estimated due to numerical inaccuracy.
+///
+/// # Proof definition
+/// Returns `Ok(out)`, where `out` does not underestimate $\Pr[X > t]$
+/// for $X \sim \mathcal{N}(0, scale)$, assuming $t > 0$,
+/// or `Err(e)` if any numerical computation overflows.
+///
+/// X is distributed $\mathcal{N}(0, scale)$ with probability density:
+/// ```math
+/// f(x) = \frac{1}{\sigma \sqrt{2 \pi}} e^{-\frac{1}{2}\left( \frac{x - \mu}{\sigma}\right)^2}
+/// ```
+pub fn conservative_continuous_gaussian_tail_to_alpha_lower(
+    scale: RBig,
+    tail: RBig,
+) -> Fallible<f64> {
+    // the SQRT_2 constant is already rounded down
+    let sqrt_2_ceil: f64 = std::f64::consts::SQRT_2.next_down_();
+
+    // tail and scale division should be big rationals for precision and to avoid overflow
+    let t = f64::inf_cast(tail / scale)?.inf_div(&sqrt_2_ceil)?;
+    // round down to nearest smaller f32
+    let t = f32::inf_cast(t)? as f64;
+    // erfc error is at most 1 f32 ulp (see erfc_err_analysis.py)
+    let t = f32::neg_inf_cast(erfc(t))?.next_down_();
+
+    (t as f64).neg_inf_div(&2.0)
 }
 
 pub(super) fn dg_pdf(x: i32, scale: f64) -> f64 {

--- a/rust/src/accuracy/tail_bounds/test.rs
+++ b/rust/src/accuracy/tail_bounds/test.rs
@@ -25,6 +25,7 @@ fn test_laplace_tail(tail: UBig, theoretical_alpha: f64, label: &str) -> Fallibl
         Default::default(),
         scale,
         None,
+        None,
     )?;
     let n = 50_000;
     let empirical_alpha = (0..n)

--- a/rust/src/accuracy/test.rs
+++ b/rust/src/accuracy/test.rs
@@ -223,7 +223,7 @@ pub fn test_empirical_laplace_accuracy() -> Fallible<()> {
     let input_domain = AtomDomain::<f64>::new_non_nan();
     let input_metric = AbsoluteDistance::<i32>::default();
     let laplace =
-        make_laplace::<_, _, MaxDivergence>(input_domain, input_metric, scale, Some(-100))?;
+        make_laplace::<_, _, MaxDivergence>(input_domain, input_metric, scale, None, Some(-100))?;
     let n = 50_000;
     let empirical_alpha = (0..n)
         .filter(|_| laplace.invoke(&0.0).unwrap().abs() > accuracy)
@@ -247,6 +247,7 @@ pub fn test_empirical_gaussian_accuracy() -> Fallible<()> {
         AtomDomain::<f64>::new_non_nan(),
         AbsoluteDistance::<u32>::default(),
         scale,
+        None,
         Some(-100),
     )?;
     let n = 50_000;
@@ -271,7 +272,8 @@ pub fn test_empirical_discrete_laplace_accuracy() -> Fallible<()> {
     println!("scale: {scale}");
     let input_domain = AtomDomain::<i32>::default();
     let input_metric = AbsoluteDistance::<i32>::default();
-    let base_dl = make_laplace::<_, _, MaxDivergence>(input_domain, input_metric, scale, None)?;
+    let base_dl =
+        make_laplace::<_, _, MaxDivergence>(input_domain, input_metric, scale, None, None)?;
     let n = 50_000;
     let empirical_alpha = (0..n)
         .filter(|_| base_dl.invoke(&0).unwrap().clamp(-127, 127).abs() >= accuracy)
@@ -298,6 +300,7 @@ pub fn test_empirical_discrete_gaussian_accuracy() -> Fallible<()> {
         AtomDomain::<i8>::default(),
         AbsoluteDistance::<i32>::default(),
         scale,
+        None,
         None,
     )?;
     let n = 50_000;

--- a/rust/src/combinators/amplify/test.rs
+++ b/rust/src/combinators/amplify/test.rs
@@ -2,6 +2,7 @@ use crate::combinators::make_population_amplification;
 use crate::domains::{AtomDomain, VectorDomain};
 use crate::error::Fallible;
 use crate::measurements::then_laplace;
+use crate::measures::MaxDivergence;
 use crate::metrics::SymmetricDistance;
 use crate::transformations::make_mean;
 
@@ -10,7 +11,7 @@ fn test_amplifier() -> Fallible<()> {
     let meas = (make_mean(
         VectorDomain::new(AtomDomain::new_closed((0., 10.))?).with_size(10),
         SymmetricDistance,
-    ) >> then_laplace(0.5, None))?;
+    ) >> then_laplace::<_, _, MaxDivergence>(0.5, None, None))?;
     let amp = make_population_amplification(&meas, 100)?;
     amp.function.eval(&vec![1.; 10])?;
     assert!(meas.check(&2, &(2. + 1e-6))?);

--- a/rust/src/combinators/chain/shr/partials.rs
+++ b/rust/src/combinators/chain/shr/partials.rs
@@ -277,6 +277,7 @@ where
 mod tests_shr {
     use crate::{
         measurements::then_laplace,
+        measures::MaxDivergence,
         transformations::{make_split_lines, then_cast_default, then_clamp, then_sum},
     };
 
@@ -288,7 +289,7 @@ mod tests_shr {
             >> then_cast_default()
             >> then_clamp((0, 1))
             >> then_sum()
-            >> then_laplace(1., None))
+            >> then_laplace::<_, _, MaxDivergence>(1., None, None))
         .map(|_| ())
     }
 }

--- a/rust/src/combinators/measure_cast/zCDP_to_approxDP/test.rs
+++ b/rust/src/combinators/measure_cast/zCDP_to_approxDP/test.rs
@@ -11,10 +11,11 @@ use super::*;
 fn test_zCDP_to_approxDP_nontrivial() -> Fallible<()> {
     let d_in = 1.0;
     let scale = 4.0;
-    let profile = make_zCDP_to_approxDP(make_gaussian(
+    let profile = make_zCDP_to_approxDP(make_gaussian::<_, _, ZeroConcentratedDivergence>(
         AtomDomain::<f64>::new_non_nan(),
         AbsoluteDistance::<f64>::default(),
         scale,
+        None,
         None,
     )?)?
     .map(&d_in)?;
@@ -42,6 +43,7 @@ fn test_zCDP_to_approxDP_insensitive() -> Fallible<()> {
         AbsoluteDistance::<f64>::default(),
         4.,
         None,
+        None,
     )?)?
     .map(&0.0)?;
 
@@ -54,10 +56,11 @@ fn test_zCDP_to_approxDP_insensitive() -> Fallible<()> {
 
 #[test]
 fn test_zCDP_to_approxDP_nonprivate() -> Fallible<()> {
-    let profile = make_zCDP_to_approxDP(make_gaussian(
+    let profile = make_zCDP_to_approxDP(make_gaussian::<_, _, ZeroConcentratedDivergence>(
         AtomDomain::<f64>::new_non_nan(),
         AbsoluteDistance::<f64>::default(),
         0.,
+        None,
         None,
     )?)?
     .map(&1.0)?;
@@ -76,6 +79,7 @@ fn test_zCDP_to_approxDP_insensitive_nonprivate() -> Fallible<()> {
         AbsoluteDistance::<f64>::default(),
         0.,
         None,
+        None,
     )?)?
     .map(&0.0)?;
 
@@ -92,6 +96,7 @@ fn test_approx_zCDP_to_approx_approxDP() -> Fallible<()> {
         AtomDomain::<f64>::new_non_nan(),
         AbsoluteDistance::<f64>::default(),
         1.,
+        None,
         None,
     )?;
 

--- a/rust/src/combinators/sequential_compositor/noninteractive/test.rs
+++ b/rust/src/combinators/sequential_compositor/noninteractive/test.rs
@@ -34,7 +34,8 @@ fn test_make_basic_composition() -> Fallible<()> {
 fn test_make_basic_composition_2() -> Fallible<()> {
     let input_domain = AtomDomain::<f64>::new_non_nan();
     let input_metric = AbsoluteDistance::default();
-    let laplace = make_laplace::<_, _, MaxDivergence>(input_domain, input_metric, 1.0f64, None)?;
+    let laplace =
+        make_laplace::<_, _, MaxDivergence>(input_domain, input_metric, 1.0f64, None, None)?;
     let measurements = vec![laplace; 2];
     let composition = make_basic_composition(measurements)?;
     let arg = 99.;

--- a/rust/src/domains/poly.rs
+++ b/rust/src/domains/poly.rs
@@ -70,6 +70,7 @@ mod tests {
             input_metric,
             0.0,
             None,
+            None,
         )?;
         let arg = 100.;
         let res_plain = op_plain.invoke(&arg)?;

--- a/rust/src/ffi/any.rs
+++ b/rust/src/ffi/any.rs
@@ -729,10 +729,11 @@ mod tests {
             .into_any();
         let t5 = transformations::then_clamp::<_, SymmetricDistance>((0.0, 10.0)).into_any();
         let t6 = transformations::then_sum::<SymmetricDistance, f64>().into_any();
-        let m1 = measurements::make_laplace(
+        let m1 = measurements::make_laplace::<_, _, MaxDivergence>(
             AtomDomain::<f64>::new_non_nan(),
             AbsoluteDistance::<f64>::default(),
             0.0,
+            None,
             None,
         )?
         .into_any();

--- a/rust/src/measurements/noise/distribution/gaussian/ffi.rs
+++ b/rust/src/measurements/noise/distribution/gaussian/ffi.rs
@@ -1,28 +1,27 @@
 use std::convert::TryFrom;
+use std::ffi::c_void;
 use std::os::raw::c_char;
 
-use crate::core::{
-    Domain, FfiResult, IntoAnyMeasurementFfiResultExt, Measure, Metric, MetricSpace,
-};
+use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt, Measure, Metric, MetricSpace};
 use crate::domains::{AtomDomain, VectorDomain};
 use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMeasurement, AnyMetric, Downcast};
 use crate::ffi::util::{Type, as_ref};
 use crate::measurements::noise::nature::Nature;
-use crate::measurements::{DiscreteGaussian, MakeNoise, make_gaussian};
-use crate::measures::ZeroConcentratedDivergence;
+use crate::measurements::{DiscreteGaussian, MakeNoise, NoiseDomain, make_gaussian};
+use crate::measures::{Approximate, ZeroConcentratedDivergence};
 use crate::metrics::{AbsoluteDistance, L2Distance};
 use crate::traits::Number;
 
-trait GaussianMetric<T> {
-    type Domain: Domain;
+trait GaussianDomain<Q>: NoiseDomain {
+    type Metric: Metric;
 }
 
-impl<T: Number, Q: Number> GaussianMetric<T> for AbsoluteDistance<Q> {
-    type Domain = AtomDomain<T>;
+impl<T: Number, Q: Number> GaussianDomain<Q> for AtomDomain<T> {
+    type Metric = AbsoluteDistance<Q>;
 }
-impl<T: Number, Q: Number> GaussianMetric<T> for L2Distance<Q> {
-    type Domain = VectorDomain<AtomDomain<T>>;
+impl<T: Number, Q: Number> GaussianDomain<Q> for VectorDomain<AtomDomain<T>> {
+    type Metric = L2Distance<Q>;
 }
 
 #[unsafe(no_mangle)]
@@ -30,6 +29,7 @@ pub extern "C" fn opendp_measurements__make_gaussian(
     input_domain: *const AnyDomain,
     input_metric: *const AnyMetric,
     scale: f64,
+    radius: *const c_void,
     k: *const i32,
     MO: *const c_char,
 ) -> FfiResult<*mut AnyMeasurement> {
@@ -37,6 +37,7 @@ pub extern "C" fn opendp_measurements__make_gaussian(
         input_domain: &AnyDomain,
         input_metric: &AnyMetric,
         scale: f64,
+        radius: *const c_void,
         k: Option<i32>,
         MO: Type,
     ) -> Fallible<AnyMeasurement>
@@ -44,28 +45,30 @@ pub extern "C" fn opendp_measurements__make_gaussian(
         T::RV<2>: MakeNoise<AtomDomain<T>, AbsoluteDistance<QI>, MO>
             + MakeNoise<VectorDomain<AtomDomain<T>>, L2Distance<QI>, MO>,
     {
-        fn monomorphize2<MI: 'static + Metric, MO: 'static + Measure, T: Number>(
+        fn monomorphize2<DI: 'static + GaussianDomain<QI>, MO: 'static + Measure, QI: Number>(
             input_domain: &AnyDomain,
             input_metric: &AnyMetric,
             scale: f64,
+            radius: Option<DI::Atom>,
             k: Option<i32>,
         ) -> Fallible<AnyMeasurement>
         where
-            MI: GaussianMetric<T>,
-            DiscreteGaussian: MakeNoise<MI::Domain, MI, MO>,
-            (MI::Domain, MI): MetricSpace,
+            DiscreteGaussian<DI::Atom>: MakeNoise<DI, DI::Metric, MO>,
+            (DI, DI::Metric): MetricSpace,
         {
-            let input_domain = input_domain.downcast_ref::<MI::Domain>()?.clone();
-            let input_metric = input_metric.downcast_ref::<MI>()?.clone();
-            make_gaussian::<MI::Domain, MI, MO>(input_domain, input_metric, scale, k).into_any()
+            let input_domain = input_domain.downcast_ref::<DI>()?.clone();
+            let input_metric = input_metric.downcast_ref::<DI::Metric>()?.clone();
+            make_gaussian::<DI, DI::Metric, MO>(input_domain, input_metric, scale, radius, k)
+                .into_any()
         }
-        let T_ = input_domain.type_.get_atom()?;
-        let MI = input_metric.type_.clone();
+        let radius = as_ref(radius as *const T).cloned();
+        let DI = input_domain.type_.clone();
+        let QI = input_metric.type_.get_atom()?;
         dispatch!(monomorphize2, [
-            (MI, [AbsoluteDistance<QI>, L2Distance<QI>]),
+            (DI, [AtomDomain<T>, VectorDomain<AtomDomain<T>>]),
             (MO, [MO]),
-            (T_, [T])
-        ], (input_domain, input_metric, scale, k))
+            (QI, [QI])
+        ], (input_domain, input_metric, scale, radius, k))
     }
 
     let input_domain = try_as_ref!(input_domain);
@@ -75,11 +78,20 @@ pub extern "C" fn opendp_measurements__make_gaussian(
     let QI_ = try_!(input_metric.type_.get_atom());
     let T_ = try_!(input_domain.type_.get_atom());
 
-    dispatch!(monomorphize, [
-        (MO, [ZeroConcentratedDivergence]),
-        (T_, @numbers),
-        (QI_, @numbers)
-    ], (input_domain, input_metric, scale, k, MO))
+    if radius.is_null() {
+        dispatch!(monomorphize, [
+            (MO, [ZeroConcentratedDivergence]),
+            (T_, @numbers),
+            (QI_, @numbers)
+        ], (input_domain, input_metric, scale, radius, k, MO))
+    } else {
+        let MO = Type::of::<Approximate<ZeroConcentratedDivergence>>();
+        dispatch!(monomorphize, [
+            (MO, [Approximate<ZeroConcentratedDivergence>]),
+            (T_, @numbers),
+            (QI_, @numbers)
+        ], (input_domain, input_metric, scale, radius, k, MO))
+    }
     .into()
 }
 
@@ -101,6 +113,7 @@ mod tests {
             util::into_raw(AnyDomain::new(AtomDomain::<i32>::default())),
             util::into_raw(AnyMetric::new(AbsoluteDistance::<i32>::default())),
             0.0,
+            null(),
             null(),
             "ZeroConcentratedDivergence".to_char_p(),
         ))?;

--- a/rust/src/measurements/noise/distribution/gaussian/mod.rs
+++ b/rust/src/measurements/noise/distribution/gaussian/mod.rs
@@ -1,13 +1,19 @@
-use dashu::{rational::RBig, rbig};
+use core::f64;
+
+use dashu::{integer::UBig, rational::RBig, rbig};
 use opendp_derive::{bootstrap, proven};
 
 use crate::{
-    core::{Domain, Measure, Measurement, Metric, MetricSpace, PrivacyMap},
+    accuracy::{
+        conservative_discrete_gaussian_tail_to_alpha,
+        conservative_discrete_gaussian_tail_to_alpha_lower,
+    },
+    core::{Measure, Measurement, Metric, MetricSpace, PrivacyMap},
     error::Fallible,
     measurements::{MakeNoise, NoiseDomain, NoisePrivacyMap, ZExpFamily, noise::nature::Nature},
-    measures::ZeroConcentratedDivergence,
+    measures::{Approximate, ZeroConcentratedDivergence},
     metrics::L2Distance,
-    traits::InfCast,
+    traits::{InfCast, InfSub},
 };
 
 #[cfg(test)]
@@ -18,8 +24,12 @@ mod ffi;
 
 #[bootstrap(
     features("contrib"),
-    arguments(k(default = b"null")),
-    generics(DI(suppress), MI(suppress), MO(default = "ZeroConcentratedDivergence"))
+    arguments(
+        radius(c_type = "void *", rust_type = "Option<T>", default = b"null"),
+        k(default = b"null")
+    ),
+    generics(DI(suppress), MI(suppress), MO(default = "ZeroConcentratedDivergence")),
+    derived_types(T = "$get_atom(get_carrier_type(input_domain))")
 )]
 /// Make a Measurement that adds noise from the Gaussian(`scale`) distribution to the input.
 ///
@@ -34,42 +44,46 @@ mod ffi;
 /// * `input_domain` - Domain of the data type to be privatized.
 /// * `input_metric` - Metric of the data type to be privatized.
 /// * `scale` - Noise scale parameter for the gaussian distribution. `scale` == standard_deviation.
+/// * `radius` - The radius of noise to be added. This is used to bound the tail of the distribution.
 /// * `k` - The noise granularity in terms of 2^k.
 ///
 /// # Generics
 /// * `DI` - Domain of the data to be privatized. Valid values are `VectorDomain<AtomDomain<T>>` or `AtomDomain<T>`.
 /// * `MI` - Input Metric to measure distances between members of the input domain.
 /// * `MO` - Output Measure. The only valid measure is `ZeroConcentratedDivergence`.
-pub fn make_gaussian<DI: Domain, MI: Metric, MO: Measure>(
+pub fn make_gaussian<DI: NoiseDomain, MI: Metric, MO: Measure>(
     input_domain: DI,
     input_metric: MI,
     scale: f64,
+    radius: Option<DI::Atom>,
     k: Option<i32>,
 ) -> Fallible<Measurement<DI, DI::Carrier, MI, MO>>
 where
-    DiscreteGaussian: MakeNoise<DI, MI, MO>,
+    DiscreteGaussian<DI::Atom>: MakeNoise<DI, MI, MO>,
     (DI, MI): MetricSpace,
 {
-    DiscreteGaussian { scale, k }.make_noise((input_domain, input_metric))
+    DiscreteGaussian { scale, k, radius }.make_noise((input_domain, input_metric))
 }
 
-pub struct DiscreteGaussian {
+pub struct DiscreteGaussian<T> {
     pub scale: f64,
     pub k: Option<i32>,
+    pub radius: Option<T>,
 }
 
 /// Gaussian mechanism
 #[proven(
     proof_path = "measurements/noise/distribution/gaussian/MakeNoise_for_DiscreteGaussian.tex"
 )]
-impl<DI: NoiseDomain, MI: Metric, MO: 'static + Measure> MakeNoise<DI, MI, MO> for DiscreteGaussian
+impl<DI: NoiseDomain, MI: Metric, MO: 'static + Measure> MakeNoise<DI, MI, MO>
+    for DiscreteGaussian<DI::Atom>
 where
     (DI, MI): MetricSpace,
     DI::Atom: Nature,
     <DI::Atom as Nature>::RV<2>: MakeNoise<DI, MI, MO>,
 {
     fn make_noise(self, input_space: (DI, MI)) -> Fallible<Measurement<DI, DI::Carrier, MI, MO>> {
-        DI::Atom::new_distribution(self.scale, self.k)?.make_noise(input_space)
+        DI::Atom::new_distribution(self.scale, self.k, self.radius)?.make_noise(input_space)
     }
 }
 
@@ -82,7 +96,14 @@ impl NoisePrivacyMap<L2Distance<RBig>, ZeroConcentratedDivergence> for ZExpFamil
         _input_metric: &L2Distance<RBig>,
         _outut_measure: &ZeroConcentratedDivergence,
     ) -> Fallible<PrivacyMap<L2Distance<RBig>, ZeroConcentratedDivergence>> {
-        let ZExpFamily { scale } = self.clone();
+        if let Some(ref radius) = self.radius {
+            return fallible!(
+                MakeMeasurement,
+                "radius ({}) introduces a delta parameter that is not compatible with zCDP",
+                radius
+            );
+        }
+        let scale = self.scale.clone();
         if scale < RBig::ZERO {
             return fallible!(MakeMeasurement, "scale ({scale}) must be non-negative");
         }
@@ -100,6 +121,62 @@ impl NoisePrivacyMap<L2Distance<RBig>, ZeroConcentratedDivergence> for ZExpFamil
             }
 
             f64::inf_cast((d_in / scale.clone()).pow(2) / rbig!(2))
+        }))
+    }
+}
+
+impl NoisePrivacyMap<L2Distance<RBig>, Approximate<ZeroConcentratedDivergence>> for ZExpFamily<2> {
+    fn noise_privacy_map(
+        &self,
+        _input_metric: &L2Distance<RBig>,
+        output_measure: &Approximate<ZeroConcentratedDivergence>,
+    ) -> Fallible<PrivacyMap<L2Distance<RBig>, Approximate<ZeroConcentratedDivergence>>> {
+        let distribution = ZExpFamily {
+            scale: self.scale.clone(),
+            radius: None,
+        };
+
+        let noise_privacy_map =
+            distribution.noise_privacy_map(&L2Distance::default(), &output_measure.0)?;
+
+        let scale = self.scale.clone();
+        if scale < RBig::ZERO {
+            return fallible!(MakeMeasurement, "scale ({}) must not be negative", scale);
+        }
+
+        let radius = self.radius.clone();
+        if radius == Some(UBig::ZERO) {
+            return fallible!(MakeMeasurement, "radius must not be non-zero");
+        }
+
+        Ok(PrivacyMap::new_fallible(move |d_in: &RBig| {
+            if d_in.is_zero() {
+                return Ok((0.0, 0.0));
+            }
+
+            if scale.clone().is_zero() {
+                return Ok((f64::INFINITY, 0.0));
+            }
+
+            let rho = noise_privacy_map.eval(d_in)?;
+
+            if let Some(r) = radius.clone() {
+                let (_, d_in_floor) = d_in.floor().into_parts();
+                if r <= d_in_floor {
+                    return Ok((0.0, 1.0));
+                } else {
+                    let large_tail_upper_bound = conservative_discrete_gaussian_tail_to_alpha(
+                        scale.clone(),
+                        r.clone() - d_in_floor,
+                    )?;
+                    let small_tail_upper_bound =
+                        conservative_discrete_gaussian_tail_to_alpha_lower(scale.clone(), r)?;
+                    let delta = large_tail_upper_bound.inf_sub(&small_tail_upper_bound)?;
+                    return Ok((rho, delta));
+                };
+            } else {
+                return Ok((rho, 0.0));
+            };
         }))
     }
 }

--- a/rust/src/measurements/noise/distribution/geometric/mod.rs
+++ b/rust/src/measurements/noise/distribution/geometric/mod.rs
@@ -52,7 +52,7 @@ pub fn make_geometric<DI: NoiseDomain, MI: Metric, MO: Measure>(
     bounds: Option<(DI::Atom, DI::Atom)>,
 ) -> Fallible<Measurement<DI, DI::Carrier, MI, MO>>
 where
-    DiscreteLaplace: MakeNoise<DI, MI, MO>,
+    DiscreteLaplace<DI::Atom>: MakeNoise<DI, MI, MO>,
     ConstantTimeGeometric<DI::Atom>: MakeNoise<DI, MI, MO>,
     (DI, MI): MetricSpace,
 {
@@ -60,7 +60,12 @@ where
     if let Some(bounds) = bounds {
         ConstantTimeGeometric { scale, bounds }.make_noise(input_space)
     } else {
-        DiscreteLaplace { scale, k: None }.make_noise(input_space)
+        DiscreteLaplace {
+            scale,
+            k: None,
+            radius: None,
+        }
+        .make_noise(input_space)
     }
 }
 
@@ -119,6 +124,7 @@ where
         let distribution = ZExpFamily {
             scale: RBig::from_f64(scale)
                 .ok_or_else(|| err!(MakeTransformation, "scale ({}) must be finite", scale))?,
+            radius: None,
         };
         let output_measure = MO::default();
 

--- a/rust/src/measurements/noise/distribution/laplace/ffi.rs
+++ b/rust/src/measurements/noise/distribution/laplace/ffi.rs
@@ -1,28 +1,27 @@
 use std::convert::TryFrom;
+use std::ffi::c_void;
 use std::os::raw::c_char;
 
-use crate::core::{
-    Domain, FfiResult, IntoAnyMeasurementFfiResultExt, Measure, Metric, MetricSpace,
-};
+use crate::core::{FfiResult, IntoAnyMeasurementFfiResultExt, Measure, Metric, MetricSpace};
 use crate::domains::{AtomDomain, VectorDomain};
 use crate::error::Fallible;
 use crate::ffi::any::{AnyDomain, AnyMeasurement, AnyMetric, Downcast};
 use crate::ffi::util::{Type, as_ref};
 use crate::measurements::noise::nature::Nature;
-use crate::measurements::{DiscreteLaplace, MakeNoise, make_laplace};
-use crate::measures::MaxDivergence;
+use crate::measurements::{DiscreteLaplace, MakeNoise, NoiseDomain, make_laplace};
+use crate::measures::{Approximate, MaxDivergence};
 use crate::metrics::{AbsoluteDistance, L1Distance};
 use crate::traits::Number;
 
-trait LaplaceMetric<T> {
-    type Domain: Domain;
+trait LaplaceDomain<Q>: NoiseDomain {
+    type Metric: Metric;
 }
 
-impl<T: Number, Q: Number> LaplaceMetric<T> for AbsoluteDistance<Q> {
-    type Domain = AtomDomain<T>;
+impl<T: Number, Q: Number> LaplaceDomain<Q> for AtomDomain<T> {
+    type Metric = AbsoluteDistance<Q>;
 }
-impl<T: Number, Q: Number> LaplaceMetric<T> for L1Distance<Q> {
-    type Domain = VectorDomain<AtomDomain<T>>;
+impl<T: Number, Q: Number> LaplaceDomain<Q> for VectorDomain<AtomDomain<T>> {
+    type Metric = L1Distance<Q>;
 }
 
 #[unsafe(no_mangle)]
@@ -30,6 +29,7 @@ pub extern "C" fn opendp_measurements__make_laplace(
     input_domain: *const AnyDomain,
     input_metric: *const AnyMetric,
     scale: f64,
+    radius: *const c_void,
     k: *const i32,
     MO: *const c_char,
 ) -> FfiResult<*mut AnyMeasurement> {
@@ -37,6 +37,7 @@ pub extern "C" fn opendp_measurements__make_laplace(
         input_domain: &AnyDomain,
         input_metric: &AnyMetric,
         scale: f64,
+        radius: *const c_void,
         k: Option<i32>,
         MO: Type,
     ) -> Fallible<AnyMeasurement>
@@ -44,28 +45,30 @@ pub extern "C" fn opendp_measurements__make_laplace(
         T::RV<1>: MakeNoise<AtomDomain<T>, AbsoluteDistance<QI>, MO>
             + MakeNoise<VectorDomain<AtomDomain<T>>, L1Distance<QI>, MO>,
     {
-        fn monomorphize2<MI: 'static + Metric, MO: 'static + Measure, T: Number>(
+        fn monomorphize2<DI: 'static + LaplaceDomain<QI>, MO: 'static + Measure, QI: Number>(
             input_domain: &AnyDomain,
             input_metric: &AnyMetric,
             scale: f64,
+            radius: Option<DI::Atom>,
             k: Option<i32>,
         ) -> Fallible<AnyMeasurement>
         where
-            MI: LaplaceMetric<T>,
-            DiscreteLaplace: MakeNoise<MI::Domain, MI, MO>,
-            (MI::Domain, MI): MetricSpace,
+            DiscreteLaplace<DI::Atom>: MakeNoise<DI, DI::Metric, MO>,
+            (DI, DI::Metric): MetricSpace,
         {
-            let input_domain = input_domain.downcast_ref::<MI::Domain>()?.clone();
-            let input_metric = input_metric.downcast_ref::<MI>()?.clone();
-            make_laplace::<MI::Domain, MI, MO>(input_domain, input_metric, scale, k).into_any()
+            let input_domain = input_domain.downcast_ref::<DI>()?.clone();
+            let input_metric = input_metric.downcast_ref::<DI::Metric>()?.clone();
+            make_laplace::<DI, DI::Metric, MO>(input_domain, input_metric, scale, radius, k)
+                .into_any()
         }
-        let T_ = input_domain.type_.get_atom()?;
-        let MI = input_metric.type_.clone();
+        let radius = as_ref(radius as *const T).cloned();
+        let DI = input_domain.type_.clone();
+        let QI = input_metric.type_.get_atom()?;
         dispatch!(monomorphize2, [
-            (MI, [AbsoluteDistance<QI>, L1Distance<QI>]),
+            (DI, [AtomDomain<T>, VectorDomain<AtomDomain<T>>]),
             (MO, [MO]),
-            (T_, [T])
-        ], (input_domain, input_metric, scale, k))
+            (QI, [QI])
+        ], (input_domain, input_metric, scale, radius, k))
     }
 
     let input_domain = try_as_ref!(input_domain);
@@ -75,11 +78,20 @@ pub extern "C" fn opendp_measurements__make_laplace(
     let QI_ = try_!(input_metric.type_.get_atom());
     let T_ = try_!(input_domain.type_.get_atom());
 
-    dispatch!(monomorphize, [
-        (MO, [MaxDivergence]),
-        (T_, @numbers),
-        (QI_, @numbers)
-    ], (input_domain, input_metric, scale, k, MO))
+    if radius.is_null() {
+        dispatch!(monomorphize, [
+            (MO, [MaxDivergence]),
+            (T_, @numbers),
+            (QI_, @numbers)
+        ], (input_domain, input_metric, scale, radius, k, MO))
+    } else {
+        let MO = Type::of::<Approximate<MaxDivergence>>();
+        dispatch!(monomorphize, [
+            (MO, [Approximate<MaxDivergence>]),
+            (T_, @numbers),
+            (QI_, @numbers)
+        ], (input_domain, input_metric, scale, radius, k, MO))
+    }
     .into()
 }
 
@@ -101,6 +113,7 @@ mod tests {
             util::into_raw(AnyDomain::new(AtomDomain::<i32>::default())),
             util::into_raw(AnyMetric::new(AbsoluteDistance::<i32>::default())),
             0.0,
+            null(),
             null(),
             "MaxDivergence".to_char_p(),
         ))?;

--- a/rust/src/measurements/noise/distribution/laplace/mod.rs
+++ b/rust/src/measurements/noise/distribution/laplace/mod.rs
@@ -1,15 +1,19 @@
 use core::f64;
-
-use dashu::{base::Signed, rational::RBig};
+use dashu::{base::Signed, integer::UBig, rational::RBig};
 use opendp_derive::{bootstrap, proven};
 
 use crate::core::{Measure, Metric, MetricSpace};
 use crate::measurements::noise::nature::Nature;
 use crate::measurements::{MakeNoise, NoiseDomain, NoisePrivacyMap, ZExpFamily};
+use crate::traits::InfSub;
 use crate::{
-    core::{Domain, Measurement, PrivacyMap},
+    accuracy::{
+        conservative_discrete_laplacian_tail_to_alpha,
+        conservative_discrete_laplacian_tail_to_alpha_lower,
+    },
+    core::{Measurement, PrivacyMap},
     error::Fallible,
-    measures::MaxDivergence,
+    measures::{Approximate, MaxDivergence},
     metrics::L1Distance,
     traits::InfCast,
 };
@@ -22,8 +26,12 @@ mod ffi;
 
 #[bootstrap(
     features("contrib"),
-    arguments(k(default = b"null")),
-    generics(DI(suppress), MI(suppress), MO(default = "MaxDivergence"))
+    arguments(
+        radius(c_type = "void *", rust_type = "Option<T>", default = b"null"),
+        k(default = b"null")
+    ),
+    generics(DI(suppress), MI(suppress), MO(default = "MaxDivergence")),
+    derived_types(T = "$get_atom(get_carrier_type(input_domain))")
 )]
 /// Make a Measurement that adds noise from the Laplace(`scale`) distribution to the input.
 ///
@@ -44,40 +52,44 @@ mod ffi;
 /// * `input_domain` - Domain of the data type to be privatized.
 /// * `input_metric` - Metric of the data type to be privatized.
 /// * `scale` - Noise scale parameter for the Laplace distribution. `scale` == standard_deviation / sqrt(2).
+/// * `radius` - The radius of noise to be added. This is used to bound the tail of the distribution.
 /// * `k` - The noise granularity in terms of 2^k, only valid for domains over floats.
 ///
 /// # Generics
 /// * `DI` - Domain of the data type to be privatized. Valid values are `VectorDomain<AtomDomain<T>>` or `AtomDomain<T>`
 /// * `MI` - Metric used to measure distance between members of the input domain.
 /// * `MO` - Measure used to quantify privacy loss. Valid values are just `MaxDivergence`
-pub fn make_laplace<DI: Domain, MI: Metric, MO: Measure>(
+pub fn make_laplace<DI: NoiseDomain, MI: Metric, MO: Measure>(
     input_domain: DI,
     input_metric: MI,
     scale: f64,
+    radius: Option<DI::Atom>,
     k: Option<i32>,
 ) -> Fallible<Measurement<DI, DI::Carrier, MI, MO>>
 where
-    DiscreteLaplace: MakeNoise<DI, MI, MO>,
+    DiscreteLaplace<DI::Atom>: MakeNoise<DI, MI, MO>,
     (DI, MI): MetricSpace,
 {
-    DiscreteLaplace { scale, k }.make_noise((input_domain, input_metric))
+    DiscreteLaplace { scale, k, radius }.make_noise((input_domain, input_metric))
 }
 
-pub struct DiscreteLaplace {
+pub struct DiscreteLaplace<T> {
     pub scale: f64,
     pub k: Option<i32>,
+    pub radius: Option<T>,
 }
 
 /// Laplace mechanism
 #[proven(proof_path = "measurements/noise/distribution/laplace/MakeNoise_for_DiscreteLaplace.tex")]
-impl<DI: NoiseDomain, MI: Metric, MO: 'static + Measure> MakeNoise<DI, MI, MO> for DiscreteLaplace
+impl<DI: NoiseDomain, MI: Metric, MO: 'static + Measure> MakeNoise<DI, MI, MO>
+    for DiscreteLaplace<DI::Atom>
 where
     (DI, MI): MetricSpace,
     DI::Atom: Nature,
     <DI::Atom as Nature>::RV<1>: MakeNoise<DI, MI, MO>,
 {
     fn make_noise(self, input_space: (DI, MI)) -> Fallible<Measurement<DI, DI::Carrier, MI, MO>> {
-        DI::Atom::new_distribution(self.scale, self.k)?.make_noise(input_space)
+        DI::Atom::new_distribution(self.scale, self.k, self.radius)?.make_noise(input_space)
     }
 }
 
@@ -90,7 +102,13 @@ impl NoisePrivacyMap<L1Distance<RBig>, MaxDivergence> for ZExpFamily<1> {
         _input_metric: &L1Distance<RBig>,
         _output_measure: &MaxDivergence,
     ) -> Fallible<PrivacyMap<L1Distance<RBig>, MaxDivergence>> {
-        let ZExpFamily { scale } = self.clone();
+        if let Some(radius) = &self.radius {
+            return fallible!(
+                MakeMeasurement,
+                "radius ({radius}) introduces a delta parameter that is not compatible with pure-DP"
+            );
+        }
+        let scale = self.scale.clone();
         if scale < RBig::ZERO {
             return fallible!(MakeMeasurement, "scale ({}) must not be negative", scale);
         }
@@ -109,6 +127,69 @@ impl NoisePrivacyMap<L1Distance<RBig>, MaxDivergence> for ZExpFamily<1> {
 
             // d_in / scale
             f64::inf_cast(d_in / scale.clone())
+        }))
+    }
+}
+
+impl NoisePrivacyMap<L1Distance<RBig>, Approximate<MaxDivergence>> for ZExpFamily<1> {
+    fn noise_privacy_map(
+        &self,
+        _input_metric: &L1Distance<RBig>,
+        output_measure: &Approximate<MaxDivergence>,
+    ) -> Fallible<PrivacyMap<L1Distance<RBig>, Approximate<MaxDivergence>>> {
+        let distribution = ZExpFamily {
+            scale: self.scale.clone(),
+            radius: None,
+        };
+
+        let noise_privacy_map =
+            distribution.noise_privacy_map(&L1Distance::default(), &output_measure.0)?;
+
+        let scale = self.scale.clone();
+        if scale < RBig::ZERO {
+            return fallible!(MakeMeasurement, "scale ({}) must not be negative", scale);
+        }
+
+        let radius = self.radius.clone();
+        if radius == Some(UBig::ZERO) {
+            return fallible!(MakeMeasurement, "radius must not be non-zero");
+        }
+
+        Ok(PrivacyMap::new_fallible(move |d_in: &RBig| {
+            if d_in.is_negative() {
+                return fallible!(FailedMap, "sensitivity ({}) must be positive", d_in);
+            }
+
+            if d_in.is_zero() {
+                return Ok((0.0, 0.0));
+            }
+
+            if scale.is_zero() {
+                return Ok((f64::INFINITY, 0.0));
+            }
+
+            let epsilon = noise_privacy_map.eval(d_in)?;
+
+            if let Some(r) = radius.clone() {
+                let (_, d_in_floor) = d_in.floor().into_parts();
+                if r <= d_in_floor {
+                    return Ok((0.0, 1.0));
+                } else {
+                    let large_tail_upper_bound = conservative_discrete_laplacian_tail_to_alpha(
+                        scale.clone(),
+                        r.clone() - d_in_floor,
+                    )?;
+                    let small_tail_upper_bound =
+                        conservative_discrete_laplacian_tail_to_alpha_lower(
+                            scale.clone(),
+                            r.clone(),
+                        )?;
+                    let delta = large_tail_upper_bound.inf_sub(&small_tail_upper_bound)?;
+                    return Ok((epsilon, delta));
+                };
+            } else {
+                return Ok((epsilon, 0.0));
+            };
         }))
     }
 }

--- a/rust/src/measurements/noise/nature/bigint/test.rs
+++ b/rust/src/measurements/noise/nature/bigint/test.rs
@@ -1,11 +1,16 @@
 use dashu::{ibig, rbig};
 
+use crate::measures::ZeroConcentratedDivergence;
+
 use super::*;
 
 #[test]
 fn test_make_noise_atomdomain_ibig() -> Fallible<()> {
-    let distribution = ZExpFamily::<2> { scale: rbig!(1) };
-    let meas =
+    let distribution = ZExpFamily::<2> {
+        scale: rbig!(1),
+        radius: None,
+    };
+    let meas: Measurement<_, _, _, ZeroConcentratedDivergence> =
         distribution.make_noise((AtomDomain::<IBig>::default(), AbsoluteDistance::default()))?;
     assert!(i8::try_from(meas.invoke(&ibig!(0))?).is_ok());
     assert_eq!(meas.map(&rbig!(0))?, 0.0);

--- a/rust/src/measurements/noise/nature/float/mod.rs
+++ b/rust/src/measurements/noise/nature/float/mod.rs
@@ -17,9 +17,10 @@ pub(crate) use utilities::*;
 #[cfg(test)]
 mod test;
 
-pub struct FloatExpFamily<const P: usize> {
+pub struct FloatExpFamily<const P: usize, T> {
     pub scale: f64,
     pub k: i32,
+    pub radius: Option<T>,
 }
 
 /// Float vector mechanism
@@ -27,7 +28,7 @@ pub struct FloatExpFamily<const P: usize> {
     proof_path = "measurements/noise/nature/float/MakeNoise_VectorDomain_for_FloatExpFamily.tex"
 )]
 impl<T: Float, const P: usize, QI: Number, MO: 'static + Measure>
-    MakeNoise<VectorDomain<AtomDomain<T>>, LpDistance<P, QI>, MO> for FloatExpFamily<P>
+    MakeNoise<VectorDomain<AtomDomain<T>>, LpDistance<P, QI>, MO> for FloatExpFamily<P, T>
 where
     i32: ExactIntCast<<T as FloatBits>::Bits>,
     RBig: TryFrom<T> + TryFrom<QI>,
@@ -37,9 +38,11 @@ where
         self,
         input_space: (VectorDomain<AtomDomain<T>>, LpDistance<P, QI>),
     ) -> Fallible<Measurement<VectorDomain<AtomDomain<T>>, Vec<T>, LpDistance<P, QI>, MO>> {
-        let FloatExpFamily { scale, k } = self;
+        let FloatExpFamily { scale, k, radius } = self;
+
         let distribution = ZExpFamily {
             scale: integerize_scale(scale, k)?,
+            radius: integerize_radius(radius, k)?,
         };
 
         let t_int = make_float_to_bigint(input_space, k)?;
@@ -104,7 +107,7 @@ where
     proof_path = "measurements/noise/nature/float/MakeNoise_AtomDomain_for_FloatExpFamily.tex"
 )]
 impl<T: Float, const P: usize, QI: Number, MO: 'static + Measure>
-    MakeNoise<AtomDomain<T>, AbsoluteDistance<QI>, MO> for FloatExpFamily<P>
+    MakeNoise<AtomDomain<T>, AbsoluteDistance<QI>, MO> for FloatExpFamily<P, T>
 where
     i32: ExactIntCast<<T as FloatBits>::Bits>,
     RBig: TryFrom<T> + TryFrom<QI>,

--- a/rust/src/measurements/noise/nature/integer/test.rs
+++ b/rust/src/measurements/noise/nature/integer/test.rs
@@ -1,6 +1,6 @@
 use dashu::rbig;
 
-use crate::metrics::L2Distance;
+use crate::{measures::MaxDivergence, metrics::L2Distance};
 
 use super::*;
 
@@ -30,14 +30,22 @@ fn test_make_noise_intexpfamily() -> Fallible<()> {
     );
 
     assert!(
-        IntExpFamily::<1> { scale: 1.0 }
-            .make_noise(space.clone())
-            .is_ok()
+        IntExpFamily::<1, _> {
+            scale: 1.0,
+            radius: None
+        }
+        .make_noise(space.clone())
+        .map(|_: Measurement<_, _, _, MaxDivergence>| ())
+        .is_ok()
     );
     assert!(
-        IntExpFamily::<1> { scale: f64::NAN }
-            .make_noise(space.clone())
-            .is_err()
+        IntExpFamily::<1, _> {
+            scale: f64::NAN,
+            radius: None
+        }
+        .make_noise(space.clone())
+        .map(|_: Measurement<_, _, _, MaxDivergence>| ())
+        .is_err()
     );
 
     Ok(())

--- a/rust/src/measurements/noise/nature/mod.rs
+++ b/rust/src/measurements/noise/nature/mod.rs
@@ -8,47 +8,71 @@ use float::get_min_k;
 
 use super::ZExpFamily;
 
-pub trait Nature {
+pub trait Nature: Sized {
     /// The random variable of given P-norm specific to the type of self.
     type RV<const P: usize>;
     /// For any parameterization,
     /// returns an equivalent random variable corresponding to the nature of `Self`,
     /// or error.
-    fn new_distribution<const P: usize>(scale: f64, k: Option<i32>) -> Fallible<Self::RV<P>>;
+    fn new_distribution<const P: usize>(
+        scale: f64,
+        k: Option<i32>,
+        radius: Option<Self>,
+    ) -> Fallible<Self::RV<P>>;
 }
 
 impl Nature for IBig {
     type RV<const P: usize> = ZExpFamily<P>;
-    fn new_distribution<const P: usize>(scale: f64, k: Option<i32>) -> Fallible<Self::RV<P>> {
+    fn new_distribution<const P: usize>(
+        scale: f64,
+        k: Option<i32>,
+        radius: Option<IBig>,
+    ) -> Fallible<Self::RV<P>> {
         if k.unwrap_or(0) != 0 {
             return fallible!(MakeMeasurement, "k is only valid for domains over floats");
         }
+        if let Some(ref r) = radius {
+            if r <= &IBig::ZERO {
+                return fallible!(MakeMeasurement, "radius must be positive");
+            }
+        }
         Ok(ZExpFamily::<P> {
             scale: RBig::try_from(scale)?,
+            radius: radius.map(|r| {
+                let (_, unsigned_radius) = r.into_parts();
+                unsigned_radius
+            }),
         })
     }
 }
 
 macro_rules! impl_Nature_float {
     ($($T:ty)+) => ($(impl Nature for $T {
-        type RV<const P: usize> = float::FloatExpFamily<P>;
-        fn new_distribution<const P: usize>(scale: f64, k: Option<i32>) -> Fallible<Self::RV<P>> {
-            Ok(float::FloatExpFamily::<P> {
+        type RV<const P: usize> = float::FloatExpFamily<P, $T>;
+        fn new_distribution<const P: usize>(scale: f64, k: Option<i32>, radius: Option<$T>) -> Fallible<Self::RV<P>> {
+            Ok(float::FloatExpFamily::<P,$T> {
                 scale,
                 k: k.unwrap_or_else(get_min_k::<$T>),
+                radius
             })
         }
     })+)
 }
+
 macro_rules! impl_Nature_int {
     ($($T:ty)+) => ($(impl Nature for $T {
-        type RV<const P: usize> = integer::IntExpFamily<P>;
-        fn new_distribution<const P: usize>(scale: f64, k: Option<i32>) -> Fallible<Self::RV<P>> {
+        type RV<const P: usize> = integer::IntExpFamily<P, $T>;
+        fn new_distribution<const P: usize>(
+            scale: f64,
+            k: Option<i32>,
+            radius: Option<$T>
+        ) -> Fallible<Self::RV<P>> {
             if k.unwrap_or(0) != 0 {
                 return fallible!(MakeMeasurement, "k is only valid for domains over floats");
             }
-            Ok(integer::IntExpFamily::<P> {
+            Ok(integer::IntExpFamily::<P,$T> {
                 scale,
+                radius
             })
         }
     })+)

--- a/rust/src/measurements/noise/test.rs
+++ b/rust/src/measurements/noise/test.rs
@@ -1,6 +1,9 @@
 use dashu::rbig;
 
-use crate::metrics::{L1Distance, L2Distance};
+use crate::{
+    measures::{MaxDivergence, ZeroConcentratedDivergence},
+    metrics::{L1Distance, L2Distance},
+};
 
 use super::*;
 
@@ -12,12 +15,20 @@ fn test_make_noise_ibig_laplace() -> Fallible<()> {
     );
 
     assert!(
-        ZExpFamily::<1> { scale: rbig!(-1) }
-            .make_noise(space.clone())
-            .is_err()
+        ZExpFamily::<1> {
+            scale: rbig!(-1),
+            radius: None
+        }
+        .make_noise(space.clone())
+        .map(|_: Measurement<_, _, _, MaxDivergence>| ())
+        .is_err()
     );
 
-    let m_noise = ZExpFamily::<1> { scale: rbig!(1) }.make_noise(space.clone())?;
+    let m_noise: Measurement<_, _, _, MaxDivergence> = ZExpFamily::<1> {
+        scale: rbig!(1),
+        radius: None,
+    }
+    .make_noise(space.clone())?;
     assert_eq!(m_noise.map(&rbig!(1))?, 1.0);
     assert!(m_noise.invoke(&vec![IBig::from(1)]).is_ok());
 
@@ -32,12 +43,20 @@ fn test_make_noise_ibig_gaussian() -> Fallible<()> {
     );
 
     assert!(
-        ZExpFamily::<2> { scale: rbig!(-1) }
-            .make_noise(space.clone())
-            .is_err()
+        ZExpFamily::<2> {
+            scale: rbig!(-1),
+            radius: None
+        }
+        .make_noise(space.clone())
+        .map(|_: Measurement<_, _, _, ZeroConcentratedDivergence>| ())
+        .is_err()
     );
 
-    let m_noise = ZExpFamily::<2> { scale: rbig!(1) }.make_noise(space.clone())?;
+    let m_noise: Measurement<_, _, _, ZeroConcentratedDivergence> = ZExpFamily::<2> {
+        scale: rbig!(1),
+        radius: None,
+    }
+    .make_noise(space.clone())?;
     assert_eq!(m_noise.map(&rbig!(1))?, 0.5);
     assert!(m_noise.invoke(&vec![IBig::from(1)]).is_ok());
 

--- a/rust/src/measurements/noise_threshold/distribution/gaussian/test.rs
+++ b/rust/src/measurements/noise_threshold/distribution/gaussian/test.rs
@@ -135,6 +135,7 @@ fn test_make_noise_threshold_zexpfamily2_large_scale() -> Fallible<()> {
     let metric = L0PInfDistance(AbsoluteDistance::<RBig>::default());
     let distribution = ZExpFamily::<2> {
         scale: rbig!(23948285282902934157),
+        radius: None,
     };
 
     let meas = distribution.make_noise_threshold((domain, metric), ibig!(23948285282902934157))?;
@@ -151,7 +152,10 @@ fn test_make_noise_threshold_zexpfamily2_large_scale() -> Fallible<()> {
 fn test_make_noise_threshold_zexpfamily2_zero_scale() -> Fallible<()> {
     let domain = MapDomain::new(AtomDomain::<bool>::default(), AtomDomain::<IBig>::default());
     let metric = L0PInfDistance(AbsoluteDistance::<RBig>::default());
-    let distribution = ZExpFamily { scale: rbig!(0) };
+    let distribution = ZExpFamily {
+        scale: rbig!(0),
+        radius: None,
+    };
 
     let meas: Measurement<_, _, _, Approximate<ZeroConcentratedDivergence>> =
         distribution.make_noise_threshold((domain, metric), ibig!(100))?;

--- a/rust/src/measurements/noise_threshold/distribution/laplace/test.rs
+++ b/rust/src/measurements/noise_threshold/distribution/laplace/test.rs
@@ -144,6 +144,7 @@ fn test_make_noise_threshold_zexpfamily1_large_scale() -> Fallible<()> {
     let metric = L0PInfDistance(AbsoluteDistance::<RBig>::default());
     let distribution = ZExpFamily::<1> {
         scale: rbig!(23948285282902934157),
+        radius: None,
     };
 
     let meas = distribution.make_noise_threshold((domain, metric), ibig!(23948285282902934157))?;
@@ -160,7 +161,10 @@ fn test_make_noise_threshold_zexpfamily1_large_scale() -> Fallible<()> {
 fn test_make_noise_threshold_zexpfamily1_zero_scale() -> Fallible<()> {
     let domain = MapDomain::new(AtomDomain::<bool>::default(), AtomDomain::<IBig>::default());
     let metric = L0PInfDistance(AbsoluteDistance::<RBig>::default());
-    let distribution = ZExpFamily { scale: rbig!(0) };
+    let distribution = ZExpFamily {
+        scale: rbig!(0),
+        radius: None,
+    };
 
     let meas: Measurement<_, _, _, Approximate<MaxDivergence>> =
         distribution.make_noise_threshold((domain, metric), ibig!(100))?;

--- a/rust/src/measurements/noise_threshold/nature/float/mod.rs
+++ b/rust/src/measurements/noise_threshold/nature/float/mod.rs
@@ -11,7 +11,7 @@ use crate::{
         MakeNoiseThreshold, NoiseThresholdPrivacyMap, ZExpFamily,
         nature::float::{
             FloatExpFamily, find_nearest_multiple_of_2k, get_min_k, get_rounding_distance,
-            integerize_scale, x_mul_2k,
+            integerize_radius, integerize_scale, x_mul_2k,
         },
     },
     metrics::{AbsoluteDistance, L0PInfDistance},
@@ -29,7 +29,7 @@ impl<TK, TV, const P: usize, QI: Number, MO: 'static + Measure>
         MapDomain<AtomDomain<TK>, AtomDomain<TV>>,
         L0PInfDistance<P, AbsoluteDistance<QI>>,
         MO,
-    > for FloatExpFamily<P>
+    > for FloatExpFamily<P, TV>
 where
     TK: Hashable,
     TV: Float,
@@ -53,9 +53,10 @@ where
             MO,
         >,
     > {
-        let FloatExpFamily { scale, k } = self;
+        let FloatExpFamily { scale, k, radius } = self;
         let distribution = ZExpFamily {
             scale: integerize_scale(scale, k)?,
+            radius: integerize_radius(radius, k)?,
         };
 
         if threshold.is_sign_negative() {

--- a/rust/src/measurements/noise_threshold/nature/float/test.rs
+++ b/rust/src/measurements/noise_threshold/nature/float/test.rs
@@ -13,14 +13,19 @@ fn test_make_noise_floatexpfamily() -> Fallible<()> {
     );
 
     assert!(
-        FloatExpFamily::<1> { scale: 1.0, k: 0 }
-            .make_noise_threshold(space.clone(), 10.0)
-            .is_ok()
+        FloatExpFamily::<1, _> {
+            scale: 1.0,
+            k: 0,
+            radius: None
+        }
+        .make_noise_threshold(space.clone(), 10.0)
+        .is_ok()
     );
     assert!(
-        FloatExpFamily::<1> {
-            scale: f64::NAN,
-            k: 0
+        FloatExpFamily::<1, _> {
+            scale: 1.0,
+            k: 0,
+            radius: None
         }
         .make_noise_threshold(space.clone(), 10.0)
         .is_err()
@@ -33,18 +38,20 @@ fn test_make_noise_floatexpfamily() -> Fallible<()> {
         L0PInfDistance(AbsoluteDistance::<f64>::default()),
     );
     assert!(
-        FloatExpFamily::<2> {
+        FloatExpFamily::<2, _> {
             scale: 1.0,
-            k: i32::MIN
+            k: i32::MIN,
+            radius: None
         }
         .make_noise_threshold(space.clone(), 10.0)
         .is_err()
     );
 
     assert!(
-        FloatExpFamily::<2> {
+        FloatExpFamily::<2, _> {
             scale: 1.0,
-            k: i32::MAX
+            k: i32::MAX,
+            radius: None
         }
         .make_noise_threshold(space.clone(), 10.0)
         .is_ok()

--- a/rust/src/measurements/noise_threshold/nature/integer/mod.rs
+++ b/rust/src/measurements/noise_threshold/nature/integer/mod.rs
@@ -12,7 +12,10 @@ use crate::{
     error::Fallible,
     measurements::{
         MakeNoiseThreshold, NoiseThresholdPrivacyMap, ZExpFamily,
-        nature::{float::integerize_scale, integer::IntExpFamily},
+        nature::{
+            float::{integerize_radius, integerize_scale},
+            integer::IntExpFamily,
+        },
     },
     metrics::{AbsoluteDistance, L0PInfDistance},
     traits::{Hashable, Integer, Number, SaturatingCast},
@@ -26,12 +29,12 @@ impl<TK, TV, const P: usize, QI: Number, MO: 'static + Measure>
         MapDomain<AtomDomain<TK>, AtomDomain<TV>>,
         L0PInfDistance<P, AbsoluteDistance<QI>>,
         MO,
-    > for IntExpFamily<P>
+    > for IntExpFamily<P, TV>
 where
     TK: Hashable,
     TV: Integer + SaturatingCast<IBig>,
     IBig: From<TV>,
-    RBig: TryFrom<QI>,
+    RBig: TryFrom<QI> + TryFrom<TV>,
     UBig: TryFrom<TV>,
     ZExpFamily<P>: NoiseThresholdPrivacyMap<L0PInfDistance<P, AbsoluteDistance<RBig>>, MO>,
 {
@@ -53,6 +56,7 @@ where
     > {
         let distribution = ZExpFamily {
             scale: integerize_scale(self.scale, 0)?,
+            radius: integerize_radius(self.radius, 0)?,
         };
 
         let t_int = make_int_to_bigint_threshold::<TK, TV, P, QI>(input_space)?;

--- a/rust/src/measurements/noise_threshold/nature/integer/test.rs
+++ b/rust/src/measurements/noise_threshold/nature/integer/test.rs
@@ -30,14 +30,20 @@ fn test_make_noise_intexpfamily() -> Fallible<()> {
     );
 
     assert!(
-        IntExpFamily::<1> { scale: 1.0 }
-            .make_noise_threshold(space.clone(), 0)
-            .is_ok()
+        IntExpFamily::<1, _> {
+            scale: 1.0,
+            radius: None
+        }
+        .make_noise_threshold(space.clone(), 0)
+        .is_ok()
     );
     assert!(
-        IntExpFamily::<1> { scale: f64::NAN }
-            .make_noise_threshold(space.clone(), 0)
-            .is_err()
+        IntExpFamily::<1, _> {
+            scale: f64::NAN,
+            radius: None
+        }
+        .make_noise_threshold(space.clone(), 0)
+        .is_err()
     );
 
     Ok(())

--- a/rust/src/traits/samplers/cks20/mod.rs
+++ b/rust/src/traits/samplers/cks20/mod.rs
@@ -142,7 +142,7 @@ pub(crate) fn sample_geometric_exp_fast(x: RBig) -> Fallible<UBig> {
 /// Specifically, the probability of returning any `x` of type [`IBig`] is
 /// ```math
 /// \forall x \in \mathbb{Z}, \quad  
-/// P[X = x] = \frac{e^{-1/scale} - 1}{e^{-1/scale} + 1} e^{-|x|/scale}, \quad
+/// P[X = x] = \frac{1 - e^{-1/scale}}{1 + e^{-1/scale}} e^{-|x|/scale}, \quad
 /// \text{where } X \sim \mathcal{L}_\mathbb{Z}(0, scale)
 /// ```
 ///

--- a/rust/src/transformations/b_ary_tree/test.rs
+++ b/rust/src/transformations/b_ary_tree/test.rs
@@ -1,4 +1,6 @@
-use crate::{measurements::then_laplace, metrics::L1Distance};
+use crate::{
+    core::Measurement, measurements::then_laplace, measures::MaxDivergence, metrics::L1Distance,
+};
 
 use super::*;
 
@@ -84,9 +86,9 @@ fn test_make_b_ary_tree() -> Fallible<()> {
 
 #[test]
 fn test_noise_b_ary_tree() -> Fallible<()> {
-    let meas =
+    let meas: Measurement<_, _, _, MaxDivergence> =
         (make_b_ary_tree::<_, i32>(Default::default(), L1Distance::<u32>::default(), 10, 2)?
-            >> then_laplace(1., None))?;
+            >> then_laplace(1., None, None))?;
     println!("noised {:?}", meas.invoke(&vec![1; 10])?);
 
     Ok(())
@@ -96,7 +98,8 @@ fn test_noise_b_ary_tree() -> Fallible<()> {
 fn test_identity() -> Fallible<()> {
     let b = 2;
     let trans = make_b_ary_tree::<_, i32>(Default::default(), L1Distance::<u32>::default(), 10, b)?;
-    let meas = (trans.clone() >> then_laplace(0., None))?;
+    let meas: Measurement<_, _, _, MaxDivergence> =
+        (trans.clone() >> then_laplace(0., None, None))?;
     let post = make_consistent_b_ary_tree::<i32, f64>(b)?;
 
     let noisy_tree = meas.invoke(&vec![1; 10])?;


### PR DESCRIPTION
Addresses Issue #2375: truncated noise addition

This PR introduces bounded variants of our noise mechanisms by implementing an optional `radius` parameter that limits the magnitude of generated noise through rejection sampling.

## Changes

- Added an optional `radius` parameter to noise mechanisms.
- Implemented rejection sampling to enforce constraints on noise magnitude.
- Implemented `NoisePrivacyMap` with respective type parameters `Approximate<MaxDivergence>` and `Approximate<ZeroConcentratedDivergence>` for Laplacian and Gaussian noise mechanisms when `radius` is provided.

  - These implementations call out to the existing implementations of `NoisePrivacyMap` with type parameters `MaxDivergence` or `ZeroConcentratedDivergence` to compute `rho` and `epsilon` parameters, while computing `delta` parameters separately.
  - For computation of `delta` parameters, new tail lower bounds are introduced for Gaussian and Laplacian distributions, specifically `conservative_discrete_laplacian_tail_to_alpha_lower` and `conservative_discrete_gaussian_tail_to_alpha_lower` and their continuous analogues.
    The bound for the discrete Gaussian is based on ["The Discrete Gaussian for Differential Privacy" by Canonne, Kamath, and Steinke (2020)](https://proceedings.neurips.cc/paper/2020/file/b53b3a3d6ab90ce0268229151c9bde11-Paper.pdf).