### PR TITLE
fix: r-universe build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -290,13 +290,16 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           # overrides packages so that dependencies for package in cwd are not installed
-          packages: RcppTOML,stringr
-      
+          packages: RcppTOML,stringr,roxygen2
+
       - name: Download R bindings
         uses: actions/download-artifact@v4
         with:
           name: r_bindings
           path: R/opendp/
+
+      - name: Generate R documentation
+        run: Rscript -e 'roxygen2::roxygenise("R/opendp", roclets = c("rd", "namespace"), load_code = roxygen2::load_source)'
 
       - name: Source tar
         run: bash tools/r_stage.sh -s

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,6 +94,13 @@ jobs:
 
       - name: Push to R branch
         run: |
+          SOURCE_MESSAGE="$(git log -1 --format=%s HEAD)"
+          if [ -z "$SOURCE_MESSAGE" ]; then
+            SOURCE_MESSAGE="Update R package for ${{ inputs.channel }}"
+          fi
+          TMPDIR="$(mktemp -d)"
+          cp -R R/opendp "$TMPDIR/opendp"
+
           git fetch
           git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git config --global user.name "$GITHUB_ACTOR"
@@ -105,10 +112,12 @@ jobs:
 
           # Keep .git so this orphaned checkout can still be committed and pushed.
           find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+          mkdir -p R
+          cp -R "$TMPDIR/opendp" R/opendp
 
           git add R/opendp/ --force
           echo "Push R package to $BRANCH branch"
-          git commit --allow-empty-message --message "$(git log $(git rev-parse origin/main) --oneline --format=%B -n1 | head -n1)"
+          git commit --message "$SOURCE_MESSAGE"
           git remote set-url origin "https://$GITHUB_ACTOR:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY"
           git push --force origin $BRANCH
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,9 +95,6 @@ jobs:
       - name: Push to R branch
         run: |
           SOURCE_MESSAGE="$(git log -1 --format=%s HEAD)"
-          if [ -z "$SOURCE_MESSAGE" ]; then
-            SOURCE_MESSAGE="Update R package for ${{ inputs.channel }}"
-          fi
           TMPDIR="$(mktemp -d)"
           cp -R R/opendp "$TMPDIR/opendp"
 

--- a/R/opendp/.Rprofile
+++ b/R/opendp/.Rprofile
@@ -1,0 +1,13 @@
+if (!nzchar(Sys.getenv("OPENDP_LIB_DIR"))) {
+  repo_lib_dirs <- c(
+    normalizePath("../../rust/target/debug", mustWork = FALSE),
+    normalizePath("../../rust/target/release", mustWork = FALSE)
+  )
+  existing_lib_dir <- Filter(
+    function(path) file.exists(file.path(path, "libopendp.a")),
+    repo_lib_dirs
+  )
+  if (length(existing_lib_dir) > 0L) {
+    Sys.setenv(OPENDP_LIB_DIR = existing_lib_dir[[1L]])
+  }
+}

