### PR TITLE
Clean up stats ToC in getting-started

### DIFF
--- a/docs/source/getting-started/statistical-modeling/index.rst
+++ b/docs/source/getting-started/statistical-modeling/index.rst
@@ -3,7 +3,7 @@ Statistical Modeling
 
 Beyond the basic statistics offered by the Polars interface,
 OpenDP offers differentially private versions of linear regression and PCA,
-with APIs modelled after :py:mod:`sklearn <opendp.extras.sklearn>`.
+with APIs modelled after scikit-learn.
 
 Another more flexible option is to use OpenDP to create synthetic data.
 Statistics calculated from synthetic data with a given privacy budget

--- a/docs/source/getting-started/statistical-modeling/index.rst
+++ b/docs/source/getting-started/statistical-modeling/index.rst
@@ -1,10 +1,19 @@
 Statistical Modeling
 ====================
 
-We intend to provide more functionality in this space in the future and are accepting contributions.
-For the time being, OpenDP has PCA and we consider it a model for future functionality.
+Beyond the basic statistics offered by the Polars interface,
+OpenDP offers differentially private versions of **linear regression** and **PCA**,
+with APIs modelled after :py:mod:`sklearn <opendp.extras.sklearn>`.
+
+Another more flexible option is to use OpenDP to create **synthetic data**.
+Statistics calculated from synthetic data with a given privacy budget
+will be less accurate than a tailored DP release using the same budget,
+but if you are unsure what analyses will be needed,
+or you need to provide tabular data so that downstream consumers can make their own analyses,
+this may be a good option.
 
 .. toctree::
+  :maxdepth: 1
 
   pca
   synthetic-data

--- a/docs/source/getting-started/statistical-modeling/index.rst
+++ b/docs/source/getting-started/statistical-modeling/index.rst
@@ -2,10 +2,10 @@ Statistical Modeling
 ====================
 
 Beyond the basic statistics offered by the Polars interface,
-OpenDP offers differentially private versions of **linear regression** and **PCA**,
+OpenDP offers differentially private versions of linear regression and PCA,
 with APIs modelled after :py:mod:`sklearn <opendp.extras.sklearn>`.
 
-Another more flexible option is to use OpenDP to create **synthetic data**.
+Another more flexible option is to use OpenDP to create synthetic data.
 Statistics calculated from synthetic data with a given privacy budget
 will be less accurate than a tailored DP release using the same budget,
 but if you are unsure what analyses will be needed,
@@ -15,5 +15,6 @@ this may be a good option.
 .. toctree::
   :maxdepth: 1
 
+  linear-regression
   pca
   synthetic-data

--- a/docs/source/getting-started/statistical-modeling/linear-regression.rst
+++ b/docs/source/getting-started/statistical-modeling/linear-regression.rst
@@ -1,0 +1,7 @@
+Linear Regression
+==========================
+
+Linear Regression is documented with examples in the API Reference,
+(:py:mod:`opendp.extras.sklearn.linear_model`)
+and the underlying algorithm is also used as
+`an example of a plug-in <../../user-guide/plugins/theil-sen-regression.ipynb>`_.

--- a/docs/source/getting-started/statistical-modeling/linear-regression.rst
+++ b/docs/source/getting-started/statistical-modeling/linear-regression.rst
@@ -4,4 +4,4 @@ Linear Regression
 Linear Regression is documented with examples in the API Reference,
 (:py:mod:`opendp.extras.sklearn.linear_model`)
 and the underlying algorithm is also used as
-`an example of a plug-in <../../user-guide/plugins/theil-sen-regression.ipynb>`_.
+`an example of a plug-in <../../api/user-guide/plugins/theil-sen-regression.html>`_.


### PR DESCRIPTION
- Fix #2482
- Provide more explanation of the available tools: Mention sklearn influence, and explain what synthetic data is good for... and not so good for.
- Add a placeholder page for linear regression. Usually I want the getting started to be self-contained, but we already have examples of linear regression in two places, and I don't want to add a third, so pointers will do. Having a statistics section and _not_ mentioning linear regression feels like a gap.