### PR TITLE
docs: replace "registry.oblivious" with "registry.opendp"

### DIFF
--- a/docs/source/theory/resources.rst
+++ b/docs/source/theory/resources.rst
@@ -10,7 +10,7 @@ Foundations
 
 Applying Differential Privacy
 -----------------------------
-* `The Privacy Deployments Registry <https://registry.oblivious.com/>`_ provides examples of the privacy budgets chosen by real-world deployments.
+* `The Privacy Deployments Registry <https://registry.opendp.org/deployments-registry/>`_ provides examples of the privacy budgets chosen by real-world deployments.
 * `DP Wizard <https://pypi.org/project/dp_wizard/>`_ produces Jupyter notebooks that demonstrate the OpenDP API on your own data.
 
 


### PR DESCRIPTION
Apart from this, it looks like there have been different set of failures each of the past few weeks. We're hitting enough services that something will not be working. I don't think retrying or extending the wait is a fix.

- Fix #2634