### PR TITLE
dev: cache rust build

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -42,8 +42,21 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             rust/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
+          key: dependencies-${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
+          # Even if there are some changes to Cargo.toml, the cache is a useful head start:
           restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Cache Rust build
+        uses: actions/cache@v4
+        with:
+          # Unless there's an advantage to caching build artifacts separately, cache all together.
+          path: |
+            rust/target/debug/libopendp.so
+            rust/target/debug/libopendp.a
+            python/src/opendp/
+            R/opendp/
+          # All the files, and only the files, which comprise the Rust source:
+          key: builds-${{ runner.os }}-rust-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
 
       - name: Check Rust version
         run: cargo --version
@@ -61,32 +74,32 @@ jobs:
       - name: Build (dynamic w/ polars)
         run: cargo build --verbose --features untrusted,ffi,polars
       
-      - name: Upload (dynamic w/ polars)
-        uses: actions/upload-artifact@v4
-        with:
-          name: dynamic_lib
-          path: rust/target/debug/libopendp.so
+      # - name: Upload (dynamic w/ polars)
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: dynamic_lib
+      #     path: rust/target/debug/libopendp.so
 
       - name: Build (static w/o Polars)
         run: cargo build --verbose --features untrusted,ffi
       
-      - name: Upload (static w/o Polars)
-        uses: actions/upload-artifact@v4
-        with:
-          name: static_lib
-          path: rust/target/debug/libopendp.a
+      # - name: Upload (static w/o Polars)
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: static_lib
+      #     path: rust/target/debug/libopendp.a
   
-      - name: Upload Python bindings
-        uses: actions/upload-artifact@v4
-        with:
-          name: python_bindings
-          path: python/src/opendp/
+      # - name: Upload Python bindings
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: python_bindings
+      #     path: python/src/opendp/
 
-      - name: Upload R bindings
-        uses: actions/upload-artifact@v4
-        with:
-          name: r_bindings
-          path: R/opendp/
+      # - name: Upload R bindings
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: r_bindings
+      #     path: R/opendp/
 
   rust-test:
     needs: rust-build
@@ -151,6 +164,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Cache Rust build (restore)
+        uses: actions/cache@v4
+        with:
+          path: |
+            rust/target/debug/libopendp.so
+            rust/target/debug/libopendp.a
+            python/src/opendp/
+            R/opendp/
+          # All the files, and only the files, which comprise the Rust source:
+          key: builds-${{ runner.os }}-rust-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -172,18 +196,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements-dev.txt
-
-      - name: Download dynamic lib
-        uses: actions/download-artifact@v4
-        with:
-          name: dynamic_lib
-          path: python/src/opendp/lib
-
-      - name: Download Python bindings
-        uses: actions/download-artifact@v4
-        with:
-          name: python_bindings
-          path: python/src/opendp/
 
       - name: Install package
         run: python -m pip install -e ${{ matrix.extra-install }}
@@ -238,11 +250,16 @@ jobs:
         # Negative lookahead could also be used, but it is only supported by PCRE, which not all greps support.
         run: "! ( grep 'https://docs.opendp.org' -r source --binary-file=without-match | grep -v https://docs.opendp.org/en/stable/api/r )"
 
-      - name: Download Python bindings
-        uses: actions/download-artifact@v4
+      - name: Cache Rust build (restore)
+        uses: actions/cache@v4
         with:
-          name: python_bindings
-          path: python/src/opendp/
+          path: |
+            rust/target/debug/libopendp.so
+            rust/target/debug/libopendp.a
+            python/src/opendp/
+            R/opendp/
+          # All the files, and only the files, which comprise the Rust source:
+          key: builds-${{ runner.os }}-rust-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
 
       - name: Install Pandoc
         run: sudo apt-get install -y pandoc
@@ -268,11 +285,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download Python bindings
-        uses: actions/download-artifact@v4
+      - name: Cache Rust build (restore)
+        uses: actions/cache@v4
         with:
-          name: python_bindings
-          path: python/src/opendp/
+          path: |
+            rust/target/debug/libopendp.so
+            rust/target/debug/libopendp.a
+            python/src/opendp/
+            R/opendp/
+          # All the files, and only the files, which comprise the Rust source:
+          key: builds-${{ runner.os }}-rust-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -296,12 +318,6 @@ jobs:
           python -m pip install flake8 pytest nbmake pytest-xdist
           python -m pip install -r requirements_notebooks.txt
 
-      - name: Download dynamic lib
-        uses: actions/download-artifact@v4
-        with:
-          name: dynamic_lib
-          path: python/src/opendp/lib
-
       - name: Install package
         run: (cd ../python && python -m pip install -e .)
 
@@ -321,19 +337,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download libs
-        uses: actions/download-artifact@v4
+      - name: Cache Rust build (restore)
+        uses: actions/cache@v4
         with:
-          # R uses a static library build that doesn't include Polars 
-          # (Polars currently links against Python)
-          name: static_lib
-          path: libs/
+          path: |
+            rust/target/debug/libopendp.so
+            rust/target/debug/libopendp.a
+            python/src/opendp/
+            R/opendp/
+          # All the files, and only the files, which comprise the Rust source:
+          key: builds-${{ runner.os }}-rust-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
 
-      - name: Download R bindings
-        uses: actions/download-artifact@v4
-        with:
-          name: r_bindings
-          path: R/opendp/
+      # TODO: Copy static lib to libs/?
 
       - name: Set up R
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -59,6 +59,8 @@ jobs:
           key: ${{ runner.os }}-rust-source-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
 
       - name: Check Rust version
+        # Here and in successive steps, check for prescence of last artifact
+        # to see if we had a cache hit or not.
         run: '[ -e R/opendp ] || cargo --version'
 
       - name: Check Format
@@ -73,33 +75,11 @@ jobs:
 
       - name: Build (dynamic w/ polars)
         run: '[ -e R/opendp ] || cargo build --verbose --features untrusted,ffi,polars'
-      
-      # - name: Upload (dynamic w/ polars)
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: dynamic_lib
-      #     path: rust/target/debug/libopendp.so
 
       - name: Build (static w/o Polars)
         run: '[ -e R/opendp ] || cargo build --verbose --features untrusted,ffi'
-      
-      # - name: Upload (static w/o Polars)
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: static_lib
-      #     path: rust/target/debug/libopendp.a
-  
-      # - name: Upload Python bindings
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: python_bindings
-      #     path: python/src/opendp/
 
-      # - name: Upload R bindings
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: r_bindings
-      #     path: R/opendp/
+      # Builds pushed to cache automatically, if there was not a hit earlier.
 
   rust-test:
     needs: rust-build
@@ -174,6 +154,9 @@ jobs:
             R/opendp/
           # All the files, and only the files, which comprise the Rust source:
           key: ${{ runner.os }}-rust-source-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
+
+      - name: Move lib into place
+        run: mv rust/target/debug/libopendp.so python/src/opendp/lib
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -261,6 +244,9 @@ jobs:
           # All the files, and only the files, which comprise the Rust source:
           key: ${{ runner.os }}-rust-source-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
 
+      - name: Move lib into place
+        run: mv rust/target/debug/libopendp.so python/src/opendp/lib
+
       - name: Install Pandoc
         run: sudo apt-get install -y pandoc
 
@@ -295,6 +281,9 @@ jobs:
             R/opendp/
           # All the files, and only the files, which comprise the Rust source:
           key: ${{ runner.os }}-rust-source-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
+
+      - name: Move lib into place
+        run: mv rust/target/debug/libopendp.so python/src/opendp/lib
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -348,7 +337,8 @@ jobs:
           # All the files, and only the files, which comprise the Rust source:
           key: ${{ runner.os }}-rust-source-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
 
-      # TODO: Copy static lib to libs/?
+      - name: Move lib into place
+        run: mv rust/target/debug/libopendp.a libs/
 
       - name: Set up R
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -156,7 +156,7 @@ jobs:
           key: ${{ runner.os }}-rust-source-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
 
       - name: Move lib into place
-        run: mv rust/target/debug/libopendp.so python/src/opendp/lib
+        run: mv ../rust/target/debug/libopendp.so src/opendp/lib
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -245,7 +245,7 @@ jobs:
           key: ${{ runner.os }}-rust-source-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
 
       - name: Move lib into place
-        run: mv rust/target/debug/libopendp.so python/src/opendp/lib
+        run: mv ../rust/target/debug/libopendp.so ../python/src/opendp/lib
 
       - name: Install Pandoc
         run: sudo apt-get install -y pandoc
@@ -283,7 +283,7 @@ jobs:
           key: ${{ runner.os }}-rust-source-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
 
       - name: Move lib into place
-        run: mv rust/target/debug/libopendp.so python/src/opendp/lib
+        run: mv ../rust/target/debug/libopendp.so ../python/src/opendp/lib
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -338,7 +338,7 @@ jobs:
           key: ${{ runner.os }}-rust-source-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
 
       - name: Move lib into place
-        run: mv rust/target/debug/libopendp.a libs/
+        run: mv ../rust/target/debug/libopendp.a libs/
 
       - name: Set up R
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -42,7 +42,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             rust/target
-          key: dependencies-${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.toml') }}
           # Even if there are some changes to Cargo.toml, the cache is a useful head start:
           restore-keys: ${{ runner.os }}-cargo-
 
@@ -56,7 +56,7 @@ jobs:
             python/src/opendp/
             R/opendp/
           # All the files, and only the files, which comprise the Rust source:
-          key: builds-${{ runner.os }}-rust-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
+          key: ${{ runner.os }}-rust-source-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
 
       - name: Check Rust version
         run: '[ -e R/opendp ] || cargo --version'
@@ -173,7 +173,7 @@ jobs:
             python/src/opendp/
             R/opendp/
           # All the files, and only the files, which comprise the Rust source:
-          key: builds-${{ runner.os }}-rust-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
+          key: ${{ runner.os }}-rust-source-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -259,7 +259,7 @@ jobs:
             python/src/opendp/
             R/opendp/
           # All the files, and only the files, which comprise the Rust source:
-          key: builds-${{ runner.os }}-rust-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
+          key: ${{ runner.os }}-rust-source-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
 
       - name: Install Pandoc
         run: sudo apt-get install -y pandoc
@@ -294,7 +294,7 @@ jobs:
             python/src/opendp/
             R/opendp/
           # All the files, and only the files, which comprise the Rust source:
-          key: builds-${{ runner.os }}-rust-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
+          key: ${{ runner.os }}-rust-source-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -346,7 +346,7 @@ jobs:
             python/src/opendp/
             R/opendp/
           # All the files, and only the files, which comprise the Rust source:
-          key: builds-${{ runner.os }}-rust-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
+          key: ${{ runner.os }}-rust-source-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
 
       # TODO: Copy static lib to libs/?
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -59,20 +59,20 @@ jobs:
           key: builds-${{ runner.os }}-rust-${{ hashFiles('rust/Cargo.toml') }}-${{ hashFiles('rust/opendp_derive/**') }}-${{ hashFiles('rust/opendp_tooling/**') }}-${{ hashFiles('rust/src/**') }}
 
       - name: Check Rust version
-        run: cargo --version
+        run: '[ -e R/opendp ] || cargo --version'
 
       - name: Check Format
         # fix formatting with: cargo fmt --manifest-path=rust/Cargo.toml --all
-        run: cargo fmt --manifest-path=Cargo.toml --all --check
+        run: '[ -e R/opendp ] || cargo fmt --manifest-path=Cargo.toml --all --check'
 
       - name: Build
-        run: cargo build --verbose --all-features
+        run: '[ -e R/opendp ] || cargo build --verbose --all-features'
       
       - name: Check --no-default-features
-        run: cargo check --verbose --no-default-features --features untrusted,bindings
+        run: '[ -e R/opendp ] || cargo check --verbose --no-default-features --features untrusted,bindings'
 
       - name: Build (dynamic w/ polars)
-        run: cargo build --verbose --features untrusted,ffi,polars
+        run: '[ -e R/opendp ] || cargo build --verbose --features untrusted,ffi,polars'
       
       # - name: Upload (dynamic w/ polars)
       #   uses: actions/upload-artifact@v4
@@ -81,7 +81,7 @@ jobs:
       #     path: rust/target/debug/libopendp.so
 
       - name: Build (static w/o Polars)
-        run: cargo build --verbose --features untrusted,ffi
+        run: '[ -e R/opendp ] || cargo build --verbose --features untrusted,ffi'
       
       # - name: Upload (static w/o Polars)
       #   uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Fix #2435

It seems like we could use github actions cache instead of artifacts between jobs, and skip successive build steps if the artifact already exists.
- Faster CI (particularly for someone mostly working on the Python codebase)
- Less config? instead of a name for the artifact, we only need to think about paths.

Questions:
- Does this actually work?
- Is there a way to avoid the boilerplate?
- Should the successive build steps be combined, rather than checking for each one?
- Is there any problem with using the existence check, rather than checking for cache hit?