### PR TITLE
Proof: sample_standard_bernoulli

### DIFF
--- a/rust/src/traits/samplers/bernoulli/sample_standard_bernoulli.tex
+++ b/rust/src/traits/samplers/bernoulli/sample_standard_bernoulli.tex
@@ -1,0 +1,83 @@
+\documentclass{article} % necessary for Overleaf to recognize the file
+\input{../lib.sty} % "rust/src/lib.sty" contains boilerplate and macros
+
+\title{\texttt{fn sample\_standard\_bernoulli}}
+\author{Pranav S Ramanujam}\date{18/01/2026}
+
+\begin{document}
+\maketitle\contrib
+Proves soundness of \rustdoc{traits/samplers/bernoulli/fn}{sample\_standard\_bernoulli}
+in \asOfCommit{rust/src/traits/samplers/bernoulli/mod.rs}{655696c}.
+
+
+\subsection*{Vetting history}
+\begin{itemize}
+    \item \vettingPR{XXXX}
+\end{itemize}
+
+\section{Hoare Triple}
+
+\subsection*{Preconditions}
+\begin{itemize}
+    \item The function \rustdoc{traits/samplers/uniform/fn}{fill\_bytes} either
+    \begin{itemize}
+        \item returns \texttt{Err(e)} if there is insufficient system entropy, or
+        \item fills the provided buffer with uniformly random bytes.
+    \end{itemize}
+\end{itemize}
+
+\subsection*{Pseudocode}
+\begin{lstlisting}[language = Python, escapechar=|]
+def sample_standard_bernoulli():
+    buffer = sample_uniform_byte()
+    return (buffer & 1) == 1   |\label{line:out}|
+\end{lstlisting}
+
+\subsection*{Postcondition}
+For any setting of the input parameters for which the preconditions hold,
+\texttt{sample\_standard\_bernoulli} either:
+\begin{itemize}
+    \item returns \texttt{Err(e)} if there is insufficient system entropy, or
+    \item returns \texttt{Ok(sample)} where \texttt{sample} is a draw from
+    $\texttt{Bernoulli}(0.5)$.
+\end{itemize}
+
+\section{Proof}
+
+Assume the preconditions are met.
+
+We first consider the behavior of the function
+\rustdoc{traits/samplers/uniform/fn}{fill\_bytes}. By the precondition, if
+\texttt{fill\_bytes} returns \texttt{Err(e)}, then
+\texttt{sample\_standard\_bernoulli} immediately returns \texttt{Err(e)} via
+the error-propagation operator \texttt{?}. This satisfies the postcondition.
+
+We now consider the case where \texttt{fill\_bytes} succeeds. In this case,
+the function fills the single-byte buffer \texttt{buffer} with a uniformly
+random value in the set $\{0,1,\dots,255\}$.
+
+The function then evaluates the expression
+\texttt{buffer[0] \& 1 == 1}. The bitwise AND operation \texttt{\& 1} extracts
+the least significant bit of \texttt{buffer[0]}. Therefore, the returned value
+is \texttt{true} if and only if the least significant bit of \texttt{buffer[0]}
+is equal to 1.
+
+Among the integers $\{0,1,\dots,255\}$, exactly half are even and half are odd.
+Even integers have least significant bit equal to 0, and odd integers have least
+significant bit equal to 1. Since \texttt{buffer[0]} is uniformly distributed
+over $\{0,1,\dots,255\}$, it follows that
+\[
+\Pr[\texttt{buffer[0] \& 1 == 1}] = \frac{128}{256} = \frac{1}{2}.
+\]
+
+Thus, conditioned on \texttt{fill\_bytes} succeeding,
+\texttt{sample\_standard\_bernoulli} returns \texttt{Ok(true)} with probability
+$1/2$ and \texttt{Ok(false)} with probability $1/2$, which is exactly the
+distribution $\texttt{Bernoulli}(0.5)$.
+
+Therefore, in all cases,
+\texttt{sample\_standard\_bernoulli} either returns \texttt{Err(e)} if there is
+insufficient system entropy, or returns a sample drawn from
+$\texttt{Bernoulli}(0.5)$, as required by the postcondition.
+
+\end{document}

