### PR TITLE
feat: optimize numpy vector FFI

### DIFF
--- a/docs/source/api/user-guide/measurements/additive-noise-mechanisms.ipynb
+++ b/docs/source/api/user-guide/measurements/additive-noise-mechanisms.ipynb
@@ -349,7 +349,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The resulting measurement expects sensitivity in terms of the appropriate Lp-distance: the vector Laplace measurement expects sensitivity in terms of an `\"l1_distance(T=f64)\"`, while the vector Gaussian measurement expects a sensitivity in terms of an `\"l2_distance(T=f64)\"`. "
+    "The resulting measurement expects sensitivity in terms of the appropriate Lp-distance: the vector Laplace measurement expects sensitivity in terms of an `\"l1_distance(T=f64)\"`, while the vector Gaussian measurement expects a sensitivity in terms of an `\"l2_distance(T=f64)\"`.\n",
+    "\n",
+    "If you want a vector-valued additive noise release to come back directly as a numpy array, chain the measurement with `dp.as_array()`. For example, `(base_lap_vec >> dp.as_array())(aggregated)` returns a one-dimensional numpy array by decoding the Rust vector release directly to numpy instead of going through a Python list first."
    ]
   },
   {
@@ -648,7 +650,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -662,7 +664,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.1"
+   "version": "3.14.0"
   }
  },
  "nbformat": 4,

