### PR TITLE
docs: Better formatting of API reference docs

### DIFF
--- a/python/src/opendp/extras/mbi/_table/__init__.py
+++ b/python/src/opendp/extras/mbi/_table/__init__.py
@@ -153,7 +153,7 @@ class ContingencyTable:
         Under the central limit theorem, the distribution will tend towards gaussian.
 
         If the estimate is gaussian-distributed,
-        use :py:func:`opendp.accuracy.gaussian_scale_to_accuracy`
+        use :py:func:`~opendp.accuracy.gaussian_scale_to_accuracy`
         to construct a confidence interval.
 
         :param attrs: attributes to preserve in uncertainty estimate

--- a/python/src/opendp/extras/mbi/_utilities/__init__.py
+++ b/python/src/opendp/extras/mbi/_utilities/__init__.py
@@ -81,7 +81,7 @@ class Algorithm(ABC):
     estimator: Callable = mirror_descent
     """Optimizer to use to fit a MarkovRandomField.
 
-    Defaults to :py:func:`opendp.extras.mbi.mirror_descent`.
+    Defaults to :py:func:`~opendp.extras.mbi.mirror_descent`.
     Any function matching the signature of ``mirror_descent`` 
     can be used to customize how the MarkovRandomField is optimized/estimated.
     See `mbi.estimation <https://private-pgm.readthedocs.io/en/latest/_autosummary_output/mbi.estimation.html>`_ for other optimizers.

--- a/python/src/opendp/extras/numpy/canonical.py
+++ b/python/src/opendp/extras/numpy/canonical.py
@@ -23,7 +23,7 @@ class BinomialCND:
     """
     Utilities to conduct statistical inference on the output of the canonical noise mechanism on binomially-distributed data.
 
-    Use :func:`opendp.measurements.make_canonical_noise` to instantiate the canonical noise mechanism.
+    Use :func:`~opendp.measurements.make_canonical_noise` to instantiate the canonical noise mechanism.
 
     The mechanism outputs a sample from X + N,
     where X ~ Binomial(n=size, p=theta), N ~ CND(0, d_in, d_out).

--- a/python/src/opendp/extras/polars/__init__.py
+++ b/python/src/opendp/extras/polars/__init__.py
@@ -58,7 +58,7 @@ class DPExpr(object):
     If both ``opendp`` and ``polars`` have been imported,
     the methods of :py:class:`DPExpr` are registered under the ``dp`` namespace in
     `Polars expressions <https://docs.pola.rs/py-polars/html/reference/expressions/index.html>`_.
-    An expression can be used as a plan in :py:func:`opendp.measurements.make_private_lazyframe`;
+    An expression can be used as a plan in :py:func:`~opendp.measurements.make_private_lazyframe`;
     See the full example there for more information.
 
     In addition to the DP-specific methods here, many Polars ``Expr`` methods are also supported,
@@ -81,7 +81,7 @@ class DPExpr(object):
     ):
         """Add noise to the expression.
 
-        If scale is None it is filled by ``global_scale`` in :py:func:`opendp.measurements.make_private_lazyframe`.
+        If scale is None it is filled by ``global_scale`` in :py:func:`~opendp.measurements.make_private_lazyframe`.
         The noise distribution is chosen according to the privacy definition:
 
         * Pure-DP: Laplace noise, where ``scale == standard_deviation / sqrt(2)``
@@ -122,7 +122,7 @@ class DPExpr(object):
     def laplace(self, scale: float | None = None):
         """Add Laplace noise to the expression.
 
-        If scale is None it is filled by ``global_scale`` in :py:func:`opendp.measurements.make_private_lazyframe`.
+        If scale is None it is filled by ``global_scale`` in :py:func:`~opendp.measurements.make_private_lazyframe`.
 
         :param scale: Noise scale parameter for the Laplace distribution. ``scale == standard_deviation / sqrt(2)``
         """
@@ -132,7 +132,7 @@ class DPExpr(object):
     def gaussian(self, scale: float | None = None):
         """Add Gaussian noise to the expression.
 
