### PR TITLE
docs: Use tilde in RST

### DIFF
--- a/docs/source/api/user-guide/combinators/amplification.rst
+++ b/docs/source/api/user-guide/combinators/amplification.rst
@@ -3,7 +3,7 @@ Amplification
 
 If your dataset is a simple sample from a larger population,
 you can make the privacy relation more permissive by wrapping your measurement with a privacy amplification combinator:
-:func:`opendp.combinators.make_population_amplification`.
+:func:`~opendp.combinators.make_population_amplification`.
 
 .. note::
 

--- a/docs/source/api/user-guide/combinators/chaining.rst
+++ b/docs/source/api/user-guide/combinators/chaining.rst
@@ -49,9 +49,9 @@ In the following example we chain :py:func:`opendp.measurements.make_laplace` wi
         >>> release = noisy_sum(dataset)
 
 In practice, these chainers are used so frequently that we've written a shorthand (``>>``).
-The syntax automatically chooses between :func:`make_chain_mt <opendp.combinators.make_chain_mt>`, 
-:func:`make_chain_tt <opendp.combinators.make_chain_tt>`, 
-and :func:`make_chain_pm <opendp.combinators.make_chain_pm>`.
+The syntax automatically chooses between :func:`opendp.combinators.make_chain_mt`, 
+:func:`opendp.combinators.make_chain_tt`, 
+and :func:`opendp.combinators.make_chain_pm`.
 
 .. tab-set::
 
@@ -95,9 +95,9 @@ In the below example, the adjustment is subtle, but the bounds were adjusted to 
 Note that ``noisy_sum_trans``'s input domain and input metric come from ``sum_trans``'s input domain and input metric.
 This is intended to enable further chaining with preprocessors such as:
 
-* :py:func:`make_cast <opendp.transformations.make_cast>`
-* :py:func:`make_impute_constant <opendp.transformations.make_impute_constant>`
-* :py:func:`make_clamp <opendp.transformations.make_clamp>` 
-* :py:func:`make_resize <opendp.transformations.make_resize>`.
+* :py:func:`opendp.transformations.make_cast`
+* :py:func:`opendp.transformations.make_impute_constant`
+* :py:func:`opendp.transformations.make_clamp` 
+* :py:func:`opendp.transformations.make_resize`.
 
 See the section on :ref:`transformations-user-guide` for more information on how to preprocess data in OpenDP.

--- a/docs/source/api/user-guide/combinators/chaining.rst
+++ b/docs/source/api/user-guide/combinators/chaining.rst
@@ -4,19 +4,19 @@ Chaining
 Two of the most essential constructors are the "chainers" that chain transformations with transformations, and transformations with measurements.
 Chainers are used to incrementally piece Transformations or Measurements together that represent longer computational pipelines.
 
-The :py:func:`opendp.combinators.make_chain_tt` constructor creates a new Transformation by stitching together two Transformations sequentially.
+The :py:func:`~opendp.combinators.make_chain_tt` constructor creates a new Transformation by stitching together two Transformations sequentially.
 The resulting Transformation contains a function that sequentially executes the function of the constituent Transformations.
 It also contains a privacy map that takes an input distance bound on the inner Transformation and emits an output distance bound on the outer transformation.
 
-The :py:func:`opendp.combinators.make_chain_mt` constructor similarly creates a new Measurement by combining an inner Transformation with an outer Measurement.
+The :py:func:`~opendp.combinators.make_chain_mt` constructor similarly creates a new Measurement by combining an inner Transformation with an outer Measurement.
 Notice that *there is no* ``make_chain_mm`` for chaining measurements together!
 Any computation beyond a measurement is postprocessing and need not be governed by relations.
 
-Postprocessing functionality is provided by the :py:func:`opendp.combinators.make_chain_pm` constructor that allows transformations to be chained onto a Measurement.
+Postprocessing functionality is provided by the :py:func:`~opendp.combinators.make_chain_pm` constructor that allows transformations to be chained onto a Measurement.
 Since the outer Transformation is postprocessing, the metrics and stability map of the outer Transformation are ignored.
 In this case, it is only necessary for the types to conform.
 
-In the following example we chain :py:func:`opendp.measurements.make_laplace` with :py:func:`opendp.transformations.make_sum`.
+In the following example we chain :py:func:`~opendp.measurements.make_laplace` with :py:func:`~opendp.transformations.make_sum`.
 
 .. tab-set::
 
@@ -49,9 +49,9 @@ In the following example we chain :py:func:`opendp.measurements.make_laplace` wi
         >>> release = noisy_sum(dataset)
 
 In practice, these chainers are used so frequently that we've written a shorthand (``>>``).
-The syntax automatically chooses between :func:`opendp.combinators.make_chain_mt`, 
-:func:`opendp.combinators.make_chain_tt`, 
-and :func:`opendp.combinators.make_chain_pm`.
+The syntax automatically chooses between :func:`~opendp.combinators.make_chain_mt`, 
+:func:`~opendp.combinators.make_chain_tt`, 
+and :func:`~opendp.combinators.make_chain_pm`.
 
 .. tab-set::
 
@@ -95,9 +95,9 @@ In the below example, the adjustment is subtle, but the bounds were adjusted to 
 Note that ``noisy_sum_trans``'s input domain and input metric come from ``sum_trans``'s input domain and input metric.
 This is intended to enable further chaining with preprocessors such as:
 
-* :py:func:`opendp.transformations.make_cast`
-* :py:func:`opendp.transformations.make_impute_constant`
-* :py:func:`opendp.transformations.make_clamp` 
-* :py:func:`opendp.transformations.make_resize`.
+* :py:func:`~opendp.transformations.make_cast`
+* :py:func:`~opendp.transformations.make_impute_constant`
+* :py:func:`~opendp.transformations.make_clamp` 
+* :py:func:`~opendp.transformations.make_resize`.
 
 See the section on :ref:`transformations-user-guide` for more information on how to preprocess data in OpenDP.

--- a/docs/source/api/user-guide/combinators/index.rst
+++ b/docs/source/api/user-guide/combinators/index.rst
@@ -20,13 +20,13 @@ Chainers are used to incrementally piece Transformations or Measurements togethe
    * - Function
      - From
      - To
-   * - :func:`opendp.combinators.make_chain_tt`
+   * - :func:`~opendp.combinators.make_chain_tt`
      - Transformation
      - Transformation
-   * - :func:`opendp.combinators.make_chain_mt`
+   * - :func:`~opendp.combinators.make_chain_mt`
      - Transformation
      - Measurement
-   * - :func:`opendp.combinators.make_chain_pm`
+   * - :func:`~opendp.combinators.make_chain_pm`
      - Measurement
      - Transformation
 
@@ -50,13 +50,13 @@ OpenDP has several compositors for making multiple releases on the same dataset:
    * - Function
      - Queries
      - Privacy Loss
-   * - :func:`opendp.combinators.make_composition`
+   * - :func:`~opendp.combinators.make_composition`
      - Non-interactive
      - Non-interactive
-   * - :func:`opendp.combinators.make_adaptive_composition`
+   * - :func:`~opendp.combinators.make_adaptive_composition`
      - Interactive
      - Non-interactive
-   * - :func:`opendp.combinators.make_fully_adaptive_composition`
+   * - :func:`~opendp.combinators.make_fully_adaptive_composition`
      - Interactive
      - Interactive
 