--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -48,7 +48,7 @@ _NUMPY_COMPATIBLE_ATOM_TYPES = frozenset(ATOM_MAP) - {'AnyMeasurementPtr', 'AnyT
 def _numpy_dtype_for_rust_type(type_name: str) -> Any:
     np = import_optional_dependency('numpy')
     if type_name not in _NUMPY_COMPATIBLE_ATOM_TYPES:
-        raise ValueError("unrecognized numpy dtype")
+        raise ValueError(f"unrecognized numpy dtype: {type_name}")
     return np.dtype(ATOM_MAP[type_name])
 
 
@@ -183,7 +183,6 @@ def c_to_py(value: Any) -> Any:
         from opendp._data import object_type, object_as_slice, slice_free
 
         obj_type = object_type(value)
-        obj_rt_type = RuntimeType.parse(obj_type)
 
         if obj_type == PrivacyProfile.__name__:
             return PrivacyProfile(value)
@@ -205,7 +204,7 @@ def c_to_py(value: Any) -> Any:
 
         ffi_slice = object_as_slice(value)
         try:
-            return _slice_to_py(ffi_slice, obj_rt_type)
+            return _slice_to_py(ffi_slice, RuntimeType.parse(obj_type))
         finally:
             slice_free(ffi_slice)
 
@@ -560,7 +559,7 @@ def _slice_to_vector(raw: FfiSlicePtr, type_name: RuntimeType) -> Sequence[Any]:
 def _numpy_to_slice(val, type_name: RuntimeType) -> FfiSlicePtr:
     np = import_optional_dependency("numpy")
     if type_name.origin != 'NDArray' or len(type_name.args) != 1:
-        raise ValueError("type_name must be NDArray<_>")  # pragma: no cover
+        raise ValueError(f"type_name must be NDArray<T> with one type argument, found {type_name}")  # pragma: no cover
 
     inner_type_name = type_name.args[0]
     if not isinstance(inner_type_name, str):
@@ -570,8 +569,10 @@ def _numpy_to_slice(val, type_name: RuntimeType) -> FfiSlicePtr:
     if not isinstance(val, np.ndarray):
         raise TypeError(f"Expected type is {type_name}.")
 
-    if val.ndim != 1 or val.dtype != np.dtype(np_dtype):
+    if val.ndim != 1:
         raise TypeError("Only 1d arrays are currently supported. Flatten first.")
+    if val.dtype != np.dtype(np_dtype):
+        raise TypeError(f"Expected dtype {np.dtype(np_dtype)}, got {val.dtype}.")
 
     contiguous = np.ascontiguousarray(val)
     array = np.ctypeslib.as_ctypes(contiguous)
@@ -583,13 +584,13 @@ def _numpy_to_slice(val, type_name: RuntimeType) -> FfiSlicePtr:
 def _slice_to_numpy(raw: FfiSlicePtr, type_name: RuntimeType):
     np = import_optional_dependency("numpy")
     if type_name.origin != 'NDArray' or len(type_name.args) != 1:
-        raise ValueError("type_name must be NDArray<_>")  # pragma: no cover
+        raise ValueError(f"type_name must be NDArray<T> with one type argument, found {type_name}")  # pragma: no cover
 
     inner_type_name = type_name.args[0]
     if not isinstance(inner_type_name, str):
         raise ValueError(f"inner type must be atomic, found {inner_type_name}")  # pragma: no cover
     
-    _numpy_dtype_for_rust_type(inner_type_name)
+    _numpy_dtype_for_rust_type(inner_type_name)  # validate numpy compatibility before casting
 
     array_ptr: Any = ctypes.cast(raw.contents.ptr, ctypes.POINTER(ATOM_MAP[inner_type_name]))
     return np.ctypeslib.as_array(array_ptr, shape=(raw.contents.len,)).copy()

--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Union, cast, MutableMapping
+from typing import Any, Sequence, Union, cast, MutableMapping
 from inspect import signature
 
 from opendp._lib import *
@@ -43,6 +43,14 @@ ATOM_MAP = {
     'AnyMeasurementPtr': Measurement,
     'AnyTransformationPtr': Transformation,
 }
+
+_NUMPY_COMPATIBLE_ATOM_TYPES = frozenset(ATOM_MAP) - {'AnyMeasurementPtr', 'AnyTransformationPtr'}
+def _numpy_dtype_for_rust_type(type_name: str) -> Any:
+    np = import_optional_dependency('numpy')
+    if type_name not in _NUMPY_COMPATIBLE_ATOM_TYPES:
+        raise ValueError("unrecognized numpy dtype")
+    return np.dtype(ATOM_MAP[type_name])
+
 
 def c_int_limits(type_name):
     c_int_type = ATOM_MAP[type_name]
@@ -175,6 +183,7 @@ def c_to_py(value: Any) -> Any:
         from opendp._data import object_type, object_as_slice, slice_free
 
         obj_type = object_type(value)
+        obj_rt_type = RuntimeType.parse(obj_type)
 
         if obj_type == PrivacyProfile.__name__:
             return PrivacyProfile(value)
@@ -196,7 +205,7 @@ def c_to_py(value: Any) -> Any:
 
         ffi_slice = object_as_slice(value)
         try:
-            return _slice_to_py(ffi_slice, RuntimeType.parse(obj_type))
+            return _slice_to_py(ffi_slice, obj_rt_type)
         finally:
             slice_free(ffi_slice)
 
@@ -323,6 +332,9 @@ def _slice_to_py(raw: FfiSlicePtr, type_name: Union[RuntimeType, str]) -> Any:
     if isinstance(type_name, RuntimeType):
         if type_name.origin == "Vec":
             return _slice_to_vector(raw, type_name)
+        
+        if type_name.origin == "NDArray":
+            return _slice_to_numpy(raw, type_name)
 
         if type_name.origin == "Function":
             return _slice_to_function(raw)
@@ -388,6 +400,9 @@ def _py_to_slice(value: Any, type_name: Union[RuntimeType, str]) -> FfiSlicePtr:
     if isinstance(type_name, RuntimeType):
         if type_name.origin == "Vec":
             return _vector_to_slice(value, type_name)
+        
+        if type_name.origin == "NDArray":
+            return _numpy_to_slice(value, type_name)
 
         if type_name.origin == "HashMap":
             return _hashmap_to_slice(value, type_name)
@@ -454,17 +469,25 @@ def _slice_to_bitvector(raw: FfiSlicePtr) -> bytes:
 
 def _vector_to_slice(val: Sequence[Any], type_name: RuntimeType) -> FfiSlicePtr:
     if type_name.origin != 'Vec' or len(type_name.args) != 1:
-        raise ValueError("type_name must be a Vec<_>")  # pragma: no cover
+        raise ValueError("type_name must be Vec<_>")  # pragma: no cover
 
     inner_type_name = type_name.args[0]
-    # TODO: can we use underlying numpy buffers directly?
+
+    np = import_optional_dependency("numpy", raise_error=False)
+    if (
+        np is not None
+        and isinstance(val, np.ndarray)
+        and isinstance(inner_type_name, str)
+        and inner_type_name in _NUMPY_COMPATIBLE_ATOM_TYPES
+    ):
+        type_name = RuntimeType("NDArray", [inner_type_name])
+        return _numpy_to_slice(val, type_name)
+
     if not isinstance(val, list):
         try:
             val = list(val)
         except TypeError:
             raise TypeError(f"Expected type is {type_name} but input data is not a list.")
-
-    inner_type_name = type_name.args[0]
 
     if isinstance(inner_type_name, RuntimeType) or inner_type_name in {"Expr", "Bound", "BitVector"}:
         c_repr = [py_to_c(v, c_type=AnyObjectPtr, type_name=inner_type_name) for v in val]
@@ -505,7 +528,7 @@ def _vector_to_slice(val: Sequence[Any], type_name: RuntimeType) -> FfiSlicePtr:
 
 def _slice_to_vector(raw: FfiSlicePtr, type_name: RuntimeType) -> Sequence[Any]:
     if type_name.origin != 'Vec' or len(type_name.args) != 1:
-        raise ValueError("type_name must be a Vec<_>")  # pragma: no cover
+        raise ValueError("type_name must be Vec<_>")  # pragma: no cover
 
     inner_type_name = type_name.args[0]
 
@@ -528,8 +551,48 @@ def _slice_to_vector(raw: FfiSlicePtr, type_name: RuntimeType) -> Sequence[Any]:
         array = ctypes.cast(raw.contents.ptr, ctypes.POINTER(ctypes.c_char_p))[0:raw.contents.len]
         return list(map(lambda v: v.decode(), array))
 
-    assert isinstance(inner_type_name, str), f"inner type must be string, found {inner_type_name} of type {type(inner_type_name)}"
+    if not isinstance(inner_type_name, str):
+        raise ValueError(f"inner type must be atomic, found {inner_type_name}")  # pragma: no cover
+    
     return ctypes.cast(raw.contents.ptr, ctypes.POINTER(ATOM_MAP[inner_type_name]))[0:raw.contents.len]
+
+
+def _numpy_to_slice(val, type_name: RuntimeType) -> FfiSlicePtr:
+    np = import_optional_dependency("numpy")
+    if type_name.origin != 'NDArray' or len(type_name.args) != 1:
+        raise ValueError("type_name must be NDArray<_>")  # pragma: no cover
+
+    inner_type_name = type_name.args[0]
+    if not isinstance(inner_type_name, str):
+        raise ValueError(f"inner type must be atomic, found {inner_type_name}")  # pragma: no cover
+
+    np_dtype = _numpy_dtype_for_rust_type(inner_type_name)
+    if not isinstance(val, np.ndarray):
+        raise TypeError(f"Expected type is {type_name}.")
+
+    if val.ndim != 1 or val.dtype != np.dtype(np_dtype):
+        raise TypeError("Only 1d arrays are currently supported. Flatten first.")
+
+    contiguous = np.ascontiguousarray(val)
+    array = np.ctypeslib.as_ctypes(contiguous)
+    ffi_slice = _wrap_in_slice(array, len(contiguous))
+    ffi_slice.depends_on(contiguous, array)
+    return ffi_slice
+
+
+def _slice_to_numpy(raw: FfiSlicePtr, type_name: RuntimeType):
+    np = import_optional_dependency("numpy")
+    if type_name.origin != 'NDArray' or len(type_name.args) != 1:
+        raise ValueError("type_name must be NDArray<_>")  # pragma: no cover
+
+    inner_type_name = type_name.args[0]
+    if not isinstance(inner_type_name, str):
+        raise ValueError(f"inner type must be atomic, found {inner_type_name}")  # pragma: no cover
+    
+    _numpy_dtype_for_rust_type(inner_type_name)
+
+    array_ptr: Any = ctypes.cast(raw.contents.ptr, ctypes.POINTER(ATOM_MAP[inner_type_name]))
+    return np.ctypeslib.as_array(array_ptr, shape=(raw.contents.len,)).copy()
 
 
 def _tuple_to_slice(val: tuple[Any, ...], type_name: Union[RuntimeType, str]) -> FfiSlicePtr:

--- a/python/src/opendp/extras/mbi/_utilities/__init__.py
+++ b/python/src/opendp/extras/mbi/_utilities/__init__.py
@@ -21,6 +21,7 @@ from opendp.metrics import (
     l2_distance,
     symmetric_distance,
 )
+from opendp.core import as_array
 from opendp.mod import (
     ApproximateDivergence,
     AtomDomain,
@@ -34,7 +35,6 @@ from opendp.mod import (
     Metric,
     Transformation,
 )
-
 if TYPE_CHECKING:  # pragma: no cover
     from opendp.extras.polars import Bound
 
@@ -297,10 +297,10 @@ def make_noise_marginal(
     scale: float,
 ) -> Measurement:
     """Make a measurement that releases a DP marginal"""
-    from opendp.extras.numpy import NPArrayDDomain
     # use jax arrays because lms will be used in optimization
     import jax.numpy as np  # type: ignore[import-not-found]
     from mbi import LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+    from opendp.extras.numpy import NPArrayDDomain
 
     clique_domain = input_domain.cast(TypedDictDomain)[clique]
     inner_metric = input_metric.cast(TypedDictDistance).inner_metric
@@ -323,10 +323,13 @@ def make_noise_marginal(
     )
 
     def function(x):
-        return LinearMeasurement(np.array(x), clique, stddev=get_std(output_measure, scale))
+        return LinearMeasurement(x, clique, stddev=get_std(output_measure, scale))
 
     return (
-        t_marginal >> then_noise(output_measure, scale) >> _new_pure_function(function)
+        t_marginal
+        >> then_noise(output_measure, scale)
+        >> as_array(T="i32")
+        >> _new_pure_function(function)
     )
 
 

--- a/python/src/opendp/extras/mbi/_utilities/__init__.py
+++ b/python/src/opendp/extras/mbi/_utilities/__init__.py
@@ -328,7 +328,7 @@ def make_noise_marginal(
     return (
         t_marginal
         >> then_noise(output_measure, scale)
-        >> as_array(T="i32")
+        >> as_array()
         >> _new_pure_function(function)
     )
 

--- a/python/src/opendp/extras/numpy/_make_np_mean/__init__.py
+++ b/python/src/opendp/extras/numpy/_make_np_mean/__init__.py
@@ -4,6 +4,7 @@ from opendp.extras._utilities import to_then
 from opendp.extras.numpy._make_np_sum import make_private_np_sum
 from opendp.mod import Domain, Metric, Measurement
 from opendp._lib import import_optional_dependency
+from opendp._internal import _new_pure_function
 
 # planning to make this public, but may make more API changes
 
@@ -52,7 +53,7 @@ def make_private_np_mean(
     if norm is not None:
         t_sum = t_clamp >> t_sum
 
-    return t_sum >> (lambda sums: np.array(sums) / size)
+    return t_sum >> _new_pure_function(lambda sums: np.array(sums) / size)
 
 
 # generate then variant of the constructor

--- a/python/src/opendp/extras/sklearn/_make_eigendecomposition/__init__.py
+++ b/python/src/opendp/extras/sklearn/_make_eigendecomposition/__init__.py
@@ -57,7 +57,7 @@ def make_private_np_eigendecomposition(
         lambda s: t_eigvals >> dp.m.then_laplace(s),
         d_in=2,  # the unit d_in: one change = 1 addition + 1 removal
         d_out=eigvals_epsilon,
-    ) >> dp.as_array(T="f64")
+    ) >> dp.as_array()
     m_eigvecs = t_sscp.output_space >> then_private_eigenvectors(
         eigvecs_epsilons,
     )

--- a/python/src/opendp/extras/sklearn/_make_eigendecomposition/__init__.py
+++ b/python/src/opendp/extras/sklearn/_make_eigendecomposition/__init__.py
@@ -57,7 +57,7 @@ def make_private_np_eigendecomposition(
         lambda s: t_eigvals >> dp.m.then_laplace(s),
         d_in=2,  # the unit d_in: one change = 1 addition + 1 removal
         d_out=eigvals_epsilon,
-    )
+    ) >> dp.as_array(T="f64")
     m_eigvecs = t_sscp.output_space >> then_private_eigenvectors(
         eigvecs_epsilons,
     )

--- a/python/src/opendp/extras/sklearn/_make_eigenvector/__init__.py
+++ b/python/src/opendp/extras/sklearn/_make_eigenvector/__init__.py
@@ -182,6 +182,7 @@ def make_private_eigenvectors(
                 (input_domain, input_metric)
                 >> then_np_sscp_projection(P)  # 2.c happens inside this transformation
                 >> then_private_eigenvector(epsilon_i)
+                >> dp.as_array(T=input_desc.T)
             )
             u = qbl(m_eigvec)
 

--- a/python/src/opendp/extras/sklearn/_make_eigenvector/__init__.py
+++ b/python/src/opendp/extras/sklearn/_make_eigenvector/__init__.py
@@ -182,7 +182,7 @@ def make_private_eigenvectors(
                 (input_domain, input_metric)
                 >> then_np_sscp_projection(P)  # 2.c happens inside this transformation
                 >> then_private_eigenvector(epsilon_i)
-                >> dp.as_array(T=input_desc.T)
+                >> dp.as_array()
             )
             u = qbl(m_eigvec)
 

--- a/python/src/opendp/extras/sklearn/decomposition/__init__.py
+++ b/python/src/opendp/extras/sklearn/decomposition/__init__.py
@@ -374,7 +374,7 @@ if _decomposition is not None:
 
         def measurement(self) -> Measurement:
             """Return a measurement that releases a fitted model."""
-            return self._prepare_fitter() >> (lambda _: self)
+            return self._prepare_fitter() >> _new_pure_function(lambda _: self)
 
         # overrides an sklearn method
         def _validate_params(*args, **kwargs):

--- a/python/src/opendp/extras/sklearn/decomposition/__init__.py
+++ b/python/src/opendp/extras/sklearn/decomposition/__init__.py
@@ -23,7 +23,7 @@ from opendp.extras.numpy._make_np_mean import make_private_np_mean
 from opendp.extras.sklearn._make_eigendecomposition import then_private_np_eigendecomposition
 from opendp.mod import Domain, Measurement, Metric
 from opendp._lib import import_optional_dependency
-from opendp._internal import _make_measurement, _make_transformation
+from opendp._internal import _make_measurement, _make_transformation, _new_pure_function
 
 if TYPE_CHECKING: # pragma: no cover
     import numpy # type: ignore[import-not-found]
@@ -114,11 +114,13 @@ def make_private_pca(
             >> then_np_clamp(norm, p=2, origin=origin)
             >> then_center()
             >> then_private_np_eigendecomposition(unit_epsilon.eigvals, unit_epsilon.eigvecs)
-            >> (lambda out: PCAResult(
-                mean=origin,
-                S=np.sqrt(np.maximum(out[0], 0))[::-1],
-                Vt=out[1].T
-            ))
+            >> _new_pure_function(
+                lambda out: PCAResult(
+                    mean=origin,
+                    S=np.sqrt(np.maximum(out[0], 0))[::-1],
+                    Vt=out[1].T,
+                )
+            )
         )
 
     if input_desc.norm is not None:

--- a/python/src/opendp/extras/sklearn/linear_model/_make_private_theil_sen/__init__.py
+++ b/python/src/opendp/extras/sklearn/linear_model/_make_private_theil_sen/__init__.py
@@ -1,6 +1,7 @@
 from opendp.mod import Measure
 import opendp.prelude as dp
 from opendp._lib import import_optional_dependency
+from opendp._internal import _new_pure_function
 
 
 def pairwise_predict(data, x_cuts):
@@ -122,5 +123,5 @@ def make_private_theil_sen(
             output_measure, y_bounds, scale, candidates_count=candidates_count
         )
         # transform median y values to coefficients (slope and intercept)
-        >> (lambda ys: P_inv @ ys)
+        >> _new_pure_function(lambda ys: P_inv @ np.asarray(ys))
     )

--- a/python/src/opendp/prelude.py
+++ b/python/src/opendp/prelude.py
@@ -45,7 +45,7 @@ from opendp.metrics import *
 from opendp.measures import *
 from opendp.typing import *
 from opendp.accuracy import *
-from opendp.core import new_function, new_queryable
+from opendp.core import as_array, new_function, new_queryable
 from opendp.context import *
 
 __all__ = ["t", "m", "c"]

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -411,6 +411,7 @@ class Carrier(RuntimeType):
 
 
 Vec: Carrier = Carrier('Vec')
+NDArray: Carrier = Carrier('NDArray')
 HashMap: Carrier = Carrier('HashMap')
 i8: str = 'i8'
 i16: str = 'i16'

--- a/python/test/context/test_context.py
+++ b/python/test/context/test_context.py
@@ -4,6 +4,7 @@ import logging
 import opendp.prelude as dp
 from opendp._internal import _make_measurement
 
+
 def test_unit_of():
     assert dp.unit_of(contributions=3) == (dp.symmetric_distance(), 3)
     assert dp.unit_of(contributions=3, ordered=True) == (dp.insert_delete_distance(), 3)

--- a/python/test/test_convert.py
+++ b/python/test/test_convert.py
@@ -114,27 +114,35 @@ def test_hashmap():
     assert c_to_py(any) == data
 
 
-def test_numpy_data():
+@pytest.mark.parametrize(
+    "value,type_name,dtype",
+    [
+        ([1, 2], "Vec<i32>", "int32"),
+        (1, "i32", "int32"),
+        ([1.0, 2.0], "Vec<f64>", "float64"),
+        (1.0, "f64", None),
+        ("A", "String", None),
+    ],
+)
+def test_numpy_data(value, type_name, dtype):
+    np = pytest.importorskip('numpy')
+    array = np.array(value, dtype=dtype) if dtype is not None else np.array(value)
+    assert c_to_py(py_to_c(array, AnyObjectPtr, type_name=type_name)) == value
+
+
+def test_as_array():
     np = pytest.importorskip('numpy')
     import opendp.prelude as dp
 
-    def roundtrip_vector(value, type_name, dtype):
-        obj = py_to_c(np.array(value, dtype=dtype), AnyObjectPtr, type_name=type_name)
-        assert c_to_py(obj) == value
-
-    def roundtrip_scalar(value, type_name, dtype=None):
-        assert value == c_to_py(py_to_c(np.array(value, dtype=dtype), AnyObjectPtr, type_name=type_name))
-
-    roundtrip_vector([1, 2], "Vec<i32>", np.int32)
-    roundtrip_scalar(1, "i32", dtype=np.int32)
-    roundtrip_vector([1., 2.], "Vec<f64>", np.float64)
-    roundtrip_scalar(1., "f64")
-    assert c_to_py(py_to_c(np.array(["A", "B"]), AnyObjectPtr, type_name="Vec<String>")) == ["A", "B"]
-    roundtrip_scalar("A", "String")
-
-    result = dp.as_array(T="i32")(np.array([1, 2], dtype=np.int32))
+    result = dp.as_array()(np.array([1, 2], dtype=np.int32))
     assert isinstance(result, np.ndarray)
     assert np.array_equal(result, np.array([1, 2], dtype=np.int32))
+
+
+def test_numpy_string_vector_roundtrip():
+    np = pytest.importorskip('numpy')
+    # `Vec<String>` still goes through the standard vector path, not the atomic ndarray fast path.
+    assert c_to_py(py_to_c(np.array(["A", "B"]), AnyObjectPtr, type_name="Vec<String>")) == ["A", "B"]
 
 
 def test_numpy_ndarray_roundtrip():
@@ -171,7 +179,7 @@ def test_numpy_ndarray_validation():
     with pytest.raises(TypeError, match="Only 1d arrays are currently supported"):
         _numpy_to_slice(np.array([[1, 2], [3, 4]], dtype=np.int32), type_name)
 
-    with pytest.raises(TypeError, match="Only 1d arrays are currently supported"):
+    with pytest.raises(TypeError, match="Expected dtype int32, got int64"):
         _numpy_to_slice(np.array([1, 2, 3], dtype=np.int64), type_name)
 
 
@@ -194,9 +202,7 @@ def test_numpy_vector_output_from_rust_transformation():
         bounds=(0, 10),
     )
 
