### PR TITLE
Maintenance: use action provided by R to upgrade pandoc version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,9 +36,9 @@ jobs:
           ref: stable
 
       - name: Setup Pandoc
-        uses: pandoc/actions/setup@v1
+        uses: r-lib/actions/setup-pandoc@v2
         with:
-          version: 2.19.2
+          pandoc-version: 2.19.2
 
       - name: Set up R
         uses: r-lib/actions/setup-r@v2


### PR DESCRIPTION
- Hopefully fix #2607 
- Release started: https://github.com/opendp/opendp/actions/runs/22202017221
- Retry w/ beta, dry-run: https://github.com/opendp/opendp/actions/runs/22230026183