### PR TITLE
docs: Add missing docstring boilerplate in extras

### DIFF
--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -3,7 +3,7 @@ The ``context`` module provides :py:class:`opendp.context.Context` and supportin
 
 For more context, see :ref:`context in the User Guide <context-user-guide>`.
 
-For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+For convenience, all the members of this module are also available from :py:mod:`opendp.prelude`.
 We suggest importing under the conventional name ``dp``:
 
 .. code:: pycon

--- a/python/src/opendp/extras/examples/__init__.py
+++ b/python/src/opendp/extras/examples/__init__.py
@@ -6,7 +6,7 @@ We suggest importing under the conventional name ``dp``:
 
     >>> import opendp.prelude as dp
 
-The classes of this module will then be accessible at ``dp.examples``.    
+The members of this module will then be accessible at ``dp.examples``.    
 '''
 
 from pathlib import Path

--- a/python/src/opendp/extras/examples/__init__.py
+++ b/python/src/opendp/extras/examples/__init__.py
@@ -1,12 +1,12 @@
 '''
-For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+For convenience, all the members of this module are also available from :py:mod:`opendp.prelude`.
 We suggest importing under the conventional name ``dp``:
 
 .. code:: pycon
 
     >>> import opendp.prelude as dp
 
-The methods of this module will then be accessible at ``dp.examples``.    
+The classes of this module will then be accessible at ``dp.examples``.    
 '''
 
 from pathlib import Path

--- a/python/src/opendp/extras/mbi/__init__.py
+++ b/python/src/opendp/extras/mbi/__init__.py
@@ -12,7 +12,7 @@ We suggest importing under the conventional name ``dp``:
 
     >>> import opendp.prelude as dp
 
-The classes of this module will then be accessible at ``dp.mbi``.
+The members of this module will then be accessible at ``dp.mbi``.
 '''
 
 from ._aim import AIM

--- a/python/src/opendp/extras/mbi/__init__.py
+++ b/python/src/opendp/extras/mbi/__init__.py
@@ -5,14 +5,14 @@ This module requires extra installs: ``pip install 'opendp[mbi]'``
 and is the name of the `Private-PGM <https://github.com/ryan112358/private-pgm>`_ package.
 OpenDP uses Private-PGM to postprocess DP releases made with the OpenDP Library.
 
-For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+For convenience, all the members of this module are also available from :py:mod:`opendp.prelude`.
 We suggest importing under the conventional name ``dp``:
 
-.. code:: python
+.. code:: pycon
 
     >>> import opendp.prelude as dp
 
-The methods of this module will then be accessible at ``dp.mbi``.
+The classes of this module will then be accessible at ``dp.mbi``.
 '''
 
 from ._aim import AIM

--- a/python/src/opendp/extras/numpy/__init__.py
+++ b/python/src/opendp/extras/numpy/__init__.py
@@ -8,7 +8,7 @@ We suggest importing under the conventional name ``dp``:
 
     >>> import opendp.prelude as dp
 
-The classes of this module will then be accessible at ``dp.numpy``.    
+The members of this module will then be accessible at ``dp.numpy``.    
 '''
 
 from __future__ import annotations

--- a/python/src/opendp/extras/numpy/__init__.py
+++ b/python/src/opendp/extras/numpy/__init__.py
@@ -1,14 +1,14 @@
 '''
 This module requires extra installs: ``pip install 'opendp[numpy]'``
 
-For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+For convenience, all the members of this module are also available from :py:mod:`opendp.prelude`.
 We suggest importing under the conventional name ``dp``:
 
 .. code:: pycon
 
     >>> import opendp.prelude as dp
 
-The methods of this module will then be accessible at ``dp.numpy``.    
+The classes of this module will then be accessible at ``dp.numpy``.    
 '''
 
 from __future__ import annotations