-    assert trans(np.array([-1, 2, 11], dtype=np.int32)) == [0, 2, 10]
-
-    result = dp.as_array(T="i32")(trans(np.array([-1, 2, 11], dtype=np.int32)))
+    result = dp.as_array()(trans(np.array([-1, 2, 11], dtype=np.int32)))
 
     assert isinstance(result, np.ndarray)
     assert np.array_equal(result, np.array([0, 2, 10], dtype=np.int32))

--- a/python/test/test_convert.py
+++ b/python/test/test_convert.py
@@ -3,6 +3,7 @@ from opendp._convert import (
     _scalar_to_slice, _slice_to_scalar,
     _vector_to_slice, _slice_to_vector,
     _hashmap_to_slice, _slice_to_hashmap,
+    _numpy_dtype_for_rust_type, _numpy_to_slice, _py_to_slice, _slice_to_numpy,
 )
 from opendp._convert import _check_and_cast_scalar
 from opendp.typing import *
@@ -115,14 +116,63 @@ def test_hashmap():
 
 def test_numpy_data():
     np = pytest.importorskip('numpy')
-    def roundtrip(value, type_name, dtype=None):
+    import opendp.prelude as dp
+
+    def roundtrip_vector(value, type_name, dtype):
+        obj = py_to_c(np.array(value, dtype=dtype), AnyObjectPtr, type_name=type_name)
+        assert c_to_py(obj) == value
+
+    def roundtrip_scalar(value, type_name, dtype=None):
         assert value == c_to_py(py_to_c(np.array(value, dtype=dtype), AnyObjectPtr, type_name=type_name))
