### PR TITLE
chore: normalize .tex proof template

### DIFF
--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -15,8 +15,10 @@ jobs:
       - name: Collect diffs
         id: "diffs"
         run: |
-          files=$(git --no-pager diff --diff-filter=d --name-only origin/${{ github.event.pull_request.base.ref }} -- '*.tex')
-          
+          set -euo pipefail
+          mb="$(git merge-base HEAD^1 HEAD^2)"
+          files="$(git --no-pager diff --diff-filter=d --name-only "$mb" HEAD^2 -- '*.tex')"
+
           # using syntax from: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
           # construct list of .tex files
           echo "tex<<EOF" >> $GITHUB_OUTPUT
@@ -25,7 +27,9 @@ jobs:
     
           # construct list of .pdf files
           echo "pdf<<EOF" >> $GITHUB_OUTPUT
-          echo "${files//$'.tex'/.pdf}" >> $GITHUB_OUTPUT
+          # Command substitution strips the trailing newline from git diff output,
+          # so re-add one before rewriting the extension on the final path.
+          printf '%s\n' "$files" | sed 's/\.tex$/.pdf/' >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
           echo "$files"

--- a/docs/source/contributing/proof-initiation.rst
+++ b/docs/source/contributing/proof-initiation.rst
@@ -97,7 +97,7 @@ Here’s a template for ``absolute_distance.tex``:
    \input{../lib.sty} % "rust/src/lib.sty" contains boilerplate and macros
 
    \title{\texttt{fn absolute\_distance}}
-   \author{Your Name(s) Here}\date{}
+   \author{\YourNameAuthor}\date{}
 
    \begin{document}
    \maketitle\contrib
@@ -121,6 +121,12 @@ This template uses several macros defined in ``rust/src/lib.sty``:
 
 -  ``\contrib`` adds a header to the document indicating the proof is in
    ``"contrib"``.
+
+-  ``\YourNameAuthor`` and similar macros expand to an author's
+   name and GitHub handle together. Use these in ``\author{...}`` so
+   author formatting stays consistent across proofs. If your name is not
+   listed in ``rust/src/lib.sty``, add a new macro there via
+   ``\proofAuthor{name}{github-handle}``.
 
 -  ``\rustdoc{path/to/fn}{ident}`` creates a link to the rust
    documentation for the function we are proving. When you build the