--- a/rust/src/traits/samplers/bernoulli/sample_standard_bernoulli.tex
+++ b/rust/src/traits/samplers/bernoulli/sample_standard_bernoulli.tex
@@ -13,11 +13,7 @@ in \asOfCommit{rust/src/traits/samplers/bernoulli/mod.rs}{655696c}.
 
 \subsection*{Preconditions}
 \noindent
-There are no preconditions for \texttt{sample\_standard\_bernoulli}, since the function takes no arguments and is therefore well-defined for all inputs.
-
-\noindent
-Similarly, \rustdoc{traits/samplers/uniform/fn}{fill\_bytes} has no preconditions. As a result, its postcondition—that it either returns \texttt{Err(e)} if there is insufficient system entropy or fills the provided buffer with uniformly random bytes—may be used directly in the proof below.
-
+There are no preconditions for \texttt{sample\_standard\_bernoulli}.
 
 \subsection*{Pseudocode}
 \begin{lstlisting}[language = Python, escapechar=|]
@@ -37,40 +33,67 @@ For any setting of the input parameters for which the preconditions hold,
 
 \section{Proof}
 
-Assume the preconditions are met.
-
 We first consider the behavior of the function
-\rustdoc{traits/samplers/uniform/fn}{fill\_bytes}. By the precondition, if
-\texttt{fill\_bytes} returns \texttt{Err(e)}, then
-\texttt{sample\_standard\_bernoulli} immediately returns \texttt{Err(e)} via
-the error-propagation operator \texttt{?}. This satisfies the postcondition.
+\rustdoc{traits/samplers/uniform/fn}{fill\_bytes}, which is invoked inside
+\texttt{fn sample_standard_bernoulli}. 
+The precondition of \rustdoc{traits/samplers/uniform/fn}{fill_bytes}
+is trivially satisfied. Hence, we may assume its postcondition, which states:
 
-We now consider the case where \texttt{fill\_bytes} succeeds. In this case,
-the function fills the single-byte buffer \texttt{buffer} with a uniformly
-random value in the set $\{0,1,\dots,255\}$.
+\begin{enumerate}
+    \item If sufficient system entropy is available, 
+    \texttt{fill_bytes} succeeds and fills the single-byte buffer
+    \texttt{buffer} with a uniformly random value in the set
+    $\{0,1,\dots,255\}$.
 
-The function then evaluates the expression
-\texttt{buffer[0] \& 1 == 1}. The bitwise AND operation \texttt{\& 1} extracts
-the least significant bit of \texttt{buffer[0]}. Therefore, the returned value
-is \texttt{true} if and only if the least significant bit of \texttt{buffer[0]}
-is equal to 1.
+    \item If insufficient system entropy is available,
+    \texttt{fill_bytes} fails and returns \texttt{Err(e)}.
+\end{enumerate}
 
-Among the integers $\{0,1,\dots,255\}$, exactly half are even and half are odd.
-Even integers have least significant bit equal to 0, and odd integers have least
-significant bit equal to 1. Since \texttt{buffer[0]} is uniformly distributed
-over $\{0,1,\dots,255\}$, it follows that
+We now analyze the behavior of
+\texttt{fn sample_standard_bernoulli} under these two cases.
+
+\paragraph{Case 1: \texttt{fill_bytes} succeeds.}
+
+In this case, \texttt{buffer[0]} is uniformly distributed over
+$\{0,1,\dots,255\}$. The function evaluates the expression
+
+\[
+\texttt{buffer[0] \& 1 == 1}.
+\]
+
+The bitwise AND operation \texttt{\& 1} extracts the least significant bit
+of \texttt{buffer[0]}. Therefore, the function returns \texttt{true} if and
+only if the least significant bit of \texttt{buffer[0]} equals $1$.
+
+Among the integers $\{0,1,\dots,255\}$, exactly half (128 values) are even
+and half are odd. Even integers have least significant bit equal to $0$,
+and odd integers have least significant bit equal to $1$. Since
+\texttt{buffer[0]} is uniformly distributed over this set, we obtain
+
 \[
 \Pr[\texttt{buffer[0] \& 1 == 1}] = \frac{128}{256} = \frac{1}{2}.
 \]
 