-    roundtrip([1, 2], "Vec<i32>", dtype=np.int32)
-    roundtrip(1, "i32", dtype=np.int32)
-    roundtrip([1., 2.], "Vec<f64>")
-    roundtrip(1., "f64")
-    roundtrip(["A", "B"], "Vec<String>")
-    roundtrip("A", "String")
+
+    roundtrip_vector([1, 2], "Vec<i32>", np.int32)
+    roundtrip_scalar(1, "i32", dtype=np.int32)
+    roundtrip_vector([1., 2.], "Vec<f64>", np.float64)
+    roundtrip_scalar(1., "f64")
+    assert c_to_py(py_to_c(np.array(["A", "B"]), AnyObjectPtr, type_name="Vec<String>")) == ["A", "B"]
+    roundtrip_scalar("A", "String")
+
+    result = dp.as_array(T="i32")(np.array([1, 2], dtype=np.int32))
+    assert isinstance(result, np.ndarray)
+    assert np.array_equal(result, np.array([1, 2], dtype=np.int32))
+
+
+def test_numpy_ndarray_roundtrip():
+    np = pytest.importorskip('numpy')
+    type_name = RuntimeType("NDArray", ["i32"])
+
+    raw = _py_to_slice(np.array([1, 2, 3], dtype=np.int32), type_name)
+    result = _slice_to_numpy(raw, type_name)
+
+    assert isinstance(result, np.ndarray)
+    assert np.array_equal(result, np.array([1, 2, 3], dtype=np.int32))
+
+
+def test_numpy_vec_input_uses_ndarray_loader():
+    np = pytest.importorskip('numpy')
+    type_name = RuntimeType("Vec", ["i32"])
+
+    raw = _vector_to_slice(np.array([1, 2, 3], dtype=np.int32), type_name)
+    result = _slice_to_vector(raw, type_name)
+
+    assert list(result) == [1, 2, 3]
+
+
+def test_numpy_ndarray_validation():
+    np = pytest.importorskip('numpy')
+    type_name = RuntimeType("NDArray", ["i32"])
+
+    with pytest.raises(ValueError, match="unrecognized numpy dtype"):
+        _numpy_dtype_for_rust_type("String")
+
+    with pytest.raises(TypeError, match="Expected type is NDArray<i32>"):
+        _numpy_to_slice([1, 2, 3], type_name)
+
+    with pytest.raises(TypeError, match="Only 1d arrays are currently supported"):
+        _numpy_to_slice(np.array([[1, 2], [3, 4]], dtype=np.int32), type_name)
+
+    with pytest.raises(TypeError, match="Only 1d arrays are currently supported"):
+        _numpy_to_slice(np.array([1, 2, 3], dtype=np.int64), type_name)
 
 
 def test_numpy_trans():
