### PR TITLE
chore: Upgrade last CI actions to Python 3.13

### DIFF
--- a/.github/workflows/credential-check.yml
+++ b/.github/workflows/credential-check.yml
@@ -37,7 +37,7 @@ jobs:
         if: ${{ inputs.assert_version }}
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.13
           cache: pip
 
       - name: Assert version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.13
 
       - name: Download Python wheel
         uses: actions/download-artifact@v4
@@ -143,7 +143,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.13
 
       - name: Publish Rust crate
         env:
@@ -176,7 +176,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.13
 
       - name: Publish GitHub Release
         if: ${{ inputs.channel == 'stable' }}


### PR DESCRIPTION
Searched with a couple regexes, and I think these are the only references that should still be updated.

- Close #2417
- Follow-up to #2412