### PR TITLE
fix: keep repo size small

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -77,7 +77,8 @@ jobs:
 
           echo "Create docs."
           make versions
-          find build/html/en -type d -name .doctrees -prune -exec rm -rf {} +
+          # Sphinx caches parsed sources in .doctrees, but the published site does not need them.
+          rm -rf build/html/en/*/.doctrees
           cp -r build /tmp
           cd ..
           git fetch
@@ -87,7 +88,8 @@ jobs:
           # create brand new history each time
           git checkout --orphan gh-pages
           git rm -rf --cached . || true
-          
+
+          # Keep .git so this orphaned checkout can still be committed and pushed.
           # sudo to have sufficient permission to delete files created by the docker user while compiling .tex
           find . -mindepth 1 -maxdepth 1 ! -name .git -exec sudo rm -rf {} +
           echo docs.opendp.org > CNAME

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -77,6 +77,7 @@ jobs:
 
           echo "Create docs."
           make versions
+          find build/html/en -type d -name .doctrees -prune -exec rm -rf {} +
           cp -r build /tmp
           cd ..
           git fetch
@@ -85,9 +86,10 @@ jobs:
 
           # create brand new history each time
           git checkout --orphan gh-pages
+          git rm -rf --cached . || true
           
           # sudo to have sufficient permission to delete files created by the docker user while compiling .tex
-          sudo rm -rf *
+          find . -mindepth 1 -maxdepth 1 ! -name .git -exec sudo rm -rf {} +
           echo docs.opendp.org > CNAME
           echo "for underscore directories" > .nojekyll
           cp -r /tmp/build/html/* .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,6 +101,8 @@ jobs:
           # create brand new history each time
           BRANCH=r-universe${{ (inputs.dry_run || inputs.channel != 'stable') && '-dev' || '' }}
           git checkout --orphan $BRANCH
+          git rm -rf --cached . || true
+          find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
 
           git add R/opendp/ --force
           echo "Push R package to $BRANCH branch"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,6 +102,8 @@ jobs:
           BRANCH=r-universe${{ (inputs.dry_run || inputs.channel != 'stable') && '-dev' || '' }}
           git checkout --orphan $BRANCH
           git rm -rf --cached . || true
+
+          # Keep .git so this orphaned checkout can still be committed and pushed.
           find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
 
           git add R/opendp/ --force

--- a/.github/workflows/update-bindings.yml
+++ b/.github/workflows/update-bindings.yml
@@ -46,7 +46,7 @@ jobs:
           path: R/opendp/
 
       - name: Drop R release tarballs from tracked history
-        run: rm -f R/opendp/src/vendor.tar.xz R/opendp/src/source.tar.xz R/opendp/src/binary.tar.xz
+        run: rm -f R/opendp/src/*.tar.xz
       
       - name: Push changes
         run: |

--- a/.github/workflows/update-bindings.yml
+++ b/.github/workflows/update-bindings.yml
@@ -44,9 +44,13 @@ jobs:
         with:
           name: r_bindings
           path: R/opendp/
+
+      - name: Drop R release tarballs from tracked history
+        run: rm -f R/opendp/src/vendor.tar.xz R/opendp/src/source.tar.xz R/opendp/src/binary.tar.xz
       
       - name: Push changes
         run: |
-          git add --force . # Generated files are git-ignored, so we need --force.
+          # Generated files are git-ignored, so we need --force.
+          git add --force python/src/opendp/ R/opendp/
           git commit -m "Update bindings"
           git push origin ${{ inputs.channel }}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -190,27 +190,45 @@ html_context = {
 }
 
 # SPHINX-MULTIVERSION STUFF
-def _select_recent_release_tags(lines=4):
-    tags = subprocess.check_output(["git", "tag", "--list", "v*"], text=True).splitlines()
-    latest_by_line = {}
+def _list_release_tags():
+    return subprocess.check_output(["git", "tag", "--list", "v*"], text=True).splitlines()
+
+
+# With a quarterly release cadence (not counting patches),
+# this will generate API docs just for the past year.
+def _select_recent_release_tags(tags):
+    """
+    Return a regex matching the latest patch release from the most recent release lines.
+
+    >>> _select_recent_release_tags(
+    ...     ["v0.11.0", "v0.11.1", "v0.12.0", "v0.12.0-rc.1", "not-a-tag"],
+    ...     number_to_keep=2,
+    ... )
+    '^(v0\\\\.11\\\\.1|v0\\\\.12\\\\.0)$'
+    """
+    # assuming quarterly release cadence
+    number_to_keep = 8
+    
+    latest_patch_for_major_minor = {}
     for tag in tags:
         match = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)", tag)
         if match is None:
             continue
         major, minor, patch = map(int, match.groups())
-        line_key = (major, minor)
-        current = latest_by_line.get(line_key)
+        major_minor = (major, minor)
+        current = latest_patch_for_major_minor.get(major_minor)
         if current is None or patch > current[0]:
-            latest_by_line[line_key] = (patch, tag)
-    selected_lines = sorted(latest_by_line, reverse=True)[:lines]
-    selected_tags = sorted(latest_by_line[line_key][1] for line_key in selected_lines)
-    if not selected_tags:
-        return r"^$"
+            latest_patch_for_major_minor[major_minor] = (patch, tag)
+
+    selected_major_minors = sorted(latest_patch_for_major_minor, reverse=True)[:number_to_keep]
+    selected_tags = sorted(
+        latest_patch_for_major_minor[major_minor][1] for major_minor in selected_major_minors
+    )
     return r"^(%s)$" % "|".join(re.escape(tag) for tag in selected_tags)
 
 
 # Whitelist pattern for tags (set to None to ignore all tags)
-smv_tag_whitelist = _select_recent_release_tags()
+smv_tag_whitelist = _select_recent_release_tags(_list_release_tags())
 # # keep all released versions, as well as prereleases for the stable version. Doesn't work, because version != stable
 # import re
 # smv_tag_whitelist = rf'(^v\d+\.\d+\.\d+$)|(^v{re.escape(version.split("-")[0])}.+$)'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,6 +5,8 @@ import os
 from datetime import datetime
 import semver
 import pypandoc
+import re
+import subprocess
 from sphinx.ext import autodoc
 
 # docs should be built without needing import the library binary for the specified version
@@ -188,8 +190,27 @@ html_context = {
 }
 
 # SPHINX-MULTIVERSION STUFF
+def _select_recent_release_tags(lines=4):
+    tags = subprocess.check_output(["git", "tag", "--list", "v*"], text=True).splitlines()
+    latest_by_line = {}
+    for tag in tags:
+        match = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)", tag)
+        if match is None:
+            continue
+        major, minor, patch = map(int, match.groups())
+        line_key = (major, minor)
+        current = latest_by_line.get(line_key)
+        if current is None or patch > current[0]:
+            latest_by_line[line_key] = (patch, tag)
+    selected_lines = sorted(latest_by_line, reverse=True)[:lines]
+    selected_tags = sorted(latest_by_line[line_key][1] for line_key in selected_lines)
+    if not selected_tags:
+        return r"^$"
+    return r"^(%s)$" % "|".join(re.escape(tag) for tag in selected_tags)
+
+
 # Whitelist pattern for tags (set to None to ignore all tags)
-smv_tag_whitelist = r'^v.*$'
+smv_tag_whitelist = _select_recent_release_tags()
 # # keep all released versions, as well as prereleases for the stable version. Doesn't work, because version != stable
 # import re
 # smv_tag_whitelist = rf'(^v\d+\.\d+\.\d+$)|(^v{re.escape(version.split("-")[0])}.+$)'


### PR DESCRIPTION
In addition to the CI changes discussed in #2679, we also need to rewrite the version tags to remove the infringing files.

Tag rewrite script:

<details>

```python
#!/usr/bin/env python3

from __future__ import annotations

import argparse
import os
import subprocess
import tempfile


TAR_PATHS = (
    "R/opendp/src/vendor.tar.xz",
    "R/opendp/src/source.tar.xz",
    "R/opendp/src/binary.tar.xz",
)
BACKUP_PREFIX = "refs/rewrites/no-r-tars/"


def git(*args: str, input_text: str | None = None, env: dict[str, str] | None = None) -> str:
    result = subprocess.run(
        ["git", *args],
        check=True,
        text=True,
        input=input_text,
        capture_output=True,
        env=env,
    )
    return result.stdout.strip()


def commit_metadata(commit: str) -> dict[str, object]:
    fmt = "%T%x00%P%x00%an%x00%ae%x00%aI%x00%cn%x00%ce%x00%cI%x00%B"
    out = git("show", "-s", f"--format={fmt}", commit)
    tree, parents, author_name, author_email, author_date, committer_name, committer_email, committer_date, message = (
        out.split("\x00", 8)
    )
    return {
        "tree": tree,
        "parents": parents.split() if parents else [],
        "author_name": author_name,
        "author_email": author_email,
        "author_date": author_date,
        "committer_name": committer_name,
        "committer_email": committer_email,
        "committer_date": committer_date,
        "message": message,
    }


def tree_has_tar_payload(commit: str) -> bool:
    return bool(git("ls-tree", "-r", "--name-only", commit, "--", *TAR_PATHS))


def rewrite_tree_without_tars(commit: str) -> str:
    with tempfile.NamedTemporaryFile(prefix="git-index-", delete=True) as index_file:
        env = os.environ.copy()
        env["GIT_INDEX_FILE"] = index_file.name
        git("read-tree", commit, env=env)
        subprocess.run(
            ["git", "rm", "--cached", "--ignore-unmatch", "--quiet", "--", *TAR_PATHS],
            check=True,
            text=True,
            env=env,
            capture_output=True,
        )
        return git("write-tree", env=env)


def commit_tree(tree: str, parents: list[str], metadata: dict[str, object]) -> str:
    env = os.environ.copy()
    env.update(
        {
            "GIT_AUTHOR_NAME": str(metadata["author_name"]),
            "GIT_AUTHOR_EMAIL": str(metadata["author_email"]),
            "GIT_AUTHOR_DATE": str(metadata["author_date"]),
            "GIT_COMMITTER_NAME": str(metadata["committer_name"]),
            "GIT_COMMITTER_EMAIL": str(metadata["committer_email"]),
            "GIT_COMMITTER_DATE": str(metadata["committer_date"]),
        }
    )
    args = ["commit-tree", tree]
    for parent in parents:
        args.extend(["-p", parent])
    return git(*args, input_text=str(metadata["message"]), env=env)


def ancestry_in_topological_order(commit: str) -> list[str]:
    out = git("rev-list", "--topo-order", "--reverse", commit)
    return out.splitlines() if out else []


def rewrite_root(commit: str, memo: dict[str, str], apply: bool) -> str:
    for current in ancestry_in_topological_order(commit):
        if current in memo:
            continue

        metadata = commit_metadata(current)
        old_parents = list(metadata["parents"])
        new_parents = [memo.get(parent, parent) for parent in old_parents]
        old_tree = str(metadata["tree"])
        has_tar_payload = tree_has_tar_payload(current)

        if not has_tar_payload and new_parents == old_parents:
            memo[current] = current
            continue

        if not apply:
            memo[current] = f"REWRITTEN:{current}"
            continue

        new_tree = rewrite_tree_without_tars(current) if has_tar_payload else old_tree
        memo[current] = commit_tree(new_tree, new_parents, metadata)

    return memo[commit]


def main() -> None:
    parser = argparse.ArgumentParser(description="Rewrite selected release tags so their reachable history no longer contains R tar payloads.")
    parser.add_argument("--pattern", default="v*", help="Tag glob to rewrite")
    parser.add_argument("--apply", action="store_true", help="Update tag refs in-place")
    parser.add_argument(
        "--backup-prefix",
        default=BACKUP_PREFIX,
        help="Namespace for backup refs that preserve the original tag targets",
    )
    args = parser.parse_args()

    tags = git("tag", "--list", args.pattern).splitlines()
    memo: dict[str, str] = {}

    for tag in tags:
        commit = git("rev-parse", f"{tag}^{{commit}}")
        rewritten = rewrite_root(commit, memo, apply=args.apply)
        if rewritten == commit:
            print(f"skip {tag} {commit} (no rewrite needed)")
            continue
        if not args.apply:
            print(f"would rewrite {tag} {commit}")
            continue
        backup_ref = f"{args.backup_prefix}{tag}"
        git("update-ref", backup_ref, commit)
        git("update-ref", f"refs/tags/{tag}", rewritten)
        print(f"rewrite {tag} {commit} -> {rewritten}")


if __name__ == "__main__":
    main()
```

</details>

Outcome:

<details>

```shell
> python tools/rewrite_release_tags_without_r_tars.py --apply
skip v0.0.1 fa7866edea718625d29f338335aef11c27973738 (no rewrite needed)
skip v0.1.0 ff022218722e2947dcdd7ec847ec93171a43a8e1 (no rewrite needed)
skip v0.10.0 ab34e697fb29807b3da4530f9e8d5d775ac29e0c (no rewrite needed)
rewrite v0.11.0 61590777f57facbebe27c77f5f320b263f34f2da -> 6b6f99b8752471352e7d669b10fa892c6c184fbb
rewrite v0.11.1 5ad8af8a1830fff926802e3613c47b7ba7b04310 -> a1ccd5684711c8c5ff635748de745e6207be5dea
rewrite v0.12.0 91a0d98ba3a5e97c4125da47c362537ecf73639b -> 21e537b840cac8f9cb9d5e349534471044f4d39f
rewrite v0.12.1 3f5ea00bc0d8a3efd84c9b9543b9e7f76ee3e2cc -> 2313473aa0141e2503280536d6ed5e86667b661a
rewrite v0.13.0 1b882feb9337768ee97b7a2e2a32cfd008e157c3 -> d03a852ed4d7faa0d1afe78167df7b73e141bb1c
rewrite v0.14.0 e480663a08252e5550743be9201f0bea47522775 -> 3ed88bb1f4b3c637769f2ecba725ea7b41ebaef7
rewrite v0.14.1 5286abc0e45c8f94e85aa545c86f9d2f83f737ec -> af19b8cc7e430c387b95674906613ca56640cb34
rewrite v0.14.2 7c31b4eec514f11acff3eeb20be9c612d6829c27 -> aef7e1af2d6bc5108f7116db4da9fc7d4732944a
skip v0.2.0 c4f67d8be6eb41a4d7c584b30224bba4e455b1dc (no rewrite needed)
skip v0.2.1 ad01f0d749e1deb795dd6f65230e799ab64bacb8 (no rewrite needed)
skip v0.2.2 7f5e14f28360db05d7d332501eaf6899dfcf017b (no rewrite needed)
skip v0.2.3 7f5e14f28360db05d7d332501eaf6899dfcf017b (no rewrite needed)
skip v0.2.4 71180d0398f47cd08f69f1d542bc136539f7dd96 (no rewrite needed)
skip v0.3.0 0707f6e7af351b24d634b0081ac7613e0ad7b092 (no rewrite needed)
skip v0.4.0 c7890d662cbf550116c16346f97cfdb707bb2b08 (no rewrite needed)
skip v0.5.0 ad80114078a9a5055e0b66628e0a812791ef43ee (no rewrite needed)
skip v0.6.0 c98ce150aeb2f049b51d9973236b9be3da53aa75 (no rewrite needed)
skip v0.6.1 6321c15a0e5604fb8d2a59f0faaeaee8bce16b19 (no rewrite needed)
skip v0.6.2 38a64dff6fd8945cbbab39c4d3fe77a00fae08e5 (no rewrite needed)
skip v0.7.0 111510a71ca9d11d4d6e5c8d7043b28fd020e25a (no rewrite needed)
skip v0.8.0 13cf95652a95545f5250324e6bee91a57df4a5cd (no rewrite needed)
skip v0.9.0 67fdae0a14ce7ff27afd7b5382f9b9a1f4c79fc9 (no rewrite needed)
skip v0.9.1 4ef6c7f108bcea9ba436948823c5c773aa95c6bf (no rewrite needed)
skip v0.9.2 14f1c07e7728f69cd630abc2b9ff728b3aa40eaa (no rewrite needed)
```

</details>

After deleting the backup ref, no remaining blobs reference the tars:
```shell
git for-each-ref --format='delete %(refname)' refs/rewrites/no-r-tars | git update-ref --stdin
git rev-list --all -- R/opendp/src/vendor.tar.xz 
```

I pushed to a new repo for inspection:
https://github.com/shoeboxam/opendp_tags

The tags look the same, but don't carry the dead weight.
Example here: https://github.com/Shoeboxam/opendp_tags/commit/aef7e1af2d6bc5108f7116db4da9fc7d4732944a

You'll notice the git clone is quite fast now, even with the tag references. The clone won't become this fast, though, because we have quite a few other branches hanging around that will need to be cleaned up.

Once I push these updated tags to github, the tar blobs will become dangling, will not be part of the clone, and will eventually be cleaned up by GitHub. This will give a 50% size reduction.

The next nightly CI will replace the gh-pages branch with the much smaller payload, resulting in another 20% size reduction.