### PR TITLE
fix: interactive postprocessing under sequentiality constraint

### DIFF
--- a/rust/src/combinators/chain/mod.rs
+++ b/rust/src/combinators/chain/mod.rs
@@ -12,7 +12,7 @@ use std::fmt::Debug;
 
 const ERROR_URL: &str = "https://github.com/opendp/opendp/discussions/297";
 
-macro_rules! assert_components_match {
+macro_rules! assert_elements_match {
     ($variant:ident, $v1:expr, $v2:expr) => {
         if &$v1 != &$v2 {
             return Err($crate::combinators::mismatch_error(
@@ -23,7 +23,7 @@ macro_rules! assert_components_match {
         }
     };
 }
-pub(crate) use assert_components_match;
+pub(crate) use assert_elements_match;
 
 pub(crate) fn mismatch_error<T: Debug>(variant: ErrorVariant, struct1: &T, struct2: &T) -> Error {
     let str1 = format!("{:?}", struct1);
@@ -89,12 +89,12 @@ where
     (DI, MI): MetricSpace,
     (DX, MX): MetricSpace,
 {
-    assert_components_match!(
+    assert_elements_match!(
         DomainMismatch,
         transformation0.output_domain,
         measurement1.input_domain
     );
-    assert_components_match!(
+    assert_elements_match!(
         MetricMismatch,
         transformation0.output_metric,
         measurement1.input_metric
@@ -138,13 +138,13 @@ where
     (DX, MX): MetricSpace,
     (DO, MO): MetricSpace,
 {
-    assert_components_match!(
+    assert_elements_match!(
         DomainMismatch,
         transformation0.output_domain,
         transformation1.input_domain
     );
 
-    assert_components_match!(
+    assert_elements_match!(
         MetricMismatch,
         transformation0.output_metric,
         transformation1.input_metric

--- a/rust/src/combinators/sequential_composition/adaptive/mod.rs
+++ b/rust/src/combinators/sequential_composition/adaptive/mod.rs
@@ -84,7 +84,9 @@ where
         output_measure.composability(Adaptivity::Adaptive)?,
         Composability::Sequential
     );
-    let d_in_max = d_in.clone();
+
+    // an upper bound on the privacy unit in the privacy map
+    let d_in_constructor = d_in.clone();
 
     Measurement::new(
         input_domain.clone(),
@@ -183,11 +185,11 @@ where
                 fallible!(FailedFunction, "unrecognized query: {:?}", query)
             })
         }),
-        PrivacyMap::new_fallible(move |d_in: &MI::Distance| {
-            if d_in.total_gt(&d_in_max)? {
+        PrivacyMap::new_fallible(move |d_in_map: &MI::Distance| {
+            if d_in_map.total_gt(&d_in_constructor)? {
                 fallible!(
                     RelationDebug,
-                    "input distance must not be greater than the d_in passed into the constructor"
+                    "d_in from the privacy map must be no greater than the d_in passed into the constructor"
                 )
             } else {
                 Ok(d_out.clone())

--- a/rust/src/combinators/sequential_composition/adaptive/mod.rs
+++ b/rust/src/combinators/sequential_composition/adaptive/mod.rs
@@ -1,11 +1,11 @@
 use opendp_derive::bootstrap;
-use std::fmt::Debug;
+use std::{cell::RefCell, fmt::Debug, rc::Rc};
 
 use crate::{
-    combinators::assert_components_match,
+    combinators::{Adaptivity, Composability, assert_elements_match},
     core::{Domain, Function, Measurement, Metric, MetricSpace, PrivacyMap},
     error::Fallible,
-    interactive::{Answer, Query, Queryable, WrapFn},
+    interactive::{Answer, Query, Queryable, Wrapper},
     traits::ProductOrd,
 };
 
@@ -15,7 +15,7 @@ mod test;
 #[cfg(feature = "ffi")]
 mod ffi;
 
-use super::SequentialCompositionMeasure;
+use super::CompositionMeasure;
 
 #[bootstrap(
     features("contrib"),
@@ -56,7 +56,7 @@ use super::SequentialCompositionMeasure;
 pub fn make_adaptive_composition<
     DI: Domain + 'static,
     MI: Metric + 'static,
-    MO: SequentialCompositionMeasure + 'static,
+    MO: CompositionMeasure + 'static,
     TO: 'static,
 >(
     input_domain: DI,
@@ -67,8 +67,8 @@ pub fn make_adaptive_composition<
 ) -> Fallible<Measurement<DI, MI, MO, Queryable<Measurement<DI, MI, MO, TO>, TO>>>
 where
     DI::Carrier: 'static + Clone,
-    MI::Distance: 'static + ProductOrd + Clone + Send + Sync,
-    MO::Distance: 'static + ProductOrd + Clone + Send + Sync + Debug,
+    MI::Distance: 'static + ProductOrd + Clone,
+    MO::Distance: 'static + ProductOrd + Clone + Debug,
     (DI, MI): MetricSpace,
 {
     if d_mids.len() == 0 {
@@ -80,11 +80,17 @@ where
 
     let d_out = output_measure.compose(d_mids.clone())?;
 
+    let require_sequentiality = matches!(
+        output_measure.composability(Adaptivity::Adaptive)?,
+        Composability::Sequential
+    );
+    let d_in_max = d_in.clone();
+
     Measurement::new(
         input_domain.clone(),
         input_metric.clone(),
         output_measure.clone(),
-        Function::new_fallible(enclose!(d_in, move |arg: &DI::Carrier| {
+        Function::new_fallible(move |data: &DI::Carrier| {
             // a new copy of the state variables is made each time the Function is called:
 
             // IMMUTABLE STATE VARIABLES
@@ -92,7 +98,7 @@ where
             let input_metric = input_metric.clone();
             let output_measure = output_measure.clone();
             let d_in = d_in.clone();
-            let arg = arg.clone();
+            let data = data.clone();
 
             // MUTABLE STATE VARIABLES
             let mut d_mids = d_mids.clone();
@@ -102,65 +108,56 @@ where
             // 2. the query (a measurement)
 
             // all state variables are moved into (or captured by) the Queryable closure here
-            Queryable::new(move |sc_qbl, query: Query<Measurement<DI, MI, MO, TO>>| {
+            Queryable::new(move |self_, query: Query<Measurement<DI, MI, MO, TO>>| {
                 // this queryable and wrapped children communicate via an AskPermission query
                 // defined here, where no-one else can access the type
-                struct AskPermission(pub usize);
+                struct AskPermission(usize);
 
                 // if the query is external (passed by the user), then it is a measurement
-                if let Query::External(measurement) = query {
-                    assert_components_match!(
-                        DomainMismatch,
-                        input_domain,
-                        measurement.input_domain
-                    );
-
-                    assert_components_match!(
-                        MetricMismatch,
-                        input_metric,
-                        measurement.input_metric
-                    );
-
-                    assert_components_match!(
-                        MeasureMismatch,
-                        output_measure,
-                        measurement.output_measure
-                    );
+                if let Query::External(meas) = query {
+                    assert_elements_match!(DomainMismatch, input_domain, meas.input_domain);
+                    assert_elements_match!(MetricMismatch, input_metric, meas.input_metric);
+                    assert_elements_match!(MeasureMismatch, output_measure, meas.output_measure);
 
                     // retrieve the last distance from d_mids, or bubble an error if d_mids is empty
                     let d_mid =
                         (d_mids.last()).ok_or_else(|| err!(FailedFunction, "out of queries"))?;
 
                     // check that the query doesn't consume too much privacy
-                    if !measurement.check(&d_in, d_mid)? {
+                    if !meas.check(&d_in, d_mid)? {
                         return fallible!(
                             FailedFunction,
                             "insufficient budget for query: {:?} > {:?}",
-                            measurement.map(&d_in)?,
+                            meas.map(&d_in)?,
                             d_mid
                         );
                     }
 
-                    let answer = if output_measure.concurrent()? {
-                        // evaluate the query directly; no wrapping is necessary
-                        measurement.invoke(&arg)
-                    } else {
-                        // if the answer contains a queryable,
-                        // wrap it so that when the child gets a query it sends an AskPermission query to this parent queryable
-                        // it gives this sequential composition queryable (or any parent of this queryable)
-                        // a chance to deny the child permission to execute
+                    let enforce_sequentiality = Rc::new(RefCell::new(false));
+                    let seq_wrapper = require_sequentiality.then(|| {
+                        // Wrap any spawned queryables with a check that no new queries have been asked.
                         let child_id = d_mids.len() - 1;
+                        let mut self_ = self_.clone();
 
-                        let mut sc_qbl = sc_qbl.clone();
-                        let wrap_logic = WrapFn::new_pre_hook(move || {
-                            sc_qbl.eval_internal(&AskPermission(child_id))
-                        });
+                        Wrapper::new_recursive_pre_hook(enclose!(
+                            enforce_sequentiality,
+                            move || {
+                                if *enforce_sequentiality.borrow() {
+                                    self_.eval_internal(&AskPermission(child_id))
+                                } else {
+                                    Ok(())
+                                }
+                            }
+                        ))
+                    });
 
-                        // evaluate the query and wrap the answer
-                        measurement.invoke_wrap(&arg, wrap_logic.as_map())
-                    }?;
+                    // evaluate the query and wrap the answer
+                    let answer = meas.invoke_wrap(&data, seq_wrapper)?;
 
-                    // we've now consumed the last d_mid. This is our only state modification
+                    // start enforcing sequentiality
+                    *enforce_sequentiality.borrow_mut() = true;
+
+                    // we've now increased our privacy spend. This is our only state modification
                     d_mids.pop();
 
                     // done!
@@ -185,9 +182,9 @@ where
 
                 fallible!(FailedFunction, "unrecognized query: {:?}", query)
             })
-        })),
-        PrivacyMap::new_fallible(move |actual_d_in: &MI::Distance| {
-            if actual_d_in.total_gt(&d_in)? {
+        }),
+        PrivacyMap::new_fallible(move |d_in: &MI::Distance| {
+            if d_in.total_gt(&d_in_max)? {
                 fallible!(
                     RelationDebug,
                     "input distance must not be greater than the d_in passed into the constructor"
@@ -242,7 +239,7 @@ where
 pub fn make_sequential_composition<
     DI: Domain + 'static,
     MI: Metric + 'static,
-    MO: SequentialCompositionMeasure + 'static,
+    MO: CompositionMeasure + 'static,
     TO: 'static,
 >(
     input_domain: DI,

--- a/rust/src/combinators/sequential_composition/mod.rs
+++ b/rust/src/combinators/sequential_composition/mod.rs
@@ -18,66 +18,90 @@ use crate::{
     traits::InfAdd,
 };
 
-pub trait SequentialCompositionMeasure: Measure {
-    fn concurrent(&self) -> Fallible<bool>;
-    fn compose(&self, d_i: Vec<Self::Distance>) -> Fallible<Self::Distance>;
+#[derive(Debug)]
+pub enum Adaptivity {
+    /// All queries are executed together in a single batch.
+    NonAdaptive,
+    /// The privacy loss parameters are non-adaptive,
+    /// but the queries can be chosen adaptively based on the results of previous queries.
+    Adaptive,
+    /// The privacy loss parameters and queries can be chosen adaptively
+    /// based on the results of previous queries.
+    FullyAdaptive,
 }
 
-impl SequentialCompositionMeasure for MaxDivergence {
-    fn concurrent(&self) -> Fallible<bool> {
-        Ok(true)
+#[derive(Debug)]
+pub enum Composability {
+    /// Previous interactive mechanisms are locked when a new query is submitted.
+    Sequential,
+    /// Previous interactive mechanisms are not locked when a new query is submitted.
+    Concurrent,
+}
+
+/// # Proof Definition
+/// `composability` returns `Ok(out)` if the composition of a vector of privacy parameters `d_mids`
+/// is bounded above by `self.compose(d_mids)` under `adaptivity` adaptivity and `out`-composability.
+/// Otherwise returns an error.
+pub trait CompositionMeasure: Measure {
+    fn composability(&self, adaptivity: Adaptivity) -> Fallible<Composability>;
+    fn compose(&self, d_mids: Vec<Self::Distance>) -> Fallible<Self::Distance>;
+}
+
+impl CompositionMeasure for MaxDivergence {
+    fn composability(&self, _adaptivity: Adaptivity) -> Fallible<Composability> {
+        Ok(Composability::Concurrent)
     }
-    fn compose(&self, d_i: Vec<Self::Distance>) -> Fallible<Self::Distance> {
-        d_i.iter().try_fold(0.0, |sum, d_i| sum.inf_add(d_i))
+    fn compose(&self, d_mids: Vec<Self::Distance>) -> Fallible<Self::Distance> {
+        d_mids.iter().try_fold(0.0, |sum, d_i| sum.inf_add(d_i))
     }
 }
 
-impl SequentialCompositionMeasure for ZeroConcentratedDivergence {
-    fn concurrent(&self) -> Fallible<bool> {
-        Ok(true)
+impl CompositionMeasure for ZeroConcentratedDivergence {
+    fn composability(&self, _adaptivity: Adaptivity) -> Fallible<Composability> {
+        Ok(Composability::Concurrent)
     }
-    fn compose(&self, d_i: Vec<Self::Distance>) -> Fallible<Self::Distance> {
-        d_i.iter().try_fold(0.0, |sum, d_i| sum.inf_add(d_i))
+    fn compose(&self, d_mids: Vec<Self::Distance>) -> Fallible<Self::Distance> {
+        d_mids.iter().try_fold(0.0, |sum, d_i| sum.inf_add(d_i))
     }
 }
 
-impl SequentialCompositionMeasure for Approximate<MaxDivergence> {
-    fn concurrent(&self) -> Fallible<bool> {
-        Ok(true)
+impl CompositionMeasure for Approximate<MaxDivergence> {
+    fn composability(&self, _adaptivity: Adaptivity) -> Fallible<Composability> {
+        Ok(Composability::Concurrent)
     }
-    fn compose(&self, d_i: Vec<Self::Distance>) -> Fallible<Self::Distance> {
-        let (d_i0, deltas): (Vec<_>, Vec<_>) = d_i.into_iter().unzip();
-        let delta = deltas
+    fn compose(&self, d_mids: Vec<Self::Distance>) -> Fallible<Self::Distance> {
+        d_mids
             .iter()
-            .try_fold(0.0, |sum, delta| sum.inf_add(delta))?;
-
-        Ok((self.0.compose(d_i0)?, delta))
+            .try_fold((0.0, 0.0), |(eps_g, del_g), (eps_i, del_i)| {
+                Ok((eps_g.inf_add(eps_i)?, del_g.inf_add(del_i)?))
+            })
     }
 }
 
-impl SequentialCompositionMeasure for Approximate<ZeroConcentratedDivergence> {
-    fn concurrent(&self) -> Fallible<bool> {
-        Ok(false)
+impl CompositionMeasure for Approximate<ZeroConcentratedDivergence> {
+    fn composability(&self, _adaptivity: Adaptivity) -> Fallible<Composability> {
+        Ok(Composability::Sequential)
     }
-    fn compose(&self, d_i: Vec<Self::Distance>) -> Fallible<Self::Distance> {
-        let (d_i0, deltas): (Vec<_>, Vec<_>) = d_i.into_iter().unzip();
-        let delta = deltas
+    fn compose(&self, d_mids: Vec<Self::Distance>) -> Fallible<Self::Distance> {
+        d_mids
             .iter()
-            .try_fold(0.0, |sum, delta| sum.inf_add(delta))?;
-
-        Ok((self.0.compose(d_i0)?, delta))
+            .try_fold((0.0, 0.0), |(eps_g, del_g), (eps_i, del_i)| {
+                Ok((eps_g.inf_add(eps_i)?, del_g.inf_add(del_i)?))
+            })
     }
 }
 
-impl SequentialCompositionMeasure for RenyiDivergence {
-    fn concurrent(&self) -> Fallible<bool> {
-        Ok(true)
+impl CompositionMeasure for RenyiDivergence {
+    fn composability(&self, _adaptivity: Adaptivity) -> Fallible<Composability> {
+        Ok(Composability::Concurrent)
     }
-    fn compose(&self, d_i: Vec<Self::Distance>) -> Fallible<Self::Distance> {
+
+    fn compose(&self, d_mids: Vec<Self::Distance>) -> Fallible<Self::Distance> {
         Ok(Function::new_fallible(move |alpha| {
-            d_i.iter()
+            d_mids
+                .iter()
                 .map(|f| f.eval(alpha))
-                .try_fold(0.0, |sum, e2| sum.inf_add(&e2?))
+                .try_fold(0.0, |sum, eps| sum.inf_add(&eps?))
         }))
     }
 }

--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -38,7 +38,7 @@ use std::fmt::{Debug, Display};
 ///
 /// # Proof Definition
 /// A type `Self` implements `Domain` iff it can represent a set of values that make up a domain.
-pub trait Domain: Clone + PartialEq + Debug + Send + Sync {
+pub trait Domain: Clone + PartialEq + Debug {
     /// The underlying type that the Domain specializes.
     /// This is the type of a member of a domain, where a domain is any data type that implements this trait.
     ///
@@ -69,7 +69,7 @@ pub trait Domain: Clone + PartialEq + Debug + Send + Sync {
 
 /// A mathematical function.
 pub struct Function<TI, TO> {
-    pub function: Arc<dyn Fn(&TI) -> Fallible<TO> + Send + Sync>,
+    pub function: Arc<dyn Fn(&TI) -> Fallible<TO>>,
 }
 impl<TI, TO> Clone for Function<TI, TO> {
     fn clone(&self) -> Self {
@@ -80,11 +80,11 @@ impl<TI, TO> Clone for Function<TI, TO> {
 }
 
 impl<TI, TO> Function<TI, TO> {
-    pub fn new(function: impl Fn(&TI) -> TO + 'static + Send + Sync) -> Self {
+    pub fn new(function: impl Fn(&TI) -> TO + 'static) -> Self {
         Self::new_fallible(move |arg| Ok(function(arg)))
     }
 
-    pub fn new_fallible(function: impl Fn(&TI) -> Fallible<TO> + 'static + Send + Sync) -> Self {
+    pub fn new_fallible(function: impl Fn(&TI) -> Fallible<TO> + 'static) -> Self {
         Self {
             function: Arc::new(function),
         }
@@ -110,7 +110,7 @@ impl<TI: 'static, TO: 'static> Function<TI, TO> {
 ///
 /// # Proof Definition
 /// A type `Self` has an implementation for `Metric` iff it can represent a metric for quantifying distances between values in a set.
-pub trait Metric: Clone + PartialEq + Debug + Send + Sync {
+pub trait Metric: Clone + PartialEq + Debug {
     /// # Proof Definition
     /// `Self::Distance` is a type that represents distances in terms of a metric `Self`.
     type Distance;
@@ -121,7 +121,7 @@ pub trait Metric: Clone + PartialEq + Debug + Send + Sync {
 /// # Proof Definition
 /// A type `Self` has an implementation for `Measure` iff it can represent a measure for quantifying distances between distributions.
 
-pub trait Measure: Default + Clone + PartialEq + Debug + Send + Sync {
+pub trait Measure: Default + Clone + PartialEq + Debug {
     /// # Proof Definition
     /// `Self::Distance` is a type that represents distances in terms of a measure `Self`.
     type Distance;
@@ -132,7 +132,7 @@ pub trait Measure: Default + Clone + PartialEq + Debug + Send + Sync {
 /// A `PrivacyMap` is implemented as a function that takes an input [`Metric::Distance`]
 /// and returns the smallest upper bound on distances between output distributions on neighboring input datasets.
 pub struct PrivacyMap<MI: Metric, MO: Measure>(
-    pub Arc<dyn Fn(&MI::Distance) -> Fallible<MO::Distance> + Send + Sync>,
+    pub Arc<dyn Fn(&MI::Distance) -> Fallible<MO::Distance>>,
 );
 
 impl<MI: Metric, MO: Measure> Clone for PrivacyMap<MI, MO> {
@@ -142,12 +142,10 @@ impl<MI: Metric, MO: Measure> Clone for PrivacyMap<MI, MO> {
 }
 
 impl<MI: Metric, MO: Measure> PrivacyMap<MI, MO> {
-    pub fn new(map: impl Fn(&MI::Distance) -> MO::Distance + 'static + Send + Sync) -> Self {
+    pub fn new(map: impl Fn(&MI::Distance) -> MO::Distance + 'static) -> Self {
         PrivacyMap(Arc::new(move |d_in: &MI::Distance| Ok(map(d_in))))
     }
-    pub fn new_fallible(
-        map: impl Fn(&MI::Distance) -> Fallible<MO::Distance> + 'static + Send + Sync,
-    ) -> Self {
+    pub fn new_fallible(map: impl Fn(&MI::Distance) -> Fallible<MO::Distance> + 'static) -> Self {
         PrivacyMap(Arc::new(map))
     }
     pub fn new_from_constant(c: MO::Distance) -> Self

--- a/rust/src/core/test.rs
+++ b/rust/src/core/test.rs
@@ -4,24 +4,6 @@ use crate::metrics::AbsoluteDistance;
 use super::*;
 
 #[test]
-#[cfg(feature = "ffi")]
-fn test_threading() -> Fallible<()> {
-    use crate::{measurements::make_randomized_response_bool, transformations::make_split_lines};
-
-    fn is_send_sync<T: Send + Sync>(_arg: &T) {}
-
-    let meas = make_randomized_response_bool(0.75, false)?;
-    is_send_sync(&meas);
-    is_send_sync(&meas.into_any());
-
-    let trans = make_split_lines()?;
-    is_send_sync(&trans);
-    is_send_sync(&trans.into_any());
-
-    Ok(())
-}
-
-#[test]
 fn test_identity() -> Fallible<()> {
     let input_domain = AtomDomain::<i32>::default();
     let output_domain = AtomDomain::<i32>::default();

--- a/rust/src/data/ffi/mod.rs
+++ b/rust/src/data/ffi/mod.rs
@@ -9,7 +9,7 @@ use std::ptr::null;
 use std::slice;
 
 #[cfg(feature = "polars")]
-use crate::metrics::{Bound, Bounds};
+use crate::metrics::polars::{Bound, Bounds};
 #[cfg(feature = "polars")]
 use ::polars::prelude::*;
 #[cfg(feature = "polars")]
@@ -1097,6 +1097,11 @@ impl ProductOrd for AnyObject {
         }
 
         let type_arg = &self.type_;
+
+        #[cfg(feature = "polars")]
+        if type_arg == &Type::of::<Bounds>() {
+            return monomorphize::<Bounds>(self, other)
+        }
         // type list is explicit because (f32, f32), (f64, f64) are not in @numbers
         dispatch!(monomorphize, [(type_arg, [
             u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, f32, f64, (f32, f32), (f64, f64)

--- a/rust/src/ffi/any.rs
+++ b/rust/src/ffi/any.rs
@@ -80,16 +80,16 @@ impl Downcast for AnyObject {
     }
 }
 
-/// A struct wrapping a Box<dyn Any + Send + Sync>, with closures allowing it to implement Clone, PartialEq and Debug.
+/// A struct wrapping a Box<dyn Any>, with closures allowing it to implement Clone, PartialEq and Debug.
 pub struct ElementBox {
-    pub value: Box<dyn Any + Send + Sync>,
+    pub value: Box<dyn Any>,
     clone_glue: fn(&Self) -> Self,
     partial_eq_glue: fn(&Self, &Self) -> bool,
     debug_glue: fn(&Self) -> String,
 }
 
 impl ElementBox {
-    pub fn new<T: 'static + Clone + PartialEq + Debug + Send + Sync>(value: T) -> Self {
+    pub fn new<T: 'static + Clone + PartialEq + Debug>(value: T) -> Self {
         Self {
             value: Box::new(value),
             clone_glue: Self::make_clone_glue::<T>(),
@@ -98,8 +98,7 @@ impl ElementBox {
         }
     }
 
-    fn make_clone_glue<T: 'static + Clone + PartialEq + Debug + Send + Sync>() -> fn(&Self) -> Self
-    {
+    fn make_clone_glue<T: 'static + Clone + PartialEq + Debug>() -> fn(&Self) -> Self {
         |self_: &Self| {
             Self::new(
                 self_
@@ -110,13 +109,13 @@ impl ElementBox {
             )
         }
     }
-    fn make_eq_glue<T: 'static + PartialEq + Send + Sync>() -> fn(&Self, &Self) -> bool {
+    fn make_eq_glue<T: 'static + PartialEq>() -> fn(&Self, &Self) -> bool {
         |self_: &Self, other: &Self| {
             // The first downcast will always succeed, so equality check is all that's necessary.
             self_.value.downcast_ref::<T>() == other.value.downcast_ref::<T>()
         }
     }
-    fn make_debug_glue<T: 'static + Debug + Send + Sync>() -> fn(&Self) -> String {
+    fn make_debug_glue<T: 'static + Debug>() -> fn(&Self) -> String {
         |self_: &Self| {
             format!(
                 "{:?}",

--- a/rust/src/measurements/make_private_expr/expr_postprocess/mod.rs
+++ b/rust/src/measurements/make_private_expr/expr_postprocess/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::combinators::{SequentialCompositionMeasure, make_composition};
+use crate::combinators::{CompositionMeasure, make_composition};
 use crate::core::{Metric, MetricSpace};
 use crate::domains::{ExprPlan, WildExprDomain};
 use crate::{
@@ -24,7 +24,7 @@ mod test;
 /// * `input_exprs` - expressions to be post-processed
 /// * `postprocessor` - function that applies post-processing to the expressions
 /// * `param` - global noise (re)scale parameter
-pub fn make_expr_postprocess<MI: 'static + Metric, MO: 'static + SequentialCompositionMeasure>(
+pub fn make_expr_postprocess<MI: 'static + Metric, MO: 'static + CompositionMeasure>(
     input_domain: WildExprDomain,
     input_metric: MI,
     output_measure: MO,
@@ -75,7 +75,7 @@ where
     )
 }
 
-pub fn match_postprocess<MI: 'static + Metric, MO: 'static + SequentialCompositionMeasure>(
+pub fn match_postprocess<MI: 'static + Metric, MO: 'static + CompositionMeasure>(
     input_domain: WildExprDomain,
     input_metric: MI,
     output_measure: MO,

--- a/rust/src/measurements/make_private_expr/mod.rs
+++ b/rust/src/measurements/make_private_expr/mod.rs
@@ -2,7 +2,7 @@ use opendp_derive::bootstrap;
 use polars_plan::dsl::Expr;
 
 use crate::{
-    combinators::{SequentialCompositionMeasure, make_approximate},
+    combinators::{CompositionMeasure, make_approximate},
     core::{Measure, Measurement, Metric, MetricSpace, Transformation},
     domains::{Context, ExprDomain, ExprPlan, Invariant, WildExprDomain},
     error::Fallible,
@@ -159,7 +159,7 @@ where
 
 fn make_private_measure_agnostic<
     MI: 'static + UnboundedMetric,
-    MO: 'static + SequentialCompositionMeasure<Distance = f64>,
+    MO: 'static + CompositionMeasure<Distance = f64>,
 >(
     input_domain: WildExprDomain,
     input_metric: L01InfDistance<MI>,

--- a/rust/src/measurements/make_private_lazyframe/group_by/mod.rs
+++ b/rust/src/measurements/make_private_lazyframe/group_by/mod.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use crate::accuracy::{
     conservative_discrete_gaussian_tail_to_alpha, conservative_discrete_laplacian_tail_to_alpha,
 };
-use crate::combinators::{SequentialCompositionMeasure, make_composition};
+use crate::combinators::{CompositionMeasure, make_composition};
 use crate::core::{Function, Measurement, PrivacyMap};
 use crate::domains::{CategoricalDomain, Context, DslPlanDomain, WildExprDomain};
 use crate::error::*;
@@ -314,7 +314,7 @@ fn match_filter(key_sanitizer: &Option<KeySanitizer>) -> Option<(String, u32)> {
         .and_then(is_threshold_predicate)
 }
 
-pub trait ApproximateMeasure: SequentialCompositionMeasure {
+pub trait ApproximateMeasure: CompositionMeasure {
     fn add_delta(d_out: Self::Distance, delta_p: f64) -> Fallible<Self::Distance>;
 }
 
@@ -335,9 +335,9 @@ macro_rules! impl_measure_non_catastrophic {
 impl_measure_non_catastrophic!(MaxDivergence);
 impl_measure_non_catastrophic!(ZeroConcentratedDivergence);
 
-impl<MO: SequentialCompositionMeasure> ApproximateMeasure for Approximate<MO>
+impl<MO: CompositionMeasure> ApproximateMeasure for Approximate<MO>
 where
-    Self: SequentialCompositionMeasure<Distance = (MO::Distance, f64)>,
+    Self: CompositionMeasure<Distance = (MO::Distance, f64)>,
 {
     fn add_delta((d_out, delta): Self::Distance, delta_p: f64) -> Fallible<Self::Distance> {
         Ok((d_out, delta.inf_add(&delta_p)?))

--- a/rust/src/measurements/make_private_lazyframe/mod.rs
+++ b/rust/src/measurements/make_private_lazyframe/mod.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 use std::fmt::Debug;
 
 use crate::{
-    combinators::{SequentialCompositionMeasure, make_approximate},
+    combinators::{CompositionMeasure, make_approximate},
     core::{Function, Measure, Measurement, Metric, MetricSpace, StabilityMap, Transformation},
     domains::{DslPlanDomain, Invariant, LazyFrameDomain, Margin},
     error::Fallible,
@@ -239,7 +239,7 @@ impl<MI, MO> PrivateDslPlan<FrameDistance<MI>, Approximate<MO>> for DslPlan
 where
     MI: UnboundedMetric,
     MI::EventMetric: UnboundedMetric,
-    MO: 'static + SequentialCompositionMeasure,
+    MO: 'static + CompositionMeasure,
     Approximate<MO>: 'static + ApproximateMeasure,
     <Approximate<MO> as Measure>::Distance: Debug,
     Expr: PrivateExpr<L01InfDistance<MI::EventMetric>, Approximate<MO>>,

--- a/rust/src/measurements/make_private_lazyframe/postprocess/mod.rs
+++ b/rust/src/measurements/make_private_lazyframe/postprocess/mod.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use polars::prelude::DslPlan;
 
-use crate::combinators::SequentialCompositionMeasure;
+use crate::combinators::CompositionMeasure;
 use crate::core::{Metric, MetricSpace};
 use crate::domains::{DslPlanDomain, LazyFrameDomain};
 use crate::{
@@ -15,7 +15,7 @@ use super::PrivateDslPlan;
 #[cfg(test)]
 mod test;
 
-pub fn match_postprocess<MI: 'static + Metric, MO: 'static + SequentialCompositionMeasure>(
+pub fn match_postprocess<MI: 'static + Metric, MO: 'static + CompositionMeasure>(
     input_domain: DslPlanDomain,
     input_metric: MI,
     output_measure: MO,

--- a/rust/src/measurements/make_private_lazyframe/select/mod.rs
+++ b/rust/src/measurements/make_private_lazyframe/select/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use crate::combinators::{SequentialCompositionMeasure, make_composition};
+use crate::combinators::{CompositionMeasure, make_composition};
 use crate::core::{Function, Measurement, MetricSpace, StabilityMap, Transformation};
 use crate::domains::{Context, DslPlanDomain, WildExprDomain};
 use crate::error::*;
@@ -33,7 +33,7 @@ pub fn make_private_select<MI, MO>(
 where
     MI: 'static + UnboundedMetric,
     MI::EventMetric: UnboundedMetric,
-    MO: 'static + SequentialCompositionMeasure,
+    MO: 'static + CompositionMeasure,
     Expr: PrivateExpr<L01InfDistance<MI::EventMetric>, MO>,
     DslPlan: StableDslPlan<FrameDistance<MI>, FrameDistance<MI::EventMetric>>,
     (DslPlanDomain, FrameDistance<MI>): MetricSpace,

--- a/rust/src/measures/ffi.rs
+++ b/rust/src/measures/ffi.rs
@@ -1,4 +1,4 @@
-use std::{ffi::c_char, fmt::Debug, marker::PhantomData};
+use std::ffi::c_char;
 
 use crate::ffi::{
     any::{AnyObject, CallbackFn, Downcast, wrap_func},
@@ -11,7 +11,7 @@ use crate::{
     error::Fallible,
     ffi::{
         any::AnyMeasure,
-        util::{self, ExtrinsicObject, Type, into_c_char_p, to_str},
+        util::{self, ExtrinsicObject, into_c_char_p, to_str},
     },
     measures::{Approximate, MaxDivergence, ZeroConcentratedDivergence},
 };
@@ -336,59 +336,6 @@ pub extern "C" fn opendp_measures__user_divergence(
 ) -> FfiResult<*mut AnyMeasure> {
     let descriptor = try_!(to_str(descriptor)).to_string();
     Ok(AnyMeasure::new(ExtrinsicDivergence { descriptor })).into()
-}
-
-pub struct TypedMeasure<Q> {
-    pub measure: AnyMeasure,
-    marker: PhantomData<fn() -> Q>,
-}
-
-impl<Q: 'static> TypedMeasure<Q> {
-    pub fn new(measure: AnyMeasure) -> Fallible<TypedMeasure<Q>> {
-        if measure.distance_type != Type::of::<Q>() {
-            return fallible!(
-                FFI,
-                "unexpected distance type in measure. Expected {}, got {}",
-                Type::of::<Q>().to_string(),
-                measure.distance_type.to_string()
-            );
-        }
-
-        Ok(TypedMeasure {
-            measure,
-            marker: PhantomData,
-        })
-    }
-}
-
-impl<Q> PartialEq for TypedMeasure<Q> {
-    fn eq(&self, other: &Self) -> bool {
-        self.measure == other.measure
-    }
-}
-
-impl<Q> Clone for TypedMeasure<Q> {
-    fn clone(&self) -> Self {
-        Self {
-            measure: self.measure.clone(),
-            marker: self.marker.clone(),
-        }
-    }
-}
-
-impl<Q> Debug for TypedMeasure<Q> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.measure)
-    }
-}
-impl<Q> Default for TypedMeasure<Q> {
-    fn default() -> Self {
-        panic!()
-    }
-}
-
-impl<Q> Measure for TypedMeasure<Q> {
-    type Distance = Q;
 }
 
 #[bootstrap(

--- a/rust/src/metrics/ffi.rs
+++ b/rust/src/metrics/ffi.rs
@@ -1,4 +1,4 @@
-use std::{ffi::c_char, fmt::Debug, marker::PhantomData};
+use std::ffi::c_char;
 
 use opendp_derive::bootstrap;
 
@@ -323,57 +323,4 @@ pub extern "C" fn opendp_metrics__user_distance(
 ) -> FfiResult<*mut AnyMetric> {
     let descriptor = try_!(to_str(descriptor)).to_string();
     Ok(AnyMetric::new(ExtrinsicDistance { descriptor })).into()
-}
-
-pub struct TypedMetric<Q> {
-    metric: AnyMetric,
-    marker: PhantomData<fn() -> Q>,
-}
-
-impl<Q: 'static> TypedMetric<Q> {
-    pub fn new(metric: AnyMetric) -> Fallible<TypedMetric<Q>> {
-        if metric.distance_type != Type::of::<Q>() {
-            return fallible!(
-                FFI,
-                "unexpected distance type in metric. Expected {}, got {}",
-                Type::of::<Q>().to_string(),
-                metric.distance_type.to_string()
-            );
-        }
-
-        Ok(TypedMetric {
-            metric,
-            marker: PhantomData,
-        })
-    }
-}
-
-impl<Q> PartialEq for TypedMetric<Q> {
-    fn eq(&self, other: &Self) -> bool {
-        self.metric == other.metric
-    }
-}
-
-impl<Q> Clone for TypedMetric<Q> {
-    fn clone(&self) -> Self {
-        Self {
-            metric: self.metric.clone(),
-            marker: self.marker.clone(),
-        }
-    }
-}
-
-impl<Q> Debug for TypedMetric<Q> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.metric)
-    }
-}
-impl<Q> Default for TypedMetric<Q> {
-    fn default() -> Self {
-        panic!()
-    }
-}
-
-impl<Q> Metric for TypedMetric<Q> {
-    type Distance = Q;
 }


### PR DESCRIPTION
Closes #2421

This PR also drops the Send and Sync bounds for threading. This was primarily added for compatibility with Polars, but was ultimately not necessary. While threading is nice, the extra pain from the bounds compounds with odometers, and we don't seem to need it.