### PR TITLE
Fix github CI syntax: only run the tests we need

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -185,13 +185,13 @@ jobs:
         # (Even in unittests we should use "importskip" rather than "skipif".)
         run: |
           case "${{ matrix.extra-install }}" in
-            PLACEHOLDER)          pytest -v -k "not contingency and not synthetic and not lazyframe and not polars and not pca and not rst"
-            numpy)                pytest -v -k "not contingency and not synthetic and not lazyframe and not polars and not pca and not rst"
-            scikit-learn)         pytest -v -k "not contingency and not synthetic and not lazyframe and not polars and not pca and not rst"
-            polars)               pytest -v -k "not contingency and not synthetic"
-            mbi)  coverage run -m pytest -v
+            PLACEHOLDER)          pytest -v -k "not contingency and not synthetic and not lazyframe and not polars and not pca and not rst";;
+            numpy)                pytest -v -k "not contingency and not synthetic and not lazyframe and not polars and not pca and not rst";;
+            scikit-learn)         pytest -v -k "not contingency and not synthetic and not lazyframe and not polars and not pca and not rst";;
+            polars)               pytest -v -k "not contingency and not synthetic";;
+            mbi)  coverage run -m pytest -v;;
 
-            *)    print "unexpected extra-install"; exit 1
+            *)    print "unexpected extra-install"; exit 1;;
           esac
 
       - name: Test replace-binary-path


### PR DESCRIPTION
- Fix #2505
- We were running extra tests, I think, because string expressions just evaluated to true
- But rather than using a lot of CI `if` checks, just put everything in one case statement: The closer we can keep it to plain shell syntax, the easier it will be to maintain.
- Use `==` instead of `contains`: Less likely to be surprised by a partial match.
- Pull out just the name of the extra, and use a dummy `PLACEHOLDER` when we don't want any extras: Less clutter.
- Add `numpy` to the test matrix: I'm not sure the extras need to be this fine grained, but if we offer an extra, I think we're on the hook for testing it.