--- a/docs/source/api/user-guide/combinators/index.rst
+++ b/docs/source/api/user-guide/combinators/index.rst
@@ -20,13 +20,13 @@ Chainers are used to incrementally piece Transformations or Measurements togethe
    * - Function
      - From
      - To
-   * - :func:`make_chain_tt <opendp.combinators.make_chain_tt>`
+   * - :func:`opendp.combinators.make_chain_tt`
      - Transformation
      - Transformation
-   * - :func:`make_chain_mt <opendp.combinators.make_chain_mt>`
+   * - :func:`opendp.combinators.make_chain_mt`
      - Transformation
      - Measurement
-   * - :func:`make_chain_pm <opendp.combinators.make_chain_pm>`
+   * - :func:`opendp.combinators.make_chain_pm`
      - Measurement
      - Transformation
 
@@ -50,13 +50,13 @@ OpenDP has several compositors for making multiple releases on the same dataset:
    * - Function
      - Queries
      - Privacy Loss
-   * - :func:`make_composition <opendp.combinators.make_composition>`
+   * - :func:`opendp.combinators.make_composition`
      - Non-interactive
      - Non-interactive
-   * - :func:`make_adaptive_composition <opendp.combinators.make_adaptive_composition>`
+   * - :func:`opendp.combinators.make_adaptive_composition`
      - Interactive
      - Non-interactive
-   * - :func:`make_fully_adaptive_composition <opendp.combinators.make_fully_adaptive_composition>`
+   * - :func:`opendp.combinators.make_fully_adaptive_composition`
      - Interactive
      - Interactive
 

--- a/docs/source/api/user-guide/combinators/measure-casting.rst
+++ b/docs/source/api/user-guide/combinators/measure-casting.rst
@@ -12,24 +12,24 @@ These combinators are used to cast the output measure of a Measurement.
      - Constructor
    * - ``MaxDivergence``
      - ``Approximate<MaxDivergence>``
-     - :func:`opendp.combinators.make_approximate`
+     - :func:`~opendp.combinators.make_approximate`
    * - ``ZeroConcentratedDivergence``
      - ``Approximate<ZeroConcentratedDivergence>``
-     - :func:`opendp.combinators.make_approximate`
+     - :func:`~opendp.combinators.make_approximate`
    * - ``MaxDivergence``
      - ``SmoothedMaxDivergence``
-     - :func:`opendp.combinators.make_fixed_approxDP_to_approxDP`
+     - :func:`~opendp.combinators.make_fixed_approxDP_to_approxDP`
    * - ``MaxDivergence``
      - ``ZeroConcentratedDivergence``
-     - :func:`opendp.combinators.make_pureDP_to_zCDP`
+     - :func:`~opendp.combinators.make_pureDP_to_zCDP`
    * - ``ZeroConcentratedDivergence``
      - ``SmoothedMaxDivergence``
-     - :func:`opendp.combinators.make_zCDP_to_approxDP`
+     - :func:`~opendp.combinators.make_zCDP_to_approxDP`
    * - ``SmoothedMaxDivergence``
      - ``Approximate<MaxDivergence>``
-     - :func:`opendp.combinators.make_fix_delta`
+     - :func:`~opendp.combinators.make_fix_delta`
 
-:func:`opendp.combinators.make_approximate` is used for casting an output measure from ``MaxDivergence`` to ``Approximate<MaxDivergence>``.
+:func:`~opendp.combinators.make_approximate` is used for casting an output measure from ``MaxDivergence`` to ``Approximate<MaxDivergence>``.
 This is useful if you want to compose pure-DP measurements with approximate-DP measurements.
 
 .. tab-set::
@@ -50,8 +50,8 @@ This is useful if you want to compose pure-DP measurements with approximate-DP m
 
 The combinator can also be used on measurements with a ``ZeroConcentratedDivergence`` privacy measure.
 
-:func:`opendp.combinators.make_pureDP_to_zCDP` is used for casting an output measure from ``MaxDivergence`` to ``ZeroConcentratedDivergence``.
-:func:`opendp.combinators.make_zCDP_to_approxDP` is used for casting an output measure from ``ZeroConcentratedDivergence`` to ``SmoothedMaxDivergence``.
+:func:`~opendp.combinators.make_pureDP_to_zCDP` is used for casting an output measure from ``MaxDivergence`` to ``ZeroConcentratedDivergence``.
+:func:`~opendp.combinators.make_zCDP_to_approxDP` is used for casting an output measure from ``ZeroConcentratedDivergence`` to ``SmoothedMaxDivergence``.
 
 .. tab-set::
 
@@ -67,7 +67,7 @@ The combinator can also be used on measurements with a ``ZeroConcentratedDiverge
         >>> profile.epsilon(delta=1e-6)
         11.688596249354896
 
-:func:`opendp.combinators.make_fix_delta` changes the output measure from ``SmoothedMaxDivergence`` to ``Approximate<MaxDivergence>``.
+:func:`~opendp.combinators.make_fix_delta` changes the output measure from ``SmoothedMaxDivergence`` to ``Approximate<MaxDivergence>``.
 It fixes the delta parameter in the curve, so that the resulting measurement can be composed with other ``Approximate<MaxDivergence>`` measurements.
 
 .. tab-set::

--- a/docs/source/api/user-guide/combinators/privacy-filters.rst
+++ b/docs/source/api/user-guide/combinators/privacy-filters.rst
@@ -36,7 +36,7 @@ that rejects any query that would cause the privacy loss to exceed 2.0:
             :start-after: privacy-filter
             :end-before: /privacy-filter
 
-Privacy filters are measurements, meaning that they can be passed into :func:`opendp.combinators.make_composition`, 
+Privacy filters are measurements, meaning that they can be passed into :func:`~opendp.combinators.make_composition`, 
 adaptive composition queryables, or into other combinators.
 However, they have the added benefit of not needing to specify privacy-loss parameters ahead-of-time.
 When the privacy filter (``meas_fully_adaptive_comp``) is invoked, 

--- a/docs/source/api/user-guide/combinators/privacy-filters.rst
+++ b/docs/source/api/user-guide/combinators/privacy-filters.rst
@@ -36,7 +36,7 @@ that rejects any query that would cause the privacy loss to exceed 2.0:
             :start-after: privacy-filter
             :end-before: /privacy-filter
 
-Privacy filters are measurements, meaning that they can be passed into :func:`make_composition <opendp.combinators.make_composition>`, 
+Privacy filters are measurements, meaning that they can be passed into :func:`opendp.combinators.make_composition`, 
 adaptive composition queryables, or into other combinators.
 However, they have the added benefit of not needing to specify privacy-loss parameters ahead-of-time.
 When the privacy filter (``meas_fully_adaptive_comp``) is invoked, 

--- a/docs/source/api/user-guide/plugins/index.rst
+++ b/docs/source/api/user-guide/plugins/index.rst
@@ -8,19 +8,19 @@ we can't implement every mechanism for every user,
 but users can provide their own code through these methods:
 
 Measurements
-    :py:func:`make_user_measurement <opendp.measurements.make_user_measurement>`
+    :py:func:`opendp.measurements.make_user_measurement`
 Transformations
-    :py:func:`make_user_transformation <opendp.transformations.make_user_transformation>`
+    :py:func:`opendp.transformations.make_user_transformation`
 Domains
-    :py:func:`user_domain <opendp.domains.user_domain>`
+    :py:func:`opendp.domains.user_domain`
 Metrics
-    :py:func:`user_distance <opendp.metrics.user_distance>`
+    :py:func:`opendp.metrics.user_distance`
 Measures