-        If scale is None it is filled by ``global_scale`` in :py:func:`opendp.measurements.make_private_lazyframe`.
+        If scale is None it is filled by ``global_scale`` in :py:func:`~opendp.measurements.make_private_lazyframe`.
 
         :param scale: Noise scale parameter for the Gaussian distribution. ``scale == standard_deviation``
         """
@@ -141,7 +141,7 @@ class DPExpr(object):
     def len(self, scale: float | None = None):
         """Compute a differentially private estimate of the number of elements in `self`, including null values.
 
-        If scale is None it is filled by ``global_scale`` in :py:func:`opendp.measurements.make_private_lazyframe`.
+        If scale is None it is filled by ``global_scale`` in :py:func:`~opendp.measurements.make_private_lazyframe`.
 
         :param scale: parameter for the noise distribution.
 
@@ -186,7 +186,7 @@ class DPExpr(object):
 
         This function is a shortcut for the exact Polars ``count`` and then noise addition.
 
-        If scale is None it is filled by ``global_scale`` in :py:func:`opendp.measurements.make_private_lazyframe`.
+        If scale is None it is filled by ``global_scale`` in :py:func:`~opendp.measurements.make_private_lazyframe`.
 
         :param scale: parameter for the noise distribution.
 
@@ -228,7 +228,7 @@ class DPExpr(object):
 
         This function is a shortcut for the exact Polars ``null_count`` and then noise addition.
 
-        If scale is None it is filled by ``global_scale`` in :py:func:`opendp.measurements.make_private_lazyframe`.
+        If scale is None it is filled by ``global_scale`` in :py:func:`~opendp.measurements.make_private_lazyframe`.
 
         :param scale: parameter for the noise distribution.
 
@@ -274,7 +274,7 @@ class DPExpr(object):
 
         This function is a shortcut for the exact Polars ``n_unique`` and then noise addition.
 
-        If scale is None it is filled by ``global_scale`` in :py:func:`opendp.measurements.make_private_lazyframe`.
+        If scale is None it is filled by ``global_scale`` in :py:func:`~opendp.measurements.make_private_lazyframe`.
 
         :param scale: parameter for the noise distribution.
 
@@ -314,7 +314,7 @@ class DPExpr(object):
     def sum(self, bounds: tuple[float, float], scale: float | None = None):
         """Compute the differentially private sum.
 
-        If scale is None it is filled by ``global_scale`` in :py:func:`opendp.measurements.make_private_lazyframe`.
+        If scale is None it is filled by ``global_scale`` in :py:func:`~opendp.measurements.make_private_lazyframe`.
 
         :param bounds: clip the input data to these lower and upper bounds
         :param scale: parameter for the noise distribution
@@ -367,7 +367,7 @@ class DPExpr(object):
         """Compute the differentially private mean.
 
         The amount of noise to be added to the sum is determined by the scale.
-        If scale is None it is filled by ``global_scale`` in :py:func:`opendp.measurements.make_private_lazyframe`.
+        If scale is None it is filled by ``global_scale`` in :py:func:`~opendp.measurements.make_private_lazyframe`.
 
         :param bounds: clip the input data to these lower and upper bounds
         :param scale: relative parameter for the scale of the noise distributions
@@ -463,7 +463,7 @@ class DPExpr(object):
         """Compute a differentially private median.
 
         The scale calibrates the level of entropy when selecting a candidate.
-        If scale is None it is filled by ``global_scale`` in :py:func:`opendp.measurements.make_private_lazyframe`.
+        If scale is None it is filled by ``global_scale`` in :py:func:`~opendp.measurements.make_private_lazyframe`.
 
         :param candidates: Potential quantiles to select from.
         :param scale: How much noise to add to the scores of candidate.
@@ -513,7 +513,7 @@ if pl is not None:
 def dp_len(scale: float | None = None):
     """Compute a differentially private estimate of the number of rows.
 
-    If scale is None it is filled by ``global_scale`` in :py:func:`opendp.measurements.make_private_lazyframe`.
+    If scale is None it is filled by ``global_scale`` in :py:func:`~opendp.measurements.make_private_lazyframe`.
 
     :param scale: parameter for the noise distribution.
 