--- a/python/src/opendp/extras/numpy/canonical.py
+++ b/python/src/opendp/extras/numpy/canonical.py
@@ -1,8 +1,8 @@
 """
-For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+For convenience, all the members of this module are also available from :py:mod:`opendp.prelude`.
 We suggest importing under the conventional name ``dp``:
 
-.. code:: python
+.. code:: pycon
 
     >>> import opendp.prelude as dp
 

--- a/python/src/opendp/extras/numpy/canonical.py
+++ b/python/src/opendp/extras/numpy/canonical.py
@@ -1,4 +1,6 @@
 """
+This module requires extra installs: ``pip install 'opendp[numpy]'``
+
 For convenience, all the members of this module are also available from :py:mod:`opendp.prelude`.
 We suggest importing under the conventional name ``dp``:
 

--- a/python/src/opendp/extras/numpy/canonical.py
+++ b/python/src/opendp/extras/numpy/canonical.py
@@ -1,3 +1,14 @@
+"""
+For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+We suggest importing under the conventional name ``dp``:
+
+.. code:: python
+
+    >>> import opendp.prelude as dp
+
+The classes of this module will then be accessible at ``dp.numpy.canonical``.
+"""
+
 from __future__ import annotations
 
 import math

--- a/python/src/opendp/extras/numpy/canonical.py
+++ b/python/src/opendp/extras/numpy/canonical.py
@@ -8,7 +8,7 @@ We suggest importing under the conventional name ``dp``:
 
     >>> import opendp.prelude as dp
 
-The classes of this module will then be accessible at ``dp.numpy.canonical``.
+The members of this module will then be accessible at ``dp.numpy.canonical``.
 """
 
 from __future__ import annotations

--- a/python/src/opendp/extras/polars/__init__.py
+++ b/python/src/opendp/extras/polars/__init__.py
@@ -11,7 +11,7 @@ We suggest importing under the conventional name ``dp``:
 
     >>> import opendp.prelude as dp
 
-The methods of this module will then be accessible at ``dp.polars``.
+The classes of this module will then be accessible at ``dp.polars``.
 """
 
 from __future__ import annotations

--- a/python/src/opendp/extras/polars/__init__.py
+++ b/python/src/opendp/extras/polars/__init__.py
@@ -11,7 +11,7 @@ We suggest importing under the conventional name ``dp``:
 
     >>> import opendp.prelude as dp
 
-The classes of this module will then be accessible at ``dp.polars``.
+The members of this module will then be accessible at ``dp.polars``.
 """
 
 from __future__ import annotations

--- a/python/src/opendp/extras/polars/contingency_table.py
+++ b/python/src/opendp/extras/polars/contingency_table.py
@@ -8,7 +8,7 @@ We suggest importing under the conventional name ``dp``:
 
     >>> import opendp.prelude as dp
 
-The classes of this module will then be accessible at ``dp.polars.contingency_table``.
+The members of this module will then be accessible at ``dp.polars.contingency_table``.
 """
 
 from typing import Optional, Type, Union

--- a/python/src/opendp/extras/polars/contingency_table.py
+++ b/python/src/opendp/extras/polars/contingency_table.py
@@ -1,4 +1,6 @@
 """
+This module requires extra installs: ``pip install 'opendp[polars]'``
+
 For convenience, all the members of this module are also available from :py:mod:`opendp.prelude`.
 We suggest importing under the conventional name ``dp``:
 

--- a/python/src/opendp/extras/polars/contingency_table.py
+++ b/python/src/opendp/extras/polars/contingency_table.py
@@ -1,8 +1,8 @@
 """
-For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+For convenience, all the members of this module are also available from :py:mod:`opendp.prelude`.
 We suggest importing under the conventional name ``dp``:
 
-.. code:: python
+.. code:: pycon
 
     >>> import opendp.prelude as dp
 

