### PR TITLE
Prefer empty lines in doctests

### DIFF
--- a/docs/source/api/user-guide/polars/polars-vs-opendp.rst
+++ b/docs/source/api/user-guide/polars/polars-vs-opendp.rst
@@ -66,7 +66,7 @@ OpenDP Polars differs from typical Polars in these ways:
         └────────┴──────────────┴─────────────────┴───────┘
 
         >>> candidates = list(range(0, 100, 10))
-        >>>
+
         >>> _ = context.query().select(
         ...     pl.col("income")
         ...     .fill_null(0)

--- a/python/src/opendp/extras/polars/__init__.py
+++ b/python/src/opendp/extras/polars/__init__.py
@@ -11,7 +11,7 @@ We suggest importing under the conventional name ``dp``:
 
     >>> import opendp.prelude as dp
 
-The classes of this module will then be accessible at ``dp.polars``.
+The members of this module will then be accessible at ``dp.polars``.
 """
 
 from __future__ import annotations
@@ -1081,7 +1081,7 @@ class LazyFrameQuery:
             ...         f"at a statistical significance level alpha of {alpha}, "
             ...         f"or with (1 - {alpha})100% = {(1 - alpha) * 100}% confidence."
             ...     )
-            
+
             >>> interpret_accuracy("Integer Laplace", 2.0, 6.429605, alpha=.05) # doctest:+SKIP
         """
         from opendp.accuracy import summarize_polars_measurement

--- a/python/src/opendp/extras/polars/__init__.py
+++ b/python/src/opendp/extras/polars/__init__.py
@@ -11,7 +11,7 @@ We suggest importing under the conventional name ``dp``:
 
     >>> import opendp.prelude as dp
 
-The methods of this module will then be accessible at ``dp.polars``.
+The classes of this module will then be accessible at ``dp.polars``.
 """
 
 from __future__ import annotations
@@ -1041,44 +1041,48 @@ class LazyFrameQuery:
 
         :example:
 
-        >>> import polars as pl
-        >>> data = pl.LazyFrame([pl.Series("convicted", [0, 1, 1, 0, 1] * 50, dtype=pl.Int32)])
-        >>>
-        >>> context = dp.Context.compositor(
-        ...     data=data,
-        ...     privacy_unit=dp.unit_of(contributions=1),
-        ...     privacy_loss=dp.loss_of(epsilon=1.0),
-        ...     split_evenly_over=1,
-        ...     margins=[dp.polars.Margin(by=(), max_length=1000)],
-        ... )
-        >>>
-        >>> query = context.query().select(
-        ...     dp.len(),
-        ...     pl.col("convicted").fill_null(0).dp.sum((0, 1))
-        ... )
-        >>>
-        >>> query.summarize(alpha=.05)  # type: ignore[union-attr]
-        shape: (2, 5)
-        ┌───────────┬──────────────┬─────────────────┬───────┬──────────┐
-        │ column    ┆ aggregate    ┆ distribution    ┆ scale ┆ accuracy │
-        │ ---       ┆ ---          ┆ ---             ┆ ---   ┆ ---      │
-        │ str       ┆ str          ┆ str             ┆ f64   ┆ f64      │
-        ╞═══════════╪══════════════╪═════════════════╪═══════╪══════════╡
-        │ len       ┆ Frame Length ┆ Integer Laplace ┆ 2.0   ┆ 6.429605 │
-        │ convicted ┆ Sum          ┆ Integer Laplace ┆ 2.0   ┆ 6.429605 │
-        └───────────┴──────────────┴─────────────────┴───────┴──────────┘
+        .. code:: pycon
+
+            >>> import polars as pl
+            >>> data = pl.LazyFrame([pl.Series("convicted", [0, 1, 1, 0, 1] * 50, dtype=pl.Int32)])
+
+            >>> context = dp.Context.compositor(
+            ...     data=data,
+            ...     privacy_unit=dp.unit_of(contributions=1),
+            ...     privacy_loss=dp.loss_of(epsilon=1.0),
+            ...     split_evenly_over=1,
+            ...     margins=[dp.polars.Margin(by=(), max_length=1000)],
+            ... )
+
+            >>> query = context.query().select(
+            ...     dp.len(),
+            ...     pl.col("convicted").fill_null(0).dp.sum((0, 1))
+            ... )
+
+            >>> query.summarize(alpha=.05)  # type: ignore[union-attr]
+            shape: (2, 5)
+            ┌───────────┬──────────────┬─────────────────┬───────┬──────────┐
+            │ column    ┆ aggregate    ┆ distribution    ┆ scale ┆ accuracy │
+            │ ---       ┆ ---          ┆ ---             ┆ ---   ┆ ---      │
+            │ str       ┆ str          ┆ str             ┆ f64   ┆ f64      │
+            ╞═══════════╪══════════════╪═════════════════╪═══════╪══════════╡
+            │ len       ┆ Frame Length ┆ Integer Laplace ┆ 2.0   ┆ 6.429605 │
+            │ convicted ┆ Sum          ┆ Integer Laplace ┆ 2.0   ┆ 6.429605 │
+            └───────────┴──────────────┴─────────────────┴───────┴──────────┘
 
         The accuracy in any given row can be interpreted with:
 
-        >>> def interpret_accuracy(distribution, scale, accuracy, alpha):
-        ...     return (
-        ...         f"When the {distribution} scale is {scale}, "
-        ...         f"the DP estimate differs from the true value by no more than {accuracy} "
-        ...         f"at a statistical significance level alpha of {alpha}, "
-        ...         f"or with (1 - {alpha})100% = {(1 - alpha) * 100}% confidence."
-        ...     )
-        ...
-        >>> interpret_accuracy("Integer Laplace", 2.0, 6.429605, alpha=.05) # doctest:+SKIP
+        .. code:: pycon
+
+            >>> def interpret_accuracy(distribution, scale, accuracy, alpha):
+            ...     return (
+            ...         f"When the {distribution} scale is {scale}, "
+            ...         f"the DP estimate differs from the true value by no more than {accuracy} "
+            ...         f"at a statistical significance level alpha of {alpha}, "
+            ...         f"or with (1 - {alpha})100% = {(1 - alpha) * 100}% confidence."
+            ...     )
+            
+            >>> interpret_accuracy("Integer Laplace", 2.0, 6.429605, alpha=.05) # doctest:+SKIP
         """
         from opendp.accuracy import summarize_polars_measurement
 

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -1455,7 +1455,6 @@ def binary_search(
     5.0
     >>> dp.binary_search(lambda x: x <= 5.)
     5.0
-    >>>
     >>> dp.binary_search(lambda x: x > 5, T=int)
     6
     >>> dp.binary_search(lambda x: x < 5, T=int)

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -264,7 +264,6 @@ class RuntimeType(object):
         Vec<String>
         >>> dp.RuntimeType.infer((12., True, "A"))
         (f64, bool, String)
-        >>>
         >>> dp.RuntimeType.infer([])
         Traceback (most recent call last):
         ...

--- a/python/test/test_docs.py
+++ b/python/test/test_docs.py
@@ -25,6 +25,7 @@ def test_thens_are_documented(module, function):
 
 
 docs_source = Path(__file__).parent.parent.parent / 'docs' / 'source'
+assert docs_source.exists()
 
 
 def get_self_and_parent(path: Path):
@@ -52,6 +53,7 @@ def test_code_block_language(rst_path: Path):
                 errors.append(f'line {i+1}: Got "{language}", expected one of: {", ".join(expected)}')
     assert not errors, '\n'.join(errors)
 
+
 @pytest.mark.parametrize(
     "rst_path",
     list(docs_source.glob("**/*.rst")),
@@ -72,6 +74,25 @@ def test_single_backticks(rst_path: Path):
             content = m.group(2)
             errors.append(f'line {i+1}: "{content}" will be italicized: add double-backticks, or change to "*".')
     assert not errors, '\n'.join(errors)
+
+
+python_src = Path(__file__).parent.parent / 'src'
+assert python_src.exists()
+
+
+@pytest.mark.parametrize(
+    "path",
+    list(docs_source.glob("**/*.rst")) + list(python_src.glob("**/*.py")),
+    ids=get_self_and_parent
+)
+def test_doctest_empty_lines(path: Path):
+    lines = path.read_text().splitlines()
+    errors = []
+    for i, line in enumerate(lines):
+        if re.search(r'>>>\s*$', line):
+            errors.append(f'line {i+1}: wrap with "code::" block and drop empty ">>>".')
+    assert not errors, '\n'.join(errors)
+
 
 @pytest.mark.parametrize(
     "nb_path",

--- a/rust/src/measurements/code/make_randomized_response_bitvec.rst
+++ b/rust/src/measurements/code/make_randomized_response_bitvec.rst
@@ -1,31 +1,33 @@
->>> import numpy as np
->>> import opendp.prelude as dp
->>>
->>> dp.enable_features("contrib")
->>>
->>> # Create the randomized response mechanism
->>> m_rr = dp.m.make_randomized_response_bitvec(
-...     dp.bitvector_domain(max_weight=4), dp.discrete_distance(), f=0.95
-... )
->>>
->>> # compute privacy loss
->>> m_rr.map(1)
-0.8006676684558611
->>>
->>> # formula is 2 * m * ln((2 - f) / f)
->>> # where m = 4 (the weight) and f = .95 (the flipping probability)
->>>
->>> # prepare a dataset to release, by encoding a bit vector as a numpy byte array
->>> data = np.packbits(
-...     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0]
-... )
->>> assert np.array_equal(data, np.array([0, 8, 12], dtype=np.uint8))
->>>
->>> # roundtrip: numpy -> bytes -> mech -> bytes -> numpy
->>> release = np.frombuffer(m_rr(data.tobytes()), dtype=np.uint8)
->>>
->>> # compare the two bit vectors:
->>> [int(bit) for bit in np.unpackbits(data)]
-[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0]
->>> [int(bit) for bit in np.unpackbits(release)]
-[...]
+.. code:: pycon
+
+    >>> import numpy as np
+    >>> import opendp.prelude as dp
+
+    >>> dp.enable_features("contrib")
+
+    >>> # Create the randomized response mechanism
+    >>> m_rr = dp.m.make_randomized_response_bitvec(
+    ...     dp.bitvector_domain(max_weight=4), dp.discrete_distance(), f=0.95
+    ... )
+
+    >>> # compute privacy loss
+    >>> m_rr.map(1)
+    0.8006676684558611
+
+    >>> # formula is 2 * m * ln((2 - f) / f)
+    >>> # where m = 4 (the weight) and f = .95 (the flipping probability)
+
+    >>> # prepare a dataset to release, by encoding a bit vector as a numpy byte array
+    >>> data = np.packbits(
+    ...     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0]
+    ... )
+    >>> assert np.array_equal(data, np.array([0, 8, 12], dtype=np.uint8))
+
+    >>> # roundtrip: numpy -> bytes -> mech -> bytes -> numpy
+    >>> release = np.frombuffer(m_rr(data.tobytes()), dtype=np.uint8)
+
+    >>> # compare the two bit vectors:
+    >>> [int(bit) for bit in np.unpackbits(data)]
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0]
+    >>> [int(bit) for bit in np.unpackbits(release)]
+    [...]


### PR DESCRIPTION
- Fix #2480

I think this helps the readability a bit, but it's minor:
- In some cases, just get rid of empty `>>>`.
- In others, add a wrapping block so we can skip lines in the doctest and still get just one block in the sphinx render.