@@ -132,6 +182,24 @@ def test_numpy_trans():
         dp.vector_domain(dp.atom_domain(bounds=(0, 10))), 
         dp.symmetric_distance(),
     )(np.array([1, 2, 3], dtype=np.int32)) == 6
+
+
+def test_numpy_vector_output_from_rust_transformation():
+    np = pytest.importorskip('numpy')
+    import opendp.prelude as dp
+
+    trans = dp.t.make_clamp(
+        dp.vector_domain(dp.atom_domain(T=int)),
+        dp.symmetric_distance(),
+        bounds=(0, 10),
+    )
+
+    assert trans(np.array([-1, 2, 11], dtype=np.int32)) == [0, 2, 10]
+
+    result = dp.as_array(T="i32")(trans(np.array([-1, 2, 11], dtype=np.int32)))
+
+    assert isinstance(result, np.ndarray)
+    assert np.array_equal(result, np.array([0, 2, 10], dtype=np.int32))
 
 
 def test_overflow():
@@ -211,4 +279,3 @@ def test_bitvec():
         val_out = np.frombuffer(c_to_py(obj), dtype=np.uint8)
         bits = np.unpackbits(val_out)
         assert (bits.tolist() + [0]).index(0) == i
-

--- a/python/test/test_core.py
+++ b/python/test/test_core.py
@@ -380,7 +380,7 @@ def test_pure_function():
 
 def test_np_array_postprocessor():
     np = pytest.importorskip("numpy")
