### PR TITLE
docs: add dp-wizard link

### DIFF
--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -3,8 +3,9 @@ Getting Started
 
 This is an overview of OpenDP's Python and R APIs.
 
-For a more conceptual overview of differential privacy see the :doc:`../theory/index` section,
-and for Python, R, and Rust library references see the :doc:`../api/index` documentation.
+* To interactively build OpenDP examples, try `DP Wizard <https://mccalluc-dp-wizard.share.connect.posit.cloud/>`_.
+* For a more conceptual overview of differential privacy see the :doc:`../theory/index` section.
+* For Python, R, and Rust library references see the :doc:`../api/index` documentation.
 
 .. toctree::
   :titlesonly:


### PR DESCRIPTION
- Fix #2409

I had forgotten that our examples page had moved. Propose linking directly to the live demo, or maybe that's too aggressive? But linking to the project page just gives them too much to read and sort through.