--- a/rust/src/accuracy/accuracy_to_discrete_gaussian_scale.tex
+++ b/rust/src/accuracy/accuracy_to_discrete_gaussian_scale.tex
@@ -2,7 +2,7 @@
 \input{../lib.sty}
 
 \title{\texttt{fn accuracy\_to\_discrete\_gaussian\_scale}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 
 \begin{document}
 \maketitle

--- a/rust/src/accuracy/accuracy_to_discrete_laplacian_scale.tex
+++ b/rust/src/accuracy/accuracy_to_discrete_laplacian_scale.tex
@@ -2,7 +2,7 @@
 \input{../lib.sty}
 
 \title{\texttt{fn accuracy\_to\_discrete\_laplacian\_scale}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 
 \begin{document}
 \maketitle

--- a/rust/src/accuracy/discrete_gaussian_scale_to_accuracy.tex
+++ b/rust/src/accuracy/discrete_gaussian_scale_to_accuracy.tex
@@ -2,7 +2,7 @@
 \input{../lib.sty}
 
 \title{\texttt{fn discrete\_gaussian\_scale\_to\_accuracy}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 
 \begin{document}
 \maketitle

--- a/rust/src/accuracy/discrete_laplacian_scale_to_accuracy.tex
+++ b/rust/src/accuracy/discrete_laplacian_scale_to_accuracy.tex
@@ -2,7 +2,7 @@
 \input{../lib.sty}
 
 \title{\texttt{fn discrete\_laplacian\_scale\_to\_accuracy}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 
 \begin{document}
 \maketitle

--- a/rust/src/accuracy/tail_bounds/conservative_continuous_gaussian_tail_to_alpha.tex
+++ b/rust/src/accuracy/tail_bounds/conservative_continuous_gaussian_tail_to_alpha.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{fn conservative\_continuous\_gaussian\_tail\_to\_alpha}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 
 \begin{document}
 \maketitle

--- a/rust/src/accuracy/tail_bounds/conservative_discrete_laplacian_tail_to_alpha.tex
+++ b/rust/src/accuracy/tail_bounds/conservative_discrete_laplacian_tail_to_alpha.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{fn conservative\_discrete\_laplacian\_tail\_to\_alpha}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 
 \begin{document}
 \maketitle

--- a/rust/src/combinators/measure_cast/zCDP_to_approxDP/cdp_delta/cdp_delta.tex
+++ b/rust/src/combinators/measure_cast/zCDP_to_approxDP/cdp_delta/cdp_delta.tex
@@ -3,7 +3,7 @@
 
 
 \title{\texttt{fn cdp\_delta}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 
 \begin{document}
 \maketitle

--- a/rust/src/combinators/measure_cast/zCDP_to_approxDP/cdp_delta/cdp_delta.tex
+++ b/rust/src/combinators/measure_cast/zCDP_to_approxDP/cdp_delta/cdp_delta.tex
@@ -160,23 +160,24 @@ Let $M: \mathcal{X}^n \rightarrow \mathcal{Y}$ be a randomized algorithm satisfy
 This follows from \ref{renyidp-approxdp-epsilon} by taking the infimum over all divergence parameters $\alpha$.
 \end{proof}
 
-\section{Pseudocode}
-\subsubsection*{Precondition}
-None.
+\section{Hoare Triple}
+\subsection*{Precondition}
+\subsubsection*{Compiler-verified}
+None
 
-\subsubsection*{Implementation}
+\subsubsection*{Caller-verified}
+None
+
+\subsection*{Pseudocode}
 \lstinputlisting[language=Python,firstline=2]{./pseudocode/cdp_delta.py}
 
 
-\subsubsection*{Postcondition}
+\subsection*{Postcondition}
 
 \begin{theorem}
     For any possible setting of $\rho$ and $\epsilon$, $\texttt{cdp\_delta}$ either returns an error, 
     or a $\delta$ such that any $\rho$-differentially private measurement is also $(\epsilon, \delta)$-differentially private.
 \end{theorem}
-
-\section{Proof}
-
 \begin{proof}
 The code always finds an $\alpha_{*} \approx \texttt{a\_max} \geq 1.01$.
 Since $\texttt{a\_max} \in (1, \infty)$, then by \ref{renyidp-approxdp-epsilon}, any $\rho$-differentially private measurement is also $(\epsilon(\texttt{a\_max}), \delta)$-differentially private.

--- a/rust/src/combinators/privacy_filter/make_privacy_filter.tex
+++ b/rust/src/combinators/privacy_filter/make_privacy_filter.tex
@@ -27,14 +27,16 @@ Proves soundness of \texttt{fn make\_privacy\_filter}.
     \item \texttt{(DI, MI)} implements \rustdoc{core/trait}{MetricSpace}.
 \end{itemize}
 
-\subsubsection*{User-verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=`]{./pseudocode/make_privacy_filter.py}
 
-\subsubsection*{Postcondition}
+\subsection*{Postcondition}
+\begin{theorem}
 \validOdometer{\texttt{(odometer, d\_out, DI, MI, MO, Q, A)}}{\texttt{make\_privacy\_filter}}
+\end{theorem}
 
 \begin{proof}[Proof of data-independent errors]
     \rustdoc{core/struct}{Function}\texttt{.eval} on line \ref{eval} has data-independent exceptions,

--- a/rust/src/combinators/privacy_filter/make_privacy_filter.tex
+++ b/rust/src/combinators/privacy_filter/make_privacy_filter.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{fn make\_privacy\_filter}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/combinators/privacy_filter/new_continuation_rule.tex
+++ b/rust/src/combinators/privacy_filter/new_continuation_rule.tex
@@ -16,13 +16,13 @@ Proves soundness of \texttt{fn new\_continuation\_rule}.
 \subsection*{Precondition}
 \subsubsection*{Compiler-verified}
 \textit{Types consistent with pseudocode.}
-\subsubsection*{User-verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=`]{./pseudocode/new_continuation_rule.py}
 
-\subsubsection*{Postcondition}
+\subsection*{Postcondition}
 \begin{theorem}
     Returns a function that wraps a queryable.
     The wrapped queryable refuses to release any query

--- a/rust/src/combinators/privacy_filter/new_continuation_rule.tex
+++ b/rust/src/combinators/privacy_filter/new_continuation_rule.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{fn new\_continuation\_rule}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/combinators/select_private_candidate/make_select_private_candidate.tex
+++ b/rust/src/combinators/select_private_candidate/make_select_private_candidate.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{fn make\_select\_private\_candidate}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/combinators/select_private_candidate/make_select_private_candidate.tex
+++ b/rust/src/combinators/select_private_candidate/make_select_private_candidate.tex
@@ -27,7 +27,7 @@ or may fail and return nothing.
     \item Argument \texttt{threshold} is of type \texttt{f64}.
 \end{itemize}
 
-\subsubsection*{User-verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}
@@ -35,8 +35,6 @@ None
 
 \subsection*{Postcondition}
 \validMeasurement{\texttt{(measurement, stop\_probability, threshold, DI, MI, TO)}}{\texttt{make\_select\_private\_candidate}}
-
-\section{Proofs}
 This section shows that the pseudocode implements Theorem 3.1 in \cite{liu2018privateselectionprivatecandidates}, where 
 \texttt{stop\_probability} is $\gamma$ and
 \texttt{threshold} is $\tau$.

--- a/rust/src/combinators/sequential_composition/CompositionMeasure_for_ApproximateMaxDivergence.tex
+++ b/rust/src/combinators/sequential_composition/CompositionMeasure_for_ApproximateMaxDivergence.tex
@@ -15,11 +15,11 @@ for \texttt{Approximate<MaxDivergence>} in \asOfCommit{mod.rs}{f5bb719}.
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 Types matching pseudocode.
 
 
-\subsubsection*{Caller-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/combinators/sequential_composition/CompositionMeasure_for_ApproximateMaxDivergence.tex
+++ b/rust/src/combinators/sequential_composition/CompositionMeasure_for_ApproximateMaxDivergence.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{CompositionMeasure for Approximate<MaxDivergence>}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/combinators/sequential_composition/CompositionMeasure_for_ApproximateZeroConcentratedDivergence.tex
+++ b/rust/src/combinators/sequential_composition/CompositionMeasure_for_ApproximateZeroConcentratedDivergence.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{CompositionMeasure for Approximate<ZeroConcentratedDivergence>}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/combinators/sequential_composition/CompositionMeasure_for_ApproximateZeroConcentratedDivergence.tex
+++ b/rust/src/combinators/sequential_composition/CompositionMeasure_for_ApproximateZeroConcentratedDivergence.tex
@@ -15,11 +15,11 @@ for \texttt{Approximate<ZeroConcentratedDivergence>} in \asOfCommit{mod.rs}{f5bb
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 Types matching pseudocode.
 
 
-\subsubsection*{Caller-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/combinators/sequential_composition/CompositionMeasure_for_MaxDivergence.tex
+++ b/rust/src/combinators/sequential_composition/CompositionMeasure_for_MaxDivergence.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{CompositionMeasure for MaxDivergence}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/combinators/sequential_composition/CompositionMeasure_for_MaxDivergence.tex
+++ b/rust/src/combinators/sequential_composition/CompositionMeasure_for_MaxDivergence.tex
@@ -15,11 +15,11 @@ for \texttt{MaxDivergence} in \asOfCommit{mod.rs}{f5bb719}.
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 Types matching pseudocode.
 
 
-\subsubsection*{Caller-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/combinators/sequential_composition/CompositionMeasure_for_RenyiDivergence.tex
+++ b/rust/src/combinators/sequential_composition/CompositionMeasure_for_RenyiDivergence.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{CompositionMeasure for RenyiDivergence}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/combinators/sequential_composition/CompositionMeasure_for_RenyiDivergence.tex
+++ b/rust/src/combinators/sequential_composition/CompositionMeasure_for_RenyiDivergence.tex
@@ -15,11 +15,11 @@ for \texttt{RenyiDivergence} in \asOfCommit{mod.rs}{f5bb719}.
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 Types matching pseudocode.
 
 
-\subsubsection*{Caller-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/combinators/sequential_composition/CompositionMeasure_for_ZeroConcentratedDivergence.tex
+++ b/rust/src/combinators/sequential_composition/CompositionMeasure_for_ZeroConcentratedDivergence.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{CompositionMeasure for ZeroConcentratedDivergence}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/combinators/sequential_composition/CompositionMeasure_for_ZeroConcentratedDivergence.tex
+++ b/rust/src/combinators/sequential_composition/CompositionMeasure_for_ZeroConcentratedDivergence.tex
@@ -15,11 +15,11 @@ for \texttt{ZeroConcentratedDivergence} in \asOfCommit{mod.rs}{f5bb719}.
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 Types matching pseudocode.
 
 
-\subsubsection*{Caller-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/combinators/sequential_composition/fully_adaptive/make_fully_adaptive_composition.tex
+++ b/rust/src/combinators/sequential_composition/fully_adaptive/make_fully_adaptive_composition.tex
@@ -31,7 +31,7 @@ None
 \subsection*{Pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=`]{./pseudocode/make_fully_adaptive_composition.py}
 
-\subsubsection*{Postcondition}
+\subsection*{Postcondition}
 \begin{theorem}
     \validOdometer{\texttt{(input\_domain, input\_metric, output\_measure, DI, MI, MO, TO)}}{\texttt{make\_fully\_adaptive\_composition}}
 \end{theorem}

--- a/rust/src/combinators/sequential_composition/fully_adaptive/make_fully_adaptive_composition.tex
+++ b/rust/src/combinators/sequential_composition/fully_adaptive/make_fully_adaptive_composition.tex
@@ -2,7 +2,7 @@
 \input{../../../lib.sty}
 
 \title{\texttt{fn make\_fully\_adaptive\_composition}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/combinators/sequential_composition/fully_adaptive/new_fully_adaptive_composition_queryable.tex
+++ b/rust/src/combinators/sequential_composition/fully_adaptive/new_fully_adaptive_composition_queryable.tex
@@ -24,14 +24,14 @@ Types matching those in the pseudocode.
     \item \texttt{(DI, MI)} implements \rustdoc{core/trait}{MetricSpace}.
 \end{itemize}
 
-\subsubsection*{User-verified}
+\subsubsection*{Caller-verified}
 \texttt{data} is a member of \texttt{input\_domain}.
 
 
 \subsection*{Pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=`]{./pseudocode/new_fully_adaptive_composition_queryable.py}
 
-\subsubsection*{Postconditions}
+\subsection*{Postcondition}
 \begin{theorem}
     \validOdometerQueryable{\texttt{(input\_domain, input\_metric, output\_measure, data, DI, MI, MO, TO)}}{\texttt{new\_fully\_adaptive\_composition\_queryable}}
 \end{theorem}

--- a/rust/src/combinators/sequential_composition/fully_adaptive/new_fully_adaptive_composition_queryable.tex
+++ b/rust/src/combinators/sequential_composition/fully_adaptive/new_fully_adaptive_composition_queryable.tex
@@ -2,7 +2,7 @@
 \input{../../../lib.sty}
 
 \title{\texttt{fn new\_fully\_adaptive\_composition\_queryable}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/domains/polars/frame/find_min_covering.tex
+++ b/rust/src/domains/polars/frame/find_min_covering.tex
@@ -2,7 +2,7 @@
 \input{../../../lib.sty}
 
 \title{\texttt{fn find\_min\_covering}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/domains/polars/frame/find_min_covering.tex
+++ b/rust/src/domains/polars/frame/find_min_covering.tex
@@ -24,17 +24,16 @@ from \texttt{sets} that spans \texttt{must\_cover}.
     \item Generic \texttt{T} is some type that implements Hash and has total Ord, so that it can be used in a B-tree set.
 \end{itemize}
 
-\subsubsection*{Human-verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=`]{./pseudocode/find_min_covering.py}
 
 \subsection*{Postcondition}
+\begin{theorem}
 Return a subset of \texttt{sets} whose intersection contains \texttt{must\_cover}, or None.
-
-\section{Proofs}
-
+\end{theorem}
 \begin{proof} 
     All that needs to be proven is that the return set covers \texttt{must\_cover}.
     While the algorithm makes a best effort to minimize the cardinality of the cover,

--- a/rust/src/domains/polars/frame/get_margin.tex
+++ b/rust/src/domains/polars/frame/get_margin.tex
@@ -20,17 +20,16 @@ whose descriptors are no more restrictive than what is known in \texttt{FrameDom
 \subsubsection*{Compiler-verified}
 Types matching pseudocode.
 
-\subsubsection*{Human-verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/get_margin.py}
 
 \subsection*{Postcondition}
+\begin{theorem}
 Returns a \texttt{Margin} that describes properties of members of \texttt{domain} when grouped by \texttt{by}.
-
-\section{Proofs}
-
+\end{theorem}
 \begin{proof} 
     On line \ref{let-margin}, \texttt{margin} is either a valid margin descriptor 
     for \texttt{by}, by the definition of \texttt{domain},

--- a/rust/src/domains/polars/frame/get_margin.tex
+++ b/rust/src/domains/polars/frame/get_margin.tex
@@ -2,7 +2,7 @@
 \input{../../../lib.sty}
 
 \title{\texttt{fn get\_margin}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/lib.sty
+++ b/rust/src/lib.sty
@@ -31,8 +31,6 @@
 \newcommand{\contrib}{{\begin{warn_box}This proof resides in \textbf{``contrib''} because it has not completed the vetting process.\end{warn_box}}} 
 \newcommand{\honestButCurious}{{\begin{warn_box}This proof relies on caller-verified preconditions, so the corresponding API belongs behind the \textbf{``honest-but-curious''} feature flag.\end{warn_box}}}
 \newcommand{\idealizedNumerics}{{\begin{warn_box}This proof relies on an idealized model of numeric computation that ignores finite-machine limitations such as non-closure and overflow, so the corresponding API belongs behind the \textbf{``idealized-numerics''} feature flag.\end{warn_box}}}
-% Deprecated alias. Prefer \idealizedNumerics.
-\newcommand{\floatingPoint}{\idealizedNumerics}
 
 % asOfCommit macro to version a code dependency. Arguments:
 %    #1: relative path to file you are dependent on
@@ -135,9 +133,24 @@
 \newtheorem{observation}{Observation}
 \newtheorem{note}{Note}
 
-\newcommand{\vicki}[1]{{ {\color{olive}{(vicki)~#1}}}}
-\newcommand{\hanwen}[1]{{ {\color{purple}{(hanwen)~#1}}}}
-\newcommand{\zach}[1]{{ {\color{red}{(zach)~#1}}}}
+\newcommand{\proofAuthor}[2]{%
+  #1%
+  \if\relax\detokenize{#2}\relax\else\ {\small(\href{https://github.com/#2}{\texttt{@#2}})}\fi%
+}
+\newcommand{\AbigailGentleAuthor}{\proofAuthor{Abigail Gentle}{abigail-gentle}}
+\newcommand{\AishwaryaRamasethuAuthor}{\proofAuthor{Aishwarya Ramasethu}{aramasethu}}
+\newcommand{\ChristianCovingtonAuthor}{\proofAuthor{Christian Covington}{ctcovington}}
+\newcommand{\ConnorWagamanAuthor}{\proofAuthor{Connor Wagaman}{cwagaman}}
+\newcommand{\GraceTianAuthor}{\proofAuthor{Grace Tian}{gracetian6}}
+\newcommand{\HanwenZhangAuthor}{\proofAuthor{Hanwen Zhang}{}}
+\newcommand{\IraGlobusHarrusAuthor}{\proofAuthor{Ira Globus-Harrus}{globusharris}}
+\newcommand{\JordanAwanAuthor}{\proofAuthor{Jordan Awan}{}}
+\newcommand{\MichaelShoemateAuthor}{\proofAuthor{Michael Shoemate}{Shoeboxam}}
+\newcommand{\SilviaCasacubertaAuthor}{\proofAuthor{S\'ilvia Casacuberta}{silviacasac}}
+\newcommand{\TudorCebereAuthor}{\proofAuthor{Tudor Cebere}{tudorcebere}}
+\newcommand{\VickiXuAuthor}{\proofAuthor{Vicki Xu}{matchaginseng}}
+\newcommand{\YuJuKuAuthor}{\proofAuthor{Yu-Ju Ku}{yuju1998}}
+\newcommand{\ZacharyRatliffAuthor}{\proofAuthor{Zachary Ratliff}{zachratliff}}
 
 \newcommand{\MultiSet}{\mathrm{MultiSet}}
 \newcommand{\len}{\mathrm{len}}

--- a/rust/src/lib.sty
+++ b/rust/src/lib.sty
@@ -29,7 +29,10 @@
 \usepackage{tcolorbox}
 \newtcolorbox{warn_box}{colback=red!5!white,colframe=red!75!black}
 \newcommand{\contrib}{{\begin{warn_box}This proof resides in \textbf{``contrib''} because it has not completed the vetting process.\end{warn_box}}} 
-\newcommand{\floatingPoint}{{\begin{warn_box}This implementation is susceptible to floating-point vulnerabilities.\end{warn_box}}} 
+\newcommand{\honestButCurious}{{\begin{warn_box}This proof relies on caller-verified preconditions, so the corresponding API belongs behind the \textbf{``honest-but-curious''} feature flag.\end{warn_box}}}
+\newcommand{\idealizedNumerics}{{\begin{warn_box}This proof relies on an idealized model of numeric computation that ignores finite-machine limitations such as non-closure and overflow, so the corresponding API belongs behind the \textbf{``idealized-numerics''} feature flag.\end{warn_box}}}
+% Deprecated alias. Prefer \idealizedNumerics.
+\newcommand{\floatingPoint}{\idealizedNumerics}
 
 % asOfCommit macro to version a code dependency. Arguments:
 %    #1: relative path to file you are dependent on
@@ -154,7 +157,6 @@
 
 
 \newcommand{\validTransformation}[2]{%
-  \begin{theorem}
   For every setting of the input parameters #1 to #2 such that the given preconditions
   hold, #2 raises an error (at compile time or run time) or returns a valid transformation. A valid transformation has the following properties:
   \begin{enumerate}
@@ -172,7 +174,6 @@
       and $\texttt{stability\_map}(\din) = \dout$, 
       then $\function(x), \function(x')$ are $\dout$-close under \texttt{output\_metric}.
   \end{enumerate}
-  \end{theorem}
 }
 
 

--- a/rust/src/measurements/canonical_noise/approximate_to_tradeoff.tex
+++ b/rust/src/measurements/canonical_noise/approximate_to_tradeoff.tex
@@ -14,13 +14,13 @@
 
 \section{Hoare Triple}
 
-\subsection*{Preconditions}
+\subsection*{Precondition}
 \subsubsection*{Compiler-verified}
 \begin{itemize}
     \item Argument \texttt{param} of type \texttt{(f64, f64)}
 \end{itemize}
 
-\subsubsection*{User-verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/canonical_noise/approximate_to_tradeoff.tex
+++ b/rust/src/measurements/canonical_noise/approximate_to_tradeoff.tex
@@ -5,7 +5,7 @@
 \addbibresource{ref.bib} 
 
 \title{\texttt{fn approximate\_to\_tradeoff}}
-\author{Aishwarya Ramasethu, Yu-Ju Ku, Jordan Awan, Michael Shoemate}
+\author{\AishwaryaRamasethuAuthor, \YuJuKuAuthor, \JordanAwanAuthor, \MichaelShoemateAuthor}
 \begin{document}
 
 \maketitle

--- a/rust/src/measurements/canonical_noise/make_canonical_noise.tex
+++ b/rust/src/measurements/canonical_noise/make_canonical_noise.tex
@@ -5,7 +5,7 @@
 \addbibresource{ref.bib} 
 
 \title{\texttt{fn make\_canonical\_noise}}
-\author{Aishwarya Ramasethu, Yu-Ju Ku, Jordan Awan, Michael Shoemate}
+\author{\AishwaryaRamasethuAuthor, \YuJuKuAuthor, \JordanAwanAuthor, \MichaelShoemateAuthor}
 \begin{document}
 
 \maketitle

--- a/rust/src/measurements/canonical_noise/make_canonical_noise.tex
+++ b/rust/src/measurements/canonical_noise/make_canonical_noise.tex
@@ -20,7 +20,7 @@ a fixed privacy guarantee \texttt{d\_out} at a fixed sensitivity \texttt{d\_in}.
 
 \section{Hoare Triple}
 
-\subsection*{Preconditions}
+\subsection*{Precondition}
 \subsubsection*{Compiler-verified}
 \begin{itemize}
     \item Argument \texttt{input\_domain} of type \texttt{AtomDomain<f64>}.
@@ -29,7 +29,7 @@ a fixed privacy guarantee \texttt{d\_out} at a fixed sensitivity \texttt{d\_in}.
     \item Argument \texttt{d\_out} of type \texttt{(f64, f64)} corresponding to epsilon and delta.
 \end{itemize}
 
-\subsubsection*{Human-verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/make_private_lazyframe/group_by/make_private_group_by.tex
+++ b/rust/src/measurements/make_private_lazyframe/group_by/make_private_group_by.tex
@@ -2,7 +2,7 @@
 \input{../../../lib.sty}
 
 \title{\texttt{fn make\_private\_group\_by}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/make_private_lazyframe/group_by/make_private_group_by.tex
+++ b/rust/src/measurements/make_private_lazyframe/group_by/make_private_group_by.tex
@@ -20,19 +20,17 @@ Proves soundness of \texttt{fn make\_private\_group\_by} in \asOfCommit{mod.rs}{
     \item Generic \texttt{MO} must implement trait \texttt{ApproximateMeasure}.
 \end{itemize}
 
-\subsubsection*{User-verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/make_private_group_by.py}
 
-\subsubsection*{Postconditions}
+\subsection*{Postcondition}
 \begin{theorem}
     \label{postcondition}
     \validMeasurement{\texttt{(input\_domain, input\_metric, \\output\_measure, plan, global\_scale, threshold, MI, MO)}}{\texttt{make\_private\_group\_by}}
 \end{theorem}
-\section{Proof}
-
 We now prove the postcondition (Theorem~\ref{postcondition}).
 \begin{proof}
 

--- a/rust/src/measurements/noise/MakeNoise_IBig_for_RV.tex
+++ b/rust/src/measurements/noise/MakeNoise_IBig_for_RV.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{MakeNoise<VectorDomain<AtomDomain<IBig>>, MI, MO> for RV}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/MakeNoise_IBig_for_RV.tex
+++ b/rust/src/measurements/noise/MakeNoise_IBig_for_RV.tex
@@ -17,7 +17,7 @@ This is the core implementation of all variations of the gaussian or laplace mec
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 \texttt{MakeNoise} is parameterized as follows:
 \begin{itemize}
     \item \texttt{MI} implements trait \rustdoc{core/trait}{Metric}
@@ -31,7 +31,7 @@ The following trait bounds are also required:
     \item \texttt{RV} implements \rustdoc{measurements/noise/trait}{NoisePrivacyMap}\texttt{<MI, MO>}
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/Sample_for_ZExpFamily1.tex
+++ b/rust/src/measurements/noise/Sample_for_ZExpFamily1.tex
@@ -14,6 +14,10 @@ Proves soundness of the implementation of \rustdoc{measurements/noise/trait}{Sam
 
 \section{Hoare Triple}
 \subsection*{Precondition}
+\subsubsection*{Compiler-verified}
+None
+
+\subsubsection*{Caller-verified}
 \texttt{self} represents a valid probability distribution.
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/Sample_for_ZExpFamily1.tex
+++ b/rust/src/measurements/noise/Sample_for_ZExpFamily1.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{impl Sample for ZExpFamily<1>}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/Sample_for_ZExpFamily2.tex
+++ b/rust/src/measurements/noise/Sample_for_ZExpFamily2.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{impl Sample for ZExpFamily<2>}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/Sample_for_ZExpFamily2.tex
+++ b/rust/src/measurements/noise/Sample_for_ZExpFamily2.tex
@@ -14,6 +14,10 @@ Proves soundness of the implementation of \rustdoc{measurements/noise/trait}{Sam
 
 \section{Hoare Triple}
 \subsection*{Precondition}
+\subsubsection*{Compiler-verified}
+None
+
+\subsubsection*{Caller-verified}
 \texttt{self} represents a valid probability distribution.
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/distribution/gaussian/MakeNoise_for_DiscreteGaussian.tex
+++ b/rust/src/measurements/noise/distribution/gaussian/MakeNoise_for_DiscreteGaussian.tex
@@ -25,7 +25,7 @@ by simplifying the type signature.
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 \texttt{MakeNoise} is parameterized as follows:
 \begin{itemize}
     \item \texttt{DI} implements trait \rustdoc{core/trait}{Domain}
@@ -44,7 +44,7 @@ The following trait bounds are also required:
         That is, it must be possible to build the mechanism from this new equivalent distribution.
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/distribution/gaussian/MakeNoise_for_DiscreteGaussian.tex
+++ b/rust/src/measurements/noise/distribution/gaussian/MakeNoise_for_DiscreteGaussian.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{MakeNoise<DI, MI, MO> for DiscreteGaussian}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/distribution/gaussian/NoisePrivacyMap_for_ZExpFamily2.tex
+++ b/rust/src/measurements/noise/distribution/gaussian/NoisePrivacyMap_for_ZExpFamily2.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{NoisePrivacyMap<L2Distance<RBig>, ZeroConcentratedDivergence> for ZExpFamily<2>}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/distribution/gaussian/NoisePrivacyMap_for_ZExpFamily2.tex
+++ b/rust/src/measurements/noise/distribution/gaussian/NoisePrivacyMap_for_ZExpFamily2.tex
@@ -14,14 +14,14 @@ Proves soundness of the implementation of \rustdoc{measurements/noise/trait}{Noi
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 \texttt{NoisePrivacyMap} is parameterized as follows:
 \begin{itemize}
     \item \texttt{MI}, the input metric, is of type \rustdoc{metrics/type}{L2Distance<RBig>}
     \item \texttt{MO}, the output measure, is of type \rustdoc{measures/struct}{ZeroConcentratedDivergence}
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/distribution/gaussian/make_gaussian.tex
+++ b/rust/src/measurements/noise/distribution/gaussian/make_gaussian.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{fn make\_gaussian}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/distribution/gaussian/make_gaussian.tex
+++ b/rust/src/measurements/noise/distribution/gaussian/make_gaussian.tex
@@ -31,7 +31,7 @@ which constructs the core mechanism and wraps it in pre-processing transformatio
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 \begin{itemize}
     \item generic \texttt{DI} implements trait \rustdoc{measurements/noise/trait}{NoiseDomain}
     \item generic \texttt{MI} implements trait \rustdoc{core/trait}{Metric}
@@ -41,7 +41,7 @@ which constructs the core mechanism and wraps it in pre-processing transformatio
     \item type \texttt{(DI, MI)} implements trait \rustdoc{core/trait}{MetricSpace}
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/distribution/geometric/MakeNoise_AtomDomain_for_ConstantTimeGeometric.tex
+++ b/rust/src/measurements/noise/distribution/geometric/MakeNoise_AtomDomain_for_ConstantTimeGeometric.tex
@@ -19,7 +19,7 @@ applying the vector mechanism, and then unpacking the resulting singleton vector
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 
 \texttt{MakeNoise} is parameterized as follows:
 \begin{itemize}
@@ -40,7 +40,7 @@ The following trait bounds are also required:
         maps built for \texttt{ZExpFamily<1>} can be used for \texttt{ConstantTimeGeometric}.
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/distribution/geometric/MakeNoise_AtomDomain_for_ConstantTimeGeometric.tex
+++ b/rust/src/measurements/noise/distribution/geometric/MakeNoise_AtomDomain_for_ConstantTimeGeometric.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{MakeNoise<AtomDomain<T>, AbsoluteDistance<T>, MO> for ConstantTimeGeometric<T>}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/distribution/geometric/MakeNoise_VectorDomain_for_ConstantTimeGeometric.tex
+++ b/rust/src/measurements/noise/distribution/geometric/MakeNoise_VectorDomain_for_ConstantTimeGeometric.tex
@@ -23,7 +23,7 @@ This layer makes interior layers simpler to work with, and does not have privacy
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 \texttt{MakeNoise} is parameterized as follows:
 \begin{itemize}
     \item \texttt{DI} is of type \texttt{VectorDomain<AtomDomain<T>>}
@@ -43,7 +43,7 @@ The following trait bounds are also required:
         maps built for \texttt{ZExpFamily<1>} can be used for \texttt{ConstantTimeGeometric}.
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/distribution/geometric/MakeNoise_VectorDomain_for_ConstantTimeGeometric.tex
+++ b/rust/src/measurements/noise/distribution/geometric/MakeNoise_VectorDomain_for_ConstantTimeGeometric.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{MakeNoise<DI, MI, MO> for DiscreteLaplace}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/distribution/geometric/make_geometric.tex
+++ b/rust/src/measurements/noise/distribution/geometric/make_geometric.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{fn make\_geometric}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/distribution/geometric/make_geometric.tex
+++ b/rust/src/measurements/noise/distribution/geometric/make_geometric.tex
@@ -18,7 +18,7 @@ which constructs the core mechanism and wraps it in pre-processing transformatio
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 \begin{itemize}
     \item generic \texttt{DI} implements trait \rustdoc{core/trait}{Domain}
     \item generic \texttt{MI} implements trait \rustdoc{core/trait}{Metric}
@@ -30,7 +30,7 @@ which constructs the core mechanism and wraps it in pre-processing transformatio
     \item type \texttt{(DI, MI)} implements trait \rustdoc{core/trait}{MetricSpace}
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/distribution/laplace/MakeNoise_for_DiscreteLaplace.tex
+++ b/rust/src/measurements/noise/distribution/laplace/MakeNoise_for_DiscreteLaplace.tex
@@ -25,7 +25,7 @@ by simplifying the type signature.
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 \texttt{MakeNoise} is parameterized as follows:
 \begin{itemize}
     \item \texttt{DI} implements trait \rustdoc{core/trait}{Domain}
@@ -44,7 +44,7 @@ The following trait bounds are also required:
         That is, it must be possible to build the mechanism from this new equivalent distribution.
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/distribution/laplace/MakeNoise_for_DiscreteLaplace.tex
+++ b/rust/src/measurements/noise/distribution/laplace/MakeNoise_for_DiscreteLaplace.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{MakeNoise<DI, MI, MO> for DiscreteLaplace}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/distribution/laplace/NoisePrivacyMap_for_ZExpFamily1.tex
+++ b/rust/src/measurements/noise/distribution/laplace/NoisePrivacyMap_for_ZExpFamily1.tex
@@ -14,14 +14,14 @@ Proves soundness of the implementation of \rustdoc{measurements/noise/trait}{Noi
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 \texttt{NoisePrivacyMap} is parameterized as follows:
 \begin{itemize}
     \item \texttt{MI}, the input metric, is of type \rustdoc{metrics/type}{L1Distance<RBig>}
     \item \texttt{MO}, the output measure, is of type \rustdoc{measures/struct}{MaxDivergence}
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/distribution/laplace/NoisePrivacyMap_for_ZExpFamily1.tex
+++ b/rust/src/measurements/noise/distribution/laplace/NoisePrivacyMap_for_ZExpFamily1.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{NoisePrivacyMap<L1Distance<RBig>, MaxDivergence> for ZExpFamily<1>}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/distribution/laplace/make_laplace.tex
+++ b/rust/src/measurements/noise/distribution/laplace/make_laplace.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{fn make\_laplace}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/distribution/laplace/make_laplace.tex
+++ b/rust/src/measurements/noise/distribution/laplace/make_laplace.tex
@@ -31,7 +31,7 @@ which constructs the core mechanism and wraps it in pre-processing transformatio
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 \begin{itemize}
     \item generic \texttt{DI} implements trait \rustdoc{core/trait}{Domain}
     \item generic \texttt{MI} implements trait \rustdoc{core/trait}{Metric}
@@ -41,7 +41,7 @@ which constructs the core mechanism and wraps it in pre-processing transformatio
     \item type \texttt{(DI, MI)} implements trait \rustdoc{core/trait}{MetricSpace}
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/nature/bigint/MakeNoise_AtomDomain_for_ZExpFamily.tex
+++ b/rust/src/measurements/noise/nature/bigint/MakeNoise_AtomDomain_for_ZExpFamily.tex
@@ -22,7 +22,7 @@ except for elementary data type.
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 
 \begin{itemize}
     \item Const-generic \texttt{P} is of type \texttt{usize}
@@ -31,7 +31,7 @@ except for elementary data type.
         This bound requires that it must be possible to construct a privacy map for this combination of noise distribution, distance type and privacy measure.
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/nature/bigint/MakeNoise_AtomDomain_for_ZExpFamily.tex
+++ b/rust/src/measurements/noise/nature/bigint/MakeNoise_AtomDomain_for_ZExpFamily.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{MakeNoise<AtomDomain<IBig>, AbsoluteDistance<RBig>, MO> for IntExpFamily<P>}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/nature/float/MakeNoise_AtomDomain_for_FloatExpFamily.tex
+++ b/rust/src/measurements/noise/nature/float/MakeNoise_AtomDomain_for_FloatExpFamily.tex
@@ -22,7 +22,7 @@ except for elementary data type.
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 
 \begin{itemize}
     \item Generic \texttt{T} implements trait \rustdoc{traits/trait}{Float} and \rustdoc{traits/trait}{SaturatingCast}\texttt{<IBig>}
@@ -38,7 +38,7 @@ except for elementary data type.
         This bound requires that it must be possible to construct a privacy map for this combination of noise distribution, distance type and privacy measure.
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/nature/float/MakeNoise_AtomDomain_for_FloatExpFamily.tex
+++ b/rust/src/measurements/noise/nature/float/MakeNoise_AtomDomain_for_FloatExpFamily.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{MakeNoise<AtomDomain<T>, AbsoluteDistance<QI>, MO> for FloatExpFamily<P>}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/nature/float/MakeNoise_VectorDomain_for_FloatExpFamily.tex
+++ b/rust/src/measurements/noise/nature/float/MakeNoise_VectorDomain_for_FloatExpFamily.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{MakeNoise<VectorDomain<AtomDomain<T>>, LpDistance<P, QI>, MO> for FloatExpFamily<P>}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/nature/float/MakeNoise_VectorDomain_for_FloatExpFamily.tex
+++ b/rust/src/measurements/noise/nature/float/MakeNoise_VectorDomain_for_FloatExpFamily.tex
@@ -22,7 +22,7 @@ and then converting back to the nearest float, or saturating to positive or nega
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 
 \begin{itemize}
     \item Generic \texttt{T} implements trait \rustdoc{traits/trait}{Float}
@@ -37,7 +37,7 @@ and then converting back to the nearest float, or saturating to positive or nega
         This bound requires that it must be possible to construct a privacy map for this combination of noise distribution, distance type and privacy measure.
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/nature/float/make_float_to_bigint.tex
+++ b/rust/src/measurements/noise/nature/float/make_float_to_bigint.tex
@@ -14,7 +14,7 @@ Proves soundness of the implementation of \rustdoc{measurements/noise/nature/fn}
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 
 \begin{itemize}
     \item Generic \texttt{T} implements trait \rustdoc{traits/trait}{Float}
@@ -26,7 +26,7 @@ Proves soundness of the implementation of \rustdoc{measurements/noise/nature/fn}
         This requirement means that the raw bits of \texttt{T} can be exactly cast to an \texttt{i32}.
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/nature/float/make_float_to_bigint.tex
+++ b/rust/src/measurements/noise/nature/float/make_float_to_bigint.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{fn make\_float\_to\_bigint}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/nature/float/then_deintegerize_vec.tex
+++ b/rust/src/measurements/noise/nature/float/then_deintegerize_vec.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{fn then\_deintegerize\_vec}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/nature/float/then_deintegerize_vec.tex
+++ b/rust/src/measurements/noise/nature/float/then_deintegerize_vec.tex
@@ -14,13 +14,13 @@ Proves soundness of the implementation of \rustdoc{measurements/noise/nature/fn}
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 
 \begin{itemize}
     \item Generic \texttt{TO} implements trait \rustdoc{traits/trait}{CastInternalRational}
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/nature/float/utilities/find_nearest_multiple_of_2k.tex
+++ b/rust/src/measurements/noise/nature/float/utilities/find_nearest_multiple_of_2k.tex
@@ -2,7 +2,7 @@
 \input{../../../../../lib.sty}
 
 \title{\texttt{fn find\_nearest\_multiple\_of\_2k}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/nature/float/utilities/find_nearest_multiple_of_2k.tex
+++ b/rust/src/measurements/noise/nature/float/utilities/find_nearest_multiple_of_2k.tex
@@ -14,10 +14,10 @@ Proves soundness of the implementation of \rustdoc{measurements/noise/distributi
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 None
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 $k \neq \texttt{i32.MIN}$
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/nature/float/utilities/floor_div.tex
+++ b/rust/src/measurements/noise/nature/float/utilities/floor_div.tex
@@ -14,10 +14,10 @@ Proves soundness of the implementation of \rustdoc{measurements/noise/distributi
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 None
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/nature/float/utilities/floor_div.tex
+++ b/rust/src/measurements/noise/nature/float/utilities/floor_div.tex
@@ -2,7 +2,7 @@
 \input{../../../../../lib.sty}
 
 \title{\texttt{fn floor\_div}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/nature/float/utilities/get_min_k.tex
+++ b/rust/src/measurements/noise/nature/float/utilities/get_min_k.tex
@@ -2,7 +2,7 @@
 \input{../../../../../lib.sty}
 
 \title{\texttt{fn get\_min\_k}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/nature/float/utilities/get_min_k.tex
+++ b/rust/src/measurements/noise/nature/float/utilities/get_min_k.tex
@@ -14,7 +14,7 @@ Proves soundness of the implementation of \rustdoc{measurements/noise/distributi
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 
 \begin{itemize}
     \item Generic \texttt{T} implements trait \rustdoc{traits/trait}{Float}
@@ -22,7 +22,7 @@ Proves soundness of the implementation of \rustdoc{measurements/noise/distributi
         where \texttt{T.Bits} is the type of the native bit representation of \texttt{T}.
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/nature/float/utilities/get_rounding_distance.tex
+++ b/rust/src/measurements/noise/nature/float/utilities/get_rounding_distance.tex
@@ -14,7 +14,7 @@ Proves soundness of the implementation of \rustdoc{measurements/noise/distributi
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 
 \begin{itemize}
     \item Generic \texttt{T} implements trait \rustdoc{traits/trait}{Float}
@@ -22,7 +22,7 @@ Proves soundness of the implementation of \rustdoc{measurements/noise/distributi
         where \texttt{T.Bits} is the type of the native bit representation of \texttt{T}.
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/nature/float/utilities/get_rounding_distance.tex
+++ b/rust/src/measurements/noise/nature/float/utilities/get_rounding_distance.tex
@@ -2,7 +2,7 @@
 \input{../../../../../lib.sty}
 
 \title{\texttt{fn get\_rounding\_distance}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/nature/float/utilities/x_mul_2k.tex
+++ b/rust/src/measurements/noise/nature/float/utilities/x_mul_2k.tex
@@ -14,10 +14,10 @@ Proves soundness of the implementation of \rustdoc{measurements/noise/distributi
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 None
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 $k \neq \texttt{i32.MIN}$
 
 

--- a/rust/src/measurements/noise/nature/float/utilities/x_mul_2k.tex
+++ b/rust/src/measurements/noise/nature/float/utilities/x_mul_2k.tex
@@ -2,7 +2,7 @@
 \input{../../../../../lib.sty}
 
 \title{\texttt{fn x\_mul\_2k}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/nature/integer/MakeNoise_AtomDomain_for_IntExpFamily.tex
+++ b/rust/src/measurements/noise/nature/integer/MakeNoise_AtomDomain_for_IntExpFamily.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{MakeNoise<AtomDomain<T>, AbsoluteDistance<QI>, MO> for IntExpFamily<P>}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/nature/integer/MakeNoise_AtomDomain_for_IntExpFamily.tex
+++ b/rust/src/measurements/noise/nature/integer/MakeNoise_AtomDomain_for_IntExpFamily.tex
@@ -22,7 +22,7 @@ except for elementary data type.
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 
 \begin{itemize}
     \item Generic \texttt{T} implements trait \rustdoc{traits/trait}{Integer} and \rustdoc{traits/trait}{SaturatingCast}\texttt{<IBig>}
@@ -38,7 +38,7 @@ except for elementary data type.
         This bound requires that it must be possible to construct a privacy map for this combination of noise distribution, distance type and privacy measure.
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/nature/integer/MakeNoise_VectorDomain_for_IntExpFamily.tex
+++ b/rust/src/measurements/noise/nature/integer/MakeNoise_VectorDomain_for_IntExpFamily.tex
@@ -21,7 +21,7 @@ The clamping is done by saturating the cast of the sampled value to the native i
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 
 \begin{itemize}
     \item Generic \texttt{T} implements trait \rustdoc{traits/trait}{Integer} and \rustdoc{traits/trait}{SaturatingCast}\texttt{<IBig>}
@@ -37,7 +37,7 @@ The clamping is done by saturating the cast of the sampled value to the native i
         This bound requires that it must be possible to construct a privacy map for this combination of noise distribution, distance type and privacy measure.
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/nature/integer/MakeNoise_VectorDomain_for_IntExpFamily.tex
+++ b/rust/src/measurements/noise/nature/integer/MakeNoise_VectorDomain_for_IntExpFamily.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{MakeNoise<VectorDomain<AtomDomain<T>>, LpDistance<P, QI>, MO> for IntExpFamily<P>}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/nature/integer/make_int_to_bigint.tex
+++ b/rust/src/measurements/noise/nature/integer/make_int_to_bigint.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{fn make\_int\_to\_bigint}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/nature/integer/make_int_to_bigint.tex
+++ b/rust/src/measurements/noise/nature/integer/make_int_to_bigint.tex
@@ -14,13 +14,13 @@ Proves soundness of the implementation of \rustdoc{measurements/noise/nature/fn}
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 
 \begin{itemize}
     \item Generic \texttt{T} implements trait \rustdoc{traits/trait}{SaturatingCast}\texttt{<IBig>}
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise/nature/integer/then_saturating_cast.tex
+++ b/rust/src/measurements/noise/nature/integer/then_saturating_cast.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{fn then\_saturating\_cast}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise/nature/integer/then_saturating_cast.tex
+++ b/rust/src/measurements/noise/nature/integer/then_saturating_cast.tex
@@ -14,13 +14,13 @@ Proves soundness of the implementation of \rustdoc{measurements/noise/nature/fn}
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 
 \begin{itemize}
     \item Generic \texttt{TO} implements trait \rustdoc{traits/trait}{SaturatingCast}\texttt{<IBig>}
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise_threshold/MakeNoiseThreshold_IBig_for_RV.tex
+++ b/rust/src/measurements/noise_threshold/MakeNoiseThreshold_IBig_for_RV.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{MakeNoiseThreshold<MapDomain<AtomDomain<TK>, AtomDomain<IBig>{}>, MI, MO> for RV}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise_threshold/MakeNoiseThreshold_IBig_for_RV.tex
+++ b/rust/src/measurements/noise_threshold/MakeNoiseThreshold_IBig_for_RV.tex
@@ -17,7 +17,7 @@ This is the core implementation of all variations of the thresholded gaussian or
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 \texttt{MakeNoise} is parameterized as follows:
 \begin{itemize}
     \item \texttt{DI} is \texttt{MapDomain<AtomDomain<TK>, AtomDomain<IBig>{}>}
@@ -33,7 +33,7 @@ The following trait bounds are required:
     \item Type \texttt{ZExpFamily<P>} implements trait \rustdoc{measurements/noise_threshold/trait}{NoiseThresholdPrivacyMap}\texttt{<L0PInfDistance<P, AbsoluteDistance<UBig>{}>, MO>}
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise_threshold/distribution/gaussian/MakeNoiseThreshold_for_DiscreteGaussian.tex
+++ b/rust/src/measurements/noise_threshold/distribution/gaussian/MakeNoiseThreshold_for_DiscreteGaussian.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{MakeNoiseThreshold<DI, MI, MO> for DiscreteGaussian}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise_threshold/distribution/gaussian/MakeNoiseThreshold_for_DiscreteGaussian.tex
+++ b/rust/src/measurements/noise_threshold/distribution/gaussian/MakeNoiseThreshold_for_DiscreteGaussian.tex
@@ -25,7 +25,7 @@ by simplifying the type signature.
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 \texttt{MakeNoiseThreshold} is parameterized as follows:
 \begin{itemize}
     \item \texttt{DI} implements trait \rustdoc{core/trait}{Domain}
@@ -45,7 +45,7 @@ The following trait bounds are also required:
     \item type \texttt{(DI, MI)} implements trait \rustdoc{core/trait}{MetricSpace}
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise_threshold/distribution/gaussian/NoiseThresholdPrivacyMap_for_ZExpFamily2.tex
+++ b/rust/src/measurements/noise_threshold/distribution/gaussian/NoiseThresholdPrivacyMap_for_ZExpFamily2.tex
@@ -14,14 +14,14 @@ Proves soundness of the implementation of \rustdoc{measurements/noise_threshold/
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 \texttt{NoiseThresholdPrivacyMap} is parameterized as follows:
 \begin{itemize}
     \item \texttt{MI}, the input metric, is of type \rustdoc{metrics/type}{L02I}\texttt{<AbsoluteDistance<UBig>>}
     \item \texttt{MO}, the output measure, is of type \rustdoc{measures/struct}{Approximate}\texttt{<ZeroConcentratedDivergence>}
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise_threshold/distribution/gaussian/NoiseThresholdPrivacyMap_for_ZExpFamily2.tex
+++ b/rust/src/measurements/noise_threshold/distribution/gaussian/NoiseThresholdPrivacyMap_for_ZExpFamily2.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{NoiseThresholdPrivacyMap<L02I<AbsoluteDistance<UBig>>, Approximate<ZeroConcentratedDivergence>> for ZExpFamily<2>}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise_threshold/distribution/gaussian/make_gaussian_threshold.tex
+++ b/rust/src/measurements/noise_threshold/distribution/gaussian/make_gaussian_threshold.tex
@@ -30,7 +30,7 @@ which constructs the core mechanism and wraps it in pre-processing transformatio
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 \begin{itemize}
     \item generic \texttt{DI} implements trait \rustdoc{measurements/noise/trait}{NoiseDomain}
     \item generic \texttt{MI} implements trait \rustdoc{core/trait}{Metric}
@@ -39,7 +39,7 @@ which constructs the core mechanism and wraps it in pre-processing transformatio
     \item type \texttt{(DI, MI)} implements trait \rustdoc{core/trait}{MetricSpace}
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise_threshold/distribution/gaussian/make_gaussian_threshold.tex
+++ b/rust/src/measurements/noise_threshold/distribution/gaussian/make_gaussian_threshold.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{fn make\_gaussian\_threshold}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise_threshold/distribution/laplace/MakeNoiseThreshold_for_DiscreteLaplace.tex
+++ b/rust/src/measurements/noise_threshold/distribution/laplace/MakeNoiseThreshold_for_DiscreteLaplace.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{MakeNoiseThreshold<DI, MI, MO> for DiscreteLaplace}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise_threshold/distribution/laplace/MakeNoiseThreshold_for_DiscreteLaplace.tex
+++ b/rust/src/measurements/noise_threshold/distribution/laplace/MakeNoiseThreshold_for_DiscreteLaplace.tex
@@ -25,7 +25,7 @@ by simplifying the type signature.
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 \texttt{MakeNoiseThreshold} is parameterized as follows:
 \begin{itemize}
     \item \texttt{DI} implements trait \rustdoc{core/trait}{Domain}
@@ -45,7 +45,7 @@ The following trait bounds are also required:
     \item type \texttt{(DI, MI)} implements trait \rustdoc{core/trait}{MetricSpace}
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise_threshold/distribution/laplace/NoiseThresholdPrivacyMap_for_ZExpFamily1.tex
+++ b/rust/src/measurements/noise_threshold/distribution/laplace/NoiseThresholdPrivacyMap_for_ZExpFamily1.tex
@@ -14,14 +14,14 @@ Proves soundness of the implementation of \rustdoc{measurements/noise_threshold/
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 \texttt{NoiseThresholdPrivacyMap} is parameterized as follows:
 \begin{itemize}
     \item \texttt{MI}, the input metric, is of type \rustdoc{metrics/type}{L01InfDistance}\texttt{<AbsoluteDistance<RBig>>}
     \item \texttt{MO}, the output measure, is of type \rustdoc{measures/struct}{Approximate}\texttt{<MaxDivergence>}
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise_threshold/distribution/laplace/NoiseThresholdPrivacyMap_for_ZExpFamily1.tex
+++ b/rust/src/measurements/noise_threshold/distribution/laplace/NoiseThresholdPrivacyMap_for_ZExpFamily1.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{NoiseThresholdPrivacyMap<L01InfDistance<AbsoluteDistance<RBig>>, Approximate<MaxDivergence>> for ZExpFamily<1>}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise_threshold/distribution/laplace/make_laplace_threshold.tex
+++ b/rust/src/measurements/noise_threshold/distribution/laplace/make_laplace_threshold.tex
@@ -30,7 +30,7 @@ which constructs the core mechanism and wraps it in pre-processing transformatio
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 \begin{itemize}
     \item generic \texttt{DI} implements trait \rustdoc{measurements/noise/trait}{NoiseDomain}
     \item generic \texttt{MI} implements trait \rustdoc{core/trait}{Metric}
@@ -39,7 +39,7 @@ which constructs the core mechanism and wraps it in pre-processing transformatio
     \item type \texttt{(DI, MI)} implements trait \rustdoc{core/trait}{MetricSpace}
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise_threshold/distribution/laplace/make_laplace_threshold.tex
+++ b/rust/src/measurements/noise_threshold/distribution/laplace/make_laplace_threshold.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{fn make\_laplace\_threshold}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise_threshold/nature/float/MakeNoiseThreshold_MapDomain_for_FloatExpFamily.tex
+++ b/rust/src/measurements/noise_threshold/nature/float/MakeNoiseThreshold_MapDomain_for_FloatExpFamily.tex
@@ -22,7 +22,7 @@ and then converting back to the nearest float, or saturating to positive or nega
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 
 \begin{itemize}
     \item Generic \texttt{TK} implements trait \rustdoc{traits/trait}{Hashable}
@@ -38,7 +38,7 @@ and then converting back to the nearest float, or saturating to positive or nega
         This bound requires that it must be possible to construct a privacy map for this combination of noise distribution, distance type and privacy measure.
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise_threshold/nature/float/MakeNoiseThreshold_MapDomain_for_FloatExpFamily.tex
+++ b/rust/src/measurements/noise_threshold/nature/float/MakeNoiseThreshold_MapDomain_for_FloatExpFamily.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{MakeNoise<MapDomain<AtomDomain<TK>, AtomDomain<TV>>, L0PInfDistance<P, AbsoluteDistance<QI>>, MO> for FloatExpFamily<P>}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise_threshold/nature/float/make_float_to_bigint_threshold.tex
+++ b/rust/src/measurements/noise_threshold/nature/float/make_float_to_bigint_threshold.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{fn make\_float\_to\_bigint\_threshold}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise_threshold/nature/float/make_float_to_bigint_threshold.tex
+++ b/rust/src/measurements/noise_threshold/nature/float/make_float_to_bigint_threshold.tex
@@ -14,7 +14,7 @@ Proves soundness of the implementation of \rustdoc{measurements/noise_threshold/
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 
 \begin{itemize}
     \item Generic \texttt{TK} implements trait \rustdoc{traits/trait}{Hashable}
@@ -27,7 +27,7 @@ Proves soundness of the implementation of \rustdoc{measurements/noise_threshold/
         This requirement means that the raw bits of \texttt{T} can be exactly cast to an \texttt{i32}.
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise_threshold/nature/float/then_deintegerize_hashmap.tex
+++ b/rust/src/measurements/noise_threshold/nature/float/then_deintegerize_hashmap.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{fn then\_deintegerize\_hashmap}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise_threshold/nature/float/then_deintegerize_hashmap.tex
+++ b/rust/src/measurements/noise_threshold/nature/float/then_deintegerize_hashmap.tex
@@ -14,13 +14,13 @@ Proves soundness of the implementation of \rustdoc{measurements/noise/nature/fn}
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 
 \begin{itemize}
     \item Generic \texttt{TV} implements trait \rustdoc{traits/trait}{CastInternalRational}
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise_threshold/nature/integer/MakeNoiseThreshold_MapDomain_for_IntExpFamily.tex
+++ b/rust/src/measurements/noise_threshold/nature/integer/MakeNoiseThreshold_MapDomain_for_IntExpFamily.tex
@@ -21,7 +21,7 @@ The clamping is done by saturating the cast of the sampled value to the native i
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 
 \begin{itemize}
     \item Generic \texttt{T} implements trait \rustdoc{traits/trait}{Integer} and \rustdoc{traits/trait}{SaturatingCast}\texttt{<IBig>}
@@ -37,7 +37,7 @@ The clamping is done by saturating the cast of the sampled value to the native i
         This bound requires that it must be possible to construct a privacy map for this combination of noise distribution, distance type and privacy measure.
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise_threshold/nature/integer/MakeNoiseThreshold_MapDomain_for_IntExpFamily.tex
+++ b/rust/src/measurements/noise_threshold/nature/integer/MakeNoiseThreshold_MapDomain_for_IntExpFamily.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{MakeNoise<MapDomain<AtomDomain<TK>, AtomDomain<TV>>, L0PInfDistance<P, AbsoluteDistance<QI>>, MO> for IntExpFamily<P>}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise_threshold/nature/integer/make_int_to_bigint_threshold.tex
+++ b/rust/src/measurements/noise_threshold/nature/integer/make_int_to_bigint_threshold.tex
@@ -14,7 +14,7 @@ Proves soundness of the implementation of \rustdoc{measurements/noise_threshold/
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 
 \begin{itemize}
     \item Generic \texttt{TK} implements trait \rustdoc{traits/trait}{Hashable}
@@ -23,7 +23,7 @@ Proves soundness of the implementation of \rustdoc{measurements/noise_threshold/
     \item Generic \texttt{QI} implements trait \rustdoc{traits/trait}{Number}
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noise_threshold/nature/integer/make_int_to_bigint_threshold.tex
+++ b/rust/src/measurements/noise_threshold/nature/integer/make_int_to_bigint_threshold.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{fn make\_int\_to\_bigint\_threshold}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise_threshold/nature/integer/then_saturating_cast_hashmap.tex
+++ b/rust/src/measurements/noise_threshold/nature/integer/then_saturating_cast_hashmap.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{fn then\_saturating\_cast\_hashmap}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/measurements/noise_threshold/nature/integer/then_saturating_cast_hashmap.tex
+++ b/rust/src/measurements/noise_threshold/nature/integer/then_saturating_cast_hashmap.tex
@@ -14,14 +14,14 @@ Proves soundness of the implementation of \rustdoc{measurements/noise_threshold/
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 
 \begin{itemize}
     \item Generic \texttt{TK} implements trait \rustdoc{traits/trait}{Hashable}
     \item Generic \texttt{TV} implements trait \rustdoc{traits/trait}{SaturatingCast}\texttt{<IBig>}
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/measurements/noisy_top_k/TopKMeasure_MaxDivergence.tex
+++ b/rust/src/measurements/noisy_top_k/TopKMeasure_MaxDivergence.tex
@@ -3,7 +3,7 @@
 \allowdisplaybreaks
 
 \title{\texttt{impl TopKMeasure for MaxDivergence}}
-\author{Tudor Cebere \and Michael Shoemate}
+\author{\TudorCebereAuthor \and \MichaelShoemateAuthor}
 \begin{document}
 \maketitle
 \contrib

--- a/rust/src/measurements/noisy_top_k/TopKMeasure_ZeroConcentratedDivergence.tex
+++ b/rust/src/measurements/noisy_top_k/TopKMeasure_ZeroConcentratedDivergence.tex
@@ -3,7 +3,7 @@
 \allowdisplaybreaks
 
 \title{\texttt{impl TopKMeasure for ZeroConcentratedDivergence}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \begin{document}
 \maketitle
 

--- a/rust/src/measurements/noisy_top_k/make_noisy_top_k.tex
+++ b/rust/src/measurements/noisy_top_k/make_noisy_top_k.tex
@@ -3,7 +3,7 @@
 \allowdisplaybreaks
 
 \title{\texttt{fn make\_noisy\_top\_k}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \begin{document}
 \maketitle
 

--- a/rust/src/measurements/noisy_top_k/noisy_top_k.tex
+++ b/rust/src/measurements/noisy_top_k/noisy_top_k.tex
@@ -5,16 +5,17 @@
 \author{Michael Shoemate}
 
 \begin{document}
-\maketitle\contrib
+\maketitle
+\contrib
 This document proves soundness of \rustdoc{measurements/noisy_top_k/fn}{noisy\_top\_k} in \asOfCommit{mod.rs}{e62b0aa2}. 
 \texttt{noisy\_top\_k} noisily selects the index of the best score from a vector of input scores $k$ times.
 
 \section{Hoare Triple}
-\subsection*{Preconditions}
-\subsubsection*{Compiler-Verified}
+\subsection*{Precondition}
+\subsubsection*{Compiler-verified}
 \textit{Types consistent with pseudocode.}
 
-\subsubsection*{Caller-Verified}
+\subsubsection*{Caller-verified}
 \begin{itemize}
     \item Each item of \texttt{x} is finite.
 \end{itemize}

--- a/rust/src/measurements/noisy_top_k/noisy_top_k.tex
+++ b/rust/src/measurements/noisy_top_k/noisy_top_k.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{fn noisy\_top\_k}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 
 \begin{document}
 \maketitle

--- a/rust/src/measurements/noisy_top_k/peel_permute_and_flip.tex
+++ b/rust/src/measurements/noisy_top_k/peel_permute_and_flip.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{fn peel\_permute\_and\_flip}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 
 \begin{document}
 \maketitle\contrib

--- a/rust/src/measurements/noisy_top_k/peel_permute_and_flip.tex
+++ b/rust/src/measurements/noisy_top_k/peel_permute_and_flip.tex
@@ -10,8 +10,12 @@ This document proves soundness of \rustdoc{measurements/noisy_top_k/fn}{peel\_pe
 \texttt{peel\_permute\_and\_flip} noisily selects the index of the greatest score from a vector of input scores $k$ times without replacement.
 
 \section{Hoare Triple}
-\subsection*{Preconditions}
+\subsection*{Precondition}
+\subsubsection*{Compiler-verified}
 \textit{Types consistent with pseudocode.}
+
+\subsubsection*{Caller-verified}
+None
 
 \subsection*{Pseudocode}
 \label{sec:python-pseudocode}

--- a/rust/src/measurements/noisy_top_k/permute_and_flip.tex
+++ b/rust/src/measurements/noisy_top_k/permute_and_flip.tex
@@ -10,8 +10,12 @@ This document proves soundness of \rustdoc{measurements/noisy_top_k}{permute\_an
 \texttt{permute\_and\_flip} noisily selects the index of the greatest score from a vector of input scores.
 
 \section{Hoare Triple}
-\subsection*{Preconditions}
+\subsection*{Precondition}
+\subsubsection*{Compiler-verified}
 \textit{Types consistent with pseudocode.}
+
+\subsubsection*{Caller-verified}
+None
 
 \subsection*{Pseudocode}
 \label{sec:python-pseudocode}

--- a/rust/src/measurements/noisy_top_k/permute_and_flip.tex
+++ b/rust/src/measurements/noisy_top_k/permute_and_flip.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{fn permute\_and\_flip}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 
 \begin{document}
 \maketitle\contrib

--- a/rust/src/measurements/randomized_response/make_randomized_response.tex
+++ b/rust/src/measurements/randomized_response/make_randomized_response.tex
@@ -4,7 +4,7 @@
 
 
 \title{\texttt{fn make\_randomized\_response}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \begin{document}
 
 \maketitle

--- a/rust/src/measurements/randomized_response/make_randomized_response.tex
+++ b/rust/src/measurements/randomized_response/make_randomized_response.tex
@@ -30,23 +30,25 @@ The mechanism returned by \texttt{make\_randomized\_response} takes in a data se
 
 \section{Hoare Triple}
 
-\subsection*{Preconditions}
+\subsection*{Precondition}
+\subsubsection*{Compiler-verified}
 \begin{itemize}
     \item Variable \texttt{categories} must be a set with members of type \texttt{T}
     \item Variable \texttt{prob} must be of type \texttt{f64}
 \end{itemize}
 
+\subsubsection*{Caller-verified}
+None
+
 \subsection*{Pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/make_randomized_response.py}
 
 \subsection*{Postcondition}
-
+\begin{theorem}
 \validMeasurement{\texttt{(categories, prob, T)}}{\\ \texttt{make\_randomized\_response}}
-
-\section{Proof}
-
+\end{theorem}
 \begin{proof} 
-\textbf{(Privacy guarantee.)} 
+\textbf{(Privacy guarantee.)}
     
 \begin{tcolorbox}
     The proof assumes the following lemma.

--- a/rust/src/measurements/randomized_response/make_randomized_response_bool.tex
+++ b/rust/src/measurements/randomized_response/make_randomized_response_bool.tex
@@ -4,7 +4,7 @@
 
 
 \title{\texttt{fn make\_randomized\_response\_bool}}
-\author{Vicki Xu, Hanwen Zhang, Zachary Ratliff}
+\author{\VickiXuAuthor, \HanwenZhangAuthor, \ZacharyRatliffAuthor}
 \begin{document}
 
 \maketitle

--- a/rust/src/measurements/randomized_response/make_randomized_response_bool.tex
+++ b/rust/src/measurements/randomized_response/make_randomized_response_bool.tex
@@ -27,21 +27,23 @@ The measurement function makes mitigations against timing channels if \texttt{co
 
 \section{Hoare Triple}
 
-\subsection*{Preconditions}
+\subsection*{Precondition}
+\subsubsection*{Compiler-verified}
 \begin{itemize}
     \item Variable \texttt{prob} must be of type \texttt{f64}
     \item Variable \texttt{constant\_time} must be of type \texttt{bool}
 \end{itemize}
 
+\subsubsection*{Caller-verified}
+None
+
 \subsection*{Pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/make_randomized_response_bool.py}
 
 \subsection*{Postcondition}
-
+\begin{theorem}
 \validMeasurement{\texttt{(prob, constant\_time)}}{\\ \texttt{make\_randomized\_response\_bool}}
-
-\section{Proof}
-
+\end{theorem}
 \begin{proof} 
 \textbf{(Privacy guarantee.)} 
 

--- a/rust/src/measurements/randomized_response_bitvec/make_randomized_response_bitvec.tex
+++ b/rust/src/measurements/randomized_response_bitvec/make_randomized_response_bitvec.tex
@@ -24,7 +24,8 @@ This is a randomizer in the local model of differential privacy, which is a simp
 Frequency estimation is the problem of generating a histogram of the empirical frequencies of categorical elements. Any categorical domain of size $k$ can be mapped to the set $[k]=\{0,1,\ldots,k-1\}$, and we can represent any element $j\in[k]$ as the $j$'th standard basis vector so that $m=1$. In cases where the domain is extremely large or even unbounded (such as a set of strings) we can hash the domain elements using a bloom filter with $m$ hash functions. In order to decode a set of outputs generated in this fashion we must perform a regression against the bloom filter representations of a set of candidate elements, neither bloom filters nor the regression tools required for this are implemented here, but details can be found in the original RAPPOR paper. We will require that $2m+1<k$, but $m$ should be much less than $k$ in order to preserve utility. As we will prove in~\ref{thm:privacy-parameter} privacy degrades linearly with $m$. 
 
 \section{Hoare Triple}
-\subsection{Preconditions}
+\subsection*{Precondition}
+\subsubsection*{Compiler-verified}
 \begin{itemize}
 	\item Variable \texttt{input\_domain} must be of type \rustdoc{domains/struct}{BitVectorDomain}, with \texttt{max\_weight}.
 	\item Variable \texttt{input\_metric} must be of type \rustdoc{metrics/struct}{DiscreteDistance}.
@@ -32,16 +33,17 @@ Frequency estimation is the problem of generating a histogram of the empirical f
     \item Variable \texttt{constant\_time} must be of type \texttt{bool}.
 \end{itemize}
 
-\subsection{Pseudocode}
+\subsubsection*{Caller-verified}
+None
+
+\subsection*{Pseudocode}
 
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/make_randomized_response_bitvec.py}
 
-\subsection{Postcondition}
+\subsection*{Postcondition}
+\begin{theorem}
 \validMeasurement{\texttt{(f, m, constant\_time)}}{\\ \texttt{make\_randomized\_response\_bitvec}}
-
-
-\section{Proof}
-
+\end{theorem}
 \subsection{Privacy}
 
 \begin{tcolorbox}

--- a/rust/src/measurements/randomized_response_bitvec/make_randomized_response_bitvec.tex
+++ b/rust/src/measurements/randomized_response_bitvec/make_randomized_response_bitvec.tex
@@ -4,7 +4,7 @@
 \newcommand\numberthis{\addtocounter{equation}{1}\tag{\theequation}}
 
 \title{\texttt{fn make\_randomized\_response\_bitvec}}
-\author{Abigail Gentle}
+\author{\AbigailGentleAuthor}
 
 \allowdisplaybreaks
 

--- a/rust/src/traits/samplers/bernoulli/sample_bernoulli_float.tex
+++ b/rust/src/traits/samplers/bernoulli/sample_bernoulli_float.tex
@@ -2,7 +2,7 @@
 \input{../../../lib.sty}
 
 \title{\texttt{fn sample\_bernoulli\_float}}
-\author{Vicki Xu, Hanwen Zhang, Zachary Ratliff}
+\author{\VickiXuAuthor, \HanwenZhangAuthor, \ZacharyRatliffAuthor}
 
 \begin{document}
 \maketitle

--- a/rust/src/traits/samplers/bernoulli/sample_bernoulli_float.tex
+++ b/rust/src/traits/samplers/bernoulli/sample_bernoulli_float.tex
@@ -27,26 +27,27 @@ like so: $\texttt{prob} = \sum_{i = 0}^{\infty} \frac{a_i}{2^{i + 1}}$.
 The algorithm samples $I \sim Geom(0.5)$ using an internal function \rustdoc{traits/samplers/geometric/fn}{sample\_geometric\_buffer}, then returns $a_I$. 
 
 \subsection{Hoare Triple}
-\subsubsection*{Preconditions}
+\subsection*{Precondition}
+\subsubsection*{Compiler-verified}
 \begin{itemize}
-    \item \textbf{User-specified types:}
-    \begin{itemize}
-        \item Variable \texttt{prob} must be of type \texttt{T}
-        \item Variable \texttt{constant\_time} must be of type \texttt{bool}
-        \item Type \texttt{T} has trait \rustdoc{traits/trait}{Float}. 
-            \texttt{Float} implies there exists an associated type \texttt{T::Bits} (defined in \rustdoc{traits/trait}{FloatBits}) that captures the underlying bit representation of \texttt{T}.
-        \item Type \texttt{T::Bits} has traits \texttt{PartialOrd} and \texttt{ExactIntCast<usize>}
-        \item Type \texttt{usize} has trait \texttt{ExactIntCast<T::Bits>}
-    \end{itemize}
+    \item Variable \texttt{prob} must be of type \texttt{T}.
+    \item Variable \texttt{constant\_time} must be of type \texttt{bool}.
+    \item Type \texttt{T} has trait \rustdoc{traits/trait}{Float}.
+        \texttt{Float} implies there exists an associated type \texttt{T::Bits} (defined in \rustdoc{traits/trait}{FloatBits}) that captures the underlying bit representation of \texttt{T}.
+    \item Type \texttt{T::Bits} has traits \texttt{PartialOrd} and \texttt{ExactIntCast<usize>}.
+    \item Type \texttt{usize} has trait \texttt{ExactIntCast<T::Bits>}.
 \end{itemize}
 
-\subsubsection*{Pseudocode}
+\subsubsection*{Caller-verified}
+None
+
+\subsection*{Pseudocode}
 
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/sample_bernoulli_float.py}
 
-\subsubsection*{Postcondition}
+\subsection*{Postcondition}
 
-\begin{definition}
+\begin{theorem}
     \label{sample-bernoulli}
     For any setting of the input parameters
     \texttt{prob} of type \texttt{T} restricted to $[0, 1]$,
@@ -57,9 +58,7 @@ The algorithm samples $I \sim Geom(0.5)$ using an internal function \rustdoc{tra
         \item returns \texttt{out} where \texttt{out} is $\top$ with probability \texttt{prob}, otherwise $\bot$.
     \end{itemize}
      If \texttt{constant\_time} is set, the implementation's runtime is constant.    
-\end{definition}
-
-\subsection{Proof}
+\end{theorem}
 \begin{proof} 
 To show the correctness of \texttt{sample\_bernoulli} we observe first that the base-2 representation of \texttt{prob} is of the form 
 \[

--- a/rust/src/traits/samplers/bernoulli/sample_bernoulli_rational.tex
+++ b/rust/src/traits/samplers/bernoulli/sample_bernoulli_rational.tex
@@ -27,25 +27,26 @@ like so: $\texttt{prob} = \sum_{i = 0}^{\infty} \frac{a_i}{2^{i + 1}}$.
 The algorithm samples $I \sim Geom(0.5)$ using an internal function \rustdoc{traits/samplers/geometric/fn}{sample\_geometric\_buffer}, then returns $a_I$. 
 
 \subsection{Hoare Triple}
-\subsubsection*{Preconditions}
+\subsection*{Precondition}
+\subsubsection*{Compiler-verified}
 \begin{itemize}
-    \item \textbf{User-specified types:}
-    \begin{itemize}
-        \item Variable \texttt{prob} must be of type \texttt{T}
-        \item Variable \texttt{constant\_time} must be of type \texttt{bool}
-        \item Type \texttt{T} has trait \rustdoc{traits/trait}{Float}. 
-            \texttt{Float} implies there exists an associated type \texttt{T::Bits} (defined in \rustdoc{traits/trait}{FloatBits}) that captures the underlying bit representation of \texttt{T}.
-        \item Type \texttt{T::Bits} has traits \texttt{PartialOrd} and \texttt{ExactIntCast<usize>}
-        \item Type \texttt{usize} has trait \texttt{ExactIntCast<T::Bits>}
-    \end{itemize}
+    \item Variable \texttt{prob} must be of type \texttt{T}.
+    \item Variable \texttt{constant\_time} must be of type \texttt{bool}.
+    \item Type \texttt{T} has trait \rustdoc{traits/trait}{Float}.
+        \texttt{Float} implies there exists an associated type \texttt{T::Bits} (defined in \rustdoc{traits/trait}{FloatBits}) that captures the underlying bit representation of \texttt{T}.
+    \item Type \texttt{T::Bits} has traits \texttt{PartialOrd} and \texttt{ExactIntCast<usize>}.
+    \item Type \texttt{usize} has trait \texttt{ExactIntCast<T::Bits>}.
 \end{itemize}
 
-\subsubsection*{Pseudocode}
+\subsubsection*{Caller-verified}
+None
+
+\subsection*{Pseudocode}
 
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/sample_bernoulli_rational.py}
 
-\subsubsection*{Postcondition}
-\begin{definition}
+\subsection*{Postcondition}
+\begin{theorem}
     \label{sample-bernoulli}
 
     For any setting of the input parameters
@@ -57,7 +58,7 @@ The algorithm samples $I \sim Geom(0.5)$ using an internal function \rustdoc{tra
         \item returns \texttt{out} where \texttt{out} is $\top$ with probability \texttt{prob}, otherwise $\bot$.
     \end{itemize}
      If \texttt{trials} is set, the implementation's runtime is constant.    
-\end{definition}
+\end{theorem}
 
 \begin{proof} 
 An integer sample is taken uniformly at random from $[0, denom)$, where \texttt{denom} is the denominator of \texttt{prob}.

--- a/rust/src/traits/samplers/bernoulli/sample_bernoulli_rational.tex
+++ b/rust/src/traits/samplers/bernoulli/sample_bernoulli_rational.tex
@@ -2,7 +2,7 @@
 \input{../../../lib.sty}
 
 \title{\texttt{fn sample\_bernoulli\_rational}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 
 \begin{document}
 \maketitle

--- a/rust/src/traits/samplers/cks20/sample_bernoulli_exp.tex
+++ b/rust/src/traits/samplers/cks20/sample_bernoulli_exp.tex
@@ -2,7 +2,7 @@
 \input{../../../lib.sty} 
  
 \title{\texttt{fn sample\_bernoulli\_exp}} 
-\author{Michael Shoemate} 
+\author{\MichaelShoemateAuthor}
  
 \begin{document} 
 \maketitle 

--- a/rust/src/traits/samplers/cks20/sample_bernoulli_exp.tex
+++ b/rust/src/traits/samplers/cks20/sample_bernoulli_exp.tex
@@ -14,24 +14,26 @@ This proof is an adaptation of \href{https://arxiv.org/pdf/2004.00010.pdf#subsec
  
 \section{Hoare Triple} 
 \subsection*{Precondition} 
-\textbf{Compiler-verified} 
+\subsubsection*{Compiler-verified}
 \begin{itemize} 
     \item Argument \texttt{x} is of type \texttt{RBig}, a bignum rational 
 \end{itemize} 
  
-\textbf{User-verified} 
-$\texttt{x} > 0$ 
+\subsubsection*{Caller-verified}
+\begin{itemize}
+    \item $\texttt{x} > 0$.
+\end{itemize}
  
 \subsection*{Pseudocode}         
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/sample_bernoulli_exp.py} 
  
 \subsection*{Postcondition} 
+\begin{theorem}
 \label{postcondition} 
 For any setting of the input parameters \texttt{x} such that the given preconditions hold, \\ 
 \texttt{sample\_bernoulli\_exp} either returns \texttt{Err(e)} due to a lack of system entropy, 
 or \texttt{Ok(out)}, where \texttt{out} is distributed as $Bernoulli(exp(-x))$. 
- 
-\section{Proof} 
+\end{theorem}
 Assume the preconditions are met. 
  
 \begin{lemma} 

--- a/rust/src/traits/samplers/cks20/sample_bernoulli_exp1.tex
+++ b/rust/src/traits/samplers/cks20/sample_bernoulli_exp1.tex
@@ -12,29 +12,29 @@ Proves soundness of \texttt{fn sample\_bernoulli\_exp1} in \asOfCommit{mod.rs}{0
 \texttt{fn sample\_bernoulli\_exp1} returns a sample from the $Bernoulli(exp(-x))$ distribution for some rational argument in $[0, 1]$.
 This proof is an adaptation of \href{https://arxiv.org/pdf/2004.00010.pdf#subsection.5.1}{subsection 5.1} of \cite{CKS20}.
 
-\subsection*{Vetting History}
-\begin{itemize}
-    \item \vettingPR{519}
-\end{itemize}
-
 \section{Hoare Triple}
-\subsection*{Preconditions}
+\subsection*{Precondition}
+\subsubsection*{Compiler-verified}
 \begin{itemize}
-    \item $\texttt{x}$ is of type $\texttt{Rational}$ and $x \in [0, 1]$
-    \item \rustdoc{traits/samplers/bernoulli/trait}{SampleBernoulli} is implemented for $\texttt{Rational}$ probabilities
+    \item $\texttt{x}$ is of type $\texttt{Rational}$.
+    \item \rustdoc{traits/samplers/bernoulli/trait}{SampleBernoulli} is implemented for $\texttt{Rational}$ probabilities.
 \end{itemize}
 
+\subsubsection*{Caller-verified}
+\begin{itemize}
+    \item $x \in [0, 1]$.
+\end{itemize}
 
 \subsection*{Pseudocode}        
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/sample_bernoulli_exp1.py}
 
 \subsection*{Postcondition}
+\begin{theorem}
 \label{postcondition}
 For any setting of the input parameter \texttt{x} such that the given preconditions hold, \\
 \texttt{sample\_bernoulli\_exp1} either returns \texttt{Err(e)} due to a lack of system entropy,
 or \texttt{Ok(out)}, where \texttt{out} is distributed as $Bernoulli(exp(-x))$.
-
-\section{Proof}
+\end{theorem}
 Assume the preconditions are met.
 
 \begin{lemma}

--- a/rust/src/traits/samplers/cks20/sample_bernoulli_exp1.tex
+++ b/rust/src/traits/samplers/cks20/sample_bernoulli_exp1.tex
@@ -2,7 +2,7 @@
 \input{../../../lib.sty}
 
 \title{\texttt{fn sample\_bernoulli\_exp1}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 
 \begin{document}
 \maketitle

--- a/rust/src/traits/samplers/cks20/sample_discrete_gaussian.tex
+++ b/rust/src/traits/samplers/cks20/sample_discrete_gaussian.tex
@@ -17,10 +17,10 @@ This proof is an adaptation of \href{https://arxiv.org/pdf/2004.00010.pdf#subsec
     \item Argument \texttt{scale} is of type \texttt{RBig}, a bignum rational 
 \end{itemize} 
  
-\subsubsection*{User-verified} 
+\subsubsection*{Caller-verified}
 $\texttt{scale} \geq 0$ 
  
-\subsection*{Implementation} 
+\subsection*{Pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/sample_discrete_gaussian.py} 
  
 \subsection*{Postcondition} 
@@ -30,9 +30,6 @@ $\texttt{scale} \geq 0$
     \texttt{sample\_discrete\_gaussian} either returns \texttt{Err(e)} due to a lack of system entropy, 
     or \texttt{Ok(out)}, where \texttt{out} is distributed as $\mathcal{N}_\mathbb{Z}(0, \texttt{scale}^2)$. 
 \end{theorem}
- 
-\section{Proof} 
- 
 \begin{definition} 
     (Discrete Gaussian). \cite{CKS20} Let $\mu, \sigma \in \mathbb{R}$ with $\sigma > 0$.  
     The discrete gaussian distribution with location $\mu$ and scale $\sigma$ is denoted $\mathcal{N}_\mathbb{Z}(\mu, \sigma^2)$.  

--- a/rust/src/traits/samplers/cks20/sample_discrete_gaussian.tex
+++ b/rust/src/traits/samplers/cks20/sample_discrete_gaussian.tex
@@ -2,7 +2,7 @@
 \input{../../../lib.sty} 
  
 \title{\texttt{fn sample\_discrete\_gaussian}} 
-\author{Michael Shoemate} 
+\author{\MichaelShoemateAuthor}
  
 \begin{document} 
 \maketitle 
@@ -102,10 +102,10 @@ We now show that conditioning $Y$ on the success of $C$ gives the desired output
 \end{proof} 
  
 \begin{proof}[Proof of Theorem~\ref{postcondition}]
-    Holds by \ref{err-e} and \ref{ok-out}. 
-\end{proof} 
- 
-\bibliographystyle{alpha} 
-\bibliography{mod} 
- 
+    Holds by \ref{err-e} and \ref{ok-out}.
+\end{proof}
+
+\bibliographystyle{alpha}
+\bibliography{mod}
+
 \end{document}

--- a/rust/src/traits/samplers/cks20/sample_discrete_laplace.tex
+++ b/rust/src/traits/samplers/cks20/sample_discrete_laplace.tex
@@ -11,26 +11,28 @@
 Proves soundness of \texttt{fn sample\_discrete\_laplace} in \asOfCommit{mod.rs}{0be3ab3e6}.
 This proof is an adaptation of \href{https://arxiv.org/pdf/2004.00010.pdf#subsection.5.2}{subsection 5.2} of \cite{CKS20}.
 
-\subsection*{Vetting history}
-\begin{itemize}
-    \item \vettingPR{519}
-    \item \vettingPR{1134}
-\end{itemize}
-
 \section{Hoare Triple}
 \subsection*{Precondition}
-$\texttt{scale} \in \mathbb{Q} \land \texttt{scale} > 0$
+\subsubsection*{Compiler-verified}
+\begin{itemize}
+    \item \texttt{scale} is of type \texttt{Rational}.
+\end{itemize}
+
+\subsubsection*{Caller-verified}
+\begin{itemize}
+    \item $\texttt{scale} > 0$.
+\end{itemize}
 
 \subsection*{Pseudocode}        
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/sample_discrete_laplace.py}
 
 \subsection*{Postcondition}
+\begin{theorem}
 \label{postcondition}
 For any setting of the input parameter \texttt{scale} such that the given preconditions hold, \\
 \texttt{sample\_discrete\_laplace} either returns \texttt{Err(e)} due to a lack of system entropy,
 or \texttt{Ok(out)}, where \texttt{out} is distributed as $\mathcal{L}_\mathbb{Z}(0, scale)$.
-
-\section{Proof}
+\end{theorem}
 \begin{definition} \cite{BV17}
     (Discrete Laplace). Let $\mu, \sigma \in \mathbb{R}$ with $\sigma > 0$. 
     The discrete laplace distribution with location $\mu$ and scale $s$ is denoted $\mathcal{L}_\mathbb{Z}(\mu, s)$. 

--- a/rust/src/traits/samplers/cks20/sample_discrete_laplace.tex
+++ b/rust/src/traits/samplers/cks20/sample_discrete_laplace.tex
@@ -2,7 +2,7 @@
 \input{../../../lib.sty}
 
 \title{\texttt{fn sample\_discrete\_laplace}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 
 \begin{document}
 \maketitle

--- a/rust/src/traits/samplers/cks20/sample_geometric_exp_fast.tex
+++ b/rust/src/traits/samplers/cks20/sample_geometric_exp_fast.tex
@@ -11,25 +11,28 @@
 Proves soundness of \texttt{fn sample\_geometric\_exp\_fast} in \asOfCommit{mod.rs}{0be3ab3e6}.
 This proof is an adaptation of \href{https://arxiv.org/pdf/2004.00010.pdf#subsection.5.2}{subsection 5.2} of \cite{CKS20}.
 
-\subsection*{Vetting history}
-\begin{itemize}
-    \item \vettingPR{519}
-\end{itemize}
-
 \section{Hoare Triple}
 \subsection*{Precondition}
-$\texttt{x} \in \mathbb{Q} \land \texttt{x} > 0$
+\subsubsection*{Compiler-verified}
+\begin{itemize}
+    \item \texttt{x} is of type \texttt{Rational}.
+\end{itemize}
+
+\subsubsection*{Caller-verified}
+\begin{itemize}
+    \item $\texttt{x} > 0$.
+\end{itemize}
 
 \subsection*{Pseudocode}        
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/sample_geometric_exp_fast.py}
 
 \subsection*{Postcondition}
+\begin{theorem}
 \label{postcondition}
 For any setting of the input parameter \texttt{x} such that the given preconditions hold, \\
 \texttt{sample\_geometric\_exp\_fast} either returns \texttt{Err(e)} due to a lack of system entropy,
 or \texttt{Ok(out)}, where \texttt{out} is distributed as $Geometric(1 - exp(-x))$.
-
-\section{Proof}
+\end{theorem}
 Assume the preconditions are met.
 
 \begin{lemma}\label{err-e}

--- a/rust/src/traits/samplers/cks20/sample_geometric_exp_fast.tex
+++ b/rust/src/traits/samplers/cks20/sample_geometric_exp_fast.tex
@@ -2,7 +2,7 @@
 \input{../../../lib.sty}
 
 \title{\texttt{fn sample\_geometric\_exp\_fast}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 
 \begin{document}
 \maketitle

--- a/rust/src/traits/samplers/cks20/sample_geometric_exp_slow.tex
+++ b/rust/src/traits/samplers/cks20/sample_geometric_exp_slow.tex
@@ -15,7 +15,7 @@ This proof is adapted from \href{https://arxiv.org/pdf/2004.00010.pdf#subsection
 \subsubsection*{Compiler-verified} 
 Argument \texttt{x} is of type \texttt{RBig}, a bignum rational 
  
-\subsubsection*{User-verified} 
+\subsubsection*{Caller-verified}
 $\texttt{x} > 0$ 
  
 \subsection*{Pseudocode}         
@@ -48,8 +48,6 @@ $\texttt{x} > 0$
         \end{cases}
     \end{equation}
 \end{definition}
- 
-\section{Proof} 
 Assume the preconditions are met. 
  
 \begin{lemma}\label{err-e} 

--- a/rust/src/traits/samplers/cks20/sample_geometric_exp_slow.tex
+++ b/rust/src/traits/samplers/cks20/sample_geometric_exp_slow.tex
@@ -2,7 +2,7 @@
 \input{../../../lib.sty} 
  
 \title{\texttt{fn sample\_geometric\_exp\_slow}} 
-\author{Michael Shoemate} 
+\author{\MichaelShoemateAuthor}
  
 \begin{document} 
 \maketitle 
@@ -80,10 +80,10 @@ Assume the preconditions are met.
 \end{proof} 
  
 \begin{proof}[Proof of Theorem~\ref{postcondition}]
-    Holds by \ref{err-e} and \ref{ok-out}. 
-\end{proof} 
- 
- 
-\bibliographystyle{alpha} 
-\bibliography{mod} 
+    Holds by \ref{err-e} and \ref{ok-out}.
+\end{proof}
+
+
+\bibliographystyle{alpha}
+\bibliography{mod}
 \end{document}

--- a/rust/src/traits/samplers/geometric/sample_geometric_buffer.tex
+++ b/rust/src/traits/samplers/geometric/sample_geometric_buffer.tex
@@ -3,7 +3,7 @@
 
 
 \title{\texttt{fn sample\_geometric\_buffer}}
-\author{Vicki Xu, Hanwen Zhang, Zachary Ratliff}
+\author{\VickiXuAuthor, \HanwenZhangAuthor, \ZacharyRatliffAuthor}
 \begin{document}
 \maketitle
 

--- a/rust/src/traits/samplers/geometric/sample_geometric_buffer.tex
+++ b/rust/src/traits/samplers/geometric/sample_geometric_buffer.tex
@@ -10,13 +10,18 @@
 This document proves soundness of \rustdoc{traits/samplers/geometric/fn}{sample\_geometric\_buffer} in \asOfCommit{mod.rs}{f5bb719}.
 
 \section{Hoare Triple}
-\subsection*{Preconditions}
+\subsection*{Precondition}
+\subsubsection*{Compiler-verified}
+None
+
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/sample_geometric_buffer.py}
 
 \subsection*{Postcondition}
+\begin{theorem}
 For any setting of the input arguments, \texttt{sample\_geometric\_buffer} either
 raises an exception if there is insufficient system entropy, 
 or returns \texttt{sample} where \texttt{sample} is drawn from a discrete distribution.
@@ -24,6 +29,7 @@ or returns \texttt{sample} where \texttt{sample} is drawn from a discrete distri
 \texttt{sample} is either 
 \texttt{geo} where \texttt{geo} is a sample from the $Geometric(p=0.5)$ distribution, and is less than $buffer\_len * 8$, or
 \texttt{None} with probability $2^{-buffer\_len * 8}$.
+\end{theorem}
 
 \begin{proof}
     \texttt{sample\_geometric\_buffer} uses \rustdoc{traits/samplers/fn}{fill\_bytes} as a subroutine to generate a buffer of $\texttt{buffer\_len}$ bytes.

--- a/rust/src/traits/samplers/psrn/canonical/InverseCDF_for_CanonicalRV.tex
+++ b/rust/src/traits/samplers/psrn/canonical/InverseCDF_for_CanonicalRV.tex
@@ -16,7 +16,7 @@ The implementation computes the inverse CDF of the canonical noise random variab
 
 \section{Hoare Triple}
 
-\subsection*{Preconditions}
+\subsection*{Precondition}
 \subsubsection*{Compiler-verified}
 \begin{itemize}
     \item Argument \texttt{self} of type \rustdoc{traits/samplers/psrn/canonical/struct}{CanonicalRV}.
@@ -25,7 +25,7 @@ The implementation computes the inverse CDF of the canonical noise random variab
     \item Generic \texttt{R} implements \rustdoc{traits/samplers/psrn/trait}{ODPRound} which denotes the rounding mode, either up or down.
 \end{itemize}
 
-\subsubsection*{Human-verified}
+\subsubsection*{Caller-verified}
 Argument \texttt{uniform} is in $[0, 1]$.
 
 \subsection*{Pseudocode}

--- a/rust/src/traits/samplers/psrn/canonical/InverseCDF_for_CanonicalRV.tex
+++ b/rust/src/traits/samplers/psrn/canonical/InverseCDF_for_CanonicalRV.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{impl InverseCDF for CanonicalRV}}
-\author{Aishwarya Ramasethu, Yu-Ju Ku, Jordan Awan, Michael Shoemate}
+\author{\AishwaryaRamasethuAuthor, \YuJuKuAuthor, \JordanAwanAuthor, \MichaelShoemateAuthor}
 \begin{document}
 
 \maketitle

--- a/rust/src/traits/samplers/psrn/canonical/quantile_cnd.tex
+++ b/rust/src/traits/samplers/psrn/canonical/quantile_cnd.tex
@@ -5,7 +5,7 @@
 \addbibresource{ref.bib} 
 
 \title{\texttt{fn quantile\_cnd}}
-\author{Aishwarya Ramasethu, Yu-Ju Ku, Jordan Awan, Michael Shoemate}
+\author{\AishwaryaRamasethuAuthor, \YuJuKuAuthor, \JordanAwanAuthor, \MichaelShoemateAuthor}
 \begin{document}
 
 \maketitle

--- a/rust/src/traits/samplers/psrn/canonical/quantile_cnd.tex
+++ b/rust/src/traits/samplers/psrn/canonical/quantile_cnd.tex
@@ -16,7 +16,7 @@ Compute the quantile of a canonical noise distribution, as specified by a tradeo
 
 \section{Hoare Triple}
 
-\subsection*{Preconditions}
+\subsection*{Precondition}
 \subsubsection*{Compiler-verified}
 \begin{itemize}
     \item Argument \texttt{uniform} of type \texttt{RBig}
@@ -24,7 +24,7 @@ Compute the quantile of a canonical noise distribution, as specified by a tradeo
     \item Argument \texttt{c} of type \texttt{RBig}
 \end{itemize}
 
-\subsubsection*{User-verified}
+\subsubsection*{Caller-verified}
 \begin{itemize}
     \item Argument \texttt{uniform} is in $[0, 1]$
     \item Argument \texttt{f} is a symmetric nontrivial tradeoff function

--- a/rust/src/traits/samplers/uniform/sample_uniform_ubig_below.tex
+++ b/rust/src/traits/samplers/uniform/sample_uniform_ubig_below.tex
@@ -20,27 +20,28 @@ but this time the bit depth is dynamically chosen to fill the last byte of a ser
 \end{itemize}
 
 \section{Hoare Triple}
-\subsection*{Preconditions}
+\subsection*{Precondition}
+\subsubsection*{Compiler-verified}
 \begin{itemize}
-    \item \textbf{Arguments}
-    \begin{itemize}
-        \item \texttt{upper} of type \texttt{UBig}
-    \end{itemize}
+    \item \texttt{upper} is of type \texttt{UBig}.
 \end{itemize}
+
+\subsubsection*{Caller-verified}
+None
 
 \subsection*{Pseudocode}
 
 \lstinputlisting[language=Python,firstline=2]{./pseudocode/sample_uniform_ubig_below.py}
 
 \subsection*{Postcondition}
+\begin{theorem}
 For any setting of the input parameter \texttt{upper},
 \texttt{sample\_uniform\_ubig\_below} either
 \begin{itemize}
     \item raises an exception if there is a lack of system entropy,
     \item returns \texttt{out} where \texttt{out} is uniformly distributed between $[0, upper)$.
 \end{itemize}
-
-\section{Proof}
+\end{theorem}
 \begin{proof}
 \texttt{byte\_len} is the fewest number of bytes necessary to represent \texttt{upper}, 
 which works out to $\mathrm{ceil}(\mathrm{ceil}(\log_2(\texttt{upper})) / 8)$.
@@ -65,7 +66,6 @@ then $\texttt{threshold} = \texttt{max} - (\texttt{max} \mod \texttt{upper})$.
 \end{proof}
 
 \end{document}
-
 
 
 

--- a/rust/src/traits/samplers/uniform/sample_uniform_ubig_below.tex
+++ b/rust/src/traits/samplers/uniform/sample_uniform_ubig_below.tex
@@ -2,7 +2,7 @@
 \input{../../../lib.sty}
 
 \title{\texttt{fn sample\_uniform\_ubig\_below}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 
 \begin{document}
 \maketitle

--- a/rust/src/traits/samplers/uniform/sample_uniform_uint_below.tex
+++ b/rust/src/traits/samplers/uniform/sample_uniform_uint_below.tex
@@ -22,33 +22,30 @@ The algorithm returns the sample, modulo the upper bound, so long as the sample 
 \end{itemize}
 
 \subsection{Hoare Triple}
-\subsubsection*{Preconditions}
+\subsection*{Precondition}
+\subsubsection*{Compiler-verified}
 \begin{itemize}
-    \item \textbf{Arguments}
-    \begin{itemize}
-        \item \texttt{upper} must be of type \texttt{T} and non-negative
-    \end{itemize}
-
-    \item \textbf{Type Arguments}
-    \begin{itemize}
-        \item \texttt{T} has traits \texttt{Integer + Unsigned + FromBytes<N>}, which narrows valid types to u16, u32, u64, u128, usize
-        \item \texttt{N}. By the definition of \texttt{FromBytes}, the compiler ensures this is the number of bytes in T.
-    \end{itemize}
+    \item \texttt{upper} must be of type \texttt{T}.
+    \item \texttt{T} has traits \texttt{Integer + Unsigned + FromBytes<N>}, which narrows valid types to u16, u32, u64, u128, usize.
+    \item By the definition of \texttt{FromBytes}, \texttt{N} is the number of bytes in \texttt{T}.
 \end{itemize}
 
-\subsubsection*{Pseudocode}
+\subsubsection*{Caller-verified}
+None
+
+\subsection*{Pseudocode}
 
 \lstinputlisting[language=Python,firstline=2]{./pseudocode/sample_uniform_uint_below.py}
 
-\subsubsection*{Postcondition}
+\subsection*{Postcondition}
+\begin{theorem}
 For any setting of the input parameter \texttt{upper},
 \texttt{sample\_uniform\_uint\_below} either
 \begin{itemize}
     \item raises an exception if there is a lack of system entropy,
     \item returns \texttt{out} where \texttt{out} is uniformly distributed between $[0, upper)$.
 \end{itemize}
-
-\subsection{Proof}
+\end{theorem}
 \begin{proof} 
 \label{unsigned-integer-proof}
 By the postcondition of \rustdoc{traits/samplers/uniform/fn}{sample\_from\_uniform\_bytes},

--- a/rust/src/traits/samplers/uniform/sample_uniform_uint_below.tex
+++ b/rust/src/traits/samplers/uniform/sample_uniform_uint_below.tex
@@ -2,7 +2,7 @@
 \input{../../../lib.sty}
 
 \title{\texttt{fn sample\_uniform\_uint\_below}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 
 \begin{document}
 \maketitle

--- a/rust/src/transformations/clamp/make_clamp.tex
+++ b/rust/src/transformations/clamp/make_clamp.tex
@@ -12,28 +12,24 @@
 \contrib
 Proves soundness of \texttt{fn make\_clamp} in \asOfCommit{mod.rs}{0db9c6036}.
 
-\subsection*{Vetting History}
-\begin{itemize}
-    \item \vettingPR{512}
-\end{itemize}
-
 \section{Hoare Triple}
 \subsection*{Precondition}
-To ensure the correctness of the output, we require the following preconditions:
-
+\subsubsection*{Compiler-verified}
 \begin{itemize}
     \item Type \texttt{TA} must have trait \texttt{ProductOrd}.
     \item Type \texttt{M} must have trait \texttt{DatasetMetric}.
 \end{itemize}
 
+\subsubsection*{Caller-verified}
+None
+
 \subsection*{Pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/make_clamp.py}
 
-\subsubsection*{Postconditions}
+\subsection*{Postcondition}
+\begin{theorem}
 \validTransformation{\texttt{(input\_domain, input\_metric, bounds)}}{\texttt{make\_clamp}}
-
-\section{Proof}
-
+\end{theorem}
 \begin{lemma}
     The invocation of \rustdoc{transformations/manipulation/fn}{make\_row\_by\_row\_fallible} (line \ref{line:row-by-row}) satisfies its preconditions.
 \end{lemma}

--- a/rust/src/transformations/clamp/make_clamp.tex
+++ b/rust/src/transformations/clamp/make_clamp.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{fn make\_clamp}}
-\author{S\'ilvia Casacuberta}
+\author{\SilviaCasacubertaAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/transformations/count/make_count.tex
+++ b/rust/src/transformations/count/make_count.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty} 
  
 \title{\texttt{fn make\_count}} 
-\author{S\'ilvia Casacuberta, Grace Tian, Connor Wagaman} 
+\author{\SilviaCasacubertaAuthor, \GraceTianAuthor, \ConnorWagamanAuthor}
 \date{} 
  
 \begin{document} 

--- a/rust/src/transformations/count/make_count.tex
+++ b/rust/src/transformations/count/make_count.tex
@@ -34,10 +34,9 @@ None
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/make_count.py} 
  
 \subsection*{Postcondition} 
+\begin{theorem}
 \validTransformation{\texttt{(input\_domain, input\_metric, TIA, TO)}}{\texttt{make\_count}} 
- 
-\section{Proofs} 
- 
+\end{theorem}
 \begin{proof} \textbf{(Part 1 -- appropriate output domain).} 
     The \texttt{output\_domain} is \texttt{AtomDomain(TO)}, so it is sufficient to show that \texttt{function} always returns non-null values of type \texttt{TO}. 
     By the definition of the \texttt{ExactIntCast} trait, \texttt{TO.exact\_int\_cast} always returns a non-null value of type \texttt{TO} or raises an exception. 

--- a/rust/src/transformations/make_stable_expr/expr_count/counting_query_stability_map.tex
+++ b/rust/src/transformations/make_stable_expr/expr_count/counting_query_stability_map.tex
@@ -3,7 +3,7 @@
 \usepackage{bbm}
 
 \title{\texttt{fn counting\_query\_stability\_map}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 
 \begin{document}
 \maketitle

--- a/rust/src/transformations/make_stable_expr/expr_count/counting_query_stability_map.tex
+++ b/rust/src/transformations/make_stable_expr/expr_count/counting_query_stability_map.tex
@@ -12,7 +12,7 @@ This document proves that the implementation of \rustdoc{transformations/make_st
 satisfies its proof definition.
 
 \section{Hoare Triple}
-\subsection*{Preconditions}
+\subsection*{Precondition}
 \subsubsection*{Compiler-verified}
 \begin{itemize}
     \item Argument \texttt{public\_info} must be Keys, Lengths or None
@@ -20,22 +20,22 @@ satisfies its proof definition.
     \item Const generic \texttt{P} must be of type \texttt{usize}
 \end{itemize}
 
-\subsubsection*{User-verified}
+\subsubsection*{Caller-verified}
 None
 
-\subsubsection*{Pseudocode}
+\subsection*{Pseudocode}
 
 \lstinputlisting[language=Python,firstline=2,escapechar=`]{./pseudocode/counting_query_stability_map.py}
 
-\subsubsection*{Postcondition}
-\begin{definition}
+\subsection*{Postcondition}
+\begin{theorem}
     \label{sample-bernoulli}
     For any setting of the input parameters \texttt{public\_info}, \texttt{M} and \texttt{P}, 
     returns a \texttt{StabilityMap} where for any predicate $p(\cdot)$ 
     and $f(x) = [\sum_i \mathbbm{1}_{p(x_{1i})}, \sum_i \mathbbm{1}_{p(x_{2i})}, \dots]$, 
     if $d_{\mathrm{PartitionDistance<M>}}(x, x') \leq d_{in}$,
     then $d_{LP}(f(x), f(x')) \leq d_{out}$, where $d_{out} = \texttt{StabilityMap.eval}(d_{in})$.
-\end{definition}
+\end{theorem}
 
 \begin{proof} 
 Since the input metric is PartitionDistance<M>,

--- a/rust/src/transformations/make_stable_expr/expr_count/make_expr_count.tex
+++ b/rust/src/transformations/make_stable_expr/expr_count/make_expr_count.tex
@@ -3,7 +3,7 @@
 \usepackage{bbm}
 
 \title{\texttt{fn make\_expr\_count}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 
 \begin{document}
 \maketitle

--- a/rust/src/transformations/make_stable_expr/expr_count/make_expr_count.tex
+++ b/rust/src/transformations/make_stable_expr/expr_count/make_expr_count.tex
@@ -12,7 +12,7 @@ This document proves that the implementation of \rustdoc{transformations/make_st
 satisfies its proof definition.
 
 \section{Hoare Triple}
-\subsection*{Preconditions}
+\subsection*{Precondition}
 \subsubsection*{Compiler-verified}
 \begin{itemize}
     \item Argument \texttt{input\_domain} of type \texttt{ExprDomain}
@@ -28,14 +28,14 @@ satisfies its proof definition.
 \subsubsection*{Caller-verified}
 None
 
-\subsubsection*{Pseudocode}
+\subsection*{Pseudocode}
 
 \lstinputlisting[language=Python,firstline=2,escapechar=`]{./pseudocode/make_expr_count.py}
 
-\subsubsection*{Postcondition}
+\subsection*{Postcondition}
+\begin{theorem}
 \validTransformation{(input\_domain, input\_metric, expr, MI, P)}{make\_expr\_count}
-
-\section{Proof}
+\end{theorem}
 Starting from line \ref{match-strategy}, 
 \texttt{expr} is analyzed to determine the type of counting query \texttt{strategy} and input to the counting query \texttt{input}.
 

--- a/rust/src/transformations/make_stable_expr/namespace_dt/expr_datetime_component/make_expr_datetime_component.tex
+++ b/rust/src/transformations/make_stable_expr/namespace_dt/expr_datetime_component/make_expr_datetime_component.tex
@@ -36,11 +36,10 @@ None
 
 \subsection*{Postcondition}
 \begin{sloppypar}
+\begin{theorem}
 \validTransformation{\texttt{(input\_domain, input\_metric, M)}}{\texttt{make\_expr\_datetime\_component}}
+\end{theorem}
 \end{sloppypar}
-
-\section{Proof}
-
 Starting from line \ref{match-strategy}, 
 \texttt{expr} is matched as if it were a temporal expression, or otherwise rejects the expression.
 All preconditions for \rustdoc{transformations/make\_stable\_expr/namespace\_dt/expr\_datetime\_component/fn}{make\_datetime\_component} 

--- a/rust/src/transformations/make_stable_expr/namespace_dt/expr_datetime_component/make_expr_datetime_component.tex
+++ b/rust/src/transformations/make_stable_expr/namespace_dt/expr_datetime_component/make_expr_datetime_component.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{fn make\_expr\_datetime\_component}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/transformations/make_stable_expr/namespace_dt/expr_datetime_component/match_datetime_component.tex
+++ b/rust/src/transformations/make_stable_expr/namespace_dt/expr_datetime_component/match_datetime_component.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{fn match\_datetime\_component}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/transformations/make_stable_expr/namespace_str/expr_strptime/make_expr_strptime.tex
+++ b/rust/src/transformations/make_stable_expr/namespace_str/expr_strptime/make_expr_strptime.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{fn make\_expr\_strptime}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/transformations/make_stable_expr/namespace_str/expr_strptime/make_expr_strptime.tex
+++ b/rust/src/transformations/make_stable_expr/namespace_str/expr_strptime/make_expr_strptime.tex
@@ -28,17 +28,16 @@ Proves soundness of \rustdoc{transformations/make_stable_expr/namespace_str/expr
     \item \texttt{Expr} implements \texttt{StableExpr<M, M>}
 \end{itemize}
 
-\subsubsection*{Human-verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=`]{./pseudocode/make_expr_strptime.py}
 
 \subsection*{Postcondition}
+\begin{theorem}
 \validTransformation{\texttt{(input\_domain, input\_metric, expr, M)}}{\texttt{make\_expr\_strptime}}
-
-\section{Proof}
-
+\end{theorem}
 Starting from line \ref{match-strategy}, 
 \texttt{expr} is matched as if it were a strptime expression, or otherwise rejects the expression.
 

--- a/rust/src/transformations/make_stable_lazyframe/group_by/make_stable_group_by.tex
+++ b/rust/src/transformations/make_stable_lazyframe/group_by/make_stable_group_by.tex
@@ -2,7 +2,7 @@
 \input{../../../lib.sty}
 
 \title{\texttt{fn make\_stable\_group\_by}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \begin{document}
 \maketitle  
 

--- a/rust/src/transformations/make_stable_lazyframe/group_by/make_stable_group_by.tex
+++ b/rust/src/transformations/make_stable_lazyframe/group_by/make_stable_group_by.tex
@@ -14,20 +14,22 @@ in \asOfCommit{mod.rs}{f5bb719}.
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler Verified}
+\subsubsection*{Compiler-verified}
 \begin{itemize}
     \item Generic \texttt{M} implements \rustdoc{transformations/cast_metric/trait}{UnboundedMetric}.
 \end{itemize}
 
-\subsubsection*{Caller Verified}
+\subsubsection*{Caller-verified}
 None
 
-\subsection*{Function}
+\subsection*{Pseudocode}
 \label{sec:python-pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/make_stable_group_by.py}
 
 \subsection*{Postcondition}
+\begin{theorem}
 \validTransformation{\texttt{(input\_domain, input\_metric, plan)}}{\\\texttt{make\_stable\_group\_by}}
+\end{theorem}
 
 \begin{proof}[Appropriate Output Domain]
     By line \ref{line:stable-keys} the grouping keys are stable row-by-row transformations of the data.

--- a/rust/src/transformations/make_stable_lazyframe/truncate/make_stable_truncate.tex
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/make_stable_truncate.tex
@@ -2,7 +2,7 @@
 \input{../../../lib.sty}
 
 \title{\texttt{fn make\_stable\_truncate}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \begin{document}
 \maketitle  
 

--- a/rust/src/transformations/make_stable_lazyframe/truncate/make_stable_truncate.tex
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/make_stable_truncate.tex
@@ -14,15 +14,20 @@ in \asOfCommit{mod.rs}{f5bb719}.
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Caller Verified}
+\subsubsection*{Compiler-verified}
 None
 
-\subsection*{Function}
+\subsubsection*{Caller-verified}
+None
+
+\subsection*{Pseudocode}
 \label{sec:python-pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/make_stable_truncate.py}
 
 \subsection*{Postcondition}
+\begin{theorem}
 \validTransformation{\texttt{(input\_domain, input\_metric, plan)}}{\\\texttt{make\_stable\_truncate}}
+\end{theorem}
 
 \begin{proof}[Appropriate Output Domain]
     By line \ref{line:stable-keys},

--- a/rust/src/transformations/make_stable_lazyframe/truncate/matching/match_group_by_truncation.tex
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/matching/match_group_by_truncation.tex
@@ -14,13 +14,13 @@ in \asOfCommit{mod.rs}{f5bb719}.
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler Verified}
+\subsubsection*{Compiler-verified}
 Types matching pseudocode.
 
-\subsection*{Precondition}
+\subsubsection*{Caller-verified}
 None 
 
-\subsection*{Function}
+\subsection*{Pseudocode}
 \label{sec:python-pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/match_group_by_truncation.py}
 

--- a/rust/src/transformations/make_stable_lazyframe/truncate/matching/match_group_by_truncation.tex
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/matching/match_group_by_truncation.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{fn match\_group\_by\_truncation}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \begin{document}
 \maketitle  
 

--- a/rust/src/transformations/make_stable_lazyframe/truncate/matching/match_num_groups_predicate.tex
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/matching/match_num_groups_predicate.tex
@@ -14,13 +14,13 @@ in \asOfCommit{mod.rs}{f5bb719}.
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler Verified}
+\subsubsection*{Compiler-verified}
 Types matching pseudocode.
 
-\subsection*{Precondition}
+\subsubsection*{Caller-verified}
 None 
 
-\subsection*{Function}
+\subsection*{Pseudocode}
 \label{sec:python-pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/match_num_groups_predicate.py}
 

--- a/rust/src/transformations/make_stable_lazyframe/truncate/matching/match_num_groups_predicate.tex
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/matching/match_num_groups_predicate.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{fn match\_num\_groups\_predicate}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \begin{document}
 \maketitle  
 

--- a/rust/src/transformations/make_stable_lazyframe/truncate/matching/match_per_group_predicate.tex
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/matching/match_per_group_predicate.tex
@@ -14,13 +14,13 @@ in \asOfCommit{mod.rs}{f5bb719}.
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler Verified}
+\subsubsection*{Compiler-verified}
 Types matching pseudocode.
 
-\subsection*{Precondition}
+\subsubsection*{Caller-verified}
 None 
 
-\subsection*{Function}
+\subsection*{Pseudocode}
 \label{sec:python-pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/match_per_group_predicate.py}
 

--- a/rust/src/transformations/make_stable_lazyframe/truncate/matching/match_per_group_predicate.tex
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/matching/match_per_group_predicate.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{fn match\_per\_group\_predicate}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \begin{document}
 \maketitle  
 

--- a/rust/src/transformations/make_stable_lazyframe/truncate/matching/match_truncation_predicate.tex
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/matching/match_truncation_predicate.tex
@@ -13,17 +13,14 @@ Proves soundness of \rustdoc{transformations/make_stable_lazyframe/truncate/matc
 in \asOfCommit{mod.rs}{f5bb719}.
 
 \section{Hoare Triple}
-\subsubsection*{Compiler Verified}
+\subsection*{Precondition}
+\subsubsection*{Compiler-verified}
 Types matching pseudocode.
 
-\subsection*{Precondition}
-\subsubsection*{Compiler Verified}
-Types matching pseudocode.
-
-\subsection*{Precondition}
+\subsubsection*{Caller-verified}
 None 
 
-\subsection*{Function}
+\subsection*{Pseudocode}
 \label{sec:python-pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/match_truncation_predicate.py}
 

--- a/rust/src/transformations/make_stable_lazyframe/truncate/matching/match_truncation_predicate.tex
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/matching/match_truncation_predicate.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{fn match\_truncation\_predicate}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \begin{document}
 \maketitle  
 

--- a/rust/src/transformations/make_stable_lazyframe/truncate/matching/match_truncations.tex
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/matching/match_truncations.tex
@@ -2,7 +2,7 @@
 \input{../../../../lib.sty}
 
 \title{\texttt{fn match\_truncations}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \begin{document}
 \maketitle  
 

--- a/rust/src/transformations/make_stable_lazyframe/truncate/matching/match_truncations.tex
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/matching/match_truncations.tex
@@ -13,13 +13,14 @@ Proves soundness of \rustdoc{transformations/make_stable_lazyframe/truncate/matc
 in \asOfCommit{mod.rs}{f5bb719}.
 
 \section{Hoare Triple}
-\subsubsection*{Compiler Verified}
+\subsection*{Precondition}
+\subsubsection*{Compiler-verified}
 Types matching pseudocode.
 
-\subsection*{Precondition}
+\subsubsection*{Caller-verified}
 None 
 
-\subsection*{Function}
+\subsection*{Pseudocode}
 \label{sec:python-pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/match_truncations.py}
 

--- a/rust/src/transformations/make_stable_lazyframe/truncate/truncate_domain.tex
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/truncate_domain.tex
@@ -14,10 +14,13 @@ in \asOfCommit{mod.rs}{f5bb719}.
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Caller Verified}
+\subsubsection*{Compiler-verified}
+None
+
+\subsubsection*{Caller-verified}
 Truncation keys are stable row-by-row transformations of the data.
 
-\subsection*{Function}
+\subsection*{Pseudocode}
 \label{sec:python-pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/truncate_domain.py}
 

--- a/rust/src/transformations/make_stable_lazyframe/truncate/truncate_domain.tex
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/truncate_domain.tex
@@ -2,7 +2,7 @@
 \input{../../../lib.sty}
 
 \title{\texttt{fn truncate\_domain}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \begin{document}
 \maketitle  
 

--- a/rust/src/transformations/make_stable_lazyframe/truncate/truncate_id_bound.tex
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/truncate_id_bound.tex
@@ -15,13 +15,16 @@ in \asOfCommit{mod.rs}{f5bb719}.
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Caller Verified}
+\subsubsection*{Compiler-verified}
+None
+
+\subsubsection*{Caller-verified}
 \begin{itemize}
     \item $\texttt{id\_bound.by} = \texttt{truncate.by}$
 \end{itemize}
 
 
-\subsection*{Function}
+\subsection*{Pseudocode}
 \label{sec:python-pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/truncate_id_bound.py}
 

--- a/rust/src/transformations/make_stable_lazyframe/truncate/truncate_id_bound.tex
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/truncate_id_bound.tex
@@ -2,7 +2,7 @@
 \input{../../../lib.sty}
 
 \title{\texttt{fn truncate\_id\_bound}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \begin{document}
 \maketitle  
 

--- a/rust/src/transformations/manipulation/make_is_equal.tex
+++ b/rust/src/transformations/manipulation/make_is_equal.tex
@@ -14,15 +14,9 @@ Proves soundness of \texttt{fn make\_is\_equal} in \asOfCommit{mod.rs}{0db9c6036
 The transformation checks if each element in a vector dataset is equivalent to a given value,
 returning a vector of booleans.
 
-\subsection*{Vetting History}
-\begin{itemize}
-    \item \vettingPR{512}
-\end{itemize}
-
 \section{Hoare Triple}
 \subsection*{Precondition}
-To ensure the correctness of the output, we require the following preconditions:
-
+\subsubsection*{Compiler-verified}
 \begin{itemize}
     \item Type \texttt{TIA} must have trait \texttt{PartialEq}.
     \item Type \texttt{M} must have trait \texttt{DatasetMetric}.
@@ -30,14 +24,16 @@ To ensure the correctness of the output, we require the following preconditions:
     \item \rustdoc{core/trait}{MetricSpace} is implemented for \texttt{(VectorDomain<AtomDomain<bool>{}>, M)}.
 \end{itemize}
 
+\subsubsection*{Caller-verified}
+None
+
 \subsection*{Pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/make_is_equal.py}
 
-\subsubsection*{Postconditions}
+\subsection*{Postcondition}
+\begin{theorem}
 \validTransformation{\texttt{(input\_domain, input\_metric, value)}}{\texttt{make\_is\_equal}}
-
-\section{Proof}
-
+\end{theorem}
 \begin{lemma}
     The invocation of \rustdoc{transformations/manipulation/fn}{make\_row\_by\_row} (line \ref{line:row-by-row}) satisfies its preconditions.
 \end{lemma}

--- a/rust/src/transformations/manipulation/make_is_equal.tex
+++ b/rust/src/transformations/manipulation/make_is_equal.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{fn make\_is\_equal}}
-\author{S\'ilvia Casacuberta}
+\author{\SilviaCasacubertaAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/transformations/manipulation/make_row_by_row.tex
+++ b/rust/src/transformations/manipulation/make_row_by_row.tex
@@ -16,15 +16,10 @@ The proof for this constructor appeals to the proof for \rustdoc{transformations
 
 \texttt{make\_row\_by\_row} returns a Transformation that applies a user-specified function to each record in the input dataset.
 
-\subsection*{Vetting History}
-\begin{itemize}
-    \item \vettingPR{562}
-\end{itemize}
-
 \section{Hoare Triple}
 \subsection*{Precondition}
+\subsubsection*{Compiler-verified}
 \begin{itemize}
-
     \item \texttt{DI} (input domain) is a type with trait \rustdoc{transformations/trait}{RowByRowDomain}\texttt{<DO>}. 
         This trait provides a way to apply a map function to each record in the input dataset to retrieve a dataset that is a member of the output domain, of type \texttt{DO}. The trait further implies that \texttt{DatasetDomain} is also implemented for \texttt{DI}.
     \item \texttt{DO} (output domain) is a type with trait \rustdoc{transformations/trait}{DatasetDomain}. 
@@ -33,6 +28,10 @@ The proof for this constructor appeals to the proof for \rustdoc{transformations
         \texttt{DatasetMetric} is used to restrict the set of valid metrics to those which measure distances between datasets.
     \item \rustdoc{core/trait}{MetricSpace} is implemented for \texttt{(DI, M)}. Therefore \texttt{M} is a valid metric on \texttt{DI}.
     \item \rustdoc{core/trait}{MetricSpace} is implemented for \texttt{(DO, M)}.
+\end{itemize}
+
+\subsubsection*{Caller-verified}
+\begin{itemize}
     \item \texttt{row\_function} has no side-effects.
     \item If the input to \texttt{row\_function} is a member of \texttt{input\_domain}'s row domain, then the output is a member of \texttt{output\_row\_domain}.
 \end{itemize}
@@ -41,10 +40,9 @@ The proof for this constructor appeals to the proof for \rustdoc{transformations
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/make_row_by_row.py}
 
 \subsection*{Postcondition}
+\begin{theorem}
 \validTransformation{\texttt{(input\_domain, input\_metric, output\_domain, row\_function, DI, DO, M)}}{\texttt{make\_row\_by\_row}}
-
-\section{Proofs}
-
+\end{theorem}
 \begin{proof} \textbf{(Part 1 -- appropriate output domain).}
     Since the preconditions for this constructor are a super-set of the preconditions on \texttt{make\_row\_by\_row\_fallible}, 
     the proof of \texttt{make\_row\_by\_row\_fallible} applies. 

--- a/rust/src/transformations/manipulation/make_row_by_row.tex
+++ b/rust/src/transformations/manipulation/make_row_by_row.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{fn make\_row\_by\_row}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/transformations/manipulation/make_row_by_row_fallible.tex
+++ b/rust/src/transformations/manipulation/make_row_by_row_fallible.tex
@@ -15,15 +15,10 @@ Proves soundness of \rustdoc{transformations/fn}{make\_row\_by\_row\_fallible} i
 \texttt{make\_row\_by\_row\_fallible} returns a Transformation that applies a user-specified function to each record in the input dataset.
 The function is permitted to return a data-independent error.
 
-\subsection*{Vetting History}
-\begin{itemize}
-    \item \vettingPR{562}
-\end{itemize}
-
 \section{Hoare Triple}
 \subsection*{Precondition}
+\subsubsection*{Compiler-verified}
 \begin{itemize}
-
     \item \texttt{DI} (input domain) is a type with trait \rustdoc{transformations/trait}{RowByRowDomain}\texttt{<DO>}. 
         This trait provides a way to apply a map function to each record in the input dataset to retrieve a dataset that is a member of the output domain, of type \texttt{DO}. The trait further implies that \texttt{DatasetDomain} is also implemented for \texttt{DI}.
     \item \texttt{DO} (output domain) is a type with trait \rustdoc{transformations/trait}{DatasetDomain}. 
@@ -32,6 +27,10 @@ The function is permitted to return a data-independent error.
         \texttt{DatasetMetric} is used to restrict the set of valid metrics to those which measure distances between datasets.
     \item \rustdoc{core/trait}{MetricSpace} is implemented for \texttt{(DI, M)}. Therefore \texttt{M} is a valid metric on \texttt{DI}.
     \item \rustdoc{core/trait}{MetricSpace} is implemented for \texttt{(DO, M)}.
+\end{itemize}
+
+\subsubsection*{Caller-verified}
+\begin{itemize}
     \item \texttt{row\_function} has no side-effects.
     \item If the input to \texttt{row\_function} is a member of \texttt{input\_domain}'s row domain, then the output is a member of \texttt{output\_row\_domain}, or a data-independent error.
 \end{itemize}
@@ -40,10 +39,9 @@ The function is permitted to return a data-independent error.
 \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/make_row_by_row_fallible.py}
 
 \subsection*{Postcondition}
+\begin{theorem}
 \validTransformation{\texttt{(input\_domain, input\_metric, output\_domain, row\_function, DI, DO, M)}}{\texttt{make\_row\_by\_row}}
-
-\section{Proofs}
-
+\end{theorem}
 \begin{proof} \textbf{(Part 1 -- appropriate output domain).}
     By the definition of \texttt{RowByRowDomain}, \texttt{DI.apply\_rows(data, row\_function)} returns a dataset in \texttt{input\_domain.translate(output\_row\_domain)},
     if \texttt{row\_function} is a mapping between \texttt{input\_domain}'s row domain to \texttt{output\_row\_domain}.

--- a/rust/src/transformations/manipulation/make_row_by_row_fallible.tex
+++ b/rust/src/transformations/manipulation/make_row_by_row_fallible.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{fn make\_row\_by\_row\_fallible}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/transformations/quantile_score_candidates/check_candidates.tex
+++ b/rust/src/transformations/quantile_score_candidates/check_candidates.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{fn check\_candidates}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \begin{document}
 \maketitle  
 

--- a/rust/src/transformations/quantile_score_candidates/check_candidates.tex
+++ b/rust/src/transformations/quantile_score_candidates/check_candidates.tex
@@ -15,9 +15,13 @@ in \asOfCommit{mod.rs}{f5bb719}.
 
 \section{Hoare Triple}
 \subsection*{Precondition}
+\subsubsection*{Compiler-verified}
 None
 
-\subsection*{Function}
+\subsubsection*{Caller-verified}
+None
+
+\subsection*{Pseudocode}
 \label{sec:python-pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=`]{./pseudocode/check_candidates.py}
 

--- a/rust/src/transformations/quantile_score_candidates/make_quantile_score_candidates.tex
+++ b/rust/src/transformations/quantile_score_candidates/make_quantile_score_candidates.tex
@@ -153,20 +153,26 @@ while still leaving enough room for datasets on the order of $10^{15}$ elements.
 
 \section{Hoare Triple}
 \subsection*{Precondition}
+\subsubsection*{Compiler-verified}
 \begin{itemize}
     \item \texttt{MI} is a type with trait \rustdoc{transformations/trait}{UnboundedMetric}.
     \item \texttt{TIA} (input atom type) is a type with trait \rustdoc{traits/trait}{Number}.
 \end{itemize}
 
-\subsection*{Function}
+\subsubsection*{Caller-verified}
+None
+
+\subsection*{Pseudocode}
 \label{sec:python-pseudocode}
 \lstinputlisting[language=Python,firstline=2]{./pseudocode/make_quantile_score_candidates.py}
 
 
 \subsection*{Postcondition}
+\begin{theorem}
 \validTransformation
     {(\texttt{input\_domain, input\_metric, candidates, alpha, MI, TIA})}
     {\texttt{make\_quantile\_\\score\_candidates}}
+\end{theorem}
 
 
 \begin{proof}[Proof of Appropriate Output Domain]

--- a/rust/src/transformations/quantile_score_candidates/make_quantile_score_candidates.tex
+++ b/rust/src/transformations/quantile_score_candidates/make_quantile_score_candidates.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{fn make\_quantile\_score\_candidates}}
-\author{Michael Shoemate \and Christian Covington \and Ira Globus-Harrus}
+\author{\MichaelShoemateAuthor \and \ChristianCovingtonAuthor \and \IraGlobusHarrusAuthor}
 \begin{document}
 \maketitle  
 

--- a/rust/src/transformations/quantile_score_candidates/score_candidates.tex
+++ b/rust/src/transformations/quantile_score_candidates/score_candidates.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{fn score\_candidates}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \begin{document}
 \maketitle  
 

--- a/rust/src/transformations/quantile_score_candidates/score_candidates.tex
+++ b/rust/src/transformations/quantile_score_candidates/score_candidates.tex
@@ -16,12 +16,12 @@ where the score is the distance between the candidate and the ideal alpha-quanti
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler Verified}
+\subsubsection*{Compiler-verified}
 \begin{itemize}
     \item Generic \texttt{TI} (input atom type) is a type with trait \texttt{PartialOrd}.
 \end{itemize}
 
-\subsubsection*{Caller Verified}
+\subsubsection*{Caller-verified}
 \begin{itemize}
     \item \texttt{x} has at most $2^{64}$ elements.
     \item \texttt{x} elements are totally ordered (excluding non-nan/non-null).
@@ -31,7 +31,7 @@ where the score is the distance between the candidate and the ideal alpha-quanti
 \end{itemize}
 
 
-\subsection*{Function}
+\subsection*{Pseudocode}
 \label{sec:python-pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=`]{./pseudocode/score_candidates.py}
 

--- a/rust/src/transformations/quantile_score_candidates/score_candidates_constants.tex
+++ b/rust/src/transformations/quantile_score_candidates/score_candidates_constants.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{fn score\_candidates\_constants}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \begin{document}
 \maketitle  
 

--- a/rust/src/transformations/quantile_score_candidates/score_candidates_constants.tex
+++ b/rust/src/transformations/quantile_score_candidates/score_candidates_constants.tex
@@ -15,9 +15,13 @@ in \asOfCommit{mod.rs}{f5bb719}.
 
 \section{Hoare Triple}
 \subsection*{Precondition}
+\subsubsection*{Compiler-verified}
 None
 
-\subsection*{Function}
+\subsubsection*{Caller-verified}
+None
+
+\subsection*{Pseudocode}
 \label{sec:python-pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=`]{./pseudocode/score_candidates_constants.py}
 

--- a/rust/src/transformations/quantile_score_candidates/score_candidates_map.tex
+++ b/rust/src/transformations/quantile_score_candidates/score_candidates_map.tex
@@ -15,9 +15,15 @@ in \asOfCommit{mod.rs}{f5bb719}.
 
 \section{Hoare Triple}
 \subsection*{Precondition}
-$\texttt{alpha\_den} > \texttt{alpha\_num}$.
+\subsubsection*{Compiler-verified}
+None
 
-\subsection*{Function}
+\subsubsection*{Caller-verified}
+\begin{itemize}
+    \item $\texttt{alpha\_den} > \texttt{alpha\_num}$.
+\end{itemize}
+
+\subsection*{Pseudocode}
 \label{sec:python-pseudocode}
 \lstinputlisting[language=Python,firstline=2,escapechar=`]{./pseudocode/score_candidates_map.py}
 

--- a/rust/src/transformations/quantile_score_candidates/score_candidates_map.tex
+++ b/rust/src/transformations/quantile_score_candidates/score_candidates_map.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{fn score\_candidates\_map}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \begin{document}
 \maketitle  
 

--- a/rust/src/transformations/scalar_to_vector/make_vec.tex
+++ b/rust/src/transformations/scalar_to_vector/make_vec.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{fn make\_vec}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}

--- a/rust/src/transformations/scalar_to_vector/make_vec.tex
+++ b/rust/src/transformations/scalar_to_vector/make_vec.tex
@@ -16,13 +16,13 @@ This transformation simply wraps an input scalar in a singleton vec.
 The output metric then becomes an Lp distance.
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 \begin{itemize}
     \item Generic \texttt{T} implements trait \rustdoc{traits/trait}{Number}
     \item Generic \texttt{Q} implements trait \rustdoc{traits/trait}{Number}
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/transformations/scalar_to_vector/then_index_or_default.tex
+++ b/rust/src/transformations/scalar_to_vector/then_index_or_default.tex
@@ -15,12 +15,12 @@ Proves soundness of the implementation of \rustdoc{transformations/fn}{then\_ind
 This postprocessor indexes into a vector or returns the default value of the type if the index does not exist.
 \section{Hoare Triple}
 \subsection*{Precondition}
-\subsubsection*{Compiler-Verified}
+\subsubsection*{Compiler-verified}
 \begin{itemize}
     \item Generic \texttt{T} implements trait \texttt{Default}
 \end{itemize}
 
-\subsubsection*{User-Verified}
+\subsubsection*{Caller-verified}
 None
 
 \subsection*{Pseudocode}

--- a/rust/src/transformations/scalar_to_vector/then_index_or_default.tex
+++ b/rust/src/transformations/scalar_to_vector/then_index_or_default.tex
@@ -2,7 +2,7 @@
 \input{../../lib.sty}
 
 \title{\texttt{fn then\_index\_or\_default}}
-\author{Michael Shoemate}
+\author{\MichaelShoemateAuthor}
 \date{}
 
 \begin{document}


### PR DESCRIPTION
* Use GitHub handles in authors
* Standardize naming of sections in Hoare triples
* Standardize use of /theorem outside of /validX macros
* Split preconditions consistently into caller and compiler verified
* Remove Vetting History
* Don't use Proof sections
* fixes a transient actions issue related to my use of Graphite where .tex change detection fails