### PR TITLE
Bump top supported python from 3.12 to 3.13

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -141,7 +141,7 @@ jobs:
       matrix:
         python-version:
           - '3.9'
-          - '3.12'
+          - '3.13'
         extra-install:
           - '.'
           - '.[scikit-learn]'
@@ -201,13 +201,13 @@ jobs:
       - name: Test coverage
         # We only expect test coverage with all extra dependencies.
         # "polars" implies "scikit-learn": see setup.cfg.
-        if: ${{ contains(matrix.extra-install, 'polars') && contains(matrix.python-version, '3.12') }}
+        if: ${{ contains(matrix.extra-install, 'polars') && contains(matrix.python-version, '3.13') }}
         run: |
           coverage report
           touch /tmp/coverage.txt
 
       - name: Upload coverage
-        if: ${{ contains(matrix.extra-install, 'polars') && contains(matrix.python-version, '3.12') }}
+        if: ${{ contains(matrix.extra-install, 'polars') && contains(matrix.python-version, '3.13') }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/license/MIT)
 
-[![Python](https://img.shields.io/badge/Python-3.9%20%E2%80%93%203.12-blue)](https://docs.opendp.org/en/stable/api/python/index.html)
+[![Python](https://img.shields.io/badge/Python-3.9%20%E2%80%93%203.13-blue)](https://docs.opendp.org/en/stable/api/python/index.html)
 [![R](https://img.shields.io/badge/R-grey)](https://docs.opendp.org/en/stable/api/r/)
 [![Rust](https://img.shields.io/badge/Rust-grey)](https://docs.rs/crate/opendp/latest)
 


### PR DESCRIPTION
- Fix #2410

Github actions relating to publishing also use 3.12, but I think they can be bumped later: Want to minimize uncertainty right now.