@@ -673,7 +673,7 @@ class SortBy:
 
 class LazyFrameQuery:
     """
-    A ``LazyFrameQuery`` may be returned by :py:func:`opendp.context.Context.query`.
+    A ``LazyFrameQuery`` may be returned by :py:func:`~opendp.context.Context.query`.
     It mimics a `Polars LazyFrame <https://docs.pola.rs/api/python/stable/reference/lazyframe/index.html>`_,
     but makes a few additions and changes as documented below."""
 
@@ -1111,7 +1111,7 @@ class LazyFrameQuery:
 
 class LazyGroupByQuery:
     """
-    A ``LazyGroupByQuery`` is returned by :py:func:`opendp.extras.polars.LazyFrameQuery.group_by`.
+    A ``LazyGroupByQuery`` is returned by :py:func:`~opendp.extras.polars.LazyFrameQuery.group_by`.
     It mimics a `Polars LazyGroupBy <https://docs.pola.rs/api/python/stable/reference/lazyframe/group_by.html>`_,
     but only supports APIs documented below."""
 
@@ -1143,7 +1143,7 @@ class Margin:
     Be aware that aspects of your data marked as "public information" are not subject to privacy protections,
     so it is important that public descriptors about the margin should be set conservatively, or not set at all.
 
-    Instances of this class are used by :py:func:`opendp.context.Context.compositor`.
+    Instances of this class are used by :py:func:`~opendp.context.Context.compositor`.
     """
 
     by: Sequence = field(default_factory=list)

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -646,7 +646,7 @@ class Queryable:
     Queryables are used for interactive mechanisms like :ref:`adaptive composition <adaptive-composition>`.
 
     Queryables can be created with :py:func:`make_adaptive_composition <opendp.combinators.make_adaptive_composition>`
-    or :py:func:`new_queryable <opendp.core.new_queryable>`.
+    or :py:func:`~opendp.core.new_queryable`.
     '''
     def __init__(self, value, query_type):
         self.value = value
@@ -663,7 +663,7 @@ class OdometerQueryable:
     '''
     Odometer Queryables are used for instances of odometers like :ref:`fully adaptive composition <fully-adaptive-composition>`.
 
-    Can be created via :py:func:`make_fully_adaptive_composition <opendp.combinators.make_fully_adaptive_composition>`.
+    Can be created via :py:func:`~opendp.combinators.make_fully_adaptive_composition`.
     '''
     def __init__(self, value):
         self.value = value
@@ -798,7 +798,7 @@ class Domain(ctypes.POINTER(AnyDomain)): # type: ignore[misc]
 class AtomDomain(Domain):
     '''The domain of all values of a given atomic type.
 
-    Create an instance of this domain with :py:func:`opendp.domains.atom_domain`.
+    Create an instance of this domain with :py:func:`~opendp.domains.atom_domain`.
 
     If bounds are set, then the domain is restricted to the bounds.
     If nullable is set, then null value(s) are included in the domain.
@@ -826,7 +826,7 @@ class AtomDomain(Domain):
 class OptionDomain(Domain):
     '''A domain whose members are either members of the ``element_domain``, or ``None``.
 
-    Create an instance of this domain with :py:func:`opendp.domains.option_domain`.
+    Create an instance of this domain with :py:func:`~opendp.domains.option_domain`.
 
     The element domain is the domain of non-null values.
     '''
@@ -843,7 +843,7 @@ class OptionDomain(Domain):
 class VectorDomain(Domain):
     '''``VectorDomain`` describes the domain of all vectors whose elements are members of a given domain.
     
-    Create an instance of this domain with :py:func:`opendp.domains.vector_domain`.
+    Create an instance of this domain with :py:func:`~opendp.domains.vector_domain`.
     '''
     _type_ = AnyDomain
     
@@ -863,7 +863,7 @@ class VectorDomain(Domain):
 class SeriesDomain(Domain):
     '''``SeriesDomain`` describes the domain of all polars Series.
     
-    Create an instance of this domain with :py:func:`opendp.domains.series_domain`.
+    Create an instance of this domain with :py:func:`~opendp.domains.series_domain`.
     '''
     _type_ = AnyDomain
 
@@ -888,7 +888,7 @@ class SeriesDomain(Domain):
 class LazyFrameDomain(Domain):
     '''``LazyFrameDomain`` describes the domain of all polars LazyFrames.
     
-    Create an instance of this domain with :py:func:`opendp.domains.lazyframe_domain`.
+    Create an instance of this domain with :py:func:`~opendp.domains.lazyframe_domain`.
     '''
     _type_ = AnyDomain
 
@@ -1125,7 +1125,7 @@ class PrivacyProfile(object):
     Given a profile function provided by the user,
     gives the epsilon corresponding to a given delta, and vice versa.
 
-    :py:func:`new_privacy_profile <opendp.measures.new_privacy_profile>`
+    :py:func:`~opendp.measures.new_privacy_profile`
     should be used to create new instances.
     '''
     def __init__(self, curve):

--- a/python/test/test_docs.py
+++ b/python/test/test_docs.py
@@ -21,7 +21,7 @@ def test_thens_are_documented(module, function):
     make_name = then_name.replace('then_', 'make_')
 
     assert function.__doc__ is not None, 'missing documentation'
-    assert f':py:func:`{m_name}.{make_name}`' in function.__doc__, f'no link to {make_name}'
+    assert f':py:func:`~{m_name}.{make_name}`' in function.__doc__, f'no link to {make_name}'
 
 
 docs_source = Path(__file__).parent.parent.parent / 'docs' / 'source'

--- a/rust/opendp_tooling/src/codegen/python.rs
+++ b/rust/opendp_tooling/src/codegen/python.rs
@@ -194,12 +194,12 @@ pub(crate) fn generate_function(
 def {then_name}(
 {then_args}
 ):  
-    r"""partial constructor of {func_name}
+    r"""Partial constructor of `{func_name}`.
 
     .. end-markdown
 
     .. seealso:: 
-      Delays application of ``input_domain`` and ``input_metric`` in :py:func:`opendp.{module_name}.{func_name}`
+      Delays application of ``input_domain`` and ``input_metric`` in :py:func:`~opendp.{module_name}.{func_name}`
 
 {doc_params}{example}
     """

