### PR TITLE
Fix link check

### DIFF
--- a/.github/workflows/weekly-doc-check.yml
+++ b/.github/workflows/weekly-doc-check.yml
@@ -74,11 +74,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r requirements-dev.txt
+          python -m pip install -r requirements.txt
 
       - name: Check markdown links
         run: |
-          find .. | grep '\.md$' | grep -v 'venv/\|.git/\|CHANGELOG\|vendor/\|R/opendp/README.md' \
+          find .. | grep '\.md$' | grep -v 'venv\|.git/\|CHANGELOG\|vendor/\|R/opendp/README.md' \
           | xargs linkchecker --no-warnings -f linkchecker-external.cfg
 
       - name: Install Pandoc

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 [![main CI](https://github.com/opendp/opendp/actions/workflows/smoke-test.yml/badge.svg)](https://github.com/opendp/opendp/actions/workflows/smoke-test.yml?query=branch%3Amain)
 [![nightly CI](https://github.com/opendp/opendp/actions/workflows/nightly.yml/badge.svg)](https://github.com/opendp/opendp/actions/workflows/nightly.yml?query=branch%3Amain)
+[![doc-check CI](https://github.com/opendp/opendp/actions/workflows/weekly-doc-check.yml/badge.svg)](https://github.com/opendp/opendp/actions/workflows/weekly-doc-check.yml?query=branch%3Amain)
 
 The OpenDP Library is a modular collection of statistical algorithms that adhere to the definition of
 [differential privacy](https://en.wikipedia.org/wiki/Differential_privacy).

--- a/docs/linkchecker-external.cfg
+++ b/docs/linkchecker-external.cfg
@@ -16,6 +16,24 @@ ignore=
   # JS sniffing is involved? Easiest just to leave this ignore in place.
   https://crates.io/crates/opendp
 
+  # 403 Forbidden:
+  https://www.unhcr.org
+
+  # On main, `make_sequential_composition` is deprecated,
+  # and has been replaced by `make_adaptive_composition`,
+  # but until there is a release, docs.rs will not have the new name.
+  # 
+  # TODO: Shouldn't be needed after next release; Remove! 
+  # 
+  # 404 Not found:
+  https://docs.rs/opendp/latest/opendp/combinators/fn.make_adaptive_composition.html
+
+  # TODO: Re-enable? Hopefully the site is down temporarily.
+  #
+  # 503 Service Unavailable:
+  https://www.globaldata.com/data-insights/macroeconomic/average-household-size-in-france-2096123/
+
+
   # Internal:
   # - Rust function docs:
   measurements/fn

--- a/docs/source/getting-started/tabular-data/essential-statistics.ipynb
+++ b/docs/source/getting-started/tabular-data/essential-statistics.ipynb
@@ -266,7 +266,7 @@
     "\n",
     "This margin provides an upper bound on how large any group can be (`max_length`).\n",
     "Since the average achieved sample size is shared [50,000 households](https://ec.europa.eu/eurostat/documents/7870049/19469785/KS-FT-24-003-EN-N.pdf/f8f6f54b-8504-0388-f754-abb004902f45?version=1.0&t=1719410273207), \n",
-    "and the average number of individuals in households is [less than three](https://www.globaldata.com/data-insights/macroeconomic/average-household-size-in-france-2096123), \n",
+    "and the average number of individuals in households is [less than three](https://www.globaldata.com/data-insights/macroeconomic/average-household-size-in-france-2096123/), \n",
     "we can use 150,000 as a conservative upper bound on the number of records per quarter.\n",
     "By giving up this relatively inconsequential fact about the data to a potential adversary, \n",
     "the library is able to ensure that overflow and/or numerical instability won't undermine privacy guarantees.\n",
@@ -925,7 +925,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.2"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/docs/source/theory/attacks/membership.ipynb
+++ b/docs/source/theory/attacks/membership.ipynb
@@ -12,7 +12,7 @@
     "An adversary can leverage a membership inference attack that takes advantage of query answers on a sequestered dataset to infer if a particular individual exists in the sequestered dataset.\n",
     "There are situations in which knowing if an individual exists within a sequestered dataset poses risk to the individual. \n",
     "\n",
-    "The membership attacks in this notebook come from [DSSUV'15, Robust Traceability from Trace Amounts.](https://privacytools.seas.harvard.edu/files/privacytools/files/robust.pdf)\n",
+    "The membership attacks in this notebook come from [DSSUV'15, Robust Traceability from Trace Amounts.](https://salil.seas.harvard.edu/publications/robust-traceability-trace-amounts)\n",
     "\n",
     "This notebook makes use of the Public Use Microdata Sample (PUMS), obtained from the Census Bureau’s American Community Survey (ACS).\n",
     "Attacks like the one demonstrated in this notebook motivate the use of statistical disclosure limitation techniques like differential privacy."
@@ -852,7 +852,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.13 ('psi')",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -866,12 +866,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "3220da548452ac41acb293d0d6efded0f046fab635503eb911c05f743e930f34"
-   }
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/docs/source/theory/resources.rst
+++ b/docs/source/theory/resources.rst
@@ -28,7 +28,7 @@ Learning About Differential Privacy
 Papers
 ------
 
-* `The Complexity of Differential Privacy <https://privacytools.seas.harvard.edu/files/privacytools/files/complexityprivacy_1.pdf>`_
+* `The Complexity of Differential Privacy <https://salil.seas.harvard.edu/publications/complexity-differential-privacy>`_
 * `Calibrating Noise to Sensitivity in Private Data Analysis <https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf>`_ (Laplace mechanism)
 * `On Significance of the Least Significant Bits For Differential Privacy <https://www.microsoft.com/en-us/research/wp-content/uploads/2012/10/lsbs.pdf>`_ (Snapping mechanism and how floating-point numbers and the laplace mechanism leak)
 * `Mechanism Design via Differential Privacy <https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/mdviadp.pdf>`_ (Exponential mechanism)


### PR DESCRIPTION
- Fix #2401

Looks like `privacytools.seas.harvard.edu` was rearranged: Annoying, but I don't think it makes sense to bother asking for the restoration of the old links.