--- a/R/opendp/.lintr
+++ b/R/opendp/.lintr
@@ -1,5 +1,5 @@
 linters: all_linters(
-    cyclocomp_linter = if (requireNamespace("cyclocomp", quietly = TRUE)) cyclocomp_linter() else NULL,
+    cyclocomp_linter = NULL,
     # Intentional configurations, and not just to get passing tests:
     return_linter = NULL, # We prefer explicit returns for clarity.
     # If "linters_with_defaults" is used then only these problems are reported:

--- a/R/opendp/.lintr
+++ b/R/opendp/.lintr
@@ -1,4 +1,5 @@
 linters: all_linters(
+    cyclocomp_linter = if (requireNamespace("cyclocomp", quietly = TRUE)) cyclocomp_linter() else NULL,
     # Intentional configurations, and not just to get passing tests:
     return_linter = NULL, # We prefer explicit returns for clarity.
     # If "linters_with_defaults" is used then only these problems are reported:

--- a/R/opendp/.rbuildignore
+++ b/R/opendp/.rbuildignore
@@ -16,6 +16,7 @@
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^\\.Rprofile$
 .*/out/.*$
 .*\.DS_Store$
 

--- a/R/opendp/DESCRIPTION
+++ b/R/opendp/DESCRIPTION
@@ -26,7 +26,7 @@ URL: https://opendp.org/, https://github.com/opendp/opendp, https://docs.opendp.
 BugReports: https://github.com/opendp/opendp/issues
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 SystemRequirements: Cargo (Rust's package manager), rustc
 Config/testthat/edition: 3
 Config/opendp/MSRV: 1.64.0

--- a/R/opendp/cleanup
+++ b/R/opendp/cleanup
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Remove the intermediate static archive after installation/check staging.
+# R CMD check flags symbols in libopendp.a itself, even though the package has
+# already linked against it to produce the final shared library.
+rm -f src/libopendp.a

--- a/R/opendp/cleanup.win
+++ b/R/opendp/cleanup.win
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Remove the intermediate static archive after installation/check staging.
+# R CMD check flags symbols in libopendp.a itself, even though the package has
+# already linked against it to produce the final shared library.
+rm -f src/libopendp.a

--- a/R/opendp/configure.win
+++ b/R/opendp/configure.win
@@ -23,7 +23,7 @@ fi
 
 # To address the change of the toolchain on R 4.2
 BEFORE_CARGO_BUILD="${BEFORE_CARGO_BUILD}"' export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" \&\&'
-BEFORE_CARGO_BUILD="${BEFORE_CARGO_BUILD}"' export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/rust/target/release/libgcc_mock" \&\&'
+BEFORE_CARGO_BUILD="${BEFORE_CARGO_BUILD}"' export LIBRARY_PATH="$${LIBRARY_PATH};/tmp/opendp-target-x86_64-pc-windows-gnu/release/libgcc_mock" \&\&'
 
 
 # If it's on CRAN, a package is not allowed to write in any other place than the

--- a/R/opendp/src/Makevars.in
+++ b/R/opendp/src/Makevars.in
@@ -24,6 +24,7 @@ rust_build:
 		echo "* extract opendp and vendor files"; \
 		$(TAR) --extract --xz -f source.tar.xz -C .; \
 		$(TAR) --extract --xz -f vendor.tar.xz -C rust; \
+		sh ../tools/prepare_rust_manifest.sh rust/Cargo.toml "@RUST_FEATURES@"; \
 		mkdir -p .cargo; \
 		cp cargo_vendor_config.toml .cargo/config.toml; \
 		echo "* build OpenDP Library (libopendp.a)"; \

--- a/R/opendp/src/Makevars.in
+++ b/R/opendp/src/Makevars.in
@@ -24,6 +24,7 @@ rust_build:
 		echo "* extract opendp and vendor files"; \
 		$(TAR) --extract --xz -f source.tar.xz -C .; \
 		$(TAR) --extract --xz -f vendor.tar.xz -C rust; \
+		# @RUST_FEATURES@ is substituted by configure. \
 		sh ../tools/prepare_rust_manifest.sh rust/Cargo.toml "@RUST_FEATURES@"; \
 		mkdir -p .cargo; \
 		cp cargo_vendor_config.toml .cargo/config.toml; \

--- a/R/opendp/src/Makevars.win.in
+++ b/R/opendp/src/Makevars.win.in
@@ -31,6 +31,7 @@ rust_build:
 		echo "* extract opendp and vendor files"; \
 		$(TAR) --extract --xz -f source.tar.xz -C .; \
 		$(TAR) --extract --xz -f vendor.tar.xz -C rust; \
+		# @RUST_FEATURES@ is substituted by configure. \
 		sh ../tools/prepare_rust_manifest.sh rust/Cargo.toml "@RUST_FEATURES@"; \
 		mkdir -p .cargo; \
 		cp cargo_vendor_config.toml .cargo/config.toml; \

--- a/R/opendp/src/Makevars.win.in
+++ b/R/opendp/src/Makevars.win.in
@@ -3,6 +3,9 @@
 # 2. right click on this file and associate the filetype with a Makefile
 
 TARGET = x86_64-pc-windows-gnu
+# Keep Cargo's Windows target output on a short path. Vendored OpenSSL can fail
+# under R's staged-install temp directories when MinGW tries to write depfiles.
+TARGET_DIR = /tmp/opendp-target-$(TARGET)
 
 # Rtools42 doesn't have the linker in the location that cargo expects, so we
 # need to overwrite it via configuration.
@@ -24,16 +27,17 @@ rust_build:
 		cp binary/libopendp.a .; \
 	elif [ -f "source.tar.xz" ]; then \
 		# https://github.com/extendr/rextendr/issues/279 \
-	    mkdir -p rust/target/release/libgcc_mock && touch rust/target/release/libgcc_mock/libgcc_eh.a \
+	    mkdir -p $(TARGET_DIR)/release/libgcc_mock && touch $(TARGET_DIR)/release/libgcc_mock/libgcc_eh.a; \
 		echo "* extract opendp and vendor files"; \
 		$(TAR) --extract --xz -f source.tar.xz -C .; \
 		$(TAR) --extract --xz -f vendor.tar.xz -C rust; \
+		sh ../tools/prepare_rust_manifest.sh rust/Cargo.toml "@RUST_FEATURES@"; \
 		mkdir -p .cargo; \
 		cp cargo_vendor_config.toml .cargo/config.toml; \
 		echo "* building OpenDP Library (libopendp.a)"; \
-		@BEFORE_CARGO_BUILD@ cargo build --manifest-path rust/Cargo.toml --target=$(TARGET) --color always --release --jobs 2 --offline --features @RUST_FEATURES@; \
+		@BEFORE_CARGO_BUILD@ export CARGO_TARGET_DIR="$(TARGET_DIR)" && cargo build --manifest-path rust/Cargo.toml --target=$(TARGET) --color always --release --jobs 2 --offline --features @RUST_FEATURES@; \
 		@AFTER_CARGO_BUILD@ \
-		cp rust/target/$(TARGET)/release/libopendp.a .; \
+		cp $(TARGET_DIR)/$(TARGET)/release/libopendp.a .; \
 	elif [ ! -z "@OPENDP_LIB_DIR@" ]; then \
 		cp @OPENDP_LIB_DIR@/libopendp.a .; \
 	else \

--- a/R/opendp/src/convert.c
+++ b/R/opendp/src/convert.c
@@ -5,7 +5,6 @@
 #include <Rdefines.h>
 #include <Rinternals.h>
 #include <R_ext/Complex.h>
-#include <R_ext/Callbacks.h>
 
 // Import C headers for rust API
 #include "Ropendp.h"

--- a/R/opendp/src/convert_elements.c
+++ b/R/opendp/src/convert_elements.c
@@ -5,7 +5,6 @@
 #include <Rdefines.h>
 #include <Rinternals.h>
 #include <R_ext/Complex.h>
-#include <R_ext/Callbacks.h>
 
 // Import C headers for rust API
 #include "Ropendp.h"

--- a/R/opendp/tools/prepare_rust_manifest.sh
+++ b/R/opendp/tools/prepare_rust_manifest.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+MANIFEST_PATH="${1:?expected manifest path}"
+RUST_FEATURES="${2:-}"
+
+case ",${RUST_FEATURES}," in
+    *,polars,*|*,polars-ffi,*)
+        exit 0
+        ;;
+esac
+
+TMP_PATH="${MANIFEST_PATH}.tmp"
+awk '
+BEGIN { skip = 0 }
+/^\[patch\.crates-io\]$/ { skip = 1; next }
+skip && /^\[/ { skip = 0 }
+!skip { print }
+' "${MANIFEST_PATH}" > "${TMP_PATH}"
+mv "${TMP_PATH}" "${MANIFEST_PATH}"

--- a/docs/source/contributing/development-environment.rst
+++ b/docs/source/contributing/development-environment.rst
@@ -228,12 +228,6 @@ First, build a debug binary that works with R. (Note that the resulting binary w
 
 If you have not already, `install R <https://cran.r-project.org/>`_.
 
-Then, set an environment variable to the absolute path of the OpenDP Library binary directory:
-
-.. code-block:: bash
-
-    export OPENDP_LIB_DIR=$(realpath target/debug)
-
 The default R install for MacOS also includes GUI elements like Tcl/Tk,
 so for the smoothest development experience we suggest these additional installs:
 
@@ -247,11 +241,24 @@ Then, install devtools in R:
 
     install.packages(c("devtools", "RcppTOML", "lintr"))
 
-After each edit to the R or Rust source, run the following command in R to (re)load the R package:
+For day-to-day R development, work from the package directory:
+
+.. code-block:: bash
+
+    cd R/opendp; R
+
+After editing R code, reload the package in your interactive R session with:
 
 .. code-block:: R
 
-    devtools::load_all("R/opendp/", recompile=TRUE)
+    pkgload::load_all()
+
+If you changed Rust or C code, or want to force recompilation of native code as
+part of the reload, use:
+
+.. code-block:: R
+
+    devtools::load_all(recompile = TRUE)
 
 .. This function...
 .. - runs "src/Makevars"
@@ -259,6 +266,9 @@ After each edit to the R or Rust source, run the following command in R to (re)l
 .. - compiles the c files in "src/", which statically links with "libopendp.a"
 .. - outputs "src/opendp.so", which is used by all R functions
 .. - reloads all R functions
+
+In a normal local checkout, both commands pick up the Rust library path
+automatically via ``R/opendp/.Rprofile``.
 
 To do a full package installation from local sources:
 
@@ -341,8 +351,7 @@ Environment Variables
    * - Name
      - Description
    * - ``OPENDP_LIB_DIR``
-     - Overrides the directory in which the OpenDP language binding looks for the OpenDP Library binary.  
-       See example in :ref:`r-setup`. 
+     - Overrides the directory in which the OpenDP language binding looks for the OpenDP Library binary.
    * - ``OPENDP_POLARS_LIB_PATH``
      - Each OpenDP Polars plugin contains a path to the OpenDP Library binary.
        When OpenDP is used as a query server, library paths in queries submitted by clients are stale (local to the client).

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -78,6 +78,9 @@ syn = { workspace = true, optional = true }
 proc-macro2 = { workspace = true, optional = true }
 cbindgen = { version = "0.28.0", optional = true }
 pyo3-build-config = { version = "=0.26.0", features = ["resolve-config"], optional = true }
+# Keep vendored OpenSSL on a pre-3.5 line for Windows Rtools/MinGW builds.
+# Newer vendored releases pull in QUIC code that fails to compile there.
+openssl-src = { version = "=300.3.1", optional = true }
 
 [patch.crates-io]
 # When building locally, orient the package to python compatibility via patches.
@@ -121,7 +124,7 @@ polars-ffi = [
     "polars-plan/ffi_plugin", 
     "polars-plan/python"
 ]
-use-openssl = ["openssl"]
+use-openssl = ["openssl", "dep:openssl-src"]
 
 # include extern "C" functions in cdylib
 ffi = ["lazy_static", "cbindgen"]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -79,6 +79,7 @@ proc-macro2 = { workspace = true, optional = true }
 cbindgen = { version = "0.28.0", optional = true }
 pyo3-build-config = { version = "=0.26.0", features = ["resolve-config"], optional = true }
 # Keep vendored OpenSSL on a pre-3.5 line for Windows Rtools/MinGW builds.
+# `openssl-src` versions `300.Y.Z` package upstream OpenSSL `3.Y.Z`.
 # Newer vendored releases pull in QUIC code that fails to compile there.
 openssl-src = { version = "=300.3.1", optional = true }
 


### PR DESCRIPTION
Fixes the apparent opendp compilation issues on both:
* https://github.com/r-universe/opendp/
* https://github.com/r-universe/opendp-dev/

The opendp package started failing due to:
* removal of Callbacks.h in R. We don't actually use it.
* openssl 3.5+ uses QUIC, which tanks the windows build until r-tools (I think?) updates. Pin to pre-3.5 via pinning openssl-src
* openssl paths are now long enough to exceed 256 characters, which tanks Windows
* r-universe is pickier about presence of docs, which weren't being generated

The opendp-dev package started failing due to:
* the new Polars patch reintroduces those crates into resolution, even though they are feature-flagged out.
* the new release CI deletes the R package before putting it on the r-universe branches

Also improves dev ergonomics by setting OPENDP_LIB_DIR automatically if not set.

Release builds:
https://github.com/opendp/opendp/actions/workflows/release.yml

R-universe opendp-dev builds:
https://github.com/r-universe/opendp-dev/actions