-    :py:func:`user_divergence <opendp.measures.user_divergence>`
+    :py:func:`opendp.measures.user_divergence`
 Postprocessors
-    :py:func:`new_function <opendp.core.new_function>`
+    :py:func:`opendp.core.new_function`
 Privacy Profiles
-    :py:func:`new_privacy_profile <opendp.measures.new_privacy_profile>`
+    :py:func:`opendp.measures.new_privacy_profile`
 
 OpenDP itself uses the plugin machinery in some cases.
 It is usually easier to prototype ideas in Python than in Rust,

--- a/docs/source/api/user-guide/plugins/index.rst
+++ b/docs/source/api/user-guide/plugins/index.rst
@@ -8,19 +8,19 @@ we can't implement every mechanism for every user,
 but users can provide their own code through these methods:
 
 Measurements
-    :py:func:`opendp.measurements.make_user_measurement`
+    :py:func:`~opendp.measurements.make_user_measurement`
 Transformations
-    :py:func:`opendp.transformations.make_user_transformation`
+    :py:func:`~opendp.transformations.make_user_transformation`
 Domains
-    :py:func:`opendp.domains.user_domain`
+    :py:func:`~opendp.domains.user_domain`
 Metrics
-    :py:func:`opendp.metrics.user_distance`
+    :py:func:`~opendp.metrics.user_distance`
 Measures
-    :py:func:`opendp.measures.user_divergence`
+    :py:func:`~opendp.measures.user_divergence`
 Postprocessors
-    :py:func:`opendp.core.new_function`
+    :py:func:`~opendp.core.new_function`
 Privacy Profiles
-    :py:func:`opendp.measures.new_privacy_profile`
+    :py:func:`~opendp.measures.new_privacy_profile`
 
 OpenDP itself uses the plugin machinery in some cases.
 It is usually easier to prototype ideas in Python than in Rust,

--- a/docs/source/api/user-guide/plugins/measurement.rst
+++ b/docs/source/api/user-guide/plugins/measurement.rst
@@ -3,7 +3,7 @@
 Measurement example
 ===================
 
-Use :func:`opendp.measurements.make_user_measurement` to construct a measurement for your own mechanism.
+Use :func:`~opendp.measurements.make_user_measurement` to construct a measurement for your own mechanism.
 
 .. note::
 

--- a/docs/source/api/user-guide/plugins/transformation.rst
+++ b/docs/source/api/user-guide/plugins/transformation.rst
@@ -2,7 +2,7 @@
 Transformation example
 ======================
 
-Use :func:`opendp.transformations.make_user_transformation` to construct your own transformation.
+Use :func:`~opendp.transformations.make_user_transformation` to construct your own transformation.
 
 .. note::
 

--- a/docs/source/api/user-guide/polars/expressions/index.rst
+++ b/docs/source/api/user-guide/polars/expressions/index.rst
@@ -12,7 +12,7 @@ the `Polars User Guide <https://docs.pola.rs/user-guide/expressions/>`_
 and `API Reference <https://docs.pola.rs/api/python/stable/reference/expressions/index.html>`_.)
 
 OpenDP also adds extensions for differential privacy under the :code:`.dp` namespace;
-these are documented under :py:class:`opendp.extras.polars.DPExpr`.
+these are documented under :py:class:`~opendp.extras.polars.DPExpr`.
 
 .. toctree::
   :maxdepth: 1

--- a/docs/source/api/user-guide/polars/polars-vs-opendp.rst
+++ b/docs/source/api/user-guide/polars/polars-vs-opendp.rst
@@ -2,7 +2,7 @@
 Polars vs. OpenDP
 =================
 
-(For the examples which follow create a :py:class:`opendp.context.Context` named :code:`context`.)
+(For the examples which follow create a :py:class:`~opendp.context.Context` named :code:`context`.)
 
 .. tab-set::
 
@@ -25,7 +25,7 @@ OpenDP Polars differs from typical Polars in these ways:
 1. **How you specify the data.**
 
    Instead of directly manipulating the data (a ``LazyFrame``),
-   you now manipulate an :py:class:`opendp.extras.polars.LazyFrameQuery`
+   you now manipulate an :py:class:`~opendp.extras.polars.LazyFrameQuery`
    returned by :code:`context.query()`
    You can think of :code:`context.query()` as a mock for the real data
    (although in reality, a ``LazyFrameQuery`` is an empty ``LazyFrame`` with some extra methods).
@@ -46,7 +46,7 @@ OpenDP Polars differs from typical Polars in these ways:
    OpenDP extends the Polars API to include differentially private methods and statistics.
    ``LazyFrame`` (now ``LazyFrameQuery``) has additional methods, like :code:`.summarize` and :code:`.release`.
 
-   Expressions also have an additional namespace :code:`.dp` with methods from :py:class:`opendp.extras.polars.DPExpr`.
+   Expressions also have an additional namespace :code:`.dp` with methods from :py:class:`~opendp.extras.polars.DPExpr`.
 
 .. tab-set::
 

--- a/docs/source/api/user-guide/programming-framework/core-structures.rst
+++ b/docs/source/api/user-guide/programming-framework/core-structures.rst
@@ -7,7 +7,7 @@ Core Structures
 
 OpenDP is focused on creating computations with specific privacy characteristics.
 These computations are modeled with two core classes in OpenDP:
-:py:class:`opendp.mod.Transformation` and :py:class:`opendp.mod.Measurement`.
+:py:class:`~opendp.mod.Transformation` and :py:class:`~opendp.mod.Measurement`.
 These classes are in all OpenDP programs, regardless of the underlying algorithm or definition of privacy.
 By modeling computations in this way, we're able to combine them in flexible arrangements and reason about the privacy properties of the resulting programs.
 OpenDP relates:
@@ -50,7 +50,7 @@ Transformation
     :width: 75%
     :alt: Diagram representing an OpenDP transformation and its six fields: input_domain, output_domain, function, input_metric, output_metric, and stability_map.
 
-A :py:class:`opendp.mod.Transformation` is a *deterministic* mapping from datasets to datasets.
+A :py:class:`~opendp.mod.Transformation` is a *deterministic* mapping from datasets to datasets.
 Transformations are used to preprocess and aggregate data.
 
 Let's assume we have a transformation called ``trans``:
@@ -77,7 +77,7 @@ Transformations need to be :ref:`chained <chaining>` with a measurement before t
 Measurement
 -----------
 
-A :py:class:`opendp.mod.Measurement` is, in contrast, a *randomized* mapping from datasets to outputs.
+A :py:class:`~opendp.mod.Measurement` is, in contrast, a *randomized* mapping from datasets to outputs.
 Measurements are used to create differentially private releases.
 
 Say we have an arbitrary instance of a Measurement, called ``meas``, and a code snippet:

--- a/docs/source/api/user-guide/programming-framework/core-structures.rst
+++ b/docs/source/api/user-guide/programming-framework/core-structures.rst
@@ -7,7 +7,7 @@ Core Structures
 
 OpenDP is focused on creating computations with specific privacy characteristics.
 These computations are modeled with two core classes in OpenDP:
-:py:class:`Transformation <opendp.mod.Transformation>` and :py:class:`Measurement <opendp.mod.Measurement>`.
+:py:class:`opendp.mod.Transformation` and :py:class:`opendp.mod.Measurement`.
 These classes are in all OpenDP programs, regardless of the underlying algorithm or definition of privacy.
 By modeling computations in this way, we're able to combine them in flexible arrangements and reason about the privacy properties of the resulting programs.
 OpenDP relates:
