### PR TITLE
fix: rename floating-point to idealized-numerics

### DIFF
--- a/R/opendp/R/mod.R
+++ b/R/opendp/R/mod.R
@@ -1,5 +1,22 @@
+normalize_features <- function(features) {
+  normalized <- vapply(
+    features,
+    function(feature) {
+      if (identical(feature, "floating-point")) {
+        warning("\"floating-point\" is deprecated. Use \"idealized-numerics\" instead.", call. = FALSE)
+        return("idealized-numerics")
+      }
+      feature
+    },
+    FUN.VALUE = character(1),
+    USE.NAMES = FALSE
+  )
+
+  as.list(normalized)
+}
+
 assert_features <- function(...) {
-  for (feature in list(...)) {
+  for (feature in normalize_features(list(...))) {
     if (!feature %in% getOption("opendp_features")) {
       stop("Attempted to use function that requires ", feature, " but ", feature, " is not enabled. See https://github.com/opendp/opendp/discussions/304, then call enable_features(\"", feature, "\")", call. = FALSE)
     }
@@ -14,7 +31,7 @@ assert_features <- function(...) {
 #' @param ... features to enable
 #' @export
 enable_features <- function(...) {
-  options(opendp_features = union(getOption("opendp_features"), list(...)))
+  options(opendp_features = union(getOption("opendp_features"), normalize_features(list(...))))
 }
 
 #' Disable features in the opendp package.
@@ -24,7 +41,7 @@ enable_features <- function(...) {
 #' @export
 disable_features <- function(...) {
   features <- getOption("opendp_features")
-  options(opendp_features = features[!features %in% list(...)])
+  options(opendp_features = features[!features %in% normalize_features(list(...))])
 }
 
 is_space <- function(x) {

--- a/R/opendp/tests/testthat/test-measurements.R
+++ b/R/opendp/tests/testthat/test-measurements.R
@@ -1,5 +1,5 @@
 library(opendp)
-enable_features("contrib", "floating-point")
+enable_features("contrib", "idealized-numerics")
 
 test_that("make_randomized_response_bool", {
   meas <- make_randomized_response_bool(0.75)

--- a/R/opendp/tests/testthat/test-mod.R
+++ b/R/opendp/tests/testthat/test-mod.R
@@ -5,3 +5,20 @@ test_that("binary search", {
 
   m_sum <- binary_search_chain(\(s) t_sum |> then_laplace(s), d_in = 1L, d_out = 1., .T = "float")
 })
+
+test_that("floating-point aliases to idealized-numerics", {
+  disable_features("floating-point", "idealized-numerics")
+
+  expect_warning(
+    enable_features("floating-point"),
+    "\"floating-point\" is deprecated. Use \"idealized-numerics\" instead."
+  )
+  expect_warning(
+    assert_features("floating-point"),
+    "\"floating-point\" is deprecated. Use \"idealized-numerics\" instead."
+  )
+  expect_true("idealized-numerics" %in% getOption("opendp_features"))
+  expect_false("floating-point" %in% getOption("opendp_features"))
+
+  disable_features("idealized-numerics")
+})

--- a/docs/source/api/user-guide/combinators/chaining.rst
+++ b/docs/source/api/user-guide/combinators/chaining.rst
@@ -25,7 +25,7 @@ In the following example we chain :py:func:`~opendp.measurements.make_laplace` w
     .. code:: pycon
 
         >>> import opendp.prelude as dp
-        >>> dp.enable_features("contrib", "floating-point")
+        >>> dp.enable_features("contrib", "idealized-numerics")
         >>> # call a constructor to produce a transformation
         >>> sum_trans = dp.t.make_sum(
         ...     dp.vector_domain(dp.atom_domain(bounds=(0, 1))),

--- a/docs/source/api/user-guide/index.rst
+++ b/docs/source/api/user-guide/index.rst
@@ -57,8 +57,12 @@ Features that are available from Python and R:
        That is, if a user/adversary is 'honest' in specifying the constructor arguments,
        then even if they later become 'curious' and try to learn something from the measurement outputs,
        they will not be able to violate the differential privacy promises of the measurement.
+   * - ``idealized-numerics``
+     - Enable to assume an idealized numeric model
+       that ignores finite-precision limitations such as non-closure and overflow,
+       resulting in an underestimation of the actual privacy loss.
    * - ``floating-point``
-     - Enable to include transformations and measurements with floating-point vulnerabilities.
+     - Deprecated alias for ``idealized-numerics``.
    * - ``rust-stack-trace``
      - Enable to allow stack traces to include stack frames from Rust.
 

--- a/docs/source/api/user-guide/limitations.rst
+++ b/docs/source/api/user-guide/limitations.rst
@@ -13,10 +13,11 @@ Privacy Concerns
 As a work in progress, OpenDP has some known privacy concerns.
 These vulnerabilities may have an impact on some applications, depending on how they operate.
 
-* **Floating point issues:** Some OpenDP Transformations and Measurements assume an idealized model of real-number arithmetic
+* **Idealized numerics issues:** Some OpenDP Transformations and Measurements assume an idealized model of real-number arithmetic
   (as is common in the differential privacy research literature).
-  Their implementations using floating-point numbers have `known issues <https://www.microsoft.com/en-us/research/wp-content/uploads/2012/10/lsbs.pdf>`_,
-  where the differential privacy property is not satisfied due to discrepancies between real-number arithmetic and floating-point arithmetic.
+  Implementations using finite data types like floating-point numbers have `known issues <https://salil.seas.harvard.edu/publications/widespread-underestimation-sensitivity-differentially-private-libraries-and-how>`_,
+  where the differential privacy property is not satisfied due to discrepancies between real-number arithmetic and finite arithmetic.
+  These APIs are surfaced behind the ``idealized-numerics`` feature flag.
   Through the ongoing process of vetting privacy proofs (see below), we clearly distinguish such mechanisms from ones
   whose concrete implementations faithfully satisfy differential privacy.
 * **Side-channel attacks:** OpenDP has not yet been hardened against side-channel attacks.
@@ -39,14 +40,6 @@ privacy-relevant properties.
 As components complete the vetting process, they will drop the ``contrib`` feature flag, and will be accessible without explicitly opting into
 unvetted components.
 
-Missing Functionality
----------------------
-
-There are some elements of the OpenDP Programming Framework, the conceptual basis for OpenDP, that are not yet implemented.
-Foremost among these is the concept of interactive measurements.
-(There is an initial prototype, implemented in Rust only, but it's not fully fleshed out).
-These elements are on our roadmap, but applications will have to wait to use them.
-
 API Stability
 -------------
 
@@ -60,5 +53,5 @@ Until then, please don't depend on interfaces remaining the same across releases
 Software Quality
 ----------------
 
-Like any software project, OpenDP likely has bugs. Because it's still an early project, it likely has many bugs!
+Like any software project, OpenDP likely has bugs.
 We strive to make high quality software, but if you encounter issues, `please let us know <https://github.com/opendp/opendp/issues>`_.

--- a/docs/source/api/user-guide/utilities/parameter-search.rst
+++ b/docs/source/api/user-guide/utilities/parameter-search.rst
@@ -35,7 +35,7 @@ This is extremely powerful!
     .. code:: pycon
 
         >>> import opendp.prelude as dp
-        >>> dp.enable_features("contrib", "floating-point")
+        >>> dp.enable_features("contrib", "idealized-numerics")
 
 * | If you have a bound on ``d_in`` and a budget ``d_out``, you can solve for the smallest noise scale that is still differentially private.
   | This is useful when you want to determine how accurate you can make a query with a given budget.

--- a/docs/source/contributing/development-environment.rst
+++ b/docs/source/contributing/development-environment.rst
@@ -84,10 +84,14 @@ Setting a feature changes how the crate compiles.
           That is, if a user/adversary is 'honest' in specifying the constructor arguments,
           then even if they later become 'curious' and try to learn something from the measurement outputs,
           they will not be able to violate the differential privacy promises of the measurement.
+      * - ``idealized-numerics``
+        - Enable to assume an idealized numeric model
+          that ignores finite-precision limitations such as non-closure and overflow,
+          resulting in an underestimation of the actual privacy loss.
       * - ``floating-point``
-        - Enable to include transformations and measurements with floating-point vulnerabilities.
+        - Deprecated alias for ``idealized-numerics``.
       * - ``untrusted``
-        - Enables untrusted features ``contrib``, ``honest-but-curious`` and ``floating-point``.
+        - Enables untrusted features ``contrib``, ``honest-but-curious`` and ``idealized-numerics``.
       * - ``ffi``
         - Enable to include C foreign function interfaces.
       * - ``polars-ffi``

--- a/docs/source/contributing/proof-initiation.rst
+++ b/docs/source/contributing/proof-initiation.rst
@@ -147,7 +147,7 @@ proof:
    an idealized numeric model that ignores finite-machine limitations
    such as non-closure and overflow. Use this when the proof holds in
    idealized numerics but the implementation is not privately sound on
-   finite computers. ``\floatingPoint`` is a deprecated alias.
+   finite computers.
 
 -  ``\YourNameAuthor`` and similar macros expand to an author's
    name and GitHub handle together. Use these in ``\author{...}`` so

--- a/docs/source/contributing/proof-initiation.rst
+++ b/docs/source/contributing/proof-initiation.rst
@@ -18,6 +18,8 @@ Each document should at least have these components:
 1. Hoare Triple
 
    1. Precondition
+      1. Compiler-verified
+      2. Caller-verified
    2. Pseudocode
    3. Postcondition
 
@@ -100,27 +102,52 @@ Here’s a template for ``absolute_distance.tex``:
    \author{\YourNameAuthor}\date{}
 
    \begin{document}
-   \maketitle\contrib
+   \maketitle
+   % Enable any applicable proof feature flags:
+   % \contrib
+   % \honestButCurious
+   % \idealizedNumerics
    Proves soundness of \rustdoc{transformations/fn}{absolute\_distance} in \asOfCommit{mod.rs}{f5bb719}.
 
-   \subsection*{Vetting history}
-   \begin{itemize}
-       \item \vettingPR{519}
-   \end{itemize}
-
    \section{Hoare Triple}
-   \subsection*{Preconditions}
+   \subsection*{Precondition}
+   \subsubsection*{Compiler-verified}
+   % List trait bounds and type constraints checked by the compiler.
+   \subsubsection*{Caller-verified}
+   % List any semantic assumptions the caller must satisfy, or write ``None''.
    \subsection*{Pseudocode}
+   \lstinputlisting[language=Python,firstline=2,escapechar=|]{./pseudocode/this.py}
    \subsection*{Postcondition}
+   \begin{theorem}
+   \label{postcondition}
+   % State the postcondition here.
+   \end{theorem}
 
-   \section{Proof}
+   % Begin lemmas and proofs!
+   \begin{proof}
+   \end{proof}
 
    \end{document}
 
 This template uses several macros defined in ``rust/src/lib.sty``:
 
+Proof documents may include feature-flag warning macros near the top of
+the file. These correspond to Rust feature flags documented in
+:ref:`rust-feature-listing`. Enable whichever warnings apply to the
+proof:
+
 -  ``\contrib`` adds a header to the document indicating the proof is in
-   ``"contrib"``.
+   ``"contrib"`` because it has not completed the vetting process.
+
+-  ``\honestButCurious`` adds a header indicating the proof relies on
+   caller-verified preconditions. Use this whenever the
+   ``Caller-verified`` subsection contains any substantive assumptions.
+
+-  ``\idealizedNumerics`` adds a header indicating the proof relies on
+   an idealized numeric model that ignores finite-machine limitations
+   such as non-closure and overflow. Use this when the proof holds in
+   idealized numerics but the implementation is not privately sound on
+   finite computers. ``\floatingPoint`` is a deprecated alias.
 
 -  ``\YourNameAuthor`` and similar macros expand to an author's
    name and GitHub handle together. Use these in ``\author{...}`` so
@@ -183,8 +210,8 @@ and link generated ``.pdf`` files from your PR.
 
 We now continue by filling out the proof sections.
 
-Preconditions
-~~~~~~~~~~~~~
+Precondition
+~~~~~~~~~~~~
 
 The function we are proving has three input parameters, consisting of
 one generic (``T``) and two arguments (``a`` and ``b``), where the
@@ -212,10 +239,14 @@ become part of the precondition for the function.
 
 .. code:: latex
 
-   \subsection*{Preconditions}
+   \subsection*{Precondition}
+   \subsubsection*{Compiler-verified}
    \begin{itemize}
        \item \texttt{T} is a type with traits \rustdoc{traits/trait}{InfSub} and \rustdoc{traits/trait}{AlertingAbs}.
    \end{itemize}
+
+   \subsubsection*{Caller-verified}
+   None
 
 In other contexts, it may make sense to specify preconditions on the
 arguments as well.
@@ -229,7 +260,7 @@ communicate the algorithm in a way that is more accessible than Rust.
 
 .. code:: latex
 
-   \section{Pseudocode}
+   \subsection*{Pseudocode}
    \begin{lstlisting}[language = Python, escapechar=|]
    def absolute_distance(a, b):
        a.inf_sub(b).alerting_abs() |\label{line:out}|

--- a/docs/source/getting-started/statistical-modeling/pca.rst
+++ b/docs/source/getting-started/statistical-modeling/pca.rst
@@ -20,7 +20,7 @@ us if you are interested in proof-writing. Thank you!
 
             >>> import opendp.prelude as dp
             >>> dp.enable_features(
-            ...     "contrib", "floating-point", "honest-but-curious"
+            ...     "contrib", "idealized-numerics", "honest-but-curious"
             ... )
 
             >>> import numpy as np

--- a/python/src/opendp/extras/numpy/_make_np_mean/__init__.py
+++ b/python/src/opendp/extras/numpy/_make_np_mean/__init__.py
@@ -30,7 +30,7 @@ def make_private_np_mean(
     import opendp.prelude as dp
     np = import_optional_dependency('numpy')
 
-    dp.assert_features("contrib", "floating-point")
+    dp.assert_features("contrib", "idealized-numerics")
 
     if norm is not None:
         t_clamp = make_np_clamp(input_domain, input_metric, norm, p, origin)

--- a/python/src/opendp/extras/numpy/_make_np_sscp/__init__.py
+++ b/python/src/opendp/extras/numpy/_make_np_sscp/__init__.py
@@ -16,7 +16,7 @@ def make_np_sscp(input_domain: Domain, input_metric: Metric) -> Transformation:
     """
     import opendp.prelude as dp
 
-    dp.assert_features("contrib", "floating-point")
+    dp.assert_features("contrib", "idealized-numerics")
 
     if not str(input_domain).startswith("NPArray2Domain"):
         raise ValueError(

--- a/python/src/opendp/extras/numpy/_make_np_sum/__init__.py
+++ b/python/src/opendp/extras/numpy/_make_np_sum/__init__.py
@@ -18,7 +18,7 @@ def make_np_sum(input_domain: Domain, input_metric: Metric) -> Transformation:
     import opendp.prelude as dp
     np = import_optional_dependency('numpy')
 
-    dp.assert_features("contrib", "floating-point")
+    dp.assert_features("contrib", "idealized-numerics")
 
     if not str(input_domain).startswith("NPArray2Domain"):
         raise ValueError(f"input_domain ({input_domain}) must be NPArray2Domain")  # pragma: no cover

--- a/python/src/opendp/extras/sklearn/_make_eigendecomposition/__init__.py
+++ b/python/src/opendp/extras/sklearn/_make_eigendecomposition/__init__.py
@@ -29,7 +29,7 @@ def make_private_np_eigendecomposition(
     """
     import opendp.prelude as dp
 
-    dp.assert_features("contrib", "floating-point")
+    dp.assert_features("contrib", "idealized-numerics")
     input_desc = input_domain.descriptor
 
     if input_desc.size is None:

--- a/python/src/opendp/extras/sklearn/_make_eigenvalues/__init__.py
+++ b/python/src/opendp/extras/sklearn/_make_eigenvalues/__init__.py
@@ -15,7 +15,7 @@ def make_eigenvalues(input_domain: Domain, input_metric: Metric) -> Transformati
     np = import_optional_dependency('numpy')
     import opendp.prelude as dp
 
-    dp.assert_features("contrib", "floating-point")
+    dp.assert_features("contrib", "idealized-numerics")
 
     if not str(input_domain).startswith("NPSSCPDomain"):
         raise ValueError("input_domain must be NPSSCPDomain")  # pragma: no cover

--- a/python/src/opendp/extras/sklearn/_make_eigenvector/__init__.py
+++ b/python/src/opendp/extras/sklearn/_make_eigenvector/__init__.py
@@ -22,7 +22,7 @@ def make_private_eigenvector(
     np = import_optional_dependency('numpy')
     import opendp.prelude as dp
 
-    dp.assert_features("contrib", "floating-point")
+    dp.assert_features("contrib", "idealized-numerics")
     
     np_csprng = get_np_csprng()
     input_desc = input_domain.descriptor
@@ -113,7 +113,7 @@ def make_np_sscp_projection(
     """
     import opendp.prelude as dp
 
-    dp.assert_features("contrib", "floating-point")
+    dp.assert_features("contrib", "idealized-numerics")
     input_desc = input_domain.descriptor
 
     if input_desc.num_features != P.shape[1]:
@@ -145,7 +145,7 @@ def make_private_eigenvectors(
     import opendp.prelude as dp
     linalg = import_optional_dependency('scipy.linalg')
 
-    dp.assert_features("contrib", "floating-point")
+    dp.assert_features("contrib", "idealized-numerics")
 
     input_desc = input_domain.descriptor
     if input_desc.p != 2:

--- a/python/src/opendp/extras/sklearn/decomposition/__init__.py
+++ b/python/src/opendp/extras/sklearn/decomposition/__init__.py
@@ -72,7 +72,7 @@ def make_private_pca(
     import opendp.prelude as dp
     np = import_optional_dependency('numpy')
 
-    dp.assert_features("contrib", "floating-point")
+    dp.assert_features("contrib", "idealized-numerics")
 
     @dataclass(kw_only=True, frozen=True)
     class PCAResult:
@@ -407,7 +407,7 @@ def _make_center(input_domain, input_metric):
     import opendp.prelude as dp
     np = import_optional_dependency('numpy')
 
-    dp.assert_features("contrib", "floating-point")
+    dp.assert_features("contrib", "idealized-numerics")
 
     input_desc = input_domain.descriptor
 

--- a/python/src/opendp/extras/sklearn/linear_model/__init__.py
+++ b/python/src/opendp/extras/sklearn/linear_model/__init__.py
@@ -85,7 +85,7 @@ class LinearRegression:
         ... except ModuleNotFoundError:
         ...     import pytest
         ...     pytest.skip('Requires extra install')
-        >>> dp.enable_features("floating-point")
+        >>> dp.enable_features("idealized-numerics")
         >>> lin_reg = dp.sklearn.linear_model.LinearRegression(
         ...     dp.max_divergence(),
         ...     x_bounds=[(0, 10)],

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -1298,7 +1298,7 @@ def binary_search_chain(
     Find a laplace measurement with the smallest noise scale that is still (d_in, d_out)-close.
 
     >>> import opendp.prelude as dp
-    >>> dp.enable_features("floating-point", "contrib")
+    >>> dp.enable_features("idealized-numerics", "contrib")
     ...
     >>> # The majority of the chain only needs to be defined once.
     >>> pre = (

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -12,6 +12,7 @@ from dataclasses import asdict
 from typing import Any, Literal, Sequence, Type, TypeVar, Union, Callable, Optional, overload, TYPE_CHECKING, cast
 import importlib
 import json
+import warnings
 
 from opendp._lib import AnyMeasurement, AnyTransformation, AnyDomain, AnyMetric, AnyMeasure, AnyFunction, AnyOdometer, import_optional_dependency, get_opendp_version
 
@@ -1241,26 +1242,43 @@ class OpenDPException(Exception):
 
 
 GLOBAL_FEATURES: set[str] = set()
+def _normalize_features(features: Sequence[str], *, stacklevel: int) -> tuple[str, ...]:
+    normalized = []
+
+    for feature in features:
+        if feature != "floating-point":
+            normalized.append(feature)
+            continue
+
+        normalized.append("idealized-numerics")
+        warnings.warn(
+            '"floating-point" is deprecated. Use "idealized-numerics" instead.',
+            DeprecationWarning,
+            stacklevel=stacklevel,
+        )
+
+    return tuple(normalized)
 
 
 def enable_features(*features: str) -> None:
     '''
     Allow the use of optional features. See :ref:`feature-listing` for details.
     '''
-    GLOBAL_FEATURES.update(set(features))
+    GLOBAL_FEATURES.update(set(_normalize_features(features, stacklevel=3)))
 
 
 def disable_features(*features: str) -> None:
     '''
     Disallow the use of optional features. See :ref:`feature-listing` for details.
     '''
-    GLOBAL_FEATURES.difference_update(set(features))
+    GLOBAL_FEATURES.difference_update(set(_normalize_features(features, stacklevel=3)))
 
 
 def assert_features(*features: str) -> None:
     '''
     Check whether a given feature is enabled. See :ref:`feature-listing` for details.
     '''
+    features = _normalize_features(features, stacklevel=3)
     missing_features = [f for f in features if f not in GLOBAL_FEATURES]
     if missing_features:
         features_string = ', '.join(f'"{f}"' for f in features)

--- a/python/test/__init__.py
+++ b/python/test/__init__.py
@@ -2,4 +2,4 @@ import opendp.prelude as dp
 
 # We don't have tests that require a feature *not* to be enabled,
 # so more stable just to enable everything at the start.
-dp.enable_features('floating-point', 'contrib', 'honest-but-curious')
+dp.enable_features('idealized-numerics', 'contrib', 'honest-but-curious')

--- a/python/test/integration/test_quantile.py
+++ b/python/test/integration/test_quantile.py
@@ -1,7 +1,7 @@
 from opendp.mod import enable_features
 import opendp.prelude as dp
 
-enable_features("floating-point", "contrib")
+enable_features("idealized-numerics", "contrib")
 
 
 def test_quantile_score_candidates():

--- a/python/test/test_typing.py
+++ b/python/test/test_typing.py
@@ -1,5 +1,6 @@
 import re
 from typing import List, Tuple, Any
+import warnings
 
 import pytest
 
@@ -99,6 +100,26 @@ def test_set_feature():
 
     disable_features("A")
     assert "A" not in GLOBAL_FEATURES
+
+
+def test_deprecated_floating_point():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        disable_features("floating-point")
+
+    disable_features("idealized-numerics")
+
+    with pytest.deprecated_call(match=re.escape('"floating-point" is deprecated. Use "idealized-numerics" instead.')):
+        enable_features("floating-point")
+
+    assert "floating-point" not in GLOBAL_FEATURES
+    assert "idealized-numerics" in GLOBAL_FEATURES
+    assert_features("idealized-numerics")
+
+    with pytest.deprecated_call(match=re.escape('"floating-point" is deprecated. Use "idealized-numerics" instead.')):
+        assert_features("floating-point")
+
+    disable_features("idealized-numerics")
 
 
 def test_default_float_type():

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -98,10 +98,12 @@ pyo3-polars = { git = "https://github.com/pola-rs/polars", tag = "py-1.36.1" }
 [features]
 default = ["partials", "use-openssl"]
 
-floating-point = []
+idealized-numerics = []
+# Deprecated alias. Prefer "idealized-numerics".
+floating-point = ["idealized-numerics"]
 contrib = []
 honest-but-curious = []
-untrusted = ["floating-point", "contrib", "honest-but-curious"]
+untrusted = ["idealized-numerics", "contrib", "honest-but-curious"]
 
 polars = [
     "dep:polars",

--- a/rust/opendp_derive/src/lib.rs
+++ b/rust/opendp_derive/src/lib.rs
@@ -42,7 +42,7 @@ mod full;
 /// You can indicate a list of features that must be enabled by the user for the function to exist.
 /// ```no_run
 /// #[bootstrap(
-///     features("contrib", "floating-point")
+///     features("contrib", "idealized-numerics")
 /// )]
 /// ```
 /// It is recommended to specify features through the `bootstrap` function, not via `cfg` attributes,

--- a/rust/src/combinators/sequential_composition/fully_adaptive/new_fully_adaptive_composition_queryable.tex
+++ b/rust/src/combinators/sequential_composition/fully_adaptive/new_fully_adaptive_composition_queryable.tex
@@ -8,7 +8,6 @@
 \begin{document}
 
 \maketitle
-
 \contrib
 Proves soundness of \texttt{fn new\_fully\_adaptive\_composition\_queryable}.
 

--- a/rust/src/lib.sty
+++ b/rust/src/lib.sty
@@ -25,7 +25,7 @@
   linkbordercolor={0 0 1}
 }
 
-% \contrib macro to indicate inclusion in "contrib".
+% macros to indicate relevant feature-flag requirements in proofs.
 \usepackage{tcolorbox}
 \newtcolorbox{warn_box}{colback=red!5!white,colframe=red!75!black}
 \newcommand{\contrib}{{\begin{warn_box}This proof resides in \textbf{``contrib''} because it has not completed the vetting process.\end{warn_box}}} 

--- a/rust/src/measurements/mod.rs
+++ b/rust/src/measurements/mod.rs
@@ -58,7 +58,7 @@ mod canonical_noise;
 #[cfg(feature = "contrib")]
 pub use canonical_noise::*;
 
-#[cfg(all(feature = "floating-point", feature = "contrib"))]
+#[cfg(all(feature = "idealized-numerics", feature = "contrib"))]
 mod alp;
-#[cfg(all(feature = "floating-point", feature = "contrib"))]
+#[cfg(all(feature = "idealized-numerics", feature = "contrib"))]
 pub use alp::*;

--- a/rust/src/measurements/noise/Sample_for_ZExpFamily1.tex
+++ b/rust/src/measurements/noise/Sample_for_ZExpFamily1.tex
@@ -8,8 +8,8 @@
 \begin{document}
 
 \maketitle
-
 \contrib
+
 Proves soundness of the implementation of \rustdoc{measurements/noise/trait}{Sample} for \texttt{ZExpFamily<1>} in \asOfCommit{mod.rs}{f5bb719}.
 
 \section{Hoare Triple}

--- a/rust/src/measurements/noise/Sample_for_ZExpFamily2.tex
+++ b/rust/src/measurements/noise/Sample_for_ZExpFamily2.tex
@@ -8,7 +8,6 @@
 \begin{document}
 
 \maketitle
-
 \contrib
 Proves soundness of the implementation of \rustdoc{measurements/noise/trait}{Sample} for \texttt{ZExpFamily<2>} in \asOfCommit{mod.rs}{f5bb719}.
 

--- a/rust/src/measurements/noise/nature/float/utilities/find_nearest_multiple_of_2k.tex
+++ b/rust/src/measurements/noise/nature/float/utilities/find_nearest_multiple_of_2k.tex
@@ -8,7 +8,6 @@
 \begin{document}
 
 \maketitle
-
 \contrib
 Proves soundness of the implementation of \rustdoc{measurements/noise/distribution/float/utilities/fn}{find\_nearest\_multiple\_of\_2k} in \asOfCommit{mod.rs}{f5bb719}.
 

--- a/rust/src/measurements/noise/nature/float/utilities/x_mul_2k.tex
+++ b/rust/src/measurements/noise/nature/float/utilities/x_mul_2k.tex
@@ -8,7 +8,6 @@
 \begin{document}
 
 \maketitle
-
 \contrib
 Proves soundness of the implementation of \rustdoc{measurements/noise/distribution/float/utilities/fn}{x\_mul\_2k} in \asOfCommit{mod.rs}{f5bb719}.
 

--- a/rust/src/polars/mod.rs
+++ b/rust/src/polars/mod.rs
@@ -568,8 +568,8 @@ pub(crate) fn get_disabled_features_message() -> String {
 
     #[cfg(not(feature = "contrib"))]
     disabled_features.push("contrib");
-    #[cfg(not(feature = "floating-point"))]
-    disabled_features.push("floating-point");
+    #[cfg(not(feature = "idealized-numerics"))]
+    disabled_features.push("idealized-numerics");
     #[cfg(not(feature = "honest-but-curious"))]
     disabled_features.push("honest-but-curious");
 

--- a/rust/src/traits/samplers/cks20/sample_bernoulli_exp1.tex
+++ b/rust/src/traits/samplers/cks20/sample_bernoulli_exp1.tex
@@ -6,7 +6,6 @@
 
 \begin{document}
 \maketitle
-
 \contrib
 Proves soundness of \texttt{fn sample\_bernoulli\_exp1} in \asOfCommit{mod.rs}{0be3ab3e6}.\\
 \texttt{fn sample\_bernoulli\_exp1} returns a sample from the $Bernoulli(exp(-x))$ distribution for some rational argument in $[0, 1]$.

--- a/rust/src/traits/samplers/cks20/sample_discrete_laplace.tex
+++ b/rust/src/traits/samplers/cks20/sample_discrete_laplace.tex
@@ -6,7 +6,6 @@
 
 \begin{document}
 \maketitle
-
 \contrib
 Proves soundness of \texttt{fn sample\_discrete\_laplace} in \asOfCommit{mod.rs}{0be3ab3e6}.
 This proof is an adaptation of \href{https://arxiv.org/pdf/2004.00010.pdf#subsection.5.2}{subsection 5.2} of \cite{CKS20}.

--- a/rust/src/traits/samplers/cks20/sample_geometric_exp_fast.tex
+++ b/rust/src/traits/samplers/cks20/sample_geometric_exp_fast.tex
@@ -6,7 +6,6 @@
 
 \begin{document}
 \maketitle
-
 \contrib
 Proves soundness of \texttt{fn sample\_geometric\_exp\_fast} in \asOfCommit{mod.rs}{0be3ab3e6}.
 This proof is an adaptation of \href{https://arxiv.org/pdf/2004.00010.pdf#subsection.5.2}{subsection 5.2} of \cite{CKS20}.

--- a/rust/src/traits/samplers/psrn/canonical/InverseCDF_for_CanonicalRV.tex
+++ b/rust/src/traits/samplers/psrn/canonical/InverseCDF_for_CanonicalRV.tex
@@ -6,7 +6,6 @@
 \begin{document}
 
 \maketitle
-
 \contrib
 
 Proves soundness of the implementation of \rustdoc{traits/samplers/psrn/trait}{InverseCDF} 

--- a/rust/src/traits/samplers/psrn/canonical/quantile_cnd.tex
+++ b/rust/src/traits/samplers/psrn/canonical/quantile_cnd.tex
@@ -9,7 +9,6 @@
 \begin{document}
 
 \maketitle
-
 \contrib
 
 Compute the quantile of a canonical noise distribution, as specified by a tradeoff function \texttt{f}.

--- a/rust/src/transformations/manipulation/make_row_by_row.tex
+++ b/rust/src/transformations/manipulation/make_row_by_row.tex
@@ -8,7 +8,6 @@
 \begin{document}
 
 \maketitle
-
 \contrib
 Proves soundness of \rustdoc{transformations/fn}{make\_row\_by\_row} in \asOfCommit{mod.rs}{f5bb719}.
 This constructor is a special case of \rustdoc{transformations/fn}{make\_row\_by\_row\_fallible}.

--- a/rust/src/transformations/manipulation/make_row_by_row_fallible.tex
+++ b/rust/src/transformations/manipulation/make_row_by_row_fallible.tex
@@ -8,7 +8,6 @@
 \begin{document}
 
 \maketitle
-
 \contrib
 Proves soundness of \rustdoc{transformations/fn}{make\_row\_by\_row\_fallible} in \asOfCommit{mod.rs}{f5bb719}.
 


### PR DESCRIPTION
"floating-point" is too narrow for what we need. Widen to any numeric dtype.