### PR TITLE
fix: skip invalid wald tests

### DIFF
--- a/rust/src/traits/samplers/cks20/test/symmetric.rs
+++ b/rust/src/traits/samplers/cks20/test/symmetric.rs
@@ -265,6 +265,13 @@ mod laplace {
             for &t in &[1usize, 2usize, 3usize, 5usize, 8usize] {
                 let phat = hist.tail_abs_ge(t) as f64 / n;
                 let p = th.tail_abs_ge(t);
+
+                // Wald normal approximation is poor for ultra-rare events.
+                // Require a minimally reasonable expected count.
+                if (N_LAPLACE as f64) * p < 10.0 {
+                    continue;
+                }
+
                 assert_close_binomial_mean(phat, p, N_LAPLACE, "laplace tail");
             }
 
@@ -507,6 +514,13 @@ mod gaussian {
             for &t in &[1usize, 2usize, 3usize, 4usize, 6usize] {
                 let phat = hist.tail_abs_ge(t) as f64 / n;
                 let p = th.tail_abs_ge(t);
+
+                // Wald normal approximation is poor for ultra-rare events.
+                // Require a minimally reasonable expected count.
+                if (N_GAUSS as f64) * p < 10.0 {
+                    continue;
+                }
+
                 assert_close_binomial_mean(phat, p, N_GAUSS, "gauss tail");
             }
 


### PR DESCRIPTION
When scale=1/2 and t=8, then prob of landing in tail is 2e-7. We run 120_000 samples, so the expected number of tail draws is np = .0238. We'll almost always get zero draws, and only about 2.3% of the time more. But the wald test is poorly calibrated in this region, with just one draw in the tail being outside of the acceptance region.