-    fun = dp.as_array(T="i32")
+    fun = dp.as_array()
 
     result = fun(np.array([1, 2, 3], dtype=np.int32))
 

--- a/python/test/test_core.py
+++ b/python/test/test_core.py
@@ -378,6 +378,16 @@ def test_pure_function():
     assert fun(1) == 2
 
 
+def test_np_array_postprocessor():
+    np = pytest.importorskip("numpy")
+    fun = dp.as_array(T="i32")
+
+    result = fun(np.array([1, 2, 3], dtype=np.int32))
+
+    assert isinstance(result, np.ndarray)
+    assert np.array_equal(result, np.array([1, 2, 3], dtype=np.int32))
+
+
 def test_pointer_classes_dont_iter():
     import opendp.prelude as dp
 

--- a/python/test/test_interactive.py
+++ b/python/test/test_interactive.py
@@ -2,7 +2,6 @@ import opendp.prelude as dp
 import pytest
 
 
-
 def test_sequential_composition():
     max_influence = 1
     sc_meas = dp.c.make_adaptive_composition(
@@ -176,4 +175,3 @@ def test_privacy_filter():
     assert qbl_filter.privacy_loss(1) == 1.0
     qbl_filter(m_count)
     assert qbl_filter.privacy_loss(1) == 2.0
-

--- a/python/test/test_user_transform.py
+++ b/python/test/test_user_transform.py
@@ -46,10 +46,11 @@ def test_make_custom_transformation_error():
 def test_numpy_user_transformation_roundtrip():
     np = pytest.importorskip("numpy")
 
-    seen = {}
+    input_is_ndarray = False
 
     def function(arg):
-        seen["input_is_ndarray"] = isinstance(arg, np.ndarray)
+        nonlocal input_is_ndarray
+        input_is_ndarray |= isinstance(arg, np.ndarray)
         return [v + 1 for v in arg]
 
     trans = dp.t.make_user_transformation(
@@ -61,10 +62,9 @@ def test_numpy_user_transformation_roundtrip():
         lambda d_in: d_in,
     )
 
-    assert trans(np.array([1, 2, 3], dtype=np.int32)) == [2, 3, 4]
-    result = dp.as_array(T="i32")(trans(np.array([1, 2, 3], dtype=np.int32)))
+    result = dp.as_array()(trans(np.array([1, 2, 3], dtype=np.int32)))
 
-    assert not seen["input_is_ndarray"]
+    assert not input_is_ndarray
     assert isinstance(result, np.ndarray)
     assert np.array_equal(result, np.array([2, 3, 4], dtype=np.int32))
 
@@ -116,7 +116,7 @@ def test_user_constructors():
         lambda d_in: d_in * 10
     )
     assert trans(2) == [2] * 10
