### PR TITLE
docs: OpenDP Commons commitments

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ OpenDP is implemented in Rust, with bindings for easy use from Python and R.
 The architecture of the OpenDP Library is based on a conceptual framework for expressing privacy-aware computations.
 This framework is described in the paper [A Programming Framework for OpenDP](https://opendp.org/files/2025/11/opendp_programming_framework_11may2020_1_01.pdf).
 
-The OpenDP Library is part of the larger [OpenDP Project](https://opendp.org), a community effort to build trustworthy,
-open source software tools for analysis of private data.
-(For simplicity in these docs, when we refer to “OpenDP,” we mean just the library, not the entire project.)
+> [!NOTE]
+> This software is part of the [**OpenDP Commons**](https://sites.harvard.edu/opendp/tools/#opendp-commons). As such, the OpenDP Executive Committee commits to:
+> - Releasing this software under an [OSI approved licence](https://opensource.org/licenses), in this case the [MIT License](https://github.com/opendp/opendp/blob/main/LICENSE).
+> - Ensuring there are at least two maintainers, in this case Michael Shoemate (`Shoeboxam`) and Chuck McCallum (`mccalluc`), who will respond within a week to new issues and PRs.
+> - On an annual basis, recruiting one or more volunteers (not active contributors) to conduct an audit, and publishing the results of the audit.
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This framework is described in the paper [A Programming Framework for OpenDP](ht
 > This software is part of the [**OpenDP Commons**](https://sites.harvard.edu/opendp/tools/#opendp-commons). As such, the OpenDP Executive Committee commits to:
 > - Releasing this software under an [OSI approved licence](https://opensource.org/licenses), in this case the [MIT License](https://github.com/opendp/opendp/blob/main/LICENSE).
 > - Ensuring there are at least two maintainers, in this case Michael Shoemate (`Shoeboxam`) and Chuck McCallum (`mccalluc`), who will respond within a week to new issues and PRs.
+> - Only making changes on `main` through PRs, and getting approval on these PRs before merging.
 > - On an annual basis, recruiting one or more volunteers (not active contributors) who will conduct a health-check, focussed not on the details of the algorithms but on the health of this repo as open source software. Their report will be linked here. The next (and first) health-check is scheduled for September 2026.
 
 <!--
@@ -33,6 +34,7 @@ If approved, a list of Commons repos will be maintained at https://opendp.org/to
 For each repo in the OpenDP Commons, the OpenDP Executive Committee commits to:
 - Releasing the software under an [OSI approved licence](https://opensource.org/licenses).
 - Ensuring there are at least two maintainers who will reply within a month (at the latest) to new issues and PRs.
+- Only making changes on `main` through PRs, and getting approval on these PRs before merging.
 - On an annual basis, recruiting one or more volunteers (not active contributors) who will conduct a health-check, focussed not on the details of the algorithms but on the health of this repo as open source software, and linking to their report from the repo.
 
 Projects can be added or removed from the OpenDP Commons with the approval of the OpenDP Executive Committee.

--- a/README.md
+++ b/README.md
@@ -26,21 +26,6 @@ This framework is described in the paper [A Programming Framework for OpenDP](ht
 > - Only making changes on `main` through PRs, and getting approval on these PRs before merging.
 > - On an annual basis, recruiting one or more volunteers (not active contributors) who will conduct a health-check, focussed not on the details of the algorithms but on the health of this repo as open source software. Their report will be linked here. The next (and first) health-check is scheduled for September 2026.
 
-<!--
-
-If approved, a list of Commons repos will be maintained at https://opendp.org/tools/#opendp-commons, with this description (corresponding to the commitments above):
-
-"""
-For each repo in the OpenDP Commons, the OpenDP Executive Committee commits to:
-- Releasing the software under an [OSI approved licence](https://opensource.org/licenses).
-- Ensuring there are at least two maintainers who will reply within a month (at the latest) to new issues and PRs.
-- Only making changes on `main` through PRs, and getting approval on these PRs before merging.
-- On an annual basis, recruiting one or more volunteers (not active contributors) who will conduct a health-check, focussed not on the details of the algorithms but on the health of this repo as open source software, and linking to their report from the repo.
-
-Projects can be added or removed from the OpenDP Commons with the approval of the OpenDP Executive Committee.
-"""
-
--->
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,22 @@ This framework is described in the paper [A Programming Framework for OpenDP](ht
 > This software is part of the [**OpenDP Commons**](https://sites.harvard.edu/opendp/tools/#opendp-commons). As such, the OpenDP Executive Committee commits to:
 > - Releasing this software under an [OSI approved licence](https://opensource.org/licenses), in this case the [MIT License](https://github.com/opendp/opendp/blob/main/LICENSE).
 > - Ensuring there are at least two maintainers, in this case Michael Shoemate (`Shoeboxam`) and Chuck McCallum (`mccalluc`), who will respond within a week to new issues and PRs.
-> - On an annual basis, recruiting one or more volunteers (not active contributors) to conduct an audit, and publishing the results of the audit.
+> - On an annual basis, recruiting one or more volunteers (not active contributors) who will conduct a health-check, focussed not on the details of the algorithms but on the health of this repo as open source software. Their report will be linked here. The next (and first) health-check is scheduled for September 2026.
+
+<!--
+
+If approved, a list of Commons repos will be maintained at https://opendp.org/tools/#opendp-commons, with this description (corresponding to the commitments above):
+
+"""
+For each repo in the OpenDP Commons, the OpenDP Executive Committee commits to:
+- Releasing the software under an [OSI approved licence](https://opensource.org/licenses).
+- Ensuring there are at least two maintainers who will reply within a month (at the latest) to new issues and PRs.
+- On an annual basis, recruiting one or more volunteers (not active contributors) who will conduct a health-check, focussed not on the details of the algorithms but on the health of this repo as open source software, and linking to their report from the repo.
+
+Projects can be added or removed from the OpenDP Commons with the approval of the OpenDP Executive Committee.
+"""
+
+-->
 
 ## Status
 


### PR DESCRIPTION
The "OpenDP Commons" is an idea which goes back to the start of the project, but we haven't been really clear about what it entails. This is a proposal: If accepted, we would also update the text on the [project site](https://sites.harvard.edu/opendp/tools/#opendp-commons).

Feedback welcome!:
- Do these commitments seem like the right sorts of things to promise?
- Will we be able to follow through on these commitments?
- Would other projects also be interested in making these commitments?
  - Maybe the response time can be left up to the repo, but not longer than a month? Would that work for **Tumult**?
  - We're not expecting all maintainers to know the entire codebase for a project, but do we need to be more explicit? Would it be possible to get a second maintainer for **DP Wizard**?
- Would it be good to set a start date and/or a due date for the audit, perhaps in the fall? 
- Salil suggested that it not be a "privacy audit" -- That might both imply something more technical than we need, and it might also be too narrow in scope. ok?
- The opendp library has a number of [older PRs with unclear status](https://docs.google.com/document/d/15H4p5pkUWB5QOidK6ds8pWPzF_-aHh0vgl7F2TN5oJ4/edit?tab=t.0). This proposal doesn't touch them, though they need attention at some point.
- Should we mention things like having a test suite, CI, and PR reviews?