### PR TITLE
docs: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,11 +2,23 @@
 name: Bug report
 about: Email security@opendp.org if your bug is security related
 labels: bug
-
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+### Describe the bug
 
-**To Reproduce**
-Code snippet to reproduce the behavior.
+- What is the bug?
+- What is the desired behavior?
+
+
+### Your environment
+
+If using OpenDP with Python:
+- `python --version`
+- The version of OpenDP installed, and any extras
+- `pip freeze` might be overkill, but is sometimes useful
+
+
+### A reproducer
+
+- Code snippet to reproduce the behavior
+- And if possible, a reference to a gist or notebook or repo where we can see the whole situation.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,8 @@
 ---
 name: Bug report
 about: Email security@opendp.org if your bug is security related
-labels: bug
+labels:
+- 'bug'
 ---
 
 ### Describe the bug

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -5,13 +5,13 @@ labels:
 - 'bug'
 ---
 
-### Describe the bug
+## Describe the bug
 
 - What is the bug?
 - What is the desired behavior?
 
 
-### Your environment
+## Your environment
 
 If using OpenDP with Python:
 - `python --version`
@@ -19,7 +19,7 @@ If using OpenDP with Python:
 - `pip freeze` might be overkill, but is sometimes useful
 
 
-### A reproducer
+## A reproducer
 
 - Code snippet to reproduce the behavior
 - And if possible, a reference to a gist or notebook or repo where we can see the whole situation.

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -5,10 +5,13 @@ labels:
 - 'docs'
 ---
 
-If new docs:
+## If new docs:
+
 - Who is the audience for the new docs?
 - What is the information that they need?
 
-If a fix:
+
+# If a fix:
+
 - Which page?
 - What needs to change?

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -1,0 +1,14 @@
+---
+name: Documentation
+about: New documentation, or fixes to existing docs
+labels:
+- 'docs'
+---
+
+If new docs:
+- Who is the audience for the new docs?
+- What is the information that they need?
+
+If a fix:
+- Which page?
+- What needs to change?

--- a/.github/ISSUE_TEMPLATE/new-contribution.md
+++ b/.github/ISSUE_TEMPLATE/new-contribution.md
@@ -1,12 +1,10 @@
 ---
 name: New contribution
 about: Solicit feedback for a contribution you'd like to make
-
 ---
-How exciting!
 
-Please review [the information to include in your issue](https://docs.opendp.org/en/stable/contributing/getting-involved.html#code-and-proof-contributions),
-and we will try to get back with you shortly.
-
-In the meantime, you might want to [review the contribution process](https://docs.opendp.org/en/stable/contributing/contribution-process.html)
-and start getting your development environment set up.
+For a new mechanism:
+- Link to the research paper(s) and/or existing implementation your contribution will be derived from:
+- Make a case for why this mechanism should be added to the library:
+  - Is it unique and does it have reasonable utility?
+  - If it has a similar behavior as another mechanism, can you show that it has greater utility or useful trade-offs?

--- a/.github/ISSUE_TEMPLATE/new-mechanism.md
+++ b/.github/ISSUE_TEMPLATE/new-mechanism.md
@@ -1,10 +1,10 @@
 ---
-name: New contribution
+name: New mechanism
 about: Solicit feedback for a contribution you'd like to make
 ---
 
 For a new mechanism:
-- Link to the research paper(s) and/or existing implementation your contribution will be derived from:
+- Link to the research paper(s) and/or existing implementation your contribution will be based on
 - Make a case for why this mechanism should be added to the library:
   - Is it unique and does it have reasonable utility?
   - If it has a similar behavior as another mechanism, can you show that it has greater utility or useful trade-offs?

--- a/.github/ISSUE_TEMPLATE/reminder.md
+++ b/.github/ISSUE_TEMPLATE/reminder.md
@@ -1,0 +1,4 @@
+---
+name: Reminder
+about: Catch-all for other work to be done
+---

--- a/.github/ISSUE_TEMPLATE/reminder.md
+++ b/.github/ISSUE_TEMPLATE/reminder.md
@@ -1,4 +1,0 @@
----
-name: Reminder
-about: Catch-all for other work to be done
----

--- a/.github/ISSUE_TEMPLATE/usability.md
+++ b/.github/ISSUE_TEMPLATE/usability.md
@@ -1,0 +1,31 @@
+---
+name: Usability
+about: Solicit feedback for a contribution you'd like to make
+labels:
+- 'usability'
+---
+
+If applicable, pick one of these and fill in the blanks:
+
+## Confusing error message for common or predictable user error?
+
+Provide:
+- your code that doesn't work
+- the error message
+- a better error message
+- code that does work, if possible
+
+
+## Something is possible with OpenDP, but harder than it should be?
+
+Provide:
+- Your working code
+- How the API could be made easier to use
+- Include an example of the usage of the proposed API
+
+
+# Typing or docstrings aren't helpful?
+
+Provide:
+- The function in question
+- Suggested edits to the documention


### PR DESCRIPTION
- Fix #2516

@Shoeboxam , I think it's much easier to capture tags and other metadata when the issue is first filed. Do you think there should be any other categories?

I was thinking about assigning to myself by default for triage, but I'm not sure about that now.