-    assert np.array_equal(dp.as_array(T="i32")(trans(2)), np.repeat(2, 10))
+    assert np.array_equal(dp.as_array()(trans(2)), np.repeat(2, 10))
     assert trans.map(1) == 10
 
     meas = dp.m.make_user_measurement(
@@ -129,7 +129,7 @@ def test_user_constructors():
     )
 
     assert meas(2) == [2] * 10
-    assert np.array_equal((meas >> dp.as_array(T="i32"))(2), np.repeat(2, 10))
+    assert np.array_equal((meas >> dp.as_array())(2), np.repeat(2, 10))
     assert meas.map(1) == 10
 
     assert (meas >> (lambda x: x[0]))(2) == 2

--- a/python/test/test_user_transform.py
+++ b/python/test/test_user_transform.py
@@ -43,6 +43,32 @@ def test_make_custom_transformation_error():
         make_duplicate(2, raises=True)([1, 2, 3])
 
 
+def test_numpy_user_transformation_roundtrip():
+    np = pytest.importorskip("numpy")
+
+    seen = {}
+
+    def function(arg):
+        seen["input_is_ndarray"] = isinstance(arg, np.ndarray)
+        return [v + 1 for v in arg]
+
+    trans = dp.t.make_user_transformation(
+        dp.vector_domain(dp.atom_domain(T=int)),
+        dp.symmetric_distance(),
+        dp.vector_domain(dp.atom_domain(T=int)),
+        dp.symmetric_distance(),
+        function,
+        lambda d_in: d_in,
+    )
+
+    assert trans(np.array([1, 2, 3], dtype=np.int32)) == [2, 3, 4]
+    result = dp.as_array(T="i32")(trans(np.array([1, 2, 3], dtype=np.int32)))
+
+    assert not seen["input_is_ndarray"]
+    assert isinstance(result, np.ndarray)
+    assert np.array_equal(result, np.array([2, 3, 4], dtype=np.int32))
+
+
 def make_constant_mechanism(constant):
     """An example user-defined measurement from Python"""
     def function(_arg):
@@ -79,6 +105,8 @@ def test_make_user_postprocessor():
 
 
 def test_user_constructors():
+    np = pytest.importorskip("numpy")
+
     trans = dp.t.make_user_transformation(
         dp.atom_domain((2, 10)),
         dp.symmetric_distance(),
@@ -87,7 +115,8 @@ def test_user_constructors():
         lambda x: [x] * 10,
         lambda d_in: d_in * 10
     )
