### PR TITLE
docs: fix linear regression link

### DIFF
--- a/docs/source/api/user-guide/plugins/theil-sen-regression.ipynb
+++ b/docs/source/api/user-guide/plugins/theil-sen-regression.ipynb
@@ -9,7 +9,7 @@
     "In this tutorial, we will be using a differentially private Theil-Sen estimator to estimate regression parameters. \n",
     "\n",
     "**NOTE**: If you actually want to use Theil-Sen, don't copy-and-paste this code!\n",
-    "It's implemented by the OpenDP library, and is available at [`opendp.extras.sklearn.linear_model`](../../python/opendp.extras.sklearn.linear_model.html).\n",
+    "It is already implemented by the OpenDP library: see the [API Reference](../../python/opendp.extras.sklearn.linear_model.rst).\n",
     "\n",
     "The Theil-Sen estimator is a robust method to fit a line to sample points by **choosing the median of the slopes between each pair of points in the data**.\n",
     "\n",


### PR DESCRIPTION
- Fix #2484

I think what happened was that notebooks are converted to rst before rendering to html, but rst syntax does not support nested tags. To fix this, we can just make the link plain text, and I've confirmed locally that it renders nicely.