-Thus, conditioned on \texttt{fill\_bytes} succeeding,
-\texttt{sample\_standard\_bernoulli} returns \texttt{Ok(true)} with probability
-$1/2$ and \texttt{Ok(false)} with probability $1/2$, which is exactly the
-distribution $\texttt{Bernoulli}(0.5)$.
+Hence, conditioned on success of \texttt{fill_bytes},
+\texttt{sample_standard_bernoulli} returns:
+\[
+\Pr[\texttt{Ok(true)}] = \frac{1}{2},
+\qquad
+\Pr[\texttt{Ok(false)}] = \frac{1}{2}.
+\]
+
+Thus, the output distribution is exactly
+$\texttt{Bernoulli}(0.5)$.
+
+\paragraph{Case 2: \texttt{fill_bytes} fails.}
+
+If \texttt{fill_bytes} returns \texttt{Err(e)}, then
+\texttt{sample_standard_bernoulli} immediately propagates the error via the
+\texttt{?} operator and returns \texttt{Err(e)}.
 
 Therefore, in all cases,
 \texttt{sample\_standard\_bernoulli} either returns \texttt{Err(e)} if there is
 insufficient system entropy, or returns a sample drawn from
-$\texttt{Bernoulli}(0.5)$, as required by the postcondition.
+$\texttt{Bernoulli}(0.5)$, as required by the postcondition. Thus, the postcondition is satisfied.
 
 \end{document}

--- a/rust/src/traits/samplers/bernoulli/sample_standard_bernoulli.tex
+++ b/rust/src/traits/samplers/bernoulli/sample_standard_bernoulli.tex
@@ -9,22 +9,15 @@
 Proves soundness of \rustdoc{traits/samplers/bernoulli/fn}{sample\_standard\_bernoulli}
 in \asOfCommit{rust/src/traits/samplers/bernoulli/mod.rs}{655696c}.
 
-
-\subsection*{Vetting history}
-\begin{itemize}
-    \item \vettingPR{XXXX}
-\end{itemize}
-
 \section{Hoare Triple}
 
 \subsection*{Preconditions}
-\begin{itemize}
-    \item The function \rustdoc{traits/samplers/uniform/fn}{fill\_bytes} either
-    \begin{itemize}
-        \item returns \texttt{Err(e)} if there is insufficient system entropy, or
-        \item fills the provided buffer with uniformly random bytes.
-    \end{itemize}
-\end{itemize}
+\noindent
+There are no preconditions for \texttt{sample\_standard\_bernoulli}, since the function takes no arguments and is therefore well-defined for all inputs.
+
+\noindent
+Similarly, \rustdoc{traits/samplers/uniform/fn}{fill\_bytes} has no preconditions. As a result, its postcondition—that it either returns \texttt{Err(e)} if there is insufficient system entropy or fills the provided buffer with uniformly random bytes—may be used directly in the proof below.
+
 
 \subsection*{Pseudocode}
 \begin{lstlisting}[language = Python, escapechar=|]

--- a/rust/src/traits/samplers/bernoulli/sample_standard_bernoulli.tex
+++ b/rust/src/traits/samplers/bernoulli/sample_standard_bernoulli.tex
@@ -1,13 +1,15 @@
-\documentclass{article} % necessary for Overleaf to recognize the file
-\input{../lib.sty} % "rust/src/lib.sty" contains boilerplate and macros
+\documentclass{article}
+\input{../../../lib.sty}
 
 \title{\texttt{fn sample\_standard\_bernoulli}}
 \author{Pranav S Ramanujam}\date{18/01/2026}
 
 \begin{document}
-\maketitle\contrib
+\maketitle
+
+\contrib
 Proves soundness of \rustdoc{traits/samplers/bernoulli/fn}{sample\_standard\_bernoulli}
-in \asOfCommit{rust/src/traits/samplers/bernoulli/mod.rs}{655696c}.
+in \asOfCommit{mod.rs}{655696c}.
 
 \section{Hoare Triple}
 
@@ -18,11 +20,14 @@ There are no preconditions for \texttt{sample\_standard\_bernoulli}.
 \subsection*{Pseudocode}
 \begin{lstlisting}[language = Python, escapechar=|]
 def sample_standard_bernoulli():
