### PR TITLE
Tidy up release docs + scripts

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -142,14 +142,12 @@ on github, or with the `gh` command line tool. Parameters:
     1. Update changelog
 
         ```shell
-        python channel_tool.py changelog
-
         git fetch --tags
         python changelog.py
         ```
         Additional manual edits will be useful to arrange individual commits thematically.
 
-    1. Update `VERSION` file on the `main` branch to match the version you want to release.
+    1. Update `VERSION` file to match the version you want to release.
 
         - If it's a patch release, no change to the version number should be needed: The patch should have been incremented after the previous release.
         - If it's a minor release, run `python channel_tool.py bump_version --position minor`

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -67,7 +67,7 @@ def main():
     changelog_update = get_changelog_update(log_lines)
 
     for line in old_changelog_lines:
-        if prev_version in line:
+        if f'[{prev_version}]' in line:
             new_changelog_lines.append(changelog_update)
             new_changelog_lines.append('')
         new_changelog_lines.append(line)

--- a/tools/channel_tool.py
+++ b/tools/channel_tool.py
@@ -3,6 +3,7 @@ import configupdater
 import datetime
 import re
 import zoneinfo
+import os
 from pathlib import Path
 
 import tomlkit
@@ -104,11 +105,11 @@ def update_version(version):
         toml["dependencies"]["opendp_tooling"]["version"] = str(stripped_version)
         toml["build-dependencies"]["opendp_tooling"]["version"] = str(stripped_version)
         return toml
-    update_file("rust/Cargo.toml", tomlkit.load, munge_cargo_root, tomlkit.dump)
+    update_file("../rust/Cargo.toml", tomlkit.load, munge_cargo_root, tomlkit.dump)
     def munge_cargo_opendp_derive(toml):
         toml["dependencies"]["opendp_tooling"]["version"] = str(stripped_version)
         return toml
-    update_file("rust/opendp_derive/Cargo.toml", tomlkit.load, munge_cargo_opendp_derive, tomlkit.dump)
+    update_file("../rust/opendp_derive/Cargo.toml", tomlkit.load, munge_cargo_opendp_derive, tomlkit.dump)
 
     # Python config
     def load_python_config(f):
@@ -120,11 +121,11 @@ def update_version(version):
         return config
     def dump_python_config(config, f):
         config.write(f)
-    update_file("python/setup.cfg", load_python_config, munge_python_config, dump_python_config)
+    update_file("../python/setup.cfg", load_python_config, munge_python_config, dump_python_config)
     
     # R Package
-    log("Updating R/opendp/DESCRIPTION")
-    with ControlEditor(path='R/opendp/DESCRIPTION') as control:
+    log("Updating ../R/opendp/DESCRIPTION")
+    with ControlEditor(path='../R/opendp/DESCRIPTION') as control:
         # while it might not look like it, this mutates the DESCRIPTION file in-place
         next(iter(control.paragraphs))["Version"] = r_version
 
@@ -255,6 +256,7 @@ def _main(argv):
 
 
 def main():
+    os.chdir(Path(__file__).parent)
     _main(sys.argv)
 
 

--- a/tools/channel_tool.py
+++ b/tools/channel_tool.py
@@ -186,8 +186,11 @@ def changelog(args):
         if channel == "dev":
             date = "TBD"
 
-    log(f"Updating heading to {new_heading_version}, {diff_source}...{diff_target}, {date}")
-    changelog_lines[i] = f"## [{new_heading_version}]({URL_BASE}{diff_source}...{diff_target}) - {date}\n"
+    old_line = changelog_lines[i]
+    new_line = f"## [{new_heading_version}]({URL_BASE}{diff_source}...{diff_target}) - {date}\n"
+    changelog_lines[i] = new_line
+    log(f"{old_line=}\n# {new_line=}")
+
     if args.prepend:
         # Prepend a new heading for the current version.
         diff_source = diff_target


### PR DESCRIPTION
- Fix #2373 (though there might be more iterations on release process)

There's a lot of complexity here, and although I got a release out last time, I'm worrying now that parts of it could have been misconfigured, since the scripts didn't run completely.

I'm also wondering how the release process works for you. My guess is that you understand what should be happening, and so you don't need to follow every step literally. ... But if you think you _are_ following the steps verbatim, then maybe there is a problem with my environment? Either way, we should make sure that both of us can run the release process without hitting errors.

The riskiest part of this PR is probably dropping `python channel_tool.py changelog` -- On the last release it didn't really make any changes, and I'm not sure what we expect it to do. There is a lot of conditional logic here.