### PR TITLE
Fix: swap in numpy cumsum for deprecated sklearn function

### DIFF
--- a/python/src/opendp/extras/sklearn/decomposition/__init__.py
+++ b/python/src/opendp/extras/sklearn/decomposition/__init__.py
@@ -320,7 +320,7 @@ if _decomposition is not None:
         def _postprocess(self, values):
             """A function that applies a release of the mean and eigendecomposition to self"""
             np = import_optional_dependency('numpy')
-            from sklearn.utils.extmath import stable_cumsum, svd_flip # type: ignore[import]
+            from sklearn.utils.extmath import svd_flip # type: ignore[import]
             from sklearn.decomposition._pca import _infer_dimension # type: ignore[import]
 
             self.mean_, S, Vt = values
@@ -350,7 +350,7 @@ if _decomposition is not None:
                 # their variance is always greater than n_components float
                 # passed. More discussion in issue: https://github.com/scikit-learn/scikit-learn/pull/15669
                 explained_variance_ratio_np = explained_variance_ratio_
-                ratio_cumsum = stable_cumsum(explained_variance_ratio_np)
+                ratio_cumsum = np.cumsum(explained_variance_ratio_np)
                 n_components = np.searchsorted(ratio_cumsum, n_components, side="right") + 1
 
             # Compute noise covariance using Probabilistic PCA model


### PR DESCRIPTION
- Fix #2588, hopefully

Sklearn had added their function originally because these _don't_ behave exactly the same, but I'm not sure if the difference in behavior matters for us, or if this was taken by chance. I think we could get exactly the same behavior by adding dtype, but if we don't need it, wouldn't want to add complexity.

Another option is [`numpy.cumulative_sum`](https://numpy.org/doc/stable/reference/generated/numpy.cumulative_sum.html#numpy.cumulative_sum).

Discussion which lead up to deprecation and removal of method, with example of behavior:
- https://github.com/scikit-learn/scikit-learn/issues/31533
