### PR TITLE
Check that all notebook cells are executed in order

### DIFF
--- a/python/test/test_docs.py
+++ b/python/test/test_docs.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+from json import loads
 import pytest
 from opendp import measurements, transformations
 
@@ -19,4 +21,13 @@ def test_thens_are_documented(module, function):
 
     assert function.__doc__ is not None, 'missing documentation'
     assert f':py:func:`{m_name}.{make_name}`' in function.__doc__, f'no link to {make_name}'
+
+
+@pytest.mark.parametrize(
+    "nb_path",
+    list((Path(__file__).parent.parent.parent / 'docs' / 'source').glob("**/*.ipynb")),
+    ids=lambda path: path.name
+)
+def test_notebooks_are_executed(nb_path):
+    loads(nb_path.read_text())
 

--- a/python/test/test_docs.py
+++ b/python/test/test_docs.py
@@ -29,5 +29,10 @@ def test_thens_are_documented(module, function):
     ids=lambda path: path.name
 )
 def test_notebooks_are_executed(nb_path):
-    loads(nb_path.read_text())
+    nb = loads(nb_path.read_text())
+    counts_sources = [(cell.get('execution_count'), ''.join(cell.get('source', ''))) for cell in nb['cells'] if cell['cell_type'] == 'code']
+    triples = [(index, count, source) for (index, (count, source)) in enumerate(counts_sources, start=1)]
+    indexes, counts, sources = zip(*triples)
+    bad_sources = [source for (index, count, source) in triples if index != count]
+    assert indexes == counts, f'First cell with missing or misordered execution:\n{bad_sources[0]}'
 


### PR DESCRIPTION
- Fix #2370

There's almost certainly a tool out there that already does this, but didn't find it with a a quick search.

I think we're on the same page that this is a goal, but I don't think we have a plan for how to get there. Would you like to just get all the notebooks executed in this PR? Or is it something we don't even want to worry about until release, and we don't want to worry about regressions between releases? I would prefer something simple and consistent, but I haven't been editing the notebooks as often as you.