@@ -50,7 +50,7 @@ Transformation
     :width: 75%
     :alt: Diagram representing an OpenDP transformation and its six fields: input_domain, output_domain, function, input_metric, output_metric, and stability_map.
 
-A :py:class:`Transformation <opendp.mod.Transformation>` is a *deterministic* mapping from datasets to datasets.
+A :py:class:`opendp.mod.Transformation` is a *deterministic* mapping from datasets to datasets.
 Transformations are used to preprocess and aggregate data.
 
 Let's assume we have a transformation called ``trans``:
@@ -77,7 +77,7 @@ Transformations need to be :ref:`chained <chaining>` with a measurement before t
 Measurement
 -----------
 
-A :py:class:`Measurement <opendp.mod.Measurement>` is, in contrast, a *randomized* mapping from datasets to outputs.
+A :py:class:`opendp.mod.Measurement` is, in contrast, a *randomized* mapping from datasets to outputs.
 Measurements are used to create differentially private releases.
 
 Say we have an arbitrary instance of a Measurement, called ``meas``, and a code snippet:

--- a/docs/source/api/user-guide/programming-framework/supporting-elements.rst
+++ b/docs/source/api/user-guide/programming-framework/supporting-elements.rst
@@ -126,7 +126,7 @@ In addition, a ``size`` parameter may be used. For example:
       >>> assert bool_vector_2_domain.member([True, True])
       >>> assert not bool_vector_2_domain.member([True, True, True])
 
-Let's look at the Transformation returned from :py:func:`opendp.transformations.make_sum`.
+Let's look at the Transformation returned from :py:func:`~opendp.transformations.make_sum`.
 
 .. tab-set::
 
@@ -161,7 +161,7 @@ The output domain is "the set of all 32-bit signed integers."
 These domains serve two purposes:
 
 #. The stability map or privacy map depends on the input domain in its proof to restrict the set of neighboring datasets or distributions.
-   An example is the relation for :py:func:`opendp.transformations.make_sum`,
+   An example is the relation for :py:func:`~opendp.transformations.make_sum`,
    which may make use of a size descriptor in the vector domain to more tightly bound the sensitivity.
 #. Combinators also use domains to ensure that the output is well-defined.
    For instance, chainer constructors check that intermediate domains are equivalent

--- a/docs/source/api/user-guide/programming-framework/supporting-elements.rst
+++ b/docs/source/api/user-guide/programming-framework/supporting-elements.rst
@@ -126,7 +126,7 @@ In addition, a ``size`` parameter may be used. For example:
       >>> assert bool_vector_2_domain.member([True, True])
       >>> assert not bool_vector_2_domain.member([True, True, True])
 
-Let's look at the Transformation returned from :py:func:`make_sum() <opendp.transformations.make_sum>`.
+Let's look at the Transformation returned from :py:func:`opendp.transformations.make_sum`.
 
 .. tab-set::
 

--- a/docs/source/api/user-guide/transformations/index.rst
+++ b/docs/source/api/user-guide/transformations/index.rst
@@ -42,23 +42,23 @@ Depending on the caster you choose, the output data may be null and you will be 
      - Input Domain
      - Output Domain
      - Input/Output Metric
-   * - :func:`opendp.transformations.make_cast`
+   * - :func:`~opendp.transformations.make_cast`
      - ``VectorDomain<AtomDomain<TIA>>``
      - ``VectorDomain<OptionDomain<AtomDomain<TOA>>>``
      - ``SymmetricDistance``
-   * - :func:`opendp.transformations.make_cast_default`
+   * - :func:`~opendp.transformations.make_cast_default`
      - ``VectorDomain<AtomDomain<TIA>>``
      - ``VectorDomain<AtomDomain<TOA>>``
      - ``SymmetricDistance``
-   * - :func:`opendp.transformations.make_cast_inherent`
+   * - :func:`~opendp.transformations.make_cast_inherent`
      - ``VectorDomain<AtomDomain<TIA>>``
      - ``VectorDomain<AtomDomain<TOA>>`` (with nullity)
      - ``SymmetricDistance``
-   * - :func:`opendp.transformations.make_is_equal`
+   * - :func:`~opendp.transformations.make_is_equal`
      - ``VectorDomain<AtomDomain<TIA>>``
      - ``VectorDomain<AtomDomain<bool>>``
      - ``SymmetricDistance``
-   * - :func:`opendp.transformations.make_is_null`
+   * - :func:`~opendp.transformations.make_is_null`
      - ``VectorDomain<AtomDomain<TIA>>``
      - ``VectorDomain<AtomDomain<bool>>``
      - ``SymmetricDistance``
@@ -76,7 +76,7 @@ then the sensitivity of non-null individuals is underestimated.
 Therefore, most aggregators must be fed completely non-null data.
 We can ensure data is non-null by imputing.
 
-When you cast with :func:`opendp.transformations.make_cast` or :func:`opendp.transformations.make_cast_default`,
+When you cast with :func:`~opendp.transformations.make_cast` or :func:`~opendp.transformations.make_cast_default`,
 the cast may fail, so the output domain may include null values (``OptionDomain`` or ``AtomDomain`` with nullity).
 We have provided imputation transformations to transform the data domain to the non-null ``VectorDomain<AtomDomain<TA>>``.
 
@@ -87,7 +87,7 @@ In this case, you should start your chain with an imputer if the floats are pote
 :OptionDomain: A representation of nulls using an Option type (``Option<bool>``, ``Option<i32>``, etc).
 :AtomDomain: A representation of nulls using the data type itself (``f32`` and ``f64``).
 
-The :func:`opendp.transformations.make_impute_constant` transformation supports imputing on either of these representations of nullity,
+The :func:`~opendp.transformations.make_impute_constant` transformation supports imputing on either of these representations of nullity,
 so long as you pass the DA (atomic domain) type argument.
 
 .. list-table::
@@ -97,23 +97,23 @@ so long as you pass the DA (atomic domain) type argument.
      - Input Domain
      - Output Domain
      - Input/Output Metric
-   * - :func:`opendp.transformations.make_impute_constant`
+   * - :func:`~opendp.transformations.make_impute_constant`
      - ``VectorDomain<OptionDomain<AtomDomain<TA>>>``
      - ``VectorDomain<AtomDomain<TA>>``
      - ``SymmetricDistance``
-   * - :func:`opendp.transformations.make_impute_constant`
+   * - :func:`~opendp.transformations.make_impute_constant`
      - ``VectorDomain<AtomDomain<TA>>`` (with nullity)
      - ``VectorDomain<AtomDomain<TA>>``
      - ``SymmetricDistance``
-   * - :func:`opendp.transformations.make_impute_uniform_float`
+   * - :func:`~opendp.transformations.make_impute_uniform_float`
      - ``VectorDomain<AtomDomain<TA>>`` (with nullity)
      - ``VectorDomain<AtomDomain<TA>>``
      - ``SymmetricDistance``
-   * - :func:`opendp.transformations.make_drop_null`
+   * - :func:`~opendp.transformations.make_drop_null`
      - ``VectorDomain<OptionDomain<AtomDomain<TA>>>``
      - ``VectorDomain<AtomDomain<TA>>``
      - ``SymmetricDistance``