-    buffer = sample_uniform_byte()
-    return (buffer & 1) == 1   |\label{line:out}|
+    buffer = [0]
+    fill_bytes(buffer)
+    return (buffer[0] & 1) == 1   |\label{line:out}|
 \end{lstlisting}
 
 \subsection*{Postcondition}
+
+\begin{theorem}
 For any setting of the input parameters for which the preconditions hold,
 \texttt{sample\_standard\_bernoulli} either:
 \begin{itemize}
@@ -30,29 +35,30 @@ For any setting of the input parameters for which the preconditions hold,
     \item returns \texttt{Ok(sample)} where \texttt{sample} is a draw from
     $\texttt{Bernoulli}(0.5)$.
 \end{itemize}
+\end{theorem}
 
-\section{Proof}
+\begin{proof}
 
 We first consider the behavior of the function
 \rustdoc{traits/samplers/uniform/fn}{fill\_bytes}, which is invoked inside
-\texttt{fn sample_standard_bernoulli}. 
-The precondition of \rustdoc{traits/samplers/uniform/fn}{fill_bytes}
+\texttt{fn sample\_standard\_bernoulli}. 
+The precondition of \rustdoc{traits/samplers/uniform/fn}{fill\_bytes}
 is trivially satisfied. Hence, we may assume its postcondition, which states:
 
 \begin{enumerate}
     \item If sufficient system entropy is available, 
-    \texttt{fill_bytes} succeeds and fills the single-byte buffer
+    \texttt{fill\_bytes} succeeds and fills the single-byte buffer
     \texttt{buffer} with a uniformly random value in the set
     $\{0,1,\dots,255\}$.
 
     \item If insufficient system entropy is available,
-    \texttt{fill_bytes} fails and returns \texttt{Err(e)}.
+    \texttt{fill\_bytes} fails and returns \texttt{Err(e)}.
 \end{enumerate}
 
 We now analyze the behavior of
-\texttt{fn sample_standard_bernoulli} under these two cases.
+\texttt{fn sample\_standard\_bernoulli} under these two cases.
 
-\paragraph{Case 1: \texttt{fill_bytes} succeeds.}
+\paragraph{Case 1: \texttt{fill\_bytes} succeeds.}
 
 In this case, \texttt{buffer[0]} is uniformly distributed over
 $\{0,1,\dots,255\}$. The function evaluates the expression
@@ -74,8 +80,8 @@ and odd integers have least significant bit equal to $1$. Since
 \Pr[\texttt{buffer[0] \& 1 == 1}] = \frac{128}{256} = \frac{1}{2}.
 \]
 
-Hence, conditioned on success of \texttt{fill_bytes},
-\texttt{sample_standard_bernoulli} returns:
+Hence, conditioned on success of \texttt{fill\_bytes},
+\texttt{sample\_standard\_bernoulli} returns:
 \[
 \Pr[\texttt{Ok(true)}] = \frac{1}{2},
 \qquad
@@ -85,10 +91,10 @@ Hence, conditioned on success of \texttt{fill_bytes},
 Thus, the output distribution is exactly
 $\texttt{Bernoulli}(0.5)$.
 
-\paragraph{Case 2: \texttt{fill_bytes} fails.}
+\paragraph{Case 2: \texttt{fill\_bytes} fails.}
 
-If \texttt{fill_bytes} returns \texttt{Err(e)}, then
-\texttt{sample_standard_bernoulli} immediately propagates the error via the
+If \texttt{fill\_bytes} returns \texttt{Err(e)}, then
+\texttt{sample\_standard\_bernoulli} immediately propagates the error via the
 \texttt{?} operator and returns \texttt{Err(e)}.
 
 Therefore, in all cases,
@@ -96,4 +102,5 @@ Therefore, in all cases,
 insufficient system entropy, or returns a sample drawn from
 $\texttt{Bernoulli}(0.5)$, as required by the postcondition. Thus, the postcondition is satisfied.
 
+\end{proof}
 \end{document}


### PR DESCRIPTION
This PR adds a formal proof of soundness for sample_standard_bernoulli, following the OpenDP proof format.

Closes opendp/opendp#2029