-    assert trans(2) == [2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+    assert trans(2) == [2] * 10
+    assert np.array_equal(dp.as_array(T="i32")(trans(2)), np.repeat(2, 10))
     assert trans.map(1) == 10
 
     meas = dp.m.make_user_measurement(
@@ -99,7 +128,8 @@ def test_user_constructors():
         TO=dp.Vec[int],
     )
 
-    assert meas(2) == [2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+    assert meas(2) == [2] * 10
+    assert np.array_equal((meas >> dp.as_array(T="i32"))(2), np.repeat(2, 10))
     assert meas.map(1) == 10
 
     assert (meas >> (lambda x: x[0]))(2) == 2

--- a/rust/opendp_tooling/src/codegen/r/mod.rs
+++ b/rust/opendp_tooling/src/codegen/r/mod.rs
@@ -47,6 +47,7 @@ const BLOCKLIST: &'static [&'static str] = &[
     "_make_transformation",
     "_make_measurement",
     "_new_pure_function",
+    "as_array",
     "_extrinsic_domain",
     "_extrinsic_domain_descriptor",
     "_extrinsic_metric_descriptor",

--- a/rust/src/core/ffi/mod.rs
+++ b/rust/src/core/ffi/mod.rs
@@ -1,3 +1,4 @@
+use std::any::TypeId;
 use std::ffi::{CStr, c_void};
 use std::fmt::{Debug, Formatter};
 use std::os::raw::c_char;
@@ -6,8 +7,8 @@ use std::{fmt, ptr};
 use opendp_derive::bootstrap;
 
 use crate::error::{Error, ErrorVariant, ExplainUnwrap, Fallible};
-use crate::ffi::any::{AnyFunction, AnyObject, CallbackFn, wrap_func};
-use crate::ffi::util;
+use crate::ffi::any::{AnyFunction, AnyObject, CallbackFn, Downcast, wrap_func};
+use crate::ffi::util::{self, Type, TypeContents};
 
 mod measurement;
 pub use measurement::*;
@@ -249,6 +250,41 @@ pub extern "C" fn opendp_core__new_function(
     let function = try_as_ref!(function).clone();
     let _TO = TO;
     FfiResult::Ok(util::into_raw(Function::new_fallible(wrap_func(function))))
+}
+
+#[bootstrap(name = "as_array")]
+#[allow(dead_code)]
+fn as_array<T: 'static>() -> Fallible<AnyFunction> {
+    let _ = TypeId::of::<T>();
+    panic!("this signature only exists for code generation")
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn opendp_core__as_array(T: *const c_char) -> FfiResult<*mut AnyFunction> {
+    fn monomorphize<T: 'static + Clone + Send + Sync>() -> Fallible<AnyFunction> {
+        let type_ = Type::new(
+            TypeId::of::<Vec<T>>(),
+            std::format!("NDArray<{}>", Type::of::<T>().descriptor),
+            TypeContents::VEC(TypeId::of::<T>()),
+        );
+        Ok(Function::new_fallible(move |arg: &AnyObject| {
+            Ok(AnyObject::new_type(
+                arg.downcast_ref::<Vec<T>>()?.clone(),
+                type_.clone(),
+            ))
+        }))
+    }
+
+    let T = try_!(Type::try_from(T));
+    dispatch!(
+        monomorphize,
+        [(
+            T,
+            [u8, u16, u32, u64, i8, i16, i32, i64, usize, f32, f64, bool]
+        )],
+        ()
+    )
+    .into()
 }
 
 #[bootstrap(

--- a/rust/src/core/ffi/mod.rs
+++ b/rust/src/core/ffi/mod.rs
@@ -254,37 +254,45 @@ pub extern "C" fn opendp_core__new_function(
 
 #[bootstrap(name = "as_array")]
 #[allow(dead_code)]
-fn as_array<T: 'static>() -> Fallible<AnyFunction> {
-    let _ = TypeId::of::<T>();
+fn as_array() -> Fallible<AnyFunction> {
     panic!("this signature only exists for code generation")
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn opendp_core__as_array(T: *const c_char) -> FfiResult<*mut AnyFunction> {
-    fn monomorphize<T: 'static + Clone + Send + Sync>() -> Fallible<AnyFunction> {
+pub extern "C" fn opendp_core__as_array() -> FfiResult<*mut AnyFunction> {
+    fn monomorphize<T: 'static + Clone + Send + Sync>(arg: &AnyObject) -> Fallible<AnyObject> {
         let type_ = Type::new(
             TypeId::of::<Vec<T>>(),
             std::format!("NDArray<{}>", Type::of::<T>().descriptor),
             TypeContents::VEC(TypeId::of::<T>()),
         );
-        Ok(Function::new_fallible(move |arg: &AnyObject| {
-            Ok(AnyObject::new_type(
-                arg.downcast_ref::<Vec<T>>()?.clone(),
-                type_.clone(),
-            ))
-        }))
+        Ok(AnyObject::new_type(
+            arg.downcast_ref::<Vec<T>>()?.clone(),
+            type_,
+        ))
     }
 
-    let T = try_!(Type::try_from(T));
-    dispatch!(
-        monomorphize,
-        [(
-            T,
-            [u8, u16, u32, u64, i8, i16, i32, i64, usize, f32, f64, bool]
-        )],
-        ()
-    )
-    .into()
+    let function = Function::new_fallible(move |arg: &AnyObject| {
+        let TypeContents::VEC(atom_id) = &arg.type_.contents else {
+            return fallible!(
+                FailedCast,
+                "Expected data of type Vec<T>. Got {}",
+                arg.type_.to_string()
+            );
+        };
+
+        let atom = try_!(Type::of_id(atom_id));
+        dispatch!(
+            monomorphize,
+            [(
+                atom,
+                [u8, u16, u32, u64, i8, i16, i32, i64, usize, f32, f64, bool]
+            )],
+            (arg)
+        )
+    });
+
+    FfiResult::Ok(util::into_raw(function))
 }
 
 #[bootstrap(

--- a/rust/src/ffi/any.rs
+++ b/rust/src/ffi/any.rs
@@ -40,6 +40,13 @@ impl AnyObject {
         }
     }
 
+    pub fn new_type<T: 'static>(value: T, type_: Type) -> Self {
+        AnyObject {
+            type_,
+            value: Box::new(value),
+        }
+    }
+
     pub fn new_raw<T: 'static>(value: T) -> *mut Self {
         crate::ffi::util::into_raw(Self::new(value))
     }


### PR DESCRIPTION
Direct FFI conversion benchmarks, mean ms per call:

* n=1_000 input: 0.013 current vs 0.423 baseline, about 32x faster
* n=100_000 input: 0.053 current vs 40.829 baseline, about 770x faster
* n=1_000 output: 0.018 current vs 0.034 baseline, about 1.9x faster
* n=100_000 output: 0.023 current vs 2.514 baseline, about 109x faster