### PR TITLE
docs: JS redirection for regression

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -33,6 +33,7 @@
                     '/getting-started/examples/pums-data-analysis.html': '/getting-started/examples/index.html',
                     '/getting-started/examples/unknown-dataset-size.html': '/api/user-guide/transformations/preprocess-size.html',
                     '/getting-started/examples/histograms.html': '/getting-started/examples/index.html',
+                    '/getting-started/statistical-modeling/regression.html': '/api/user-guide/plugins/theil-sen-regression.html',
 
                     '/contact.html': '/contributing/contact.html',
                     '/contributor/': '/contributing/',


### PR DESCRIPTION
- Fix #2396

I expect that another PR
- #2403

will re-establish the `getting-started/statistical-modeling/regression.html` path, but it would be good to point users to the new location until that is merged. (That PR will probably remove this redirect.)