### PR TITLE
fix: additive noise sampler bias, statistical testing

### DIFF
--- a/rust/src/measurements/make_private_lazyframe/group_by/test.rs
+++ b/rust/src/measurements/make_private_lazyframe/group_by/test.rs
@@ -7,8 +7,6 @@ use crate::polars::PrivacyNamespace;
 use crate::traits::samplers::test::{check_chi_square, check_kolmogorov_smirnov};
 use polars::prelude::*;
 
-use statrs::function::erf;
-
 use crate::metrics::SymmetricDistance;
 
 use super::*;
@@ -103,7 +101,7 @@ fn test_stable_keys_zcdp() -> Fallible<()> {
 
 #[test]
 fn test_explicit_keys() -> Fallible<()> {
-    static N_SAMPLES: u32 = 1000;
+    static N_SAMPLES: u32 = 5000;
     static N_CANDIDATES: usize = 10;
 
     let lf_domain = LazyFrameDomain::new(vec![
@@ -137,22 +135,26 @@ fn test_explicit_keys() -> Fallible<()> {
     )?;
 
     let release = meas.invoke(&lf)?.collect()?;
-    let gauss_samples: Vec<_> = release.column("sum")?.f64()?.iter().flatten().collect();
-    let gauss_samples = <[f64; 1000]>::try_from(gauss_samples).unwrap();
+    let lap_samples: Vec<_> = release.column("sum")?.f64()?.iter().flatten().collect();
+    let lap_samples = <[f64; 5000]>::try_from(lap_samples).unwrap();
 
-    pub fn normal_cdf(x: f64) -> f64 {
-        (erf::erf(x / std::f64::consts::SQRT_2) + 1.0) / 2.0
+    pub fn laplace_cdf(x: f64) -> f64 {
+        if x < 0.0 {
+            0.5 * x.exp()
+        } else {
+            1.0 - 0.5 * (-x).exp()
+        }
     }
 
-    check_kolmogorov_smirnov(gauss_samples, normal_cdf)?;
+    check_kolmogorov_smirnov(lap_samples, laplace_cdf)?;
 
     // check for uniformity of samples (all scores are matching)
     let unif_samples: Vec<_> = release.column("med")?.f64()?.iter().flatten().collect();
-    let mut counts = [0.0; N_CANDIDATES];
-    unif_samples.iter().for_each(|&s| counts[s as usize] += 1.0);
+    let mut counts = [0; N_CANDIDATES];
+    unif_samples.iter().for_each(|&s| counts[s as usize] += 1);
     check_chi_square(
-        counts,
-        [N_SAMPLES as f64 / (N_CANDIDATES as f64); N_CANDIDATES],
+        &counts,
+        &[N_SAMPLES as f64 / (N_CANDIDATES as f64); N_CANDIDATES],
     )?;
 
     Ok(())

--- a/rust/src/measurements/noise/distribution/gaussian/test.rs
+++ b/rust/src/measurements/noise/distribution/gaussian/test.rs
@@ -60,7 +60,7 @@ fn test_make_gaussian_kolmogorov_smirnov() -> Fallible<()> {
     let input_domain = VectorDomain::new(AtomDomain::<f64>::new_non_nan());
     let input_metric = L2Distance::<f64>::default();
     let meas = make_gaussian(input_domain, input_metric, 1.0, None)?;
-    let samples = <[f64; 1000]>::try_from(meas.invoke(&vec![0.0; 1000])?).unwrap();
+    let samples = <[f64; 5000]>::try_from(meas.invoke(&vec![0.0; 5000])?).unwrap();
 
     pub fn normal_cdf(x: f64) -> f64 {
         (erf::erf(x / std::f64::consts::SQRT_2) + 1.0) / 2.0

--- a/rust/src/measurements/noise/distribution/laplace/test.rs
+++ b/rust/src/measurements/noise/distribution/laplace/test.rs
@@ -59,7 +59,7 @@ fn test_make_laplace_kolmogorov_smirnov() -> Fallible<()> {
     let input_domain = VectorDomain::new(AtomDomain::<f64>::new_non_nan());
     let input_metric = L1Distance::<f64>::default();
     let meas = make_laplace(input_domain, input_metric, 1.0, None)?;
-    let samples = <[f64; 1000]>::try_from(meas.invoke(&vec![0.0; 1000])?).unwrap();
+    let samples = <[f64; 5000]>::try_from(meas.invoke(&vec![0.0; 5000])?).unwrap();
 
     pub fn laplace_cdf(x: f64) -> f64 {
         match x {

--- a/rust/src/measurements/noisy_top_k/test.rs
+++ b/rust/src/measurements/noisy_top_k/test.rs
@@ -8,18 +8,22 @@ use super::*;
 #[test]
 fn test_rnm_gumbel_distribution_varied() -> Fallible<()> {
     let scores: [_; 10] = from_fn(|i| i);
-    let trials = 1000;
-    let mut observed = [0.0; 10];
+    // trials is high enough that bin-sizes even on low scores are sufficiently high to be significant
+    let trials = 10_000;
+    let mut observed = [0; 10];
     (0..trials).try_for_each(|_| {
-        observed[noisy_top_k(&scores, 1.0, 1, false, true)?[0]] += 1.0;
+        observed[noisy_top_k(&scores, 1.0, 1, false, true)?[0]] += 1;
         Fallible::Ok(())
     })?;
 
     // compute softmax to get expected
     let numer: f64 = (0..10).map(|i| (i as f64).exp()).sum();
-    let expected = from_fn(|i| (i as f64).exp() / numer * (trials as f64));
+    let expected: Vec<f64> = (0..10)
+        .map(|i| (i as f64).exp() / numer * (trials as f64))
+        .collect();
 
-    check_chi_square(observed, expected)
+    // avoid running the test on the low-outcome values where it is invalid
+    check_chi_square(&observed[2..], &expected[2..])
 }
 
 #[test]
@@ -150,48 +154,47 @@ fn test_permute_and_flip() {
 #[test]
 fn test_permute_and_flip_distribution_zero() -> Fallible<()> {
     let scores = vec![rbig!(0).clone(); 10];
-    let mut observed = [0.0; 10];
     (0..1000).try_for_each(|_| {
-        observed[permute_and_flip(&scores, &rbig!(0), false)?] += 1.0;
+        if permute_and_flip(&scores, &rbig!(0), false)? != 9 {
+            panic!("P&F with zero scale should deterministically select last index");
+        }
         Fallible::Ok(())
-    })?;
-    let mut expected = [0.0; 10];
-    expected[0] = 1000.0;
-    check_chi_square(observed, expected)
+    })
 }
 
 #[test]
 fn test_permute_and_flip_distribution_uniform() -> Fallible<()> {
     let scores = vec![rbig!(0).clone(); 10];
-    let mut observed = [0.0; 10];
+    let mut observed = [0; 10];
     (0..1000).try_for_each(|_| {
-        observed[permute_and_flip(&scores, &rbig!(1), false)?] += 1.0;
+        observed[permute_and_flip(&scores, &rbig!(1), false)?] += 1;
         Fallible::Ok(())
     })?;
-    check_chi_square(observed, [100.0; 10])
+    check_chi_square(&observed, &[100.0; 10])
 }
 
 #[test]
 fn test_permute_and_flip_distribution_varied() -> Fallible<()> {
     let scores: [_; 10] = from_fn(RBig::from);
     let trials = 10000;
-    let mut observed = [0.0; 10];
+    let mut observed = [0; 10];
     (0..trials).try_for_each(|_| {
-        observed[permute_and_flip(&scores, &rbig!(1), false)?] += 1.0 / trials as f64;
+        observed[permute_and_flip(&scores, &rbig!(1), false)?] += 1;
         Fallible::Ok(())
     })?;
 
-    let expected = permute_and_flip_pmf(
+    let expected: Vec<f64> = permute_and_flip_pmf(
         &scores
             .into_iter()
             .map(|r| r.to_f64().value())
             .collect::<Vec<_>>(),
         1.0,
     )
-    .try_into()
-    .unwrap();
+    .into_iter()
+    .map(|p| p * trials as f64)
+    .collect();
 
-    check_chi_square(observed, expected)
+    check_chi_square(&observed[3..], &expected[3..])
 }
 
 /// Implements the PMF of the permute and flip algorithm,

--- a/rust/src/traits/samplers/bernoulli/test.rs
+++ b/rust/src/traits/samplers/bernoulli/test.rs
@@ -1,43 +1,120 @@
-use dashu::rbig;
+use crate::traits::samplers::test::{
+    ALPHA, BASE_N, assert_close_normal, run_wilson_test, sample_mean_bool,
+};
 
 use super::*;
-use crate::traits::samplers::test::*;
+use dashu::rbig;
+
+pub const N_RATIONAL: usize = 2 * BASE_N;
+pub const N_FLOAT: usize = 3 * BASE_N;
 
 #[test]
-fn test_bernoulli_float() {
-    [0.2, 0.5, 0.7, 0.9].iter().for_each(|p| {
-        let sampler = || {
-            if sample_bernoulli_float(*p, false).unwrap() {
-                1.
-            } else {
-                0.
-            }
-        };
-        assert!(
-            test_proportion_parameters(sampler, *p, 0.00001, *p / 100.),
-            "empirical evaluation of the bernoulli({:?}) distribution failed",
-            p
-        )
-    })
+fn bernoulli_rational_boundaries() -> Fallible<()> {
+    assert!(!sample_bernoulli_rational(rbig!(0))?);
+    assert!(sample_bernoulli_rational(rbig!(1))?);
+    Ok(())
 }
 
 #[test]
-fn test_bernoulli_rational() {
-    [rbig!(1 / 5), rbig!(1 / 2), rbig!(7 / 10), rbig!(9 / 10)]
-        .iter()
-        .for_each(|p| {
-            let sampler = || {
-                if sample_bernoulli_rational(p.clone()).unwrap() {
-                    1.
-                } else {
-                    0.
-                }
-            };
-            let f_p = p.to_f64().value();
-            assert!(
-                test_proportion_parameters(sampler, f_p, 0.00001, f_p / 100.),
-                "empirical evaluation of the bernoulli({:?}) distribution failed",
-                p
-            )
-        })
+fn bernoulli_rational_rejects_invalid_inputs() {
+    assert!(sample_bernoulli_rational(rbig!(-1 / 2)).is_err());
+    assert!(sample_bernoulli_rational(rbig!(3 / 2)).is_err());
+}
+
+#[test]
+fn wilson_rational_fixed_points() {
+    let ps = vec![
+        rbig!(0 / 1),
+        rbig!(1 / 16),
+        rbig!(1 / 2),
+        rbig!(15 / 16),
+        rbig!(1 / 1),
+    ];
+
+    for p in ps {
+        let p0 = p.to_f64().value();
+        run_wilson_test(
+            || sample_bernoulli_rational(p.clone()).unwrap(),
+            p0,
+            N_RATIONAL,
+            ALPHA,
+            "sample_bernoulli_rational",
+        );
+    }
+}
+
+fn run_wilson_test_float<T: Float>(p: T, constant_time: bool, n: usize, label: &str)
+where
+    T::Bits: ExactIntCast<usize>,
+    usize: ExactIntCast<T::Bits>,
+{
+    run_wilson_test(
+        || sample_bernoulli_float::<T>(p, constant_time).unwrap(),
+        p.to_f64().unwrap(),
+        n,
+        ALPHA,
+        label,
+    );
+}
+
+#[test]
+fn bernoulli_float_boundaries_f64() -> Fallible<()> {
+    for _ in 0..20_000 {
+        assert!(!sample_bernoulli_float::<f64>(0.0, false)?);
+        assert!(!sample_bernoulli_float::<f64>(0.0, true)?);
+        assert!(sample_bernoulli_float::<f64>(1.0, false)?);
+        assert!(sample_bernoulli_float::<f64>(1.0, true)?);
+    }
+    Ok(())
+}
+
+const PROBS: [f64; 10] = [0.0, 0.5, 0.25, 0.125, 0.75, 0.1, 0.2, 0.3, 0.7, 0.99];
+
+#[test]
+fn wilson_float_f64_fixed_points() {
+    for &p in &PROBS {
+        run_wilson_test_float::<f64>(p, false, N_FLOAT, "bernoulli_float f64 non-constant-time");
+        run_wilson_test_float::<f64>(p, true, N_FLOAT, "bernoulli_float f64 constant-time");
+    }
+}
+
+#[test]
+fn wilson_float_f32_fixed_points() {
+    for &p in &PROBS {
+        run_wilson_test_float::<f32>(
+            p as f32,
+            false,
+            N_FLOAT / 2,
+            "bernoulli_float f32 non-constant-time",
+        );
+        run_wilson_test_float::<f32>(
+            p as f32,
+            true,
+            N_FLOAT / 2,
+            "bernoulli_float f32 constant-time",
+        );
+    }
+}
+
+#[test]
+fn bernoulli_float_constant_time_and_nonconstant_match_f64() {
+    // Compare ct vs non-ct at same p via a mean-difference test
+    for &p in &PROBS {
+        let m_ct = sample_mean_bool(|| sample_bernoulli_float::<f64>(p, true).unwrap(), N_FLOAT);
+        let m_nc = sample_mean_bool(|| sample_bernoulli_float::<f64>(p, false).unwrap(), N_FLOAT);
+
+        // Under the null, both estimators target the same mean p, so
+        // SE(diff) = sqrt(Var(hat1)+Var(hat2)) with Var(hat)=p(1-p)/N.
+        let se_diff = (2.0 * p * (1.0 - p) / (N_FLOAT as f64)).sqrt();
+        assert_close_normal(m_ct, m_nc, se_diff, "ct vs non-ct (f64)");
+    }
+}
+
+#[test]
+fn bernoulli_float_power_of_two_spot_checks_f64() {
+    let ps: Vec<f64> = vec![0.5, 0.25, 0.125, 0.0625, 0.03125];
+    for &p in &ps {
+        run_wilson_test_float::<f64>(p, false, N_FLOAT, "dyadic f64 non-constant-time");
+        run_wilson_test_float::<f64>(p, true, N_FLOAT, "dyadic f64 constant-time");
+    }
 }

--- a/rust/src/traits/samplers/cks20/mod.rs
+++ b/rust/src/traits/samplers/cks20/mod.rs
@@ -44,7 +44,7 @@
 
 use crate::error::Fallible;
 use dashu::{
-    base::Abs,
+    base::{Abs, Sign},
     integer::{IBig, UBig},
     rational::RBig,
     rbig,
@@ -52,6 +52,32 @@ use dashu::{
 use opendp_derive::proven;
 
 use super::{sample_bernoulli_rational, sample_standard_bernoulli, sample_uniform_ubig_below};
+
+#[cfg(test)]
+mod test;
+
+fn gcd_ubig(mut a: UBig, mut b: UBig) -> UBig {
+    while !b.is_zero() {
+        let r = &a % &b;
+        a = b;
+        b = r;
+    }
+    a
+}
+
+fn div_rbig_by_ubig_exact(numer: &UBig, denom: &UBig, k: &UBig) -> RBig {
+    assert!(!k.is_zero(), "division by zero");
+
+    if numer.is_zero() {
+        return RBig::ZERO;
+    }
+
+    let g = gcd_ubig(numer.clone(), k.clone());
+    let n_red = numer / &g;
+    let k_red = k / g;
+
+    RBig::from_parts(n_red.into(), (denom * k_red).into())
+}
 
 #[proven]
 /// Sample exactly from the Bernoulli(exp(-x)) distribution, where $x \in [0, 1]$.
@@ -61,9 +87,18 @@ use super::{sample_bernoulli_rational, sample_standard_bernoulli, sample_uniform
 /// `sample_bernoulli_exp1` either returns `Err(e)`, due to a lack of system entropy,
 /// or `Ok(out)`, where `out` is distributed as $Bernoulli(exp(-x))$.
 fn sample_bernoulli_exp1(x: RBig) -> Fallible<bool> {
+    let (numer_signed, denom) = x.into_parts();
+    let (Sign::Positive, numer) = numer_signed.into_parts() else {
+        return fallible!(FailedFunction, "x must be in [0, 1]");
+    };
+
     let mut k = UBig::ONE;
     loop {
-        if sample_bernoulli_rational(x.clone() / &k)? {
+        // Build x/k with corrected exact division, bypassing buggy RBig `/`.
+        // Drop when fix is available upstream: https://github.com/cmpute/dashu/issues/57
+        let x_div_k = div_rbig_by_ubig_exact(&numer, &denom, &k);
+
+        if sample_bernoulli_rational(x_div_k)? {
             k += UBig::ONE;
         } else {
             return Ok(k % 2u8 == 1);

--- a/rust/src/traits/samplers/cks20/test/bernoulli.rs
+++ b/rust/src/traits/samplers/cks20/test/bernoulli.rs
@@ -1,0 +1,278 @@
+use dashu::rbig;
+
+use crate::traits::samplers::cks20::sample_bernoulli_exp1;
+use crate::traits::samplers::sample_bernoulli_exp;
+use crate::traits::samplers::test::{ALPHA, run_wilson_test};
+use crate::traits::samplers::test::{FP_SLOP, TEST_Z, assert_close_normal, sample_mean_bool};
+
+use super::*;
+
+pub const N_ENDPOINTS: usize = 1_000;
+
+fn test_fixed_points_wilson(
+    sampler: impl Fn(RBig) -> bool,
+    xs: &[RBig],
+    n: usize,
+    alpha: f64,
+    label: &str,
+) {
+    for x in xs {
+        let p0 = p_exp_neg(x);
+        run_wilson_test(|| sampler(x.clone()), p0, n, alpha, label);
+    }
+}
+
+/// Collect empirical p_hat and theoretical p for monotonicity tests
+fn collect_phat_and_p<S>(sampler: S, xs: &[RBig], n: usize) -> Vec<(f64, f64)>
+where
+    S: Fn(RBig) -> bool,
+{
+    xs.iter()
+        .map(|x| {
+            let p = p_exp_neg(x);
+            let p_hat = sample_mean_bool(|| sampler(x.clone()), n);
+            (p_hat, p)
+        })
+        .collect()
+}
+
+pub fn assert_monotone_decreasing(phats_and_ps: &[(f64, f64)], n: usize) {
+    for i in 0..(phats_and_ps.len() - 1) {
+        let (p_hat_a, p_a) = phats_and_ps[i];
+        let (p_hat_b, p_b) = phats_and_ps[i + 1];
+
+        let se_a = (p_a * (1.0 - p_a) / (n as f64)).sqrt();
+        let se_b = (p_b * (1.0 - p_b) / (n as f64)).sqrt();
+        let band = TEST_Z * (se_a * se_a + se_b * se_b).sqrt() + FP_SLOP;
+
+        assert!(
+            p_hat_a + band >= p_hat_b,
+            "monotonicity violated: p_hat[{}]={} < p_hat[{}]={} beyond band {}",
+            i,
+            p_hat_a,
+            i + 1,
+            p_hat_b,
+            band
+        );
+    }
+}
+
+/// Check that exp(−(a+b))=exp(−a)exp(−b) for the bernoulli sampler S.
+fn assert_factorizes_addition<S>(sampler: S, a: &RBig, b: &RBig, n: usize)
+where
+    S: Fn(RBig) -> bool,
+{
+    let ab = a.clone() + b.clone();
+
+    let p_a_hat = sample_mean_bool(|| sampler(a.clone()), n);
+    let p_b_hat = sample_mean_bool(|| sampler(b.clone()), n);
+    let p_ab_hat = sample_mean_bool(|| sampler(ab.clone()), n);
+
+    // Use theoretical p only to compute uncertainty bands.
+    let p_a = p_exp_neg(a);
+    let p_b = p_exp_neg(b);
+    let p_ab = p_exp_neg(&ab);
+
+    let se_ab = (p_ab * (1.0 - p_ab) / (n as f64)).sqrt();
+    let se_a = (p_a * (1.0 - p_a) / (n as f64)).sqrt();
+    let se_b = (p_b * (1.0 - p_b) / (n as f64)).sqrt();
+
+    let prod_hat = p_a_hat * p_b_hat;
+    let se_prod = ((p_b * p_b) * (se_a * se_a) + (p_a * p_a) * (se_b * se_b)).sqrt();
+
+    let se_diff = (se_ab * se_ab + se_prod * se_prod).sqrt();
+    assert_close_normal(p_ab_hat, prod_hat, se_diff, "factorization");
+}
+
+// ------------------------------------------------------------
+// exp1 tests
+// ------------------------------------------------------------
+
+const XS1: [RBig; 6] = [
+    rbig!(0 / 1),
+    rbig!(1 / 8),
+    rbig!(1 / 4),
+    rbig!(1 / 2),
+    rbig!(3 / 4),
+    rbig!(1 / 1),
+];
+
+#[test]
+fn exp1_matches_exp_neg_x_fixed_points_wilson() {
+    let sampler = |x: RBig| sample_bernoulli_exp1(x).unwrap();
+    test_fixed_points_wilson(sampler, &XS1, N_BERNOULLI, ALPHA, "exp1 fixed point");
+}
+
+#[test]
+fn exp1_is_monotone_decreasing() {
+    let sampler = |x: RBig| sample_bernoulli_exp1(x).unwrap();
+    let stats = collect_phat_and_p(sampler, &XS1, N_BERNOULLI);
+    assert_monotone_decreasing(&stats, N_BERNOULLI);
+}
+
+#[test]
+fn exp1_endpoints() {
+    let sampler = |x: RBig| sample_bernoulli_exp1(x).unwrap();
+
+    let x0 = rbig!(0 / 1);
+    for _ in 0..N_ENDPOINTS {
+        assert!(sampler(x0.clone()));
+    }
+
+    // For x=1 use Wilson instead of mean-close.
+    let x1 = rbig!(1 / 1);
+    let p0 = p_exp_neg(&x1);
+    run_wilson_test(
+        || sampler(x1.clone()),
+        p0,
+        N_BERNOULLI,
+        ALPHA,
+        "exp1 endpoint x=1",
+    );
+}
+
+// ------------------------------------------------------------
+// exp tests
+// ------------------------------------------------------------
+
+const XS: [RBig; 10] = [
+    rbig!(0 / 1),
+    rbig!(1 / 8),
+    rbig!(3 / 4),
+    rbig!(1 / 1),
+    rbig!(3 / 2),
+    rbig!(2),
+    rbig!(9 / 4),
+    rbig!(3),
+    rbig!(7 / 2),
+    rbig!(5),
+];
+
+#[test]
+fn exp_matches_exp_neg_x_fixed_points_wilson() {
+    let sampler = |x: RBig| sample_bernoulli_exp(x).unwrap();
+    test_fixed_points_wilson(sampler, &XS, N_BERNOULLI, ALPHA, "exp fixed point");
+}
+
+#[test]
+fn exp_factorizes_over_addition() {
+    let sampler = |x: RBig| sample_bernoulli_exp(x).unwrap();
+    let pairs: Vec<(RBig, RBig)> = vec![
+        (rbig!(1 / 2), rbig!(1 / 2)),
+        (rbig!(1), rbig!(1 / 4)),
+        (rbig!(2), rbig!(3 / 4)),
+        (rbig!(5 / 2), rbig!(1 / 8)),
+    ];
+    for (a, b) in pairs {
+        assert_factorizes_addition(&sampler, &a, &b, N_BERNOULLI);
+    }
+}
+
+#[test]
+fn exp_is_monotone_decreasing() {
+    let sampler = |x: RBig| sample_bernoulli_exp(x).unwrap();
+    let stats = collect_phat_and_p(sampler, &XS, N_BERNOULLI);
+    assert_monotone_decreasing(&stats, N_BERNOULLI);
+}
+
+#[test]
+fn exp_endpoints() {
+    let sampler = |x: RBig| sample_bernoulli_exp(x).unwrap();
+
+    let x0 = rbig!(0 / 1);
+    for _ in 0..N_ENDPOINTS {
+        assert!(sampler(x0.clone()));
+    }
+
+    let x1 = rbig!(1);
+    let p0 = p_exp_neg(&x1);
+    run_wilson_test(
+        || sampler(x1.clone()),
+        p0,
+        N_BERNOULLI,
+        ALPHA,
+        "exp endpoint x=1",
+    );
+}
+
+fn assert_factorizes_addition_empirical(a: &RBig, b: &RBig, n: usize) {
+    let ab = a.clone() + b.clone();
+
+    let p_ab_hat = sample_mean_bool(|| sample_bernoulli_exp(ab.clone()).unwrap(), n);
+
+    let p_and_hat = sample_mean_bool(
+        || sample_bernoulli_exp(a.clone()).unwrap() && sample_bernoulli_exp(b.clone()).unwrap(),
+        n,
+    );
+
+    let se_diff = 1.0 / (2.0_f64 * (n as f64)).sqrt();
+    assert_close_normal(p_ab_hat, p_and_hat, se_diff, "factorization (large denom)");
+}
+
+fn assert_scaling_identity_empirical(x: &RBig, m: u32, n: usize) {
+    assert!(m >= 2);
+    let mx = x.clone() * RBig::from(m);
+
+    let p_mx_hat = sample_mean_bool(|| sample_bernoulli_exp(mx.clone()).unwrap(), n);
+
+    let p_and_hat = sample_mean_bool(
+        || {
+            let mut ok = true;
+            for _ in 0..m {
+                ok &= sample_bernoulli_exp(x.clone()).unwrap();
+                if !ok {
+                    break;
+                }
+            }
+            ok
+        },
+        n,
+    );
+
+    let se_diff = 1.0 / (2.0_f64 * (n as f64)).sqrt();
+    assert_close_normal(
+        p_mx_hat,
+        p_and_hat,
+        se_diff,
+        "scaling identity (large denom)",
+    );
+}
+
+#[test]
+fn exp_factorization_holds_for_large_denominators() {
+    let n = N_BERNOULLI;
+    let xs = vec![
+        // small dyadic values
+        RBig::from(1i64) / RBig::from(1i64 << 30),
+        RBig::from(3i64) / RBig::from(1i64 << 30),
+        // Fermat prime denominators
+        RBig::from(1i64) / RBig::from(65_537i64),
+        RBig::from(32_768i64) / RBig::from(65_537i64),
+        RBig::from(65_536i64) / RBig::from(65_537i64),
+        // big denominator
+        RBig::from(12_345i64) / RBig::from(1_000_003i64),
+        RBig::from(999_983i64) / RBig::from(1_000_003i64),
+    ];
+
+    let pairs: Vec<(RBig, RBig)> = vec![
+        (xs[0].clone(), xs[2].clone()), // tiny dyadic, tiny fermat
+        (xs[1].clone(), xs[5].clone()), // tiny dyadic, large denom
+        (xs[3].clone(), xs[2].clone()), // half fermat, tiny fermat
+        (xs[4].clone(), xs[0].clone()), // about 1, tiny dyadic
+    ];
+
+    for (a, b) in pairs {
+        assert_factorizes_addition_empirical(&a, &b, n);
+    }
+}
+
+#[test]
+fn exp_scaling_identity_holds_for_large_denominators() {
+    let n = N_BERNOULLI;
+
+    let x1 = RBig::from(1i64) / RBig::from(65_537i64);
+    let x2 = RBig::from(12_345i64) / RBig::from(1_000_003i64);
+
+    assert_scaling_identity_empirical(&x1, 7, n);
+    assert_scaling_identity_empirical(&x2, 13, n);
+}

--- a/rust/src/traits/samplers/cks20/test/gcd.rs
+++ b/rust/src/traits/samplers/cks20/test/gcd.rs
@@ -1,0 +1,71 @@
+use crate::traits::samplers::cks20::gcd_ubig;
+
+use dashu::integer::UBig;
+
+fn u(n: u64) -> UBig {
+    UBig::from(n)
+}
+
+#[test]
+fn gcd_basic_identities() {
+    assert_eq!(gcd_ubig(u(0), u(0)), u(0));
+    assert_eq!(gcd_ubig(u(0), u(7)), u(7));
+    assert_eq!(gcd_ubig(u(7), u(0)), u(7));
+    assert_eq!(gcd_ubig(u(1), u(0)), u(1));
+    assert_eq!(gcd_ubig(u(0), u(1)), u(1));
+}
+
+#[test]
+fn gcd_symmetry() {
+    let a = u(54);
+    let b = u(24);
+    assert_eq!(gcd_ubig(a.clone(), b.clone()), gcd_ubig(b, a));
+}
+
+#[test]
+fn gcd_known_values() {
+    assert_eq!(gcd_ubig(u(54), u(24)), u(6));
+    assert_eq!(gcd_ubig(u(48), u(180)), u(12));
+    assert_eq!(gcd_ubig(u(17), u(29)), u(1));
+    assert_eq!(gcd_ubig(u(100), u(10)), u(10));
+    assert_eq!(gcd_ubig(u(10), u(100)), u(10));
+    assert_eq!(gcd_ubig(u(270), u(192)), u(6));
+}
+
+#[test]
+fn gcd_common_factor_property() {
+    let a = u(21);
+    let b = u(6);
+    let c = u(14);
+
+    let left = gcd_ubig(&a * &c, &b * &c);
+    let right = gcd_ubig(a, b) * c;
+
+    assert_eq!(left, right);
+}
+
+#[test]
+fn gcd_divides_both() {
+    let a = u(123456);
+    let b = u(7890);
+    let g = gcd_ubig(a.clone(), b.clone());
+
+    if !g.is_zero() {
+        assert!((&a % &g).is_zero());
+        assert!((&b % &g).is_zero());
+    } else {
+        assert!(a.is_zero() && b.is_zero());
+    }
+}
+
+#[test]
+fn gcd_large_constructed() {
+    let q = u(1_000_003);
+    let p = u(12345);
+    let r = u(67891);
+
+    let a = &p * &q;
+    let b = &r * &q;
+
+    assert_eq!(gcd_ubig(a, b), q);
+}

--- a/rust/src/traits/samplers/cks20/test/geometric.rs
+++ b/rust/src/traits/samplers/cks20/test/geometric.rs
@@ -1,0 +1,180 @@
+use super::*;
+use crate::traits::samplers::{
+    cks20::sample_geometric_exp_slow,
+    sample_geometric_exp_fast,
+    test::{assert_close_binomial_mean, assert_close_normal, check_chi_square_from_probs},
+};
+use dashu::{integer::UBig, rbig};
+
+// Geometric(p) over {0,1,2,...} with P(K=k)=(1-p)^k p.
+// Here p = 1 - exp(-x), q = exp(-x).
+fn geom_pq(x: &RBig) -> (f64, f64) {
+    let q = p_exp_neg(x);
+    let p = 1.0 - q;
+    (p, q)
+}
+
+fn geom_mean_var(x: &RBig) -> (f64, f64) {
+    let (p, q) = geom_pq(x);
+    let mean = q / p;
+    let var = q / (p * p);
+    (mean, var)
+}
+
+#[derive(Debug, Clone)]
+struct GeomSummary {
+    n: usize,
+    mean: f64,
+    p0: f64,
+}
+
+fn sample_geom_summary(mut sampler: impl FnMut() -> UBig, n: usize) -> GeomSummary {
+    let mut sum = 0.0_f64;
+    let mut zeros: u64 = 0;
+
+    for _ in 0..n {
+        let k = sampler();
+        if k.is_zero() {
+            zeros += 1;
+        }
+        let k_u64 = u64::try_from(k).unwrap();
+        sum += k_u64 as f64;
+    }
+
+    GeomSummary {
+        n,
+        mean: sum / (n as f64),
+        p0: (zeros as f64) / (n as f64),
+    }
+}
+
+fn assert_geom_moments(x: &RBig, summ: &GeomSummary) {
+    let (mean, var) = geom_mean_var(x);
+
+    let se_mean = (var / (summ.n as f64)).sqrt();
+    assert_close_normal(summ.mean, mean, se_mean, "geom mean");
+
+    let (p, _q) = geom_pq(x); // P(K=0) = p
+    assert_close_binomial_mean(summ.p0, p, summ.n, "P(K=0)");
+}
+
+fn choose_kmax_for_chi2(x: &RBig, n: usize, min_exp: f64, hard_cap: usize) -> usize {
+    let (p, q) = geom_pq(x);
+    let n_f = n as f64;
+
+    // Want expected count for bin kmax-1 and tail to be >= min_exp, but simplest:
+    // ensure expected count for k=kmax-1 (smallest explicit bin) is >= min_exp.
+    // That is: n * q^(kmax-1) * p >= min_exp.
+    for kmax in (2..=hard_cap).rev() {
+        let exp_cnt = n_f * q.powi((kmax as i32) - 1) * p;
+        if exp_cnt >= min_exp {
+            return kmax;
+        }
+    }
+    2
+}
+
+fn assert_binned_chi_square(x: &RBig, n: usize, kmax: usize, mut sampler: impl FnMut() -> UBig) {
+    // observed counts for bins: 0..kmax-1 plus tail bin kmax
+    let mut observed = vec![0u64; kmax + 1];
+
+    for _ in 0..n {
+        let k = sampler();
+        let k_u64 = u64::try_from(k).unwrap();
+        if (k_u64 as usize) < kmax {
+            observed[k_u64 as usize] += 1;
+        } else {
+            observed[kmax] += 1;
+        }
+    }
+
+    let (p, q) = geom_pq(x);
+
+    // expected probabilities for same bins
+    // P(K=k)=q^k p, tail P(K>=kmax)=q^kmax
+    let mut probs = vec![0f64; kmax + 1];
+    for k in 0..kmax {
+        probs[k] = q.powi(k as i32) * p;
+    }
+    probs[kmax] = q.powi(kmax as i32);
+
+    check_chi_square_from_probs(&observed, &probs).unwrap()
+}
+
+#[test]
+fn geometric_fast_x0_is_zero() {
+    let x0 = rbig!(0);
+    for _ in 0..10_000 {
+        let k = sample_geometric_exp_fast(x0.clone()).unwrap();
+        assert!(k.is_zero());
+    }
+}
+
+#[test]
+fn geometric_slow_matches_moments_and_p0_at_fixed_points() {
+    let xs = vec![rbig!(1 / 2), rbig!(1), rbig!(2), rbig!(3)];
+
+    for x in xs {
+        let summ = sample_geom_summary(
+            || sample_geometric_exp_slow(x.clone()).unwrap(),
+            N_GEOM_SLOW,
+        );
+        assert_geom_moments(&x, &summ);
+    }
+}
+
+#[test]
+fn geometric_fast_matches_moments_and_p0_at_fixed_points() {
+    let xs = vec![
+        rbig!(1 / 2),
+        rbig!(3 / 4),
+        rbig!(1),
+        rbig!(3 / 2),
+        rbig!(2),
+        rbig!(9 / 4),
+        rbig!(3),
+        rbig!(5),
+    ];
+
+    for x in xs {
+        let summ = sample_geom_summary(
+            || sample_geometric_exp_fast(x.clone()).unwrap(),
+            N_GEOM_FAST,
+        );
+        assert_geom_moments(&x, &summ);
+    }
+}
+
+#[test]
+fn geometric_fast_goodness_of_fit_binned_chi_square() {
+    let x = rbig!(1);
+
+    // Choose kmax based on expected counts so the test stays valid if N changes.
+    let kmax = choose_kmax_for_chi2(&x, N_GEOM_FAST, 10.0, 20);
+    assert_binned_chi_square(&x, N_GEOM_FAST, kmax, || {
+        sample_geometric_exp_fast(x.clone()).unwrap()
+    });
+}
+
+#[test]
+fn geometric_fast_and_slow_agree_on_mean_statistically() {
+    let xs = vec![rbig!(1 / 2), rbig!(1), rbig!(2)];
+
+    for x in xs {
+        let fast = sample_geom_summary(
+            || sample_geometric_exp_fast(x.clone()).unwrap(),
+            N_GEOM_FAST,
+        );
+        let slow = sample_geom_summary(
+            || sample_geometric_exp_slow(x.clone()).unwrap(),
+            N_GEOM_SLOW,
+        );
+
+        let (_mean, var) = geom_mean_var(&x);
+        let se_fast = (var / (N_GEOM_FAST as f64)).sqrt();
+        let se_slow = (var / (N_GEOM_SLOW as f64)).sqrt();
+        let se_diff = (se_fast * se_fast + se_slow * se_slow).sqrt();
+
+        assert_close_normal(fast.mean, slow.mean, se_diff, "fast vs slow mean");
+    }
+}

--- a/rust/src/traits/samplers/cks20/test/mod.rs
+++ b/rust/src/traits/samplers/cks20/test/mod.rs
@@ -1,0 +1,18 @@
+mod bernoulli;
+mod gcd;
+mod geometric;
+mod symmetric;
+
+use dashu::rational::RBig;
+
+use crate::traits::samplers::test::BASE_N;
+
+pub const N_BERNOULLI: usize = 2 * BASE_N;
+pub const N_GEOM_FAST: usize = 2 * BASE_N;
+pub const N_GEOM_SLOW: usize = BASE_N / 2;
+pub const N_LAPLACE: usize = 2 * BASE_N;
+pub const N_GAUSS: usize = 2 * BASE_N;
+
+pub fn p_exp_neg(x: &RBig) -> f64 {
+    (-x.to_f64().value()).exp()
+}

--- a/rust/src/traits/samplers/cks20/test/symmetric.rs
+++ b/rust/src/traits/samplers/cks20/test/symmetric.rs
@@ -1,0 +1,565 @@
+use std::convert::TryFrom;
+
+use dashu::integer::IBig;
+use dashu::rbig;
+
+use crate::traits::samplers::{
+    sample_discrete_gaussian,
+    test::{assert_close_binomial_mean, assert_close_normal},
+};
+
+use super::*;
+
+pub const N_DEGENERATE: usize = 50_000;
+
+#[derive(Debug)]
+pub struct SignedHist {
+    pub kmax: usize,
+    /// counts for x in [-kmax..=kmax], followed by tail bin for |x|>kmax
+    pub counts: Vec<u64>,
+}
+
+impl SignedHist {
+    pub fn sample(n: usize, kmax: usize, mut sampler: impl FnMut() -> IBig) -> Self {
+        let bins = 2 * kmax + 1;
+        let mut counts = vec![0u64; bins + 1];
+        let offset = kmax as i64;
+
+        for _ in 0..n {
+            let xi = i64::try_from(sampler()).unwrap();
+            if (-offset..=offset).contains(&xi) {
+                counts[(xi + offset) as usize] += 1;
+            } else {
+                counts[bins] += 1;
+            }
+        }
+
+        Self { kmax, counts }
+    }
+
+    pub fn tail_count(&self) -> u64 {
+        self.counts[2 * self.kmax + 1]
+    }
+
+    pub fn abs_counts(&self) -> Vec<u64> {
+        let mut out = vec![0u64; self.kmax + 1];
+        out[0] = self.counts[self.kmax];
+        for k in 1..=self.kmax {
+            out[k] = self.counts[self.kmax + k] + self.counts[self.kmax - k];
+        }
+        out
+    }
+
+    pub fn pos_neg_excl0(&self) -> (u64, u64) {
+        let mut pos = 0u64;
+        let mut neg = 0u64;
+        for k in 1..=self.kmax {
+            pos += self.counts[self.kmax + k];
+            neg += self.counts[self.kmax - k];
+        }
+        (pos, neg)
+    }
+
+    /// Count of samples with |X| >= t, including the tail bin.
+    pub fn tail_abs_ge(&self, t: usize) -> u64 {
+        let abs = self.abs_counts();
+        abs[t..].iter().sum::<u64>() + self.tail_count()
+    }
+}
+
+/// Weighted log-ratio check:
+/// compares ln(C[k+1]/C[k]) to ln_ratio_theory(k) over k_range,
+/// weighting by delta-method variance ~ 1/C[k+1] + 1/C[k].
+pub fn assert_log_ratio_matches(
+    abs_counts: &[u64],
+    k_range: std::ops::RangeInclusive<usize>,
+    ln_ratio_theory: impl Fn(usize) -> f64,
+    min_count: u64,
+    label: &str,
+    assert_close_normal: impl Fn(f64, f64, f64, &str),
+) {
+    let mut weighted_err_sum = 0.0;
+    let mut weight_sum = 0.0;
+
+    for k in k_range {
+        let c_k = abs_counts[k];
+        let c_k1 = abs_counts[k + 1];
+        if c_k < min_count || c_k1 < min_count {
+            continue;
+        }
+        let c_k_f = c_k as f64;
+        let c_k1_f = c_k1 as f64;
+
+        let ln_r_hat = (c_k1_f / c_k_f).ln();
+        let ln_r_theory = ln_ratio_theory(k);
+
+        let se = (1.0 / c_k1_f + 1.0 / c_k_f).sqrt();
+        let w = 1.0 / (se * se);
+
+        weighted_err_sum += w * (ln_r_hat - ln_r_theory);
+        weight_sum += w;
+    }
+
+    assert!(
+        weight_sum > 0.0,
+        "insufficient counts for ratio test: {label} (increase N or adjust k-range/kmax)"
+    );
+
+    let avg_err = weighted_err_sum / weight_sum;
+    let se_avg = (1.0 / weight_sum).sqrt();
+    assert_close_normal(avg_err, 0.0, se_avg, label);
+}
+
+mod laplace {
+    use crate::traits::samplers::{sample_discrete_laplace, test::check_chi_square_from_probs};
+
+    use super::*;
+
+    #[derive(Clone, Debug)]
+    struct LaplaceTheory {
+        a: f64,   // exp(-1/scale)
+        p0: f64,  // P(X=0)
+        var: f64, // Var(X)
+    }
+
+    impl LaplaceTheory {
+        fn build(scale: f64) -> Self {
+            assert!(scale.is_finite() && scale > 0.0);
+            let a = (-(1.0 / scale)).exp();
+            let p0 = (1.0 - a) / (1.0 + a);
+            let var = 2.0 * a / ((1.0 - a) * (1.0 - a));
+            Self { a, p0, var }
+        }
+
+        fn p_signed(&self, x: i64) -> f64 {
+            self.p0 * self.a.powi(x.abs() as i32)
+        }
+
+        fn tail_abs_ge(&self, t: usize) -> f64 {
+            if t == 0 {
+                1.0
+            } else {
+                (2.0 * self.p0 * self.a.powi(t as i32) / (1.0 - self.a)).clamp(0.0, 1.0)
+            }
+        }
+
+        fn ln_abs_ratio(&self, _k: usize) -> f64 {
+            // for k>=1: P(|X|=k+1)/P(|X|=k) = a
+            self.a.ln()
+        }
+    }
+
+    #[test]
+    fn scale_zero_is_always_zero() {
+        let s0 = rbig!(0);
+        for _ in 0..N_DEGENERATE {
+            let x = sample_discrete_laplace(s0.clone()).unwrap();
+            assert!(x.is_zero());
+        }
+    }
+
+    #[test]
+    fn p0_and_mean_match_theory_at_fixed_points() {
+        let scales = vec![rbig!(1 / 2), rbig!(1), rbig!(2), rbig!(3)];
+
+        for s in scales {
+            if s.is_zero() {
+                continue;
+            }
+            let th = LaplaceTheory::build(s.to_f64().value());
+
+            let mut sum: i128 = 0;
+
+            for _ in 0..N_LAPLACE {
+                let x = sample_discrete_laplace(s.clone()).unwrap();
+                let xi = i64::try_from(x).unwrap();
+                sum += xi as i128;
+            }
+
+            let mean_hat = (sum as f64) / (N_LAPLACE as f64);
+
+            let se_mean = (th.var / (N_LAPLACE as f64)).sqrt();
+            assert_close_normal(mean_hat, 0.0, se_mean, "laplace mean");
+        }
+    }
+
+    #[test]
+    fn per_k_symmetry_matches_theory() {
+        let s = rbig!(1);
+        let th = LaplaceTheory::build(s.to_f64().value());
+        let kmax = 8usize;
+
+        let mut pos = vec![0u64; kmax + 1];
+        let mut neg = vec![0u64; kmax + 1];
+
+        for _ in 0..N_LAPLACE {
+            let x = sample_discrete_laplace(s.clone()).unwrap();
+            let xi = i64::try_from(x).unwrap();
+            if xi > 0 && (xi as usize) <= kmax {
+                pos[xi as usize] += 1;
+            } else if xi < 0 && ((-xi) as usize) <= kmax {
+                neg[(-xi) as usize] += 1;
+            }
+        }
+
+        for k in 1..=kmax {
+            let pk = th.p_signed(k as i64);
+            let se = (pk * (1.0 - pk) / (N_LAPLACE as f64)).sqrt();
+
+            let pk_hat = pos[k] as f64 / (N_LAPLACE as f64);
+            let nk_hat = neg[k] as f64 / (N_LAPLACE as f64);
+
+            assert_close_normal(pk_hat, pk, se, "P(+k)");
+            assert_close_normal(nk_hat, pk, se, "P(-k)");
+
+            let se_diff = (se * se + se * se).sqrt();
+            assert_close_normal(pk_hat, nk_hat, se_diff, "laplace symmetry");
+        }
+    }
+
+    #[test]
+    fn goodness_of_fit_chi_square_binned() {
+        let s = rbig!(1);
+        let th = LaplaceTheory::build(s.to_f64().value());
+
+        let kmax = 9usize;
+        let hist = SignedHist::sample(N_LAPLACE, kmax, || {
+            sample_discrete_laplace(s.clone()).unwrap()
+        });
+
+        let bins = 2 * kmax + 1;
+        let mut probs = vec![0f64; bins + 1];
+
+        for idx in 0..bins {
+            let x = (idx as i64) - (kmax as i64);
+            probs[idx] = th.p_signed(x);
+        }
+        probs[bins] = (1.0 - probs[..bins].iter().sum::<f64>()).max(0.0);
+
+        check_chi_square_from_probs(&hist.counts, &probs).unwrap()
+    }
+
+    #[test]
+    fn sharp_invariants() {
+        let scales = vec![rbig!(1 / 2), rbig!(1), rbig!(2), rbig!(3)];
+        let kmax = 60usize;
+
+        for s in scales {
+            if s.is_zero() {
+                continue;
+            }
+            let th = LaplaceTheory::build(s.to_f64().value());
+
+            let hist = SignedHist::sample(N_LAPLACE, kmax, || {
+                sample_discrete_laplace(s.clone()).unwrap()
+            });
+
+            let abs = hist.abs_counts();
+            let n = N_LAPLACE as f64;
+
+            // P(0)
+            let p0_hat = abs[0] as f64 / n;
+            assert_close_binomial_mean(p0_hat, th.p0, N_LAPLACE, "laplace P(0)");
+
+            // Tail checks P(|X|>=t)
+            for &t in &[1usize, 2usize, 3usize, 5usize, 8usize] {
+                let phat = hist.tail_abs_ge(t) as f64 / n;
+                let p = th.tail_abs_ge(t);
+                assert_close_binomial_mean(phat, p, N_LAPLACE, "laplace tail");
+            }
+
+            // Adjacent abs ratio on log scale (constant ln(a))
+            assert_log_ratio_matches(
+                &abs,
+                2..=12,
+                |k| th.ln_abs_ratio(k),
+                50,
+                "laplace log-ratio slope",
+                assert_close_normal,
+            );
+        }
+    }
+}
+
+mod gaussian {
+    use crate::traits::samplers::test::check_chi_square_from_probs;
+
+    use super::*;
+
+    #[derive(Clone, Debug)]
+    struct GaussTheory {
+        sigma: f64,
+        z: f64,
+        e2: f64,
+        e4: f64,
+        k_trunc: i64,
+    }
+
+    impl GaussTheory {
+        fn build(sigma: f64) -> Self {
+            assert!(sigma.is_finite() && sigma > 0.0);
+
+            let mut z = 1.0_f64;
+            let mut m2 = 0.0_f64;
+            let mut m4 = 0.0_f64;
+            let mut k_trunc = 0_i64;
+
+            for k in 1..=300_i64 {
+                let kk = (k as f64) * (k as f64);
+                let wk = (-(kk) / (2.0 * sigma * sigma)).exp();
+                let pair = 2.0 * wk;
+
+                z += pair;
+                m2 += pair * kk;
+                m4 += pair * kk * kk;
+
+                k_trunc = k;
+
+                if pair < 1e-16 * z {
+                    break;
+                }
+            }
+
+            Self {
+                sigma,
+                z,
+                e2: m2 / z,
+                e4: m4 / z,
+                k_trunc,
+            }
+        }
+
+        fn w(&self, k: i64) -> f64 {
+            let kk = (k as f64) * (k as f64);
+            (-(kk) / (2.0 * self.sigma * self.sigma)).exp()
+        }
+
+        fn p_signed(&self, k: i64) -> f64 {
+            self.w(k) / self.z
+        }
+
+        fn tail_abs_ge(&self, t: usize) -> f64 {
+            assert!(t >= 1);
+            let mut tail = 0.0;
+            for k in (t as i64)..=self.k_trunc {
+                tail += self.w(k);
+            }
+            (2.0 * tail / self.z).clamp(0.0, 1.0)
+        }
+
+        fn ln_ratio_k(&self, k: usize) -> f64 {
+            // ln(P(k+1)/P(k)) = - (2k+1)/(2 sigma^2)
+            -((2 * k + 1) as f64) / (2.0 * self.sigma * self.sigma)
+        }
+
+        fn choose_kmax_for_expected(self: &Self, n: usize, min_exp: f64, hard_cap: usize) -> usize {
+            let n_f = n as f64;
+            for k in (0..=hard_cap).rev() {
+                let pk = self.p_signed(k as i64);
+                if n_f * pk >= min_exp {
+                    return k;
+                }
+            }
+            0
+        }
+
+        fn slope_theory(&self) -> f64 {
+            -1.0 / (2.0 * self.sigma * self.sigma)
+        }
+    }
+
+    #[test]
+    fn scale_zero_is_always_zero() {
+        let s0 = rbig!(0);
+        for _ in 0..N_DEGENERATE {
+            let x = sample_discrete_gaussian(s0.clone()).unwrap();
+            assert!(x.is_zero());
+        }
+    }
+
+    #[test]
+    fn mean_and_second_moment_match_theory() {
+        let scales = vec![rbig!(1), rbig!(2), rbig!(3)];
+
+        for s in scales {
+            if s.is_zero() {
+                continue;
+            }
+            let th = GaussTheory::build(s.to_f64().value());
+
+            // empirical mean + m2 in one pass
+            let mut sum: i128 = 0;
+            let mut sum2: f64 = 0.0;
+
+            for _ in 0..N_GAUSS {
+                let x = sample_discrete_gaussian(s.clone()).unwrap();
+                let xi = i64::try_from(x).unwrap();
+                sum += xi as i128;
+                sum2 += (xi as f64) * (xi as f64);
+            }
+
+            let mean_hat = (sum as f64) / (N_GAUSS as f64);
+            let m2_hat = sum2 / (N_GAUSS as f64);
+
+            let se_mean = (m2_hat / (N_GAUSS as f64)).sqrt();
+            assert_close_normal(mean_hat, 0.0, se_mean, "gauss mean");
+
+            let var_x2 = (th.e4 - th.e2 * th.e2).max(0.0);
+            let se_m2 = (var_x2 / (N_GAUSS as f64)).sqrt();
+            assert_close_normal(m2_hat, th.e2, se_m2, "gauss E[X^2]");
+        }
+    }
+
+    #[test]
+    fn per_k_symmetry_matches_theory() {
+        let s = rbig!(1);
+        let th = GaussTheory::build(s.to_f64().value());
+        let kmax = th.choose_kmax_for_expected(N_GAUSS, 10.0, 25).min(10);
+
+        let mut pos = vec![0u64; kmax + 1];
+        let mut neg = vec![0u64; kmax + 1];
+
+        for _ in 0..N_GAUSS {
+            let x = sample_discrete_gaussian(s.clone()).unwrap();
+            let xi = i64::try_from(x).unwrap();
+            if xi > 0 && (xi as usize) <= kmax {
+                pos[xi as usize] += 1;
+            } else if xi < 0 && ((-xi) as usize) <= kmax {
+                neg[(-xi) as usize] += 1;
+            }
+        }
+
+        for k in 1..=kmax {
+            let pk = th.p_signed(k as i64);
+            let se = (pk * (1.0 - pk) / (N_GAUSS as f64)).sqrt();
+
+            let pk_hat = pos[k] as f64 / (N_GAUSS as f64);
+            let nk_hat = neg[k] as f64 / (N_GAUSS as f64);
+
+            assert_close_normal(pk_hat, pk, se, "P(+k)");
+            assert_close_normal(nk_hat, pk, se, "P(-k)");
+
+            let se_diff = (se * se + se * se).sqrt();
+            assert_close_normal(pk_hat, nk_hat, se_diff, "gauss symmetry");
+        }
+    }
+
+    #[test]
+    fn discrete_gaussian_goodness_of_fit_binned_chi_square() {
+        let s = rbig!(2);
+        let th = GaussTheory::build(s.to_f64().value());
+
+        // Choose kmax so edge expected counts are >= 10 (very safe).
+        let kmax = th.choose_kmax_for_expected(N_GAUSS, 10.0, 60);
+        assert!(
+            kmax >= 3,
+            "kmax too small; increase N_GAUSS or reduce min_exp"
+        );
+
+        let hist = SignedHist::sample(N_GAUSS, kmax, || {
+            sample_discrete_gaussian(s.clone()).unwrap()
+        });
+
+        let bins = 2 * kmax + 1;
+        let mut probs = vec![0f64; bins + 1];
+
+        // Expected probs for x in [-kmax..kmax]
+        for idx in 0..bins {
+            let x = (idx as i64) - (kmax as i64);
+            probs[idx] = th.p_signed(x);
+        }
+
+        // Tail = P(|X| > kmax)
+        let mass = probs[..bins].iter().sum::<f64>();
+        probs[bins] = (1.0 - mass).max(0.0);
+
+        // Let the shared chi-square helper enforce expected>=5, compute statistic, and compare.
+        check_chi_square_from_probs(&hist.counts, &probs).unwrap()
+    }
+
+    #[test]
+    fn sharp_invariants() {
+        let scales = vec![rbig!(1), rbig!(2), rbig!(3)];
+        let kmax = 60usize;
+
+        for s in scales {
+            if s.is_zero() {
+                continue;
+            }
+            let th = GaussTheory::build(s.to_f64().value());
+
+            let hist = SignedHist::sample(N_GAUSS, kmax, || {
+                sample_discrete_gaussian(s.clone()).unwrap()
+            });
+
+            let abs = hist.abs_counts();
+            let n = N_GAUSS as f64;
+
+            // Sign symmetry excluding zero
+            let (pos, neg) = hist.pos_neg_excl0();
+            let nonzero = (pos + neg) as usize;
+            if nonzero > 0 {
+                let phat = pos as f64 / nonzero as f64;
+                assert_close_binomial_mean(phat, 0.5, nonzero, "gauss sign symmetry");
+            }
+
+            // Tail checks P(|X|>=t)
+            for &t in &[1usize, 2usize, 3usize, 4usize, 6usize] {
+                let phat = hist.tail_abs_ge(t) as f64 / n;
+                let p = th.tail_abs_ge(t);
+                assert_close_binomial_mean(phat, p, N_GAUSS, "gauss tail");
+            }
+
+            // Adjacent ratio check on log scale
+            assert_log_ratio_matches(
+                &abs,
+                2..=12,
+                |k| th.ln_ratio_k(k),
+                50,
+                "gauss log-ratio slope",
+                assert_close_normal,
+            );
+
+            // Quadratic log-shape slope check (heuristic, low-flake)
+            // log P(|X|=k) = const - k^2/(2 sigma^2) for k>=1
+            let mut xs = Vec::<f64>::new(); // k^2
+            let mut ys = Vec::<f64>::new(); // log(count)
+            let mut ws = Vec::<f64>::new(); // weight ~ count
+
+            for k in 1..=kmax {
+                let c = abs[k];
+                if c >= 80 {
+                    xs.push((k as f64) * (k as f64));
+                    ys.push((c as f64).ln());
+                    ws.push(c as f64);
+                }
+            }
+
+            if xs.len() >= 6 {
+                let w_sum: f64 = ws.iter().sum();
+                let x_bar: f64 = xs.iter().zip(ws.iter()).map(|(x, w)| x * w).sum::<f64>() / w_sum;
+                let y_bar: f64 = ys.iter().zip(ws.iter()).map(|(y, w)| y * w).sum::<f64>() / w_sum;
+
+                let mut num = 0.0;
+                let mut den = 0.0;
+                for ((x, y), w) in xs.iter().zip(ys.iter()).zip(ws.iter()) {
+                    num += w * (x - x_bar) * (y - y_bar);
+                    den += w * (x - x_bar) * (x - x_bar);
+                }
+                let slope_hat = num / den;
+                let slope_theory = th.slope_theory();
+
+                // Heuristic tolerance: catches large mistakes without flakiness.
+                let tol = 0.15 * slope_theory.abs() + 1e-6;
+                assert!(
+                    (slope_hat - slope_theory).abs() <= tol,
+                    "gauss log-shape slope mismatch: slope_hat={}, slope_theory={}, tol={}, sigma={}",
+                    slope_hat,
+                    slope_theory,
+                    tol,
+                    th.sigma
+                );
+            }
+        }
+    }
+}

--- a/rust/src/traits/samplers/psrn/canonical/test.rs
+++ b/rust/src/traits/samplers/psrn/canonical/test.rs
@@ -27,6 +27,7 @@ fn test_sample_cnd_interval_progression() -> Fallible<()> {
 }
 
 // CDF from Definition 3.7 in https://arxiv.org/pdf/2108.04303
+#[allow(non_snake_case)]
 fn F_f(x: f64, f: impl Fn(f64) -> f64 + Clone, c: f64) -> f64 {
     if x < -0.5 {
         f(1. - F_f(x + 1.0, f.clone(), c))
@@ -47,11 +48,11 @@ fn test_cnd_psrn() -> Fallible<()> {
         tradeoff: &tradeoff,
         fixed_point: &c,
     };
-    let samples = (0..1000)
+    let samples = (0..5000)
         .map(|_| PartialSample::new(cnd.clone()).value())
         .collect::<Fallible<Vec<f64>>>()?;
 
-    let samples = <[f64; 1000]>::try_from(samples).unwrap();
+    let samples = <[f64; 5000]>::try_from(samples).unwrap();
 
     let f_tradeoff = |x: f64| -> f64 { tradeoff(RBig::from_f64(x).unwrap()).to_f64().value() };
     let f_c = c.to_f64().value();

--- a/rust/src/traits/samplers/test.rs
+++ b/rust/src/traits/samplers/test.rs
@@ -1,64 +1,60 @@
-use std::fmt::Debug;
-use std::iter::Sum;
-use std::ops::{Div, Sub};
-
-use num::traits::real::Real;
 use statrs::function::erf;
-
-use num::{NumCast, One};
 
 use crate::error::Fallible;
 
-/// returns z-statistic that satisfies p == ∫P(x)dx over (-∞, z),
-///     where P is the standard normal distribution
+pub const TEST_Z: f64 = 6.0;
+pub const FP_SLOP: f64 = 5e-12;
+pub const ALPHA: f64 = 1e-6;
+pub const BASE_N: usize = 60_000;
+
+pub fn sample_mean_bool(mut f: impl FnMut() -> bool, n: usize) -> f64 {
+    (0..n).filter(|_| f()).count() as f64 / n as f64
+}
+
+// Φ^{-1}(p) = -sqrt(2)*erfc^{-1}(2p)
 pub fn normal_cdf_inverse(p: f64) -> f64 {
-    std::f64::consts::SQRT_2 * erf::erfc_inv(2.0 * p)
+    -std::f64::consts::SQRT_2 * erf::erfc_inv(2.0 * p)
 }
 
-macro_rules! c {
-    ($expr:expr; $ty:ty) => {{
-        let t: $ty = NumCast::from($expr).unwrap();
-        t
-    }};
+// Wilson (two-sided) proportion acceptance test.
+fn wilson_contains_p0(k: usize, n: usize, p0: f64, alpha: f64) -> bool {
+    assert!((0.0..=1.0).contains(&p0));
+    assert!(n > 0);
+    assert!(alpha > 0.0 && alpha < 1.0);
+
+    let z = normal_cdf_inverse(1.0 - alpha / 2.0);
+    let n_f = n as f64;
+    let phat = k as f64 / n_f;
+    let z2 = z * z;
+
+    let denom = 1.0 + z2 / n_f;
+    let center = (phat + z2 / (2.0 * n_f)) / denom;
+    let half = (z / denom) * (phat * (1.0 - phat) / n_f + z2 / (4.0 * n_f * n_f)).sqrt();
+
+    let lo = (center - half).max(0.0);
+    let hi = (center + half).min(1.0);
+
+    lo - FP_SLOP <= p0 && p0 <= hi + FP_SLOP
 }
 
-pub fn test_proportion_parameters<T, FS: Fn() -> T>(
-    sampler: FS,
-    p_pop: T,
+pub fn run_wilson_test(
+    mut sampler: impl FnMut() -> bool,
+    p0: f64,
+    n: usize,
     alpha: f64,
-    err_margin: T,
-) -> bool
-where
-    T: Sum<T> + Sub<Output = T> + Div<Output = T> + Real + Debug + One,
-{
-    // |z_{alpha/2}|
-    let z_stat = c!(normal_cdf_inverse(alpha / 2.).abs(); T);
-
-    // derived sample size necessary to conduct the test
-    let n: T = (p_pop * (T::one() - p_pop) * (z_stat / err_margin).powi(2)).ceil();
-
-    // confidence interval for the mean
-    let abs_p_tol = z_stat * (p_pop * (T::one() - p_pop) / n).sqrt(); // almost the same as err_margin
-
-    println!(
-        "sampling {:?} observations to detect a change in proportion with {:.4?}% confidence",
-        c!(n; u32),
-        (1. - alpha) * 100.
+    label: &str,
+) {
+    let k = (0..n).filter(|_| sampler()).count();
+    assert!(
+        wilson_contains_p0(k, n, p0, alpha),
+        "{}: Wilson rejected. n={}, k={}, p_hat={}, p0={}, alpha={}",
+        label,
+        n,
+        k,
+        k as f64 / n as f64,
+        p0,
+        alpha
     );
-
-    // take n samples from the distribution, compute average as empirical proportion
-    let p_emp: T = (0..c!(n; u32)).map(|_| sampler()).sum::<T>() / n;
-
-    let passed = (p_emp - p_pop).abs() < abs_p_tol;
-
-    println!("stat: (tolerance, pop, emp, passed)");
-    println!(
-        "    proportion:     {:?}, {:?}, {:?}, {:?}",
-        abs_p_tol, p_pop, p_emp, passed
-    );
-    println!();
-
-    passed
 }
 
 #[allow(dead_code)]
@@ -71,74 +67,145 @@ where
 /// then the p-value is the false discovery rate,
 /// or chance of this test failing even when the data is a sample from the distribution.
 pub fn check_kolmogorov_smirnov(
-    mut samples: [f64; 1000],
+    mut samples: [f64; 5000],
     cdf: impl Fn(f64) -> f64,
 ) -> Fallible<()> {
-    // first, compute the test statistic. For a one-sample KS test,
-    // this is the greatest distance between the empirical CDF of the samples and the expected CDF.
     samples.sort_by(|a, b| a.total_cmp(b));
-
     let n = samples.len() as f64;
-    let statistic = samples
-        .into_iter()
-        .enumerate()
-        .map(|(i, s)| {
-            let empirical_cdf = i as f64 / n;
-            let idealized_cdf = cdf(s);
-            (empirical_cdf - idealized_cdf).abs()
-        })
-        .max_by(|a, b| a.total_cmp(b))
-        .unwrap();
 
-    // The KS-test is nonparametric,
-    // so the critical value only changes in response to the number of samples (hardcoded at 1000),
-    // not the distribution.
-    //
-    // The p-value corresponds to the mass of the tail of the KS distribution beyond the critical value.
-    // The mass of the tail is the complement of the cumulative distribution function,
-    // which is also called the survival function.
-    // The inverse of the survival function `isf` tells us the critical value corresponding to a given mass of the tail.
-    //
-    // We therefore derive the critical value via the inverse survival function of the two-sided, one-sample KS distribution:
-    // ```python
-    // from scipy.stats import kstwo
-    // CRIT_VALUE = kstwo(n=1000).isf(1e-6)
-    // ```
-    static CRIT_VALUE: f64 = 0.08494641956324511;
+    let mut d_plus = 0f64;
+    let mut d_minus = 0f64;
+
+    for (idx0, &x) in samples.iter().enumerate() {
+        let i = (idx0 + 1) as f64; // 1..=n
+        let f = cdf(x).clamp(0.0, 1.0);
+
+        // D+ = max_i (i/n - F(x_i))
+        d_plus = d_plus.max(i / n - f);
+
+        // D- = max_i (F(x_i) - (i-1)/n)
+        d_minus = d_minus.max(f - (i - 1.0) / n);
+    }
+
+    let statistic = d_plus.max(d_minus);
+
+    // Critical value must correspond to the SAME statistic definition above.
+    // Derived in Python:
+    //   from scipy.stats import kstwo
+    //   kstwo(n=5000).isf(1e-6)
+    static CRIT_VALUE: f64 = 0.038051617888080105;
+
     if statistic > CRIT_VALUE {
         return fallible!(
             FailedFunction,
-            "Statistic ({statistic}) exceeds critical value ({CRIT_VALUE})! This indicates that the data is not sampled from the same distribution specified by the cdf. There is a 1e-6 probability of this being a false positive."
+            "KS statistic ({statistic}) exceeds critical value ({CRIT_VALUE}). \
+             Under the KS assumptions (i.i.d. samples; continuous reference CDF), \
+             Type I error probability (false positive) is <= 1e-6."
+        );
+    }
+    Ok(())
+}
+
+#[allow(dead_code)]
+/// Conduct a Pearson chi-squared goodness-of-fit test.
+///
+/// - `observed[i]` are observed counts (integers).
+/// - `expected[i]` are expected counts (floats) for the same bins.
+///
+/// This uses a conservative normal-approx bound for the chi-square critical value:
+///     chi2 <= df + Z * sqrt(2*df)
+/// where `df = #bins - 1`.
+///
+/// This avoids hardcoding a specific df/alpha table while keeping flakiness low.
+///
+/// Notes:
+/// - Requires all expected counts >= 5 for the usual chi-square approximation.
+/// - Assumes expected counts are fixed a priori (no data-dependent binning, unless you adjust df/alpha appropriately).
+pub fn check_chi_square(observed: &[u64], expected: &[f64]) -> Fallible<()> {
+    if observed.len() != expected.len() {
+        return fallible!(
+            FailedFunction,
+            "observed/expected length mismatch: {} vs {}",
+            observed.len(),
+            expected.len()
+        );
+    }
+    if observed.is_empty() {
+        return fallible!(FailedFunction, "no bins");
+    }
+
+    // Preconditions: expected counts must be finite and >= 5.
+    for (i, &e) in expected.iter().enumerate() {
+        if !e.is_finite() || e <= 0.0 {
+            return fallible!(
+                FailedFunction,
+                "expected[{i}] must be finite and > 0, got {e}"
+            );
+        }
+        if e < 5.0 {
+            return fallible!(
+                FailedFunction,
+                "expected[{i}] too small for chi-square approximation: expected={e} (<5)."
+            );
+        }
+    }
+
+    // df = k - 1 - params_estimated
+    let k = observed.len();
+    let df = (k - 1) as f64;
+
+    // Statistic
+    let mut statistic = 0.0f64;
+    for (&o, &e) in observed.iter().zip(expected.iter()) {
+        let o = o as f64;
+        let diff = o - e;
+        statistic += diff * diff / e;
+    }
+
+    // Conservative critical value (upper tail) without special functions:
+    // chi2 ~ approx Normal(mean=df, var=2df)
+    let crit_value = df + TEST_Z * (2.0 * df).sqrt();
+
+    if statistic > crit_value {
+        return fallible!(
+            FailedFunction,
+            "Chi-square rejected: statistic={statistic} > crit={crit_value} (df={df}, z={TEST_Z}). \
+             Assumes iid samples and fixed expected counts. \
+             Type I error probability (false positive) is <= 1e-6."
         );
     }
 
     Ok(())
 }
 
-#[allow(dead_code)]
-/// Conduct a chi-squared test.
-///
-/// Since the critical values are difficult to compute in Rust,
-/// this function hardcodes the critical value corresponding to a p-value of 1e-6 for 9 degrees of freedom.
-///
-/// Assuming the samples are draws from the expected distribution,
-/// then the p-value is the false discovery rate,
-/// or chance of this test failing even when the data is a sample from the distribution.
-pub fn check_chi_square(observed: [f64; 10], expected: [f64; 10]) -> Fallible<()> {
-    let statistic = observed
-        .iter()
-        .zip(expected)
-        .map(|(o, e)| (o - e).powi(2) / e)
-        .sum::<f64>();
-
-    // from scipy.stats import chi2
-    // CRIT_VALUE = chi2(df=9).isf(1e-6)
-    static CRIT_VALUE: f64 = 44.81093787068782;
-    if statistic > CRIT_VALUE {
-        return fallible!(
-            FailedFunction,
-            "Statistic ({statistic}) exceeds critical value ({CRIT_VALUE})! This indicates that the data is not sampled from the same distribution specified by the cdf. There is a 1e-6 probability of this being a false positive."
-        );
+pub fn check_chi_square_from_probs(observed: &[u64], probs: &[f64]) -> Fallible<()> {
+    if observed.len() != probs.len() {
+        return fallible!(FailedFunction, "length mismatch");
     }
-    Ok(())
+    let n: u64 = observed.iter().sum();
+    let n_f = n as f64;
+    let expected: Vec<f64> = probs.iter().map(|p| n_f * p).collect();
+    check_chi_square(observed, &expected)
+}
+
+/// Conduct a wald z-test.
+pub fn assert_close_normal(est: f64, target: f64, se: f64, what: &str) {
+    let tol = TEST_Z * se + FP_SLOP;
+    let err = (est - target).abs();
+    assert!(
+        err <= tol,
+        "{}: est={} target={} err={} tol={} (se={})",
+        what,
+        est,
+        target,
+        err,
+        tol,
+        se
+    );
+}
+
+/// Conducts a wald z-test on the mean of a binomial RV.
+pub fn assert_close_binomial_mean(p_hat: f64, p: f64, n: usize, what: &str) {
+    let se = (p * (1.0 - p) / (n as f64)).sqrt();
+    assert_close_normal(p_hat, p, se, what);
 }

--- a/rust/src/traits/samplers/uniform/test.rs
+++ b/rust/src/traits/samplers/uniform/test.rs
@@ -1,5 +1,64 @@
+use std::mem::size_of;
+
+use dashu::integer::UBig;
+
+use crate::traits::samplers::test::check_chi_square;
+
 use super::*;
-use std::collections::HashMap;
+
+fn counts_u64<I: IntoIterator<Item = u64>>(samples: I, k: usize) -> Vec<u64> {
+    let mut c = vec![0u64; k];
+    for s in samples {
+        c[s as usize] += 1;
+    }
+    c
+}
+
+fn expected_uniform_counts(n: usize, k: usize) -> Vec<f64> {
+    vec![n as f64 / k as f64; k]
+}
+
+fn run_chisq_on_u64_samples<I: IntoIterator<Item = u64>>(
+    samples: I,
+    n: usize,
+    k: usize,
+) -> Fallible<()> {
+    let observed = counts_u64(samples, k);
+    let expected = expected_uniform_counts(n, k);
+    check_chi_square(&observed, &expected)
+}
+
+fn run_chisq_uint_below<T, const N: usize>(
+    upper: T,
+    n: usize,
+    k: usize,
+    label: &str,
+) -> Fallible<()>
+where
+    T: Integer + num::Unsigned + FromBytes<N> + Copy + TryInto<u64>,
+    <T as TryInto<u64>>::Error: std::fmt::Debug,
+{
+    // Generate samples as u64
+    let mut samples = Vec::<u64>::with_capacity(n);
+    for _ in 0..n {
+        let s = sample_uniform_uint_below::<T, N>(upper)?;
+        let v: u64 = s.try_into().expect("sample fits u64 in tests");
+        debug_assert!((v as usize) < k, "{label}: sample out of range");
+        samples.push(v);
+    }
+    run_chisq_on_u64_samples(samples, n, k)
+}
+
+fn run_chisq_ubig_below(upper: UBig, n: usize, k: usize, label: &str) -> Fallible<()> {
+    let mut samples = Vec::<u64>::with_capacity(n);
+    for _ in 0..n {
+        let s = sample_uniform_ubig_below(upper.clone())?;
+        let v: u64 = s.to_string().parse().expect("sample fits u64 in tests");
+        debug_assert!((v as usize) < k, "{label}: sample out of range");
+        samples.push(v);
+    }
+    run_chisq_on_u64_samples(samples, n, k)
+}
 
 #[test]
 fn test_sample_from_uniform_bytes() -> Fallible<()> {
@@ -9,55 +68,49 @@ fn test_sample_from_uniform_bytes() -> Fallible<()> {
         )+}
     }
 
-    // this is just testing that the algorithm runs; is not a distributional test
     sample!(u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize);
     Ok(())
 }
 
 #[test]
-fn test_uniform_int_below() -> Fallible<()> {
-    assert!(sample_uniform_uint_below(7u32)? < 7);
+fn test_uniform_uint_below_chisq_across_dtypes_and_k() -> Fallible<()> {
+    const CASES: &[(usize, usize)] = &[(64, 8_000), (256, 50_000), (257, 60_000)];
+
+    for &(k, n) in CASES {
+        assert!(k >= 2);
+
+        // u8 can only represent uppers up to 255 (u8::MAX). So skip k=256,257 for u8.
+        if k <= u8::MAX as usize {
+            run_chisq_uint_below::<u8, { size_of::<u8>() }>(k as u8, n, k, "u8")?;
+        }
+
+        if k <= u16::MAX as usize {
+            run_chisq_uint_below::<u16, { size_of::<u16>() }>(k as u16, n, k, "u16")?;
+        }
+
+        if k <= u32::MAX as usize {
+            run_chisq_uint_below::<u32, { size_of::<u32>() }>(k as u32, n, k, "u32")?;
+        }
+
+        // u64 always fits for these k
+        run_chisq_uint_below::<u64, { size_of::<u64>() }>(k as u64, n, k, "u64")?;
+    }
+
     Ok(())
 }
 
 #[test]
-#[ignore]
-fn test_sample_uniform_int_below() -> Fallible<()> {
-    let mut counts = HashMap::new();
-    // this checks that the output distribution of each number is uniform
-    (0..10000).try_for_each(|_| {
-        let sample = sample_uniform_uint_below(7u32)?;
-        *counts.entry(sample).or_insert(0) += 1;
-        Fallible::Ok(())
-    })?;
-    println!("{:?}", counts);
-    Ok(())
-}
+fn test_uniform_ubig_below_chisq_across_k() -> Fallible<()> {
+    const CASES: &[(usize, usize)] = &[
+        (64, 8_000),
+        (256, 50_000),
+        (257, 60_000),
+        (1_000, 120_000), // exp=120
+    ];
 
-#[test]
-#[ignore]
-fn test_sample_uniform_int_below_ubig() -> Fallible<()> {
-    let mut counts = HashMap::new();
-    // this checks that the output distribution of each number is uniform
-    (0..10000).try_for_each(|_| {
-        let sample = sample_uniform_ubig_below(UBig::from(255u8))?;
-        *counts.entry(sample).or_insert(0) += 1;
-        Fallible::Ok(())
-    })?;
-    println!("{:?}", counts);
-    Ok(())
-}
+    for &(k, n) in CASES {
+        run_chisq_ubig_below(UBig::from(k as u64), n, k, "ubig")?;
+    }
 
-#[test]
-#[ignore]
-fn test_sample_uniform_int() -> Fallible<()> {
-    let mut counts = HashMap::new();
-    // this checks that the output distribution of each number is uniform
-    (0..10000).try_for_each(|_| {
-        let sample: u32 = sample_from_uniform_bytes()?;
-        *counts.entry(sample).or_insert(0) += 1;
-        Fallible::Ok(())
-    })?;
-    println!("{:?}", counts);
     Ok(())
 }


### PR DESCRIPTION
Closes #2638 

* replaced buggy implementation of rational division in Dashu
* expanded the statistical testing suite

The new test suite:
* Bernoulli(p=x) across f32, f64 and rational
    * wilson tests at fixed points and powers of 2
    * test that constant-time float sampling does not affect distributional output
    * extreme points
* Bernoulli(p=e^-x) - the exp1 and exp samples from CKS20
    * wilson tests at fixed points
    * test that the probability factorizes
    * test that probabilities decrease monotonically as x increases
    * extreme points (0, 1, large rationals)
* gcd - deterministic tests
* Geometric(p=1 - exp(-x)) - the fast and slow geometric samplers from CKS20
    * chisq test for binned discrete outcomes
    * test moments at fixed points
    * test that fast and slow sampler moments match
    * extreme points
* DiscreteLaplace(scale=s)
    * test zero mass and mean
    * test symmetry
    * test binned chisq goodness of fit
    * test tail bounds for fixed points
    * test log ratio
    * extreme points
* DiscreteGaussian(scale=s)
    * test zero mass and second moment
    * test symmetry
    * test binned chisq goodness of fit
    * test tail bounds for fixed points
    * test quadratic log ratio
    * extreme points
* Uniform(0, k) across native types and UBig
    * chisq goodness of fit across fixed points

I also adjusted the implementation of the kolmogorov-smirnov test and sample sizes to increase power.