### PR TITLE
Docs: remove intern announcement from banner

### DIFF
--- a/docs/source/announcement.html
+++ b/docs/source/announcement.html
@@ -4,6 +4,5 @@
 -->
 <div>
     OpenDP is hiring a <a href="https://academicpositions.harvard.edu/postings/15563">research associate</a>
-    and a <a href="https://jobs.smartrecruiters.com/HarvardUniversity/3743990010782028-senior-data-privacy-software-developer">senior data privacy software developer</a>,
-    and we're also accepting applications for <a href="https://opendp.org/summer-opportunities/">summer 2025 interns and fellows</a>.
+    and a <a href="https://jobs.smartrecruiters.com/HarvardUniversity/3743990010782028-senior-data-privacy-software-developer">senior data privacy software developer</a>.
 </div>


### PR DESCRIPTION
If the reference to this file were already deployed, the banner update would take effect on merge to main.