--- a/python/src/opendp/extras/polars/contingency_table.py
+++ b/python/src/opendp/extras/polars/contingency_table.py
@@ -1,3 +1,14 @@
+"""
+For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+We suggest importing under the conventional name ``dp``:
+
+.. code:: python
+
+    >>> import opendp.prelude as dp
+
+The classes of this module will then be accessible at ``dp.polars.contingency_table``.
+"""
+
 from typing import Optional, Type, Union
 from opendp.context import Query
 from opendp.extras.mbi._table import ContingencyTable

--- a/python/src/opendp/extras/sklearn/__init__.py
+++ b/python/src/opendp/extras/sklearn/__init__.py
@@ -1,14 +1,14 @@
 '''
 This module requires extra installs: ``pip install 'opendp[scikit-learn]'``
 
-For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+For convenience, all the members of this module are also available from :py:mod:`opendp.prelude`.
 We suggest importing under the conventional name ``dp``:
 
 .. code:: pycon
 
     >>> import opendp.prelude as dp
 
-The methods of this module will then be accessible at ``dp.sklearn``.
+The classes of this module will then be accessible at ``dp.sklearn``.
 Submodule organization will follow the conventions of `scikit-learn <https://scikit-learn.org/stable/api/index.html>`_.
 '''
 

--- a/python/src/opendp/extras/sklearn/__init__.py
+++ b/python/src/opendp/extras/sklearn/__init__.py
@@ -8,7 +8,7 @@ We suggest importing under the conventional name ``dp``:
 
     >>> import opendp.prelude as dp
 
-The classes of this module will then be accessible at ``dp.sklearn``.
+The members of this module will then be accessible at ``dp.sklearn``.
 Submodule organization will follow the conventions of `scikit-learn <https://scikit-learn.org/stable/api/index.html>`_.
 '''
 

--- a/python/src/opendp/extras/sklearn/decomposition/__init__.py
+++ b/python/src/opendp/extras/sklearn/decomposition/__init__.py
@@ -1,14 +1,14 @@
 '''
 This module requires extra installs: ``pip install 'opendp[scikit-learn]'``
 
-For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+For convenience, all the members of this module are also available from :py:mod:`opendp.prelude`.
 We suggest importing under the conventional name ``dp``:
 
 .. code:: pycon
 
     >>> import opendp.prelude as dp
 
-The methods of this module will then be accessible at ``dp.sklearn.decomposition``.    
+The classes of this module will then be accessible at ``dp.sklearn.decomposition``.    
 
 See also our :ref:`tutorial on diffentially private PCA <dp-pca>`.
 '''

--- a/python/src/opendp/extras/sklearn/decomposition/__init__.py
+++ b/python/src/opendp/extras/sklearn/decomposition/__init__.py
@@ -8,7 +8,7 @@ We suggest importing under the conventional name ``dp``:
 
     >>> import opendp.prelude as dp
 
-The classes of this module will then be accessible at ``dp.sklearn.decomposition``.    
+The members of this module will then be accessible at ``dp.sklearn.decomposition``.    
 
 See also our :ref:`tutorial on diffentially private PCA <dp-pca>`.
 '''