-   * - :func:`opendp.transformations.make_drop_null`
+   * - :func:`~opendp.transformations.make_drop_null`
      - ``VectorDomain<AtomDomain<TA>>`` (with nullity)
      - ``VectorDomain<AtomDomain<TA>>``
      - ``SymmetricDistance``
@@ -122,7 +122,7 @@ Indexing
 --------
 Indexing operations provide a way to relabel categorical data, or bin numeric data into categorical data.
 These operations work with ``usize`` data types: an integer data type representing an index.
-:func:`opendp.transformations.make_find` finds the index of each input datum in a set of categories.
+:func:`~opendp.transformations.make_find` finds the index of each input datum in a set of categories.
 In other words, it transforms a categorical data vector to a vector of numeric indices.
 
 .. tab-set::
@@ -150,7 +150,7 @@ In other words, it transforms a categorical data vector to a vector of numeric i
         >>> finder(["A", "B", "C", "A", "D"])
         [0, 1, 2, 0, 3]
 
-:func:`opendp.transformations.make_find_bin` is a binning operation that transforms numerical input data to a vector of bin indices.
+:func:`~opendp.transformations.make_find_bin` is a binning operation that transforms numerical input data to a vector of bin indices.
 
 .. tab-set::
 
@@ -166,7 +166,7 @@ In other words, it transforms a categorical data vector to a vector of numeric i
         >>> binner([0.0, 1.0, 3.0, 15.0])
         [0, 1, 2, 3]
 
-:func:`opendp.transformations.make_index` uses each indicial input datum as an index into a category set.
+:func:`~opendp.transformations.make_index` uses each indicial input datum as an index into a category set.
 
 .. tab-set::
 
@@ -192,15 +192,15 @@ You can use combinations of the indicial transformers to map hashable data to in
      - Input Domain
      - Output Domain
      - Input/Output Metric
-   * - :func:`opendp.transformations.make_find`
+   * - :func:`~opendp.transformations.make_find`
      - ``VectorDomain<AtomDomain<TIA>>``
      - ``VectorDomain<OptionDomain<AtomDomain<usize>>>``
      - ``SymmetricDistance``
-   * - :func:`opendp.transformations.make_find_bin`
+   * - :func:`~opendp.transformations.make_find_bin`
      - ``VectorDomain<AtomDomain<TIA>>``
      - ``VectorDomain<AtomDomain<usize>>``
      - ``SymmetricDistance``
-   * - :func:`opendp.transformations.make_index`
+   * - :func:`~opendp.transformations.make_index`
      - ``VectorDomain<AtomDomain<usize>>``
      - ``VectorDomain<AtomDomain<TOA>>``
      - ``SymmetricDistance``
@@ -209,7 +209,7 @@ You can use combinations of the indicial transformers to map hashable data to in
 Clamping
 --------
 Many aggregators depend on bounded data to limit the influence that perturbing an individual may have on a query.
-For example, the stability map for the :func:`opendp.transformations.make_sum` aggregator is ``d_out = d_in * max(|L|, U)``.
+For example, the stability map for the :func:`~opendp.transformations.make_sum` aggregator is ``d_out = d_in * max(|L|, U)``.
 This relation states that adding or removing ``d_in`` records may influence the sum by ``d_in`` * the greatest magnitude of a record.
 
 Any aggregator that needs bounded data will indicate it in the function name.
@@ -225,7 +225,7 @@ Only chain with a clamp transformation if the aggregator you intend to use needs
      - Input Domain
      - Output Domain
      - Input/Output Metric
-   * - :func:`opendp.transformations.make_clamp`
+   * - :func:`~opendp.transformations.make_clamp`
      - ``VectorDomain<AtomDomain<TA>>``
      - ``VectorDomain<AtomDomain<TA>>`` (with bounds)
      - ``SymmetricDistance``
