### PR TITLE
fix: Python/R -> Rust API docs links

### DIFF
--- a/rust/opendp_derive/src/lib.rs
+++ b/rust/opendp_derive/src/lib.rs
@@ -65,6 +65,16 @@ mod full;
 ///     pass
 /// ```
 ///
+/// # Rust Link
+/// Set to the expected path of Rust documentation, if it can't be correctly inferred.
+///
+/// ```compile_fail
+/// #[bootstrap(rust_path = "domains/struct.AtomDomain")]
+/// fn my_func() {}
+/// ```
+///
+/// This gives a manual way to fix dead links to rust documentation in bindings language documentation.
+///
 /// # Arguments, Generics and Return
 /// You can pass additional metadata that is specific to each argument or generic.
 ///

--- a/rust/opendp_tooling/src/bootstrap/arguments.rs
+++ b/rust/opendp_tooling/src/bootstrap/arguments.rs
@@ -14,6 +14,8 @@ pub struct BootstrapArguments {
     pub name: Option<String>,
     pub proof_path: Option<String>,
     #[darling(default)]
+    pub rust_path: Option<String>,
+    #[darling(default)]
     pub has_ffi: Option<bool>,
     #[darling(default)]
     pub unproven: bool,

--- a/rust/opendp_tooling/src/bootstrap/docstring.rs
+++ b/rust/opendp_tooling/src/bootstrap/docstring.rs
@@ -35,7 +35,7 @@ impl BootstrapDocstring {
         name: &String,
         attrs: Vec<Attribute>,
         output: &ReturnType,
-        path: Option<(&str, &str)>,
+        rust_path: Option<String>,
         features: Vec<String>,
     ) -> Result<BootstrapDocstring> {
         // look for this attr:
@@ -96,9 +96,9 @@ impl BootstrapDocstring {
         }
 
         // add a link to rust documentation (with a gap line)
-        if let Some((module, name)) = &path {
+        if let Some(rust_path) = &rust_path {
             description.push(String::new());
-            description.push(make_rustdoc_link(module, name)?)
+            description.push(make_rustdoc_link(name, rust_path)?)
         }
 
         let mut add_section_to_description = |section_name: &str| {
@@ -463,7 +463,7 @@ fn new_comment_attribute(comment: &str) -> Attribute {
     }
 }
 
-pub fn make_rustdoc_link(module: &str, name: &str) -> Result<String> {
+pub fn make_rustdoc_link(name: &str, path: &str) -> Result<String> {
     // link from foreign library docs to rust docs
     let proof_uri = if let Ok(rustdoc_port) = std::env::var("OPENDP_RUSTDOC_PORT") {
         format!("http://localhost:{rustdoc_port}")
@@ -483,6 +483,6 @@ pub fn make_rustdoc_link(module: &str, name: &str) -> Result<String> {
 
     Ok(format!(
         // RST does not support nested markup, so do not try `{name}`!
-        "[{name} in Rust documentation.]({proof_uri}/opendp/{module}/fn.{name}.html)"
+        "[{name} in Rust documentation.]({proof_uri}/opendp/{path}.html)"
     ))
 }

--- a/rust/opendp_tooling/src/bootstrap/mod.rs
+++ b/rust/opendp_tooling/src/bootstrap/mod.rs
@@ -38,22 +38,22 @@ impl Function {
         // Parse the signature
         let signature = BootstrapSignature::from_syn(item_fn.sig.clone())?;
 
+        let name = arguments.name.clone().unwrap_or(signature.name.clone());
+
         // Parse the docstring
-        let path = if arguments.name.is_none() {
-            module.map(|module| {
-                let name = arguments.name.as_ref().unwrap_or(&signature.name).as_str();
-                (module, name)
-            })
+        let rust_path = if let Some(path) = &arguments.rust_path {
+            Some(path.clone())
+        } else if arguments.name.is_none() {
+            module.map(|module| format!("{module}/fn.{name}"))
         } else {
             None
         };
 
-        let name = arguments.name.clone().unwrap_or(signature.name.clone());
         let docstring = BootstrapDocstring::from_attrs(
             &name,
             item_fn.attrs,
             &item_fn.sig.output,
-            path,
+            rust_path,
             arguments.features.0.clone(),
         )?;
 

--- a/rust/src/combinators/select_private_candidate/mod.rs
+++ b/rust/src/combinators/select_private_candidate/mod.rs
@@ -33,7 +33,7 @@ mod test;
 /// This ensures that the float value is accessible to the algorithm.
 /// The candidate, left as arbitrary Python data, is held behind the ExtrinsicObject.
 ///
-/// Algorithm 1 in `Private selection from private candidates <https://arxiv.org/pdf/1811.07971.pdf#page=7>`_ (Liu and Talwar, STOC 2019).
+/// Algorithm 1 in [Private selection from private candidates](https://arxiv.org/pdf/1811.07971.pdf#page=7) (Liu and Talwar, STOC 2019).
 ///
 /// # Arguments
 /// * `measurement` - A measurement that releases a 2-tuple of (score, candidate)

--- a/rust/src/core/ffi/mod.rs
+++ b/rust/src/core/ffi/mod.rs
@@ -211,6 +211,7 @@ pub extern "C" fn opendp_core___error_free(this: *mut FfiError) -> bool {
 }
 
 #[bootstrap(
+    rust_path = "core/struct.Function",
     features("contrib", "honest-but-curious"),
     arguments(function(rust_type = "$pass_through(TO)"))
 )]

--- a/rust/src/domains/ffi.rs
+++ b/rust/src/domains/ffi.rs
@@ -118,6 +118,7 @@ pub extern "C" fn opendp_domains__domain_carrier_type(
 }
 
 #[bootstrap(
+    rust_path = "domains/struct.AtomDomain",
     arguments(
         bounds(
             rust_type = "Option<(T, T)>",
@@ -307,6 +308,7 @@ pub extern "C" fn opendp_domains___atom_domain_nan(
 }
 
 #[bootstrap(
+    rust_path = "domains/struct.OptionDomain",
     arguments(element_domain(c_type = "AnyDomain *")),
     generics(D(example = "element_domain")),
     returns(c_type = "FfiResult<AnyDomain *>", hint = "OptionDomain")

--- a/rust/src/domains/polars/datetime/ffi.rs
+++ b/rust/src/domains/polars/datetime/ffi.rs
@@ -12,6 +12,7 @@ use crate::{
 use super::DatetimeDomain;
 
 #[bootstrap(
+    rust_path = "domains/struct.DatetimeDomain",
     arguments(time_unit(default = "us"), time_zone(default = b"null")),
     generics(DI(suppress)),
     returns(c_type = "FfiResult<AnyDomain *>")

--- a/rust/src/domains/polars/series/ffi.rs
+++ b/rust/src/domains/polars/series/ffi.rs
@@ -22,6 +22,7 @@ use crate::{
 use super::{SeriesDomain, SeriesElementDomain};
 
 #[bootstrap(
+    rust_path = "domains/struct.SeriesDomain",
     arguments(element_domain(c_type = "AnyDomain *", rust_type = b"null")),
     generics(DI(suppress)),
     returns(c_type = "FfiResult<AnyDomain *>", hint = "SeriesDomain")

--- a/rust/src/measures/ffi.rs
+++ b/rust/src/measures/ffi.rs
@@ -170,6 +170,7 @@ pub extern "C" fn opendp_measures__fixed_smoothed_max_divergence() -> FfiResult<
 }
 
 #[bootstrap(
+    rust_path = "measures/struct.Approximate",
     generics(M(suppress)),
     arguments(measure(c_type = "AnyMeasure *", rust_type = b"null")),
     returns(c_type = "FfiResult<AnyMeasure *>", hint = "ApproximateDivergence")

--- a/rust/src/metrics/ffi.rs
+++ b/rust/src/metrics/ffi.rs
@@ -134,7 +134,10 @@ pub extern "C" fn opendp_metrics__hamming_distance() -> FfiResult<*mut AnyMetric
     FfiResult::Ok(util::into_raw(AnyMetric::new(HammingDistance)))
 }
 
-#[bootstrap(returns(c_type = "FfiResult<AnyMetric *>"))]
+#[bootstrap(
+    rust_path = "metrics/struct.AbsoluteDistance",
+    returns(c_type = "FfiResult<AnyMetric *>")
+)]
 /// Construct an instance of the `AbsoluteDistance` metric.
 ///
 /// # Arguments
@@ -152,7 +155,10 @@ pub extern "C" fn opendp_metrics__absolute_distance(T: *const c_char) -> FfiResu
     dispatch!(monomorphize, [(T, @numbers)], ())
 }
 
-#[bootstrap(returns(c_type = "FfiResult<AnyMetric *>"))]
+#[bootstrap(
+    rust_path = "metrics/type.L1Distance",
+    returns(c_type = "FfiResult<AnyMetric *>")
+)]
 /// Construct an instance of the `L1Distance` metric.
 ///
 /// # Arguments
@@ -169,7 +175,10 @@ pub extern "C" fn opendp_metrics__l1_distance(T: *const c_char) -> FfiResult<*mu
     dispatch!(monomorphize, [(T, @numbers)], ())
 }
 
-#[bootstrap(returns(c_type = "FfiResult<AnyMetric *>"))]
+#[bootstrap(
+    rust_path = "metrics/type.L2Distance",
+    returns(c_type = "FfiResult<AnyMetric *>")
+)]
 /// Construct an instance of the `L2Distance` metric.
 ///
 /// # Arguments