--- a/rust/src/combinators/sequential_composition/adaptive/mod.rs
+++ b/rust/src/combinators/sequential_composition/adaptive/mod.rs
@@ -236,7 +236,7 @@ where
 /// * `TO` - Output Type.
 #[deprecated(
     since = "0.14.0",
-    note = "This function has been renamed, use `make_adaptive_composition` instead."
+    note = "This function has been renamed: use :py:func:`~opendp.combinators.make_adaptive_composition` instead."
 )]
 pub fn make_sequential_composition<
     DI: Domain + 'static,

--- a/rust/src/combinators/sequential_composition/non_adaptive/ffi.rs
+++ b/rust/src/combinators/sequential_composition/non_adaptive/ffi.rs
@@ -67,7 +67,7 @@ pub extern "C" fn opendp_combinators__make_composition(
 /// * `measurements` - A vector of Measurements to compose.
 #[deprecated(
     since = "0.14.0",
-    note = "This function has been renamed, use `make_composition` instead."
+    note = "This function has been renamed: use :py:func:`~opendp.combinators.make_composition` instead."
 )]
 #[unsafe(no_mangle)]
 pub extern "C" fn opendp_combinators__make_basic_composition(

--- a/rust/src/combinators/sequential_composition/non_adaptive/mod.rs
+++ b/rust/src/combinators/sequential_composition/non_adaptive/mod.rs
@@ -134,7 +134,7 @@ where
 /// * `measurements` - A vector of Measurements to compose.
 #[deprecated(
     since = "0.14.0",
-    note = "This function has been renamed, use `make_composition` instead."
+    note = "This function has been renamed: use :py:func:`~opendp.combinators.make_composition` instead."
 )]
 pub fn make_basic_composition<DI, MI, MO, TO>(
     measurements: Vec<Measurement<DI, MI, MO, TO>>,

--- a/rust/src/measurements/noisy_max/mod.rs
+++ b/rust/src/measurements/noisy_max/mod.rs
@@ -63,7 +63,7 @@ where
     arguments(optimize(c_type = "char *", rust_type = "String", default = "max"),),
     generics(MO(suppress), TIA(suppress))
 )]
