### PR TITLE
fix: patch-free publish-able polars build

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -60,8 +60,8 @@ polars-expr = { version = "=0.52.0", features = ["json"], optional = true }
 polars-plan = { version = "=0.52.0", optional = true }
 polars-utils = { version = "=0.52.0", optional = true }
 polars-arrow = { version = "=0.52.0", optional = true }
-pyo3-polars = { version = "*", features = ["derive", "dtype-array", "dtype-categorical", "dtype-struct", "lazy"], optional = true }
-pyo3 = { version = "*", features = ["abi3-py310"], optional = true }
+pyo3-polars = { version = "=0.25.0", features = ["derive", "dtype-array", "dtype-categorical", "dtype-struct", "lazy"], optional = true }
+pyo3 = { version = "=0.26.0", features = ["abi3-py310"], optional = true }
 
 # matches the version specified in Polars: 
 #   https://github.com/pola-rs/polars/blob/main/Cargo.toml
@@ -72,11 +72,12 @@ serde-pickle = { version = "1.1", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 
 [build-dependencies]
+autocfg = "1.4"
 opendp_tooling = { path = "opendp_tooling", optional = true, version = "0.14.2-dev" }
 syn = { workspace = true, optional = true }
 proc-macro2 = { workspace = true, optional = true }
 cbindgen = { version = "0.28.0", optional = true }
-pyo3-build-config = { version = "*", features = ["resolve-config"], optional = true }
+pyo3-build-config = { version = "=0.26.0", features = ["resolve-config"], optional = true }
 
 [patch.crates-io]
 # When building locally, orient the package to python compatibility via patches.

--- a/rust/build/main.rs
+++ b/rust/build/main.rs
@@ -1,10 +1,22 @@
 #[cfg(feature = "derive")]
 mod derive;
 
+use std::process::Command;
+
 fn main() {
+    // causes patch_polars to update if patch is commented out
+    println!("cargo:rerun-if-changed=Cargo.toml");
+    println!("cargo:rerun-if-changed=Cargo.lock");
+
+    autocfg::emit_possibility("patch_polars");
+
     let polars = std::env::var_os("CARGO_FEATURE_POLARS").is_some();
     let ffi = std::env::var_os("CARGO_FEATURE_FFI").is_some();
     let polars_ffi = std::env::var_os("CARGO_FEATURE_POLARS_FFI").is_some();
+
+    if polars && resolved_polars_plan_uses_git_patch() {
+        println!("cargo:rustc-cfg=patch_polars");
+    }
 
     if polars && ffi && !polars_ffi {
         eprintln!(
@@ -24,4 +36,37 @@ fn main() {
 
     #[cfg(feature = "derive")]
     crate::derive::main();
+}
+
+fn resolved_polars_plan_uses_git_patch() -> bool {
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
+    let manifest_path = format!("{manifest_dir}/Cargo.toml");
+
+    let mut command = Command::new(cargo);
+    command.args([
+        "metadata",
+        "--format-version",
+        "1",
+        "--manifest-path",
+        &manifest_path,
+        "--features",
+        "polars",
+    ]);
+
+    let Ok(output) = command.output() else {
+        return false;
+    };
+
+    if !output.status.success() {
+        return false;
+    }
+
+    let Ok(stdout) = String::from_utf8(output.stdout) else {
+        return false;
+    };
+
+    stdout.contains(
+        "\"id\":\"git+https://github.com/pola-rs/polars?tag=py-1.36.1#polars-plan@0.52.0\"",
+    )
 }

--- a/rust/build/main.rs
+++ b/rust/build/main.rs
@@ -8,6 +8,10 @@ fn main() {
     println!("cargo:rerun-if-changed=Cargo.toml");
     println!("cargo:rerun-if-changed=Cargo.lock");
 
+    // We need to be able to build against two different Polars versions:
+    // 1. Polars on Crates.io, tied to a Rust crate release
+    // 2. Polars on PyPI, tied to a specific commit hash via a patch
+    // Local builds are always variant 1, which is convenient because it allows Python interchange.
     autocfg::emit_possibility("patch_polars");
 
     let polars = std::env::var_os("CARGO_FEATURE_POLARS").is_some();

--- a/rust/src/measurements/make_private_lazyframe/group_by/matching.rs
+++ b/rust/src/measurements/make_private_lazyframe/group_by/matching.rs
@@ -101,10 +101,23 @@ pub(crate) fn match_group_by(mut plan: DslPlan) -> Fallible<Option<MatchGroupBy>
         _ => None,
     };
 
+    #[cfg(patch_polars)]
     let DslPlan::GroupBy {
         input,
         keys,
         predicates,
+        aggs,
+        apply,
+        maintain_order,
+        options,
+    } = plan
+    else {
+        return Ok(None);
+    };
+    #[cfg(not(patch_polars))]
+    let DslPlan::GroupBy {
+        input,
+        keys,
         aggs,
         apply,
         maintain_order,
@@ -126,6 +139,7 @@ pub(crate) fn match_group_by(mut plan: DslPlan) -> Fallible<Option<MatchGroupBy>
         return fallible!(MakeMeasurement, "Apply is not supported in logical plan");
     }
 
+    #[cfg(patch_polars)]
     if !predicates.is_empty() {
         // Support could be added by composing over the measurements and then composing with the aggs.
         // Not a priority to add because we'd typically rather keep groups in the DP release,

--- a/rust/src/measurements/make_private_lazyframe/group_by/mod.rs
+++ b/rust/src/measurements/make_private_lazyframe/group_by/mod.rs
@@ -170,10 +170,20 @@ where
     }
 
     let function = Function::new_fallible(move |arg: &DslPlan| {
+        #[cfg(patch_polars)]
         let output = DslPlan::GroupBy {
             input: Arc::new(arg.clone()),
             keys: group_by.clone(),
             predicates: vec![],
+            aggs: f_comp.eval(&arg)?.into_iter().map(|p| p.expr).collect(),
+            apply: None,
+            maintain_order: false,
+            options: Default::default(),
+        };
+        #[cfg(not(patch_polars))]
+        let output = DslPlan::GroupBy {
+            input: Arc::new(arg.clone()),
+            keys: group_by.clone(),
             aggs: f_comp.eval(&arg)?.into_iter().map(|p| p.expr).collect(),
             apply: None,
             maintain_order: false,

--- a/rust/src/transformations/make_stable_lazyframe/group_by/mod.rs
+++ b/rust/src/transformations/make_stable_lazyframe/group_by/mod.rs
@@ -9,6 +9,8 @@ use crate::transformations::StableExpr;
 use crate::transformations::traits::UnboundedMetric;
 use polars::chunked_array::cast::CastOptions;
 use polars::prelude::*;
+#[cfg(not(patch_polars))]
+use polars_plan::dsl::WindowType;
 use polars_plan::prelude::GroupbyOptions;
 
 use super::StableDslPlan;
@@ -27,10 +29,23 @@ pub fn make_stable_group_by<M: UnboundedMetric>(
     input_metric: FrameDistance<M>,
     plan: DslPlan,
 ) -> Fallible<Transformation<DslPlanDomain, FrameDistance<M>, DslPlanDomain, FrameDistance<M>>> {
+    #[cfg(patch_polars)]
     let DslPlan::GroupBy {
         input,
         keys,
         predicates,
+        aggs,
+        apply,
+        maintain_order,
+        options,
+    } = plan
+    else {
+        return fallible!(MakeTransformation, "Expected group-by in logical plan");
+    };
+    #[cfg(not(patch_polars))]
+    let DslPlan::GroupBy {
+        input,
+        keys,
         aggs,
         apply,
         maintain_order,
@@ -47,6 +62,7 @@ pub fn make_stable_group_by<M: UnboundedMetric>(
         );
     }
 
+    #[cfg(patch_polars)]
     if !predicates.is_empty() {
         // This is equivalent to running a filter after, as far as I can tell.
         // Possibly useful to support.
@@ -124,14 +140,27 @@ pub fn make_stable_group_by<M: UnboundedMetric>(
         middle_metric.clone(),
         output_domain,
         middle_metric.clone(),
-        Function::new(move |plan: &DslPlan| DslPlan::GroupBy {
-            input: Arc::new(plan.clone()),
-            keys: keys.clone(),
-            predicates: vec![],
-            aggs: aggs.clone(),
-            apply: None,
-            maintain_order: false,
-            options: options.clone(),
+        Function::new(move |plan: &DslPlan| {
+            #[cfg(patch_polars)]
+            let output = DslPlan::GroupBy {
+                input: Arc::new(plan.clone()),
+                keys: keys.clone(),
+                predicates: vec![],
+                aggs: aggs.clone(),
+                apply: None,
+                maintain_order: false,
+                options: options.clone(),
+            };
+            #[cfg(not(patch_polars))]
+            let output = DslPlan::GroupBy {
+                input: Arc::new(plan.clone()),
+                keys: keys.clone(),
+                aggs: aggs.clone(),
+                apply: None,
+                maintain_order: false,
+                options: options.clone(),
+            };
+            output
         }),
         StabilityMap::new_fallible(move |d_in: &Bounds| {
             let contributed_rows = d_in.get_bound(&HashSet::new()).per_group;
@@ -172,6 +201,7 @@ const INVITE: &'static str = "Please open an issue if this would be useful to yo
 /// because they can be broadcasted.
 pub(crate) fn check_infallible(expr: &Expr, resize: Resize) -> Fallible<()> {
     Ok(match expr {
+        #[cfg(patch_polars)]
         Expr::Rolling {
             function,
             index_column,
@@ -181,6 +211,7 @@ pub(crate) fn check_infallible(expr: &Expr, resize: Resize) -> Fallible<()> {
             check_infallible(&*index_column, resize)?;
         }
         Expr::Element => (),
+        #[cfg(patch_polars)]
         Expr::Over {
             function,
             partition_by,
@@ -191,6 +222,27 @@ pub(crate) fn check_infallible(expr: &Expr, resize: Resize) -> Fallible<()> {
             partition_by
                 .iter()
                 .try_for_each(|by| check_infallible(&*by, Resize::Ban))?;
+            if let Some((order, _)) = order_by {
+                check_infallible(order, Resize::Ban)?;
+            }
+        }
+        #[cfg(not(patch_polars))]
+        Expr::Window {
+            function,
+            partition_by,
+            order_by,
+            options,
+        } => {
+            if *options != WindowType::Over(WindowMapping::GroupsToRows) {
+                return fallible!(
+                    MakeTransformation,
+                    "Only groups-to-rows window expressions are currently supported. {INVITE}"
+                );
+            }
+            check_infallible(&*function, resize)?;
+            partition_by
+                .iter()
+                .try_for_each(|by| check_infallible(by, Resize::Ban))?;
             if let Some((order, _)) = order_by {
                 check_infallible(order, Resize::Ban)?;
             }
@@ -243,6 +295,7 @@ pub(crate) fn check_infallible(expr: &Expr, resize: Resize) -> Fallible<()> {
             AggExpr::Std(e, _) => check_infallible(e, Resize::Allow)?,
             AggExpr::Var(e, _) => check_infallible(e, Resize::Allow)?,
             AggExpr::AggGroups(e) => check_infallible(e, Resize::Allow)?,
+            #[cfg(patch_polars)]
             AggExpr::FirstNonNull(e) | AggExpr::LastNonNull(e) => {
                 check_infallible(e, Resize::Allow)?
             }
@@ -454,7 +507,10 @@ fn check_infallible_function(
             | ArrayFunction::ArgMax => check_inputs!(),
 
             // Still unary, but changes row count (Array width is schema-known, but it is a resize)
+            #[cfg(patch_polars)]
             ArrayFunction::Explode(_) => check_inputs!(resize = "array.explode"),
+            #[cfg(not(patch_polars))]
+            ArrayFunction::Explode { .. } => check_inputs!(resize = "array.explode"),
 
             // Multi-input: allow scalar broadcast, but ban mismatched lengths if Resize::Ban
             ArrayFunction::Get(_)
@@ -480,10 +536,11 @@ fn check_infallible_function(
             | BinaryFunction::EndsWith
             | BinaryFunction::HexEncode
             | BinaryFunction::Size
-            | BinaryFunction::Slice
-            | BinaryFunction::Head
-            | BinaryFunction::Tail
             | BinaryFunction::Reinterpret(_, _) => check_inputs!(aligned_rows),
+            #[cfg(patch_polars)]
+            BinaryFunction::Slice | BinaryFunction::Head | BinaryFunction::Tail => {
+                check_inputs!(aligned_rows)
+            }
 
             // Decode may raise if strict=true (invalid encoding depends on data)
             BinaryFunction::HexDecode(strict) => {

--- a/rust/src/transformations/make_stable_lazyframe/truncate/matching/mod.rs
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/matching/mod.rs
@@ -8,6 +8,8 @@ use crate::{
     transformations::make_stable_lazyframe::group_by::{Resize, check_infallible},
 };
 use opendp_derive::proven;
+#[cfg(not(patch_polars))]
+use polars_plan::dsl::WindowType;
 use polars_plan::prelude::GroupbyOptions;
 
 use polars::prelude::{
@@ -101,6 +103,19 @@ fn match_group_by_truncation(
     plan: &DslPlan,
     identifier: &Expr,
 ) -> Option<(DslPlan, Truncation, Bound)> {
+    #[cfg(patch_polars)]
+    let DslPlan::GroupBy {
+        input,
+        keys,
+        aggs,
+        apply,
+        options,
+        ..
+    } = plan.clone()
+    else {
+        return None;
+    };
+    #[cfg(not(patch_polars))]
     let DslPlan::GroupBy {
         input,
         keys,
@@ -187,10 +202,21 @@ fn match_truncation_predicate(predicate: &Expr, identifier: &Expr) -> Fallible<O
                 // don't throw an error as non-truncation filters may still be valid
                 _ => return Ok(None),
             };
+            #[cfg(patch_polars)]
             let Expr::Over {
                 function,
                 partition_by,
                 mapping: WindowMapping::GroupsToRows,
+                ..
+            } = over.as_ref()
+            else {
+                return Ok(None);
+            };
+            #[cfg(not(patch_polars))]
+            let Expr::Window {
+                function,
+                partition_by,
+                options: WindowType::Over(WindowMapping::GroupsToRows),
                 ..
             } = over.as_ref()
             else {

--- a/rust/src/transformations/make_stable_lazyframe/truncate/mod.rs
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/mod.rs
@@ -84,15 +84,28 @@ pub fn make_stable_truncate(
                     input: Arc::new(plan.clone()),
                     predicate: predicate.clone(),
                 },
-                Truncation::GroupBy { keys, aggs } => DslPlan::GroupBy {
-                    input: Arc::new(plan),
-                    keys: keys.clone(),
-                    aggs: aggs.clone(),
-                    predicates: vec![],
-                    apply: None,
-                    maintain_order: false,
-                    options: Arc::new(GroupbyOptions::default()),
-                },
+                Truncation::GroupBy { keys, aggs } => {
+                    #[cfg(patch_polars)]
+                    let output = DslPlan::GroupBy {
+                        input: Arc::new(plan),
+                        keys: keys.clone(),
+                        aggs: aggs.clone(),
+                        predicates: vec![],
+                        apply: None,
+                        maintain_order: false,
+                        options: Arc::new(GroupbyOptions::default()),
+                    };
+                    #[cfg(not(patch_polars))]
+                    let output = DslPlan::GroupBy {
+                        input: Arc::new(plan),
+                        keys: keys.clone(),
+                        aggs: aggs.clone(),
+                        apply: None,
+                        maintain_order: false,
+                        options: Arc::new(GroupbyOptions::default()),
+                    };
+                    output
+                }
             })
         }),
         StabilityMap::new_fallible(move |id_bounds: &Bounds| {


### PR DESCRIPTION
I found build regressions in the non-patched polars version while testing the crates.io publish pipeline.

Ideally the crate publish path is checked as part of CI, but patches can only be disabled by simulating an entire publish (quite heavy) or doctoring the Cargo.toml. 

To be unmarked from draft once we see a successful release build push to crates.io:
https://github.com/opendp/opendp/actions/workflows/release.yml