--- a/python/src/opendp/extras/sklearn/linear_model/__init__.py
+++ b/python/src/opendp/extras/sklearn/linear_model/__init__.py
@@ -1,14 +1,14 @@
 """
 This module requires extra installs: ``pip install 'opendp[scikit-learn]'``
 
-For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+For convenience, all the members of this module are also available from :py:mod:`opendp.prelude`.
 We suggest importing under the conventional name ``dp``:
 
 .. code:: pycon
 
     >>> import opendp.prelude as dp
 
-The methods of this module will then be accessible at ``dp.sklearn.linear_model``.
+The classes of this module will then be accessible at ``dp.sklearn.linear_model``.
 
 If you're interested in the underlying algorithm, we've also
 `implemented Theil-Sen Regression as a demonstration of OpenDP plugins <../user-guide/plugins/theil-sen-regression.html>`_.

--- a/python/src/opendp/extras/sklearn/linear_model/__init__.py
+++ b/python/src/opendp/extras/sklearn/linear_model/__init__.py
@@ -8,7 +8,7 @@ We suggest importing under the conventional name ``dp``:
 
     >>> import opendp.prelude as dp
 
-The classes of this module will then be accessible at ``dp.sklearn.linear_model``.
+The members of this module will then be accessible at ``dp.sklearn.linear_model``.
 
 If you're interested in the underlying algorithm, we've also
 `implemented Theil-Sen Regression as a demonstration of OpenDP plugins <../user-guide/plugins/theil-sen-regression.html>`_.

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -6,7 +6,7 @@ but they may feel out of place in Python. These utilities try to fill that gap.
 
 For more context, see :ref:`typing in the User Guide <typing-user-guide>`.
 
-For convenience, all the functions of this module are also available from :py:mod:`opendp.prelude`.
+For convenience, all the members of this module are also available from :py:mod:`opendp.prelude`.
 We suggest importing under the conventional name ``dp``:
 
 .. code:: pycon

--- a/python/test/test_docs.py
+++ b/python/test/test_docs.py
@@ -73,15 +73,15 @@ First cell with missing or misordered execution:\n{bad_sources[0].splitlines()[0
 
 def is_public_and_not_top(path: Path):
     '''
-    >>> is_public(Path('_parent/child.py'))
+    >>> is_public_and_not_top(Path('_parent/child.py'))
     False
-    >>> is_public(Path('_parent/__init__.py'))
+    >>> is_public_and_not_top(Path('_parent/__init__.py'))
     False
-    >>> is_public(Path('parent/__init__.py'))
+    >>> is_public_and_not_top(Path('parent/__init__.py'))
     True
-    >>> is_public(Path('parent/_child.py'))
+    >>> is_public_and_not_top(Path('parent/_child.py'))
     False
-    >>> is_public(Path('parent/child.py'))
+    >>> is_public_and_not_top(Path('parent/child.py'))
     True
     '''
     return not path.parent.name.startswith('_') and (
@@ -117,7 +117,7 @@ def get_docstring(py_path: Path):
     py = py_path.read_text()
     module_ast = ast.parse(py)
     # This is a little fragile, but as long as a docstring is first, it should work.
-    return module_ast.body[0].value.value.strip()
+    return module_ast.body[0].value.value.strip() # type: ignore[attr-defined]
  
 
 @pytest.mark.parametrize(

--- a/python/test/test_docs.py
+++ b/python/test/test_docs.py
@@ -99,8 +99,19 @@ public_extras = [
     public_extras,
     ids=lambda path: f'{path.parent.name}/{path.name}'
 )
-def test_extras_boilerplate(py_path):
+def test_extras_boilerplate_convenience(py_path):
     if py_path.parent.name == 'extras' and py_path.name == '__init__.py':
         pytest.skip("top-level is a special case")
     py = py_path.read_text()
-    assert 'For convenience' in py
+    expected_ns = f'dp.{py_path.name}'
+    expected = f"""
+For convenience, all the members of this module are also available from :py:mod:`opendp.prelude`.
+We suggest importing under the conventional name ``dp``:
+
+.. code:: pycon
+
+    >>> import opendp.prelude as dp
+"""
+    # The classes of this module will then be accessible at ``{expected_ns}``.
+
+    assert expected in py

--- a/python/test/test_docs.py
+++ b/python/test/test_docs.py
@@ -136,7 +136,7 @@ We suggest importing under the conventional name ``dp``:
 
     >>> import opendp.prelude as dp
 
-The classes of this module will then be accessible at ``{expected_ns}``.    
+The members of this module will then be accessible at ``{expected_ns}``.    
 """.strip()
     assert expected in actual, f"expected not in actual: {expected=}\n{actual=}"
 


### PR DESCRIPTION
- Fix #2486

This got a little more complicated than I would have liked, but it should make sure the text gets added to any new modules.