### PR TITLE
fix: polars,ffi -> polars-ffi & remove extension-module features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ on:
         required: false
         default: false
 env:
-  FEATURES: untrusted,ffi,polars,extension-module
+  FEATURES: untrusted,polars-ffi
 
 jobs:
   credential-check:

--- a/docs/source/contributing/development-environment.rst
+++ b/docs/source/contributing/development-environment.rst
@@ -94,10 +94,8 @@ Setting a feature changes how the crate compiles.
         - Build Polars with linking against Python. Enables both ``polars`` and ``ffi``.
       * - ``derive``
         - Enable to support code generation and links to proofs in documentation.
-      * - ``extension-module``
-        - Enable creation of a python extension module for use by Python Polars. Must be disabled for Rust tests. Enable for Python builds to skip linking to ``libpython``.
       * - ``bindings``
-        - Enable to generate Python and R source code. Also enables the ``ffi``, ``derive`` and ``extension-module`` features. 
+        - Enable to generate Python and R source code. Also enables the ``ffi`` and ``derive`` features. 
       * - ``partials``
         - Enabled by default. When enabled, ``then_*`` functions are generated from ``make_*`` functions. Also enables the ``derive`` feature.
       * - ``use-openssl``

--- a/python/setup.py
+++ b/python/setup.py
@@ -16,7 +16,7 @@ if not os.path.isdir("src/opendp/lib") and os.path.isdir("src/opendp/rust"):
                 target="opendp/lib/opendp",
                 path="src/opendp/rust/Cargo.toml",
                 args=["--color", "always"],
-                features=["untrusted", "ffi", "polars", "extension-module"],
+                features=["untrusted", "polars-ffi"],
                 binding=Binding.NoBinding,
             )
         ]


### PR DESCRIPTION
- Remove extension-module: The recent Polars update allowed a newer PyO3 version where extension modules are no longer enabled via a crate feature that conflicts with testing. 
- Replace polars,ffi with polars-ffi: This is now a separate feature because new deps are necessary when both features are enabled.