@@ -249,11 +249,11 @@ to metrics that are sensitive to ordering (``InsertDeleteDistance`` and ``Hammin
      - Input/Output Domain
      - Input Metric
      - Output Metric
-   * - :func:`opendp.transformations.make_ordered_random`
+   * - :func:`~opendp.transformations.make_ordered_random`
      - ``VectorDomain<AtomDomain<TA>>``
      - ``SymmetricDistance``
      - ``InsertDeleteDistance``
-   * - :func:`opendp.transformations.make_unordered`
+   * - :func:`~opendp.transformations.make_unordered`
      - ``VectorDomain<AtomDomain<TA>>``
      - ``InsertDeleteDistance``
      - ``SymmetricDistance``
@@ -273,19 +273,19 @@ and provide the following constructors to convert to/from "bounded"-dp metrics `
      - Input/Output Domain
      - Input Metric
      - Output Metric
-   * - :func:`opendp.transformations.make_metric_bounded`
+   * - :func:`~opendp.transformations.make_metric_bounded`
      - ``SizedDomain<VectorDomain<AtomDomain<TA>>>``
      - ``SymmetricDistance``
      - ``ChangeOneDistance``
-   * - :func:`opendp.transformations.make_metric_bounded`
+   * - :func:`~opendp.transformations.make_metric_bounded`
      - ``SizedDomain<VectorDomain<AtomDomain<TA>>>``
      - ``InsertDeleteDistance``
      - ``HammingDistance``
-   * - :func:`opendp.transformations.make_metric_unbounded`
+   * - :func:`~opendp.transformations.make_metric_unbounded`
      - ``SizedDomain<VectorDomain<AtomDomain<TA>>>``
      - ``ChangeOneDistance``
      - ``SymmetricDistance``
-   * - :func:`opendp.transformations.make_metric_unbounded`
+   * - :func:`~opendp.transformations.make_metric_unbounded`
      - ``SizedDomain<VectorDomain<AtomDomain<TA>>>``
      - ``HammingDistance``
      - ``InsertDeleteDistance``
@@ -302,7 +302,7 @@ the resulting dataset distance is 2.
 Therefore, the resize transformation is 2-stable: ``map(d_in) = 2 * d_in``.
 
 Similarly to data bounds, many aggregators calibrate their stability map based on knowledge of a known dataset size.
-For example, the relation downstream for the :func:`opendp.transformations.make_mean` aggregator is ``map(d_in) = d_in // 2 * (U - L) / n``.
+For example, the relation downstream for the :func:`~opendp.transformations.make_mean` aggregator is ``map(d_in) = d_in // 2 * (U - L) / n``.
 Notice that any addition and removal may, in the worst case, change a record from ``L`` to ``U``.
 Such a substitution would influence the mean by ``(U - L) / n``.
 
@@ -321,7 +321,7 @@ The input and output metrics may be configured to any combination of ``Symmetric
      - Input Domain
      - Output Domain
      - Input/Output Metric
-   * - :func:`opendp.transformations.make_resize`
+   * - :func:`~opendp.transformations.make_resize`
      - ``VectorDomain<DA>``
      - ``SizedDomain<VectorDomain<DA>>``
      - ``SymmetricDistance/InsertDeleteDistance``
@@ -342,13 +342,13 @@ Aggregators compute a summary statistic on individual-level data.
 Aggregators that produce scalar-valued statistics have an output_metric of ``AbsoluteDistance[TO]``.
 This output metric can be chained with most noise-addition measurements interchangeably.
 
-However, aggregators that produce vector-valued statistics like :func:`opendp.transformations.make_count_by_categories`
+However, aggregators that produce vector-valued statistics like :func:`~opendp.transformations.make_count_by_categories`
 provide the option to choose the output metric: ``L1Distance[TOA]`` or ``L2Distance[TOA]``.
-These default to ``L1Distance[TOA]``, which chains with L1 noise mechanisms like :func:`opendp.measurements.make_laplace` and :func:`opendp.measurements.make_laplace`.
-If you set the output metric to ``L2Distance[TOA]``, you can chain with L2 mechanisms like :func:`opendp.measurements.make_gaussian`.
+These default to ``L1Distance[TOA]``, which chains with L1 noise mechanisms like :func:`~opendp.measurements.make_laplace` and :func:`~opendp.measurements.make_laplace`.
+If you set the output metric to ``L2Distance[TOA]``, you can chain with L2 mechanisms like :func:`~opendp.measurements.make_gaussian`.
 
-The constructor :func:`opendp.transformations.make_count_by` does a similar aggregation as :func:`opendp.transformations.make_count_by_categories`,
-but does not need a category set (you instead chain with :func:`opendp.measurements.make_laplace_threshold`).
+The constructor :func:`~opendp.transformations.make_count_by` does a similar aggregation as :func:`~opendp.transformations.make_count_by_categories`,
+but does not need a category set (you instead chain with :func:`~opendp.measurements.make_laplace_threshold`).
 
 The ``make_sized_bounded_covariance`` aggregator is Rust-only at this time because data loaders for data of type ``Vec<(T, T)>`` are not implemented.
 
@@ -370,37 +370,37 @@ See the notebooks for code examples and deeper explanations:
      - Output Domain
      - Input Metric
      - Output Metric
-   * - :func:`opendp.transformations.make_count`
+   * - :func:`~opendp.transformations.make_count`
      - ``VectorDomain<AtomDomain<TIA>>``
      - ``AtomDomain<TO>``
      - ``SymmetricDistance``
      - ``AbsoluteDistance<TO>``
-   * - :func:`opendp.transformations.make_count_distinct`
+   * - :func:`~opendp.transformations.make_count_distinct`
      - ``VectorDomain<AtomDomain<TIA>>``
      - ``AtomDomain<TO>``
      - ``SymmetricDistance``
      - ``AbsoluteDistance<TO>``
-   * - :func:`opendp.transformations.make_count_by_categories`
+   * - :func:`~opendp.transformations.make_count_by_categories`
      - ``VectorDomain<AtomDomain<TIA>>``
      - ``VectorDomain<AtomDomain<TOA>>``
      - ``SymmetricDistance``
      - ``L1Distance<TOA>/L2Distance<TOA>``
-   * - :func:`opendp.transformations.make_count_by`
+   * - :func:`~opendp.transformations.make_count_by`
      - ``VectorDomain<AtomDomain<TI>>``
      - ``MapDomain<AtomDomain<TI>, AtomDomain<TO>>``
      - ``SymmetricDistance``
      - ``L1Distance<TO>``
-   * - :func:`opendp.transformations.make_sum`
+   * - :func:`~opendp.transformations.make_sum`
      - ``VectorDomain<AtomDomain<T>>`` (with bounds and optionally size)
      - ``AtomDomain<T>``
      - ``SymmetricDistance/InsertDeleteDistance``
      - ``AbsoluteDistance<TO>``
-   * - :func:`opendp.transformations.make_mean`
+   * - :func:`~opendp.transformations.make_mean`
      - ``VectorDomain<AtomDomain<T>>`` (with size and bounds)
      - ``AtomDomain<T>``
      - ``SymmetricDistance``
      - ``AbsoluteDistance<TO>``
-   * - :func:`opendp.transformations.make_variance`
+   * - :func:`~opendp.transformations.make_variance`
      - ``VectorDomain<AtomDomain<T>>`` (with size and bounds)
      - ``AtomDomain<T>``
      - ``SymmetricDistance``
@@ -412,7 +412,7 @@ See the notebooks for code examples and deeper explanations:
      - ``AbsoluteDistance<TO>``
 
 
-:func:`opendp.transformations.make_sum` makes a best guess as to which summation strategy to use based on the input space.
+:func:`~opendp.transformations.make_sum` makes a best guess as to which summation strategy to use based on the input space.
 Should you need it, the following constructors give greater control over the sum.
 
 .. dropdown:: Algorithm Details
@@ -442,37 +442,37 @@ Should you need it, the following constructors give greater control over the sum
     * - Aggregator
       - Input Domain
       - Input Metric
-    * - :func:`opendp.transformations.make_sized_bounded_int_checked_sum`
+    * - :func:`~opendp.transformations.make_sized_bounded_int_checked_sum`
       - ``VectorDomain<AtomDomain<T>>`` (with size and bounds)
       - ``SymmetricDistance``
-    * - :func:`opendp.transformations.make_bounded_int_monotonic_sum`
+    * - :func:`~opendp.transformations.make_bounded_int_monotonic_sum`
       - ``VectorDomain<AtomDomain<T>>`` (with bounds)
       - ``SymmetricDistance``
-    * - :func:`opendp.transformations.make_sized_bounded_int_monotonic_sum`
+    * - :func:`~opendp.transformations.make_sized_bounded_int_monotonic_sum`
       - ``VectorDomain<AtomDomain<T>>`` (with size and bounds)
       - ``SymmetricDistance``
-    * - :func:`opendp.transformations.make_bounded_int_ordered_sum`
-      - ``VectorDomain<AtomDomain<T>>`` (with bounds)
-      - ``InsertDeleteDistance``
-    * - :func:`opendp.transformations.make_sized_bounded_int_ordered_sum`
-      - ``VectorDomain<AtomDomain<T>>`` (with size and bounds)
-      - ``InsertDeleteDistance``
-    * - :func:`opendp.transformations.make_bounded_int_split_sum`
-      - ``VectorDomain<AtomDomain<T>>`` (with bounds)
-      - ``SymmetricDistance``
-    * - :func:`opendp.transformations.make_sized_bounded_int_split_sum`
-      - ``VectorDomain<AtomDomain<T>>`` (with size and bounds)
-      - ``SymmetricDistance``
-    * - :func:`opendp.transformations.make_bounded_float_checked_sum`
-      - ``VectorDomain<AtomDomain<T>>`` (with bounds)
-      - ``SymmetricDistance``
-    * - :func:`opendp.transformations.make_sized_bounded_float_checked_sum`
-      - ``VectorDomain<AtomDomain<T>>`` (with size and bounds)
-      - ``SymmetricDistance``
-    * - :func:`opendp.transformations.make_bounded_float_ordered_sum`
+    * - :func:`~opendp.transformations.make_bounded_int_ordered_sum`
       - ``VectorDomain<AtomDomain<T>>`` (with bounds)
       - ``InsertDeleteDistance``
-    * - :func:`opendp.transformations.make_sized_bounded_float_ordered_sum`
+    * - :func:`~opendp.transformations.make_sized_bounded_int_ordered_sum`
+      - ``VectorDomain<AtomDomain<T>>`` (with size and bounds)
+      - ``InsertDeleteDistance``
+    * - :func:`~opendp.transformations.make_bounded_int_split_sum`
+      - ``VectorDomain<AtomDomain<T>>`` (with bounds)
+      - ``SymmetricDistance``
+    * - :func:`~opendp.transformations.make_sized_bounded_int_split_sum`
+      - ``VectorDomain<AtomDomain<T>>`` (with size and bounds)
+      - ``SymmetricDistance``
+    * - :func:`~opendp.transformations.make_bounded_float_checked_sum`
+      - ``VectorDomain<AtomDomain<T>>`` (with bounds)
+      - ``SymmetricDistance``
+    * - :func:`~opendp.transformations.make_sized_bounded_float_checked_sum`
+      - ``VectorDomain<AtomDomain<T>>`` (with size and bounds)
+      - ``SymmetricDistance``
+    * - :func:`~opendp.transformations.make_bounded_float_ordered_sum`
+      - ``VectorDomain<AtomDomain<T>>`` (with bounds)
+      - ``InsertDeleteDistance``
+    * - :func:`~opendp.transformations.make_sized_bounded_float_ordered_sum`
       - ``VectorDomain<AtomDomain<T>>`` (with size and bounds)
       - ``InsertDeleteDistance``
   
@@ -489,4 +489,4 @@ See the following notebook for more information:
 
    aggregation-quantile
 
-These use :func:`opendp.transformations.make_b_ary_tree`, :func:`opendp.transformations.make_consistent_b_ary_tree` and :func:`opendp.transformations.make_quantiles_from_counts`.
+These use :func:`~opendp.transformations.make_b_ary_tree`, :func:`~opendp.transformations.make_consistent_b_ary_tree` and :func:`~opendp.transformations.make_quantiles_from_counts`.

--- a/docs/source/api/user-guide/utilities/parameter-search.rst
+++ b/docs/source/api/user-guide/utilities/parameter-search.rst
@@ -22,9 +22,9 @@ because the relation itself acts as your predicate function.
 
 OpenDP comes with some utility functions to make these binary searches easier to conduct:
 
-* :func:`opendp.mod.binary_search_chain`: Pass it a function that makes a measurement or transformation from one numeric argument, as well as ``d_in`` and ``d_out``. Returns the tightest chain.
-* :func:`opendp.mod.binary_search_param`: Same as binary_search_chain, but returns the discovered parameter.
-* :func:`opendp.mod.binary_search`: Pass a predicate function and bounds. Returns the discovered parameter. Useful when you just want to solve for ``d_in`` or ``d_out``.
+* :func:`~opendp.mod.binary_search_chain`: Pass it a function that makes a measurement or transformation from one numeric argument, as well as ``d_in`` and ``d_out``. Returns the tightest chain.
+* :func:`~opendp.mod.binary_search_param`: Same as binary_search_chain, but returns the discovered parameter.
+* :func:`~opendp.mod.binary_search`: Pass a predicate function and bounds. Returns the discovered parameter. Useful when you just want to solve for ``d_in`` or ``d_out``.
 
 This is extremely powerful!
 
@@ -120,7 +120,7 @@ Generally speaking, each step the algorithm takes is exponentially larger than t
 If bounds are not passed to the binary search algorithm, an exponential search is run to find the bounds for the binary search.
 This is generally less likely to overflow than if you were to set large binary search bounds, because the magnitude of exponential bounds queries starts small.
 
-:func:`opendp.mod.exponential_bounds_search` uses a number of heuristics that tend to work well on most problems.
+:func:`~opendp.mod.exponential_bounds_search` uses a number of heuristics that tend to work well on most problems.
 If the heuristics fail you, then pass your own bounds into the binary search utilities.
 
 .. dropdown:: Algorithm Details

--- a/docs/source/api/user-guide/utilities/serialization.rst
+++ b/docs/source/api/user-guide/utilities/serialization.rst
@@ -6,7 +6,7 @@ Serialization
 LazyFrameQuery Serialization
 ----------------------------
 
-For a :py:class:`opendp.extras.polars.LazyFrameQuery`,
+For a :py:class:`~opendp.extras.polars.LazyFrameQuery`,
 the plan can be extracted and then used to create a new object,
 perhaps on a remote server.
 

--- a/docs/source/api/user-guide/utilities/serialization.rst
+++ b/docs/source/api/user-guide/utilities/serialization.rst
@@ -6,7 +6,7 @@ Serialization
 LazyFrameQuery Serialization
 ----------------------------
 
-For a :py:class:`LazyFrameQuery <opendp.extras.polars.LazyFrameQuery>`,
+For a :py:class:`opendp.extras.polars.LazyFrameQuery`,
 the plan can be extracted and then used to create a new object,
 perhaps on a remote server.
 

--- a/docs/source/api/user-guide/utilities/typing.rst
+++ b/docs/source/api/user-guide/utilities/typing.rst
@@ -54,10 +54,10 @@ There are additional modifiers:
 
 Some examples being:
 
-* ``TA`` for the atomic type. ``float`` could be the TA for a float :py:func:`opendp.transformations.make_clamp`.
-* ``TIA`` for Atomic Input Type. ``str`` could be the TIA for a :py:func:`opendp.transformations.make_count`.
-* ``MO`` for Output Metric. ``AbsoluteDistance[int]`` could be the MO for a :py:func:`opendp.transformations.make_count_by_categories`.
-* ``QO`` for Output distance. ``float`` could be the QO for a :py:func:`opendp.measurements.make_laplace`.
+* ``TA`` for the atomic type. ``float`` could be the TA for a float :py:func:`~opendp.transformations.make_clamp`.
+* ``TIA`` for Atomic Input Type. ``str`` could be the TIA for a :py:func:`~opendp.transformations.make_count`.
+* ``MO`` for Output Metric. ``AbsoluteDistance[int]`` could be the MO for a :py:func:`~opendp.transformations.make_count_by_categories`.
+* ``QO`` for Output distance. ``float`` could be the QO for a :py:func:`~opendp.measurements.make_laplace`.
 
 The API docs should also include explanations in most contexts.
 
@@ -105,7 +105,7 @@ It can be more convenient to denote types in terms of Python types, so we've add
    * - ``bool``
      - ``bool``
 
-You can change the default type for floats and ints via :py:func:`opendp.typing.set_default_float_type` and :py:func:`opendp.typing.set_default_int_type`, respectively.
+You can change the default type for floats and ints via :py:func:`~opendp.typing.set_default_float_type` and :py:func:`~opendp.typing.set_default_int_type`, respectively.
 These functions make it easy to set the default bit depth throughout your code, all at once.
 
 This can be particularly useful when working with NumPy arrays which default to ``i64``, or when working with deep learning libraries that default to single-precision floats. 

--- a/docs/source/api/user-guide/utilities/typing.rst
+++ b/docs/source/api/user-guide/utilities/typing.rst
@@ -54,10 +54,10 @@ There are additional modifiers:
 
 Some examples being:
 
-* ``TA`` for the atomic type. ``float`` could be the TA for a float :py:func:`clamp transformation <opendp.transformations.make_clamp>`.
-* ``TIA`` for Atomic Input Type. ``str`` could be the TIA for a :py:func:`count transformation <opendp.transformations.make_count>`.
-* ``MO`` for Output Metric. ``AbsoluteDistance[int]`` could be the MO for a :py:func:`histogram transformation <opendp.transformations.make_count_by_categories>`.
-* ``QO`` for Output distance. ``float`` could be the QO for a :py:func:`Laplace measurement <opendp.measurements.make_laplace>`.
+* ``TA`` for the atomic type. ``float`` could be the TA for a float :py:func:`opendp.transformations.make_clamp`.
+* ``TIA`` for Atomic Input Type. ``str`` could be the TIA for a :py:func:`opendp.transformations.make_count`.
+* ``MO`` for Output Metric. ``AbsoluteDistance[int]`` could be the MO for a :py:func:`opendp.transformations.make_count_by_categories`.
+* ``QO`` for Output distance. ``float`` could be the QO for a :py:func:`opendp.measurements.make_laplace`.
 
 The API docs should also include explanations in most contexts.
 

--- a/docs/source/getting-started/statistical-modeling/synthetic-data.rst
+++ b/docs/source/getting-started/statistical-modeling/synthetic-data.rst
@@ -8,14 +8,14 @@ and then generate synthetic data with the same relationships.
 
 Read the :ref:`contingency table <contingency-tables>` documentation first for install instructions,
 how to preprocess data, and how to specify and/or release keys.
-Synthetic data works in much the same way, but the query workload is no longer fixed (using the :py:class:`opendp.extras.mbi.Fixed` algorithm).
+Synthetic data works in much the same way, but the query workload is no longer fixed (using the :py:class:`~opendp.extras.mbi.Fixed` algorithm).
 
-All algorithms for differentially private contingency table estimation inherit from :py:class:`opendp.extras.mbi.Algorithm`:
+All algorithms for differentially private contingency table estimation inherit from :py:class:`~opendp.extras.mbi.Algorithm`:
 
-* :py:class:`opendp.extras.mbi.Fixed` (static, pre-defined workload) 
-* :py:class:`opendp.extras.mbi.AIM` (synthetic data: adaptive and iterative mechanism) 
-* :py:class:`opendp.extras.mbi.MST` (synthetic data: minimum spanning tree) 
-* :py:class:`opendp.extras.mbi.Sequential` (run a sequence of algorithms)
+* :py:class:`~opendp.extras.mbi.Fixed` (static, pre-defined workload) 
+* :py:class:`~opendp.extras.mbi.AIM` (synthetic data: adaptive and iterative mechanism) 
+* :py:class:`~opendp.extras.mbi.MST` (synthetic data: minimum spanning tree) 
+* :py:class:`~opendp.extras.mbi.Sequential` (run a sequence of algorithms)
 
 Let's get started by setting up the context for the Labor Force dataset.
 
@@ -35,7 +35,7 @@ Let's get started by setting up the context for the Labor Force dataset.
     ...     privacy_loss=dp.loss_of(rho=0.2, delta=2e-7),
     ... )
 
-We now release a contingency table via the :py:class:`opendp.extras.mbi.AIM` algorithm.
+We now release a contingency table via the :py:class:`~opendp.extras.mbi.AIM` algorithm.
 
 .. code:: pycon
 

--- a/docs/source/getting-started/tabular-data/contingency-tables.rst
+++ b/docs/source/getting-started/tabular-data/contingency-tables.rst
@@ -107,7 +107,7 @@ In this setting, the scale and threshold are reasonably small.
 To make the threshold smaller, consider adding more key-sets 
 or bounding the number of groups a user may contribute.
 
-When you release, all marginals are estimated and stored inside a :py:class:`opendp.extras.mbi.ContingencyTable`.
+When you release, all marginals are estimated and stored inside a :py:class:`~opendp.extras.mbi.ContingencyTable`.
 The contingency table supports counting queries over arbitrary sets of grouping columns.
 
 .. code:: pycon

--- a/docs/source/getting-started/tabular-data/identifier-truncation.rst
+++ b/docs/source/getting-started/tabular-data/identifier-truncation.rst
@@ -153,6 +153,6 @@ are together in the data pipeline. OpenDP does, however, enforce that
 group-by truncations are the last truncations in the data pipeline.
 
 See :ref:`Bounds <bounds-user-guide>` in the API user guide, and
-:py:func:`opendp.extras.polars.LazyFrameQuery.truncate_per_group`
-and :py:func:`opendp.extras.polars.LazyFrameQuery.truncate_num_groups`
+:py:func:`~opendp.extras.polars.LazyFrameQuery.truncate_per_group`
+and :py:func:`~opendp.extras.polars.LazyFrameQuery.truncate_num_groups`
 in the API documentation for more on configuring truncation.

--- a/docs/source/getting-started/tabular-data/identifier-truncation.rst
+++ b/docs/source/getting-started/tabular-data/identifier-truncation.rst
@@ -153,6 +153,6 @@ are together in the data pipeline. OpenDP does, however, enforce that
 group-by truncations are the last truncations in the data pipeline.
 
 See :ref:`Bounds <bounds-user-guide>` in the API user guide, and
-:py:func:`truncate_per_group <opendp.extras.polars.LazyFrameQuery.truncate_per_group>`
-and :py:func:`truncate_num_groups <opendp.extras.polars.LazyFrameQuery.truncate_num_groups>`
+:py:func:`opendp.extras.polars.LazyFrameQuery.truncate_per_group`
+and :py:func:`opendp.extras.polars.LazyFrameQuery.truncate_num_groups`
 in the API documentation for more on configuring truncation.

--- a/docs/source/getting-started/utility.rst
+++ b/docs/source/getting-started/utility.rst
@@ -25,10 +25,10 @@ or derive the necessary noise scale to meet a given target accuracy and statisti
 The noise distribution may be either Laplace or Gaussian.
 
 :Laplacian: | Applies to any L1 noise addition mechanism.
-  | :func:`make_laplace() <opendp.measurements.make_laplace>`
-  | :func:`make_laplace_threshold() <opendp.measurements.make_laplace_threshold>`
+  | :func:`opendp.measurements.make_laplace`
+  | :func:`opendp.measurements.make_laplace_threshold`
 :Gaussian: | Applies to any L2 noise addition mechanism.
-  | :func:`make_gaussian() <opendp.measurements.make_gaussian>`
+  | :func:`opendp.measurements.make_gaussian`
 
 The library provides the following functions for converting between noise scale and accuracy:
 

--- a/docs/source/getting-started/utility.rst
+++ b/docs/source/getting-started/utility.rst
@@ -25,17 +25,17 @@ or derive the necessary noise scale to meet a given target accuracy and statisti
 The noise distribution may be either Laplace or Gaussian.
 
 :Laplacian: | Applies to any L1 noise addition mechanism.
-  | :func:`opendp.measurements.make_laplace`
-  | :func:`opendp.measurements.make_laplace_threshold`
+  | :func:`~opendp.measurements.make_laplace`
+  | :func:`~opendp.measurements.make_laplace_threshold`
 :Gaussian: | Applies to any L2 noise addition mechanism.
-  | :func:`opendp.measurements.make_gaussian`
+  | :func:`~opendp.measurements.make_gaussian`
 
 The library provides the following functions for converting between noise scale and accuracy:
 
-* :func:`opendp.accuracy.laplacian_scale_to_accuracy`
-* :func:`opendp.accuracy.accuracy_to_laplacian_scale`
-* :func:`opendp.accuracy.gaussian_scale_to_accuracy`
-* :func:`opendp.accuracy.accuracy_to_gaussian_scale`
+* :func:`~opendp.accuracy.laplacian_scale_to_accuracy`
+* :func:`~opendp.accuracy.accuracy_to_laplacian_scale`
+* :func:`~opendp.accuracy.gaussian_scale_to_accuracy`
+* :func:`~opendp.accuracy.accuracy_to_gaussian_scale`
 
 To demonstrate, the following snippet finds the necessary gaussian scale such that the input to 
 :code:`make_gaussian(input_domain, input_metric, scale=1.)` differs from the release by no more than 2 with 95% confidence.


### PR DESCRIPTION
- Fix #2542

Skipping `docs/source/api/user-guide/measurements/index.rst` because it is covered by
- #2543