-#[deprecated(since = "0.14.0", note = "use `make_noisy_max` instead")]
+#[deprecated(since = "0.14.0", note = "Use :py:func:`~opendp.measurements.make_noisy_max` instead.")]
 /// Make a Measurement that takes a vector of scores and privately selects the index of the highest score.
 ///
 /// # Arguments

--- a/rust/src/transformations/dataframe/apply/mod.rs
+++ b/rust/src/transformations/dataframe/apply/mod.rs
@@ -15,7 +15,7 @@ use super::{DataFrame, DataFrameDomain};
 #[cfg(feature = "ffi")]
 mod ffi;
 
-#[deprecated(note = "Use Polars instead", since = "0.12.0")]
+#[deprecated(note = "Use Polars instead.", since = "0.12.0")]
 /// Internal function to map a transformation onto a column of a dataframe.
 fn make_apply_transformation_dataframe<K: Hashable, VI: Primitive, VO: Primitive, M>(
     input_domain: DataFrameDomain<K>,
@@ -61,7 +61,7 @@ where
     )
 }
 
-#[deprecated(note = "Use Polars instead", since = "0.12.0")]
+#[deprecated(note = "Use Polars instead.", since = "0.12.0")]
 #[bootstrap(
     features("contrib"),
     arguments(
@@ -129,7 +129,7 @@ where
         M = "$get_type(input_metric)"
     )
 )]
-#[deprecated(note = "Use Polars instead", since = "0.12.0")]
+#[deprecated(note = "Use Polars instead.", since = "0.12.0")]
 /// Make a Transformation that checks if each element in a column in a dataframe is equivalent to `value`.
 ///
 /// # Arguments

--- a/rust/src/transformations/dataframe/create/mod.rs
+++ b/rust/src/transformations/dataframe/create/mod.rs
@@ -62,7 +62,7 @@ fn create_dataframe<K: Hashable>(col_names: Vec<K>, records: &[Vec<&str>]) -> Da
 }
 
 #[bootstrap(features("contrib"))]
-#[deprecated(note = "Use Polars instead", since = "0.12.0")]
+#[deprecated(note = "Use Polars instead.", since = "0.12.0")]
 /// Make a Transformation that constructs a dataframe from a `Vec<Vec<String>>` (a vector of records).
 ///
 /// # Arguments
@@ -107,7 +107,7 @@ fn split_dataframe<K: Hashable>(separator: &str, col_names: Vec<K>, s: &str) -> 
     features("contrib"),
     arguments(separator(c_type = "char *", rust_type = b"null"))
 )]
-#[deprecated(note = "Use Polars instead", since = "0.12.0")]
+#[deprecated(note = "Use Polars instead.", since = "0.12.0")]
 /// Make a Transformation that splits each record in a String into a `Vec<Vec<String>>`,
 /// and loads the resulting table into a dataframe keyed by `col_names`.
 ///

--- a/rust/src/transformations/dataframe/select/mod.rs
+++ b/rust/src/transformations/dataframe/select/mod.rs
@@ -14,7 +14,7 @@ use super::{DataFrame, DataFrameDomain};
 mod ffi;
 
 #[bootstrap(features("contrib"))]
-#[deprecated(note = "Use Polars instead", since = "0.12.0")]
+#[deprecated(note = "Use Polars instead.", since = "0.12.0")]
 /// Make a Transformation that retrieves the column `key` from a dataframe as `Vec<TOA>`.
 ///
 /// # Arguments

--- a/rust/src/transformations/dataframe/subset/mod.rs
+++ b/rust/src/transformations/dataframe/subset/mod.rs
@@ -12,7 +12,7 @@ use super::{DataFrame, DataFrameDomain};
 #[cfg(feature = "ffi")]
 mod ffi;
 
-#[deprecated(note = "Use Polars instead", since = "0.12.0")]
+#[deprecated(note = "Use Polars instead.", since = "0.12.0")]
 #[bootstrap(features("contrib"))]
 /// Make a Transformation that subsets a dataframe by a boolean column.
 ///


### PR DESCRIPTION
- Fix #2522 
- Fix #2515
- Grammar: Capitalize first letter; Fix comma splices; Add periods.
- Use tilde in `func` references. (Doing in codegen and python what #2542 does in RST.)