@@ -194,6 +203,7 @@ pub extern "C" fn opendp_metrics__discrete_distance() -> FfiResult<*mut AnyMetri
 }
 
 #[bootstrap(
+    rust_path = "metrics/type.L01InfDistance",
     arguments(metric(c_type = "AnyMetric *", rust_type = b"null")),
     generics(M(suppress)),
     returns(c_type = "FfiResult<AnyMetric *>")
@@ -224,6 +234,7 @@ pub extern "C" fn opendp_metrics__l01inf_distance(
 }
 
 #[bootstrap(
+    rust_path = "metrics/type.L02InfDistance",
     arguments(metric(c_type = "AnyMetric *", rust_type = b"null")),
     generics(M(suppress)),
     returns(c_type = "FfiResult<AnyMetric *>")
@@ -250,6 +261,7 @@ pub extern "C" fn opendp_metrics__l02inf_distance(
 }
 
 #[bootstrap(
+    rust_path = "metrics/struct.LInfDistance",
     arguments(monotonic(default = false)),
     returns(c_type = "FfiResult<AnyMetric *>")
 )]

--- a/rust/src/metrics/mod.rs
+++ b/rust/src/metrics/mod.rs
@@ -603,7 +603,7 @@ impl MetricSpace for (BitVectorDomain, DiscreteDistance) {
 /// we say that $x$, $x'$ are $d$-close under the l-infinity metric (abbreviated as $d_{\infty}$) whenever
 ///
 /// ```math
-/// d_{\infty}(x, x') = max_{i} |x_i - x'_i|
+/// d_{\infty}(x, x') = \max_{i} |x_i - x'_i|
 /// ```
 ///
 /// If `monotonic` is `true`, then the distance is infinity if any of the differences have opposing signs.
@@ -613,7 +613,7 @@ impl MetricSpace for (BitVectorDomain, DiscreteDistance) {
 /// ```math
 /// d_{\infty}(x, x') = \begin{cases}
 ///     \infty & \text{if } \exists i, x_i \cdot x'_i < 0 \land \texttt{monotonic} \\
-///     \max_i \abs{x_i - x'_i} & \text{otherwise} \\
+///     \max_i |x_i - x'_i| & \text{otherwise} \\
 /// \end{cases}
 /// ```
 ///


### PR DESCRIPTION
Close #1025

This introduces a mechanism to manually set the destination in generated links. We'll still need to be vigilant not to introduce breaking links in the future.