### PR TITLE
docs: add cites and utility/runtime information

### DIFF
--- a/rust/src/combinators/privacy_filter/mod.rs
+++ b/rust/src/combinators/privacy_filter/mod.rs
@@ -38,6 +38,15 @@ mod ffi;
 /// to reject any query that would increase the total privacy loss
 /// above the privacy guarantee of the mechanism.
 ///
+/// # Citations
+/// * [RRUV21 Privacy Odometers and Filters: Pay-as-you-Go Composition](https://arxiv.org/abs/1605.08294v1)
+/// * [HSTVVXZ23 Concurrent Composition for Interactive Differential Privacy with Adaptive Privacy-Loss Parameters](https://arxiv.org/abs/2309.05901)
+///
+/// # Runtime
+/// Construction is `O(1)`.
+/// Each answered query adds `O(1)` filter bookkeeping
+/// plus one privacy-loss query to the wrapped odometer/queryable.
+///
 /// # Arguments
 /// * `odometer` - A privacy odometer
 /// * `d_in` - Upper bound on the distance between adjacent datasets

--- a/rust/src/combinators/sequential_composition/adaptive/mod.rs
+++ b/rust/src/combinators/sequential_composition/adaptive/mod.rs
@@ -30,6 +30,11 @@ use super::CompositionMeasure;
 /// Construct a Measurement that when invoked,
 /// returns a queryable that interactively composes measurements.
 ///
+/// # Citations
+/// * [LW22 Composition Theorems for Interactive Differential Privacy](https://arxiv.org/abs/2207.09397)
+/// * [VW21 Concurrent Composition of Differential Privacy](https://arxiv.org/abs/2105.14427)
+/// * [HSTVVXZ23 Concurrent Composition for Interactive Differential Privacy with Adaptive Privacy-Loss Parameters](https://arxiv.org/abs/2309.05901)
+///
 /// **Composition Properties**
 ///
 /// * sequential: all measurements are applied to the same dataset
@@ -40,6 +45,11 @@ use super::CompositionMeasure;
 /// If the privacy measure supports concurrency,
 /// this compositor allows you to spawn multiple interactive mechanisms
 /// and interleave your queries amongst them.
+///
+/// # Runtime
+/// Construction is `O(q)` in the number of budget entries `q = d_mids.len()`.
+/// Each accepted query adds `O(1)` compositor bookkeeping
+/// beyond the cost of checking and evaluating the queried measurement.
 ///
 /// # Arguments
 /// * `input_domain` - indicates the space of valid input datasets
@@ -211,6 +221,11 @@ where
 /// Construct a Measurement that when invoked,
 /// returns a queryable that interactively composes measurements.
 ///
+/// # Citations
+/// * [LW22 Composition Theorems for Interactive Differential Privacy](https://arxiv.org/abs/2207.09397)
+/// * [VW21 Concurrent Composition of Differential Privacy](https://arxiv.org/abs/2105.14427)
+/// * [HSTVVXZ23 Concurrent Composition for Interactive Differential Privacy with Adaptive Privacy-Loss Parameters](https://arxiv.org/abs/2309.05901)
+///
 /// **Composition Properties**
 ///
 /// * sequential: all measurements are applied to the same dataset
@@ -221,6 +236,11 @@ where
 /// If the privacy measure supports concurrency,
 /// this compositor allows you to spawn multiple interactive mechanisms
 /// and interleave your queries amongst them.
+///
+/// # Runtime
+/// Construction is `O(q)` in the number of budget entries `q = d_mids.len()`.
+/// Each accepted query adds `O(1)` compositor bookkeeping
+/// beyond the cost of checking and evaluating the queried measurement.
 ///
 /// # Arguments
 /// * `input_domain` - indicates the space of valid input datasets

--- a/rust/src/combinators/sequential_composition/fully_adaptive/mod.rs
+++ b/rust/src/combinators/sequential_composition/fully_adaptive/mod.rs
@@ -25,6 +25,16 @@ mod ffi;
 )]
 /// Construct an odometer that can spawn a compositor queryable.
 ///
+/// # Citations
+/// * [WRRW23 Fully Adaptive Composition in Differential Privacy](https://arxiv.org/abs/2203.05481)
+/// * [VZ23 Concurrent Composition Theorems for Differential Privacy](http://dx.doi.org/10.1145/3564246.3585241)
+/// * [HSTVVXZ23 Concurrent Composition for Interactive Differential Privacy with Adaptive Privacy-Loss Parameters](https://arxiv.org/abs/2309.05901)
+///
+/// # Runtime
+/// Constructing the odometer is `O(1)`.
+/// Each invocation adds `O(1)` bookkeeping beyond the cost of the queried measurement,
+/// while a privacy-loss query over `m` prior invocations costs `O(m)`.
+///
 /// # Arguments
 /// * `input_domain` - indicates the space of valid input datasets
 /// * `input_metric` - how distances are measured between members of the input domain

--- a/rust/src/combinators/sequential_composition/non_adaptive/mod.rs
+++ b/rust/src/combinators/sequential_composition/non_adaptive/mod.rs
@@ -17,6 +17,9 @@ use super::{Adaptivity, Composability, CompositionMeasure};
 /// Construct the DP composition of [`measurement0`, `measurement1`, ...].
 /// Returns a Measurement that when invoked, computes `[measurement0(x), measurement1(x), ...]`
 ///
+/// # Citations
+/// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
+///
 /// **Composition Properties**
 ///
 /// * sequential: all measurements are applied to the same dataset
@@ -120,6 +123,9 @@ where
 
 /// Construct the DP composition \[`measurement0`, `measurement1`, ...\].
 /// Returns a Measurement that when invoked, computes `[measurement0(x), measurement1(x), ...]`
+///
+/// # Citations
+/// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
 ///
 /// All metrics and domains must be equivalent.
 ///

--- a/rust/src/measurements/make_private_expr/expr_dp_frame_len/mod.rs
+++ b/rust/src/measurements/make_private_expr/expr_dp_frame_len/mod.rs
@@ -60,7 +60,8 @@ impl OpenDPPlugin for DPFrameLenShim {
     }
 }
 
-pub fn make_expr_dp_frame_len<MI: 'static + UnboundedMetric, MO: NoiseExprMeasure>(
+/// Make a dp frame-length expression measurement.
+pub(crate) fn make_expr_dp_frame_len<MI: 'static + UnboundedMetric, MO: NoiseExprMeasure>(
     input_domain: WildExprDomain,
     input_metric: L01InfDistance<MI>,
     output_measure: MO,

--- a/rust/src/measurements/make_private_expr/expr_dp_mean/mod.rs
+++ b/rust/src/measurements/make_private_expr/expr_dp_mean/mod.rs
@@ -64,14 +64,14 @@ impl OpenDPPlugin for DPMeanShim {
     }
 }
 
-/// Make a dp sum expression measurement.
+/// Make a dp mean expression measurement.
 ///
 /// # Arguments
 /// * `input_domain` - ExprDomain
 /// * `input_metric` - The metric space under which neighboring LazyFrames are compared
 /// * `expr` - The expression to which the noise will be added
 /// * `global_scale` - (Re)scale the noise parameter for the noise distribution
-pub fn make_expr_dp_mean<MI: 'static + UnboundedMetric, MO: NoiseExprMeasure>(
+pub(crate) fn make_expr_dp_mean<MI: 'static + UnboundedMetric, MO: NoiseExprMeasure>(
     input_domain: WildExprDomain,
     input_metric: L01InfDistance<MI>,
     output_measure: MO,

--- a/rust/src/measurements/make_private_expr/expr_dp_median/mod.rs
+++ b/rust/src/measurements/make_private_expr/expr_dp_median/mod.rs
@@ -68,7 +68,7 @@ impl OpenDPPlugin for DPMedianShim {
 /// * `input_metric` - The metric space under which neighboring LazyFrames are compared
 /// * `expr` - The expression to which the noise will be added
 /// * `global_scale` - (Re)scale the noise parameter for the noise distribution
-pub fn make_expr_dp_median<MI: 'static + UnboundedMetric, MO: NoiseExprMeasure>(
+pub(crate) fn make_expr_dp_median<MI: 'static + UnboundedMetric, MO: NoiseExprMeasure>(
     input_domain: WildExprDomain,
     input_metric: L01InfDistance<MI>,
     output_measure: MO,

--- a/rust/src/measurements/make_private_expr/expr_dp_quantile/mod.rs
+++ b/rust/src/measurements/make_private_expr/expr_dp_quantile/mod.rs
@@ -75,7 +75,7 @@ impl OpenDPPlugin for DPQuantileShim {
 /// * `input_metric` - The metric space under which neighboring LazyFrames are compared
 /// * `expr` - The expression to which the noise will be added
 /// * `global_scale` - (Re)scale the noise parameter for the noise distribution
-pub fn make_expr_dp_quantile<MI: 'static + UnboundedMetric, MO: NoiseExprMeasure>(
+pub(crate) fn make_expr_dp_quantile<MI: 'static + UnboundedMetric, MO: NoiseExprMeasure>(
     input_domain: WildExprDomain,
     input_metric: L01InfDistance<MI>,
     output_measure: MO,

--- a/rust/src/measurements/make_private_expr/expr_dp_sum/mod.rs
+++ b/rust/src/measurements/make_private_expr/expr_dp_sum/mod.rs
@@ -74,7 +74,7 @@ impl OpenDPPlugin for DPSumShim {
 /// * `input_metric` - The metric space under which neighboring LazyFrames are compared
 /// * `expr` - The expression to which the noise will be added
 /// * `global_scale` - (Re)scale the noise parameter for the noise distribution
-pub fn make_expr_dp_sum<MI: 'static + UnboundedMetric, MO: NoiseExprMeasure>(
+pub(crate) fn make_expr_dp_sum<MI: 'static + UnboundedMetric, MO: NoiseExprMeasure>(
     input_domain: WildExprDomain,
     input_metric: L01InfDistance<MI>,
     output_measure: MO,

--- a/rust/src/measurements/make_private_expr/expr_noise/mod.rs
+++ b/rust/src/measurements/make_private_expr/expr_noise/mod.rs
@@ -146,7 +146,7 @@ pub enum Support {
 /// * `input_metric` - The metric space under which neighboring LazyFrames are compared
 /// * `expr` - The expression to which the noise will be added
 /// * `global_scale` - (Re)scale the noise parameter for the noise distribution
-pub fn make_expr_noise<MI: 'static + UnboundedMetric, MO: NoiseExprMeasure>(
+pub(crate) fn make_expr_noise<MI: 'static + UnboundedMetric, MO: NoiseExprMeasure>(
     input_domain: WildExprDomain,
     input_metric: L01InfDistance<MI>,
     expr: Expr,

--- a/rust/src/measurements/make_private_expr/expr_noisy_max/mod.rs
+++ b/rust/src/measurements/make_private_expr/expr_noisy_max/mod.rs
@@ -43,7 +43,7 @@ mod test;
 /// * `input_metric` - The metric space under which neighboring LazyFrames are compared
 /// * `expr` - The expression to which the selection will be applied
 /// * `global_scale` - (Re)scale the noise distribution
-pub fn make_expr_noisy_max<MI: 'static + UnboundedMetric, MO: 'static + TopKMeasure>(
+pub(crate) fn make_expr_noisy_max<MI: 'static + UnboundedMetric, MO: 'static + TopKMeasure>(
     input_domain: WildExprDomain,
     input_metric: L01InfDistance<MI>,
     expr: Expr,

--- a/rust/src/measurements/make_private_expr/mod.rs
+++ b/rust/src/measurements/make_private_expr/mod.rs
@@ -69,6 +69,9 @@ pub(crate) mod expr_noisy_max;
 )]
 /// Create a differentially private measurement from an [`Expr`].
 ///
+/// # Citations
+/// * [Rogers23 A Unifying Privacy Analysis Framework for Unknown Domain Algorithms in Differential Privacy](https://arxiv.org/abs/2309.09170)
+///
 /// # Arguments
 /// * `input_domain` - The domain of the input data.
 /// * `input_metric` - How to measure distances between neighboring input data sets.

--- a/rust/src/measurements/make_private_lazyframe/group_by/mod.rs
+++ b/rust/src/measurements/make_private_lazyframe/group_by/mod.rs
@@ -37,7 +37,7 @@ use polars_plan::prelude::ProjectionOptions;
 /// * `plan` - The LazyFrame to transform.
 /// * `global_scale` - The parameter for the measurement.
 /// * `threshold` - Only keep groups with length greater than threshold
-pub fn make_private_group_by<MI, MO>(
+pub(crate) fn make_private_group_by<MI, MO>(
     input_domain: DslPlanDomain,
     input_metric: FrameDistance<MI>,
     output_measure: MO,

--- a/rust/src/measurements/make_private_lazyframe/mod.rs
+++ b/rust/src/measurements/make_private_lazyframe/mod.rs
@@ -98,6 +98,17 @@ where
 /// Any data inside the [`LazyFrame`] is ignored,
 /// but it is still recommended to start with an empty [`DataFrame`] and build up the computation using the [`LazyFrame`] API.
 ///
+/// # Citations
+/// Depending on the query plan, this constructor may rely on:
+///
+/// * [Rogers23 A Unifying Privacy Analysis Framework for Unknown Domain Algorithms in Differential Privacy](https://arxiv.org/abs/2309.09170)
+/// * [GRS12 Universally Utility-Maximizing Privacy Mechanisms](https://theory.stanford.edu/~tim/papers/priv.pdf)
+/// * [CKS20 The Discrete Gaussian for Differential Privacy](https://arxiv.org/abs/2004.00010)
+/// * [DMNS06 Calibrating Noise to Sensitivity in Private Data Analysis](https://people.csail.mit.edu/asmith/PS/sensitivity-tcc-final.pdf)
+/// * [CSVW22 Widespread Underestimation of Sensitivity in Differentially Private Libraries and How to Fix It](https://arxiv.org/abs/2207.10635)
+/// * [Smith11 Privacy-Preserving Statistical Estimation with Optimal Convergence Rates](https://doi.org/10.1145/1993636.1993743)
+/// * [MS20 Permute-and-Flip: A New Mechanism for Differentially Private Selection](https://arxiv.org/abs/2010.12603)
+///
 /// # Arguments
 /// * `input_domain` - The domain of the input data.
 /// * `input_metric` - How to measure distances between neighboring input data sets.

--- a/rust/src/measurements/make_private_lazyframe/select/mod.rs
+++ b/rust/src/measurements/make_private_lazyframe/select/mod.rs
@@ -22,7 +22,7 @@ mod test;
 /// * `output_measure` - The measure of the output LazyFrame.
 /// * `plan` - The LazyFrame to transform.
 /// * `global_scale` - The parameter for the measurement.
-pub fn make_private_select<MI, MO>(
+pub(crate) fn make_private_select<MI, MO>(
     input_domain: DslPlanDomain,
     input_metric: FrameDistance<MI>,
     output_measure: MO,

--- a/rust/src/measurements/noise_threshold/distribution/gaussian/mod.rs
+++ b/rust/src/measurements/noise_threshold/distribution/gaussian/mod.rs
@@ -40,6 +40,24 @@ mod test;
 /// Larger granularities are more computationally efficient, but have a looser privacy map.
 /// If k is not set, k defaults to the smallest granularity.
 ///
+/// # Citations
+/// * [Rogers23 A Unifying Privacy Analysis Framework for Unknown Domain Algorithms in Differential Privacy](https://arxiv.org/abs/2309.09170)
+/// * [CKS20 The Discrete Gaussian for Differential Privacy](https://arxiv.org/abs/2004.00010)
+///
+/// # Proof Navigation
+/// * This constructor delegates to [`MakeNoiseThreshold`] for [`DiscreteGaussian`].
+/// * Threshold-specific privacy accounting is implemented by [`NoiseThresholdPrivacyMap`].
+/// * See also [`make_noise_threshold`] for the distribution-agnostic entry point.
+///
+/// # Runtime
+/// For an input map with `m` entries, each release performs `O(m)` wrapper work
+/// plus one discrete-Gaussian draw per entry.
+///
+/// # Utility
+/// If an item's value is separated from the threshold by margin `g`,
+/// the probability of thresholding it incorrectly decays subgaussianly as
+/// `O(exp(-(g / scale)^2))` up to constants from the discrete Gaussian tail bound.
+///
 /// # Arguments
 /// * `input_domain` - Domain of the input.
 /// * `input_metric` - Metric for the input domain.

--- a/rust/src/measurements/noise_threshold/distribution/laplace/mod.rs
+++ b/rust/src/measurements/noise_threshold/distribution/laplace/mod.rs
@@ -39,6 +39,24 @@ mod test;
 /// Larger granularities are more computationally efficient, but have a looser privacy map.
 /// If k is not set, k defaults to the smallest granularity.
 ///
+/// # Citations
+/// * [Rogers23 A Unifying Privacy Analysis Framework for Unknown Domain Algorithms in Differential Privacy](https://arxiv.org/abs/2309.09170)
+/// * [CKS20 The Discrete Gaussian for Differential Privacy](https://arxiv.org/abs/2004.00010)
+///
+/// # Proof Navigation
+/// * This constructor delegates to [`MakeNoiseThreshold`] for [`DiscreteLaplace`].
+/// * Threshold-specific privacy accounting is implemented by [`NoiseThresholdPrivacyMap`].
+/// * See also [`make_noise_threshold`] for the distribution-agnostic entry point.
+///
+/// # Runtime
+/// For an input map with `m` entries, each release performs `O(m)` wrapper work
+/// plus one discrete-Laplace draw per entry.
+///
+/// # Utility
+/// If an item's value is separated from the threshold by margin `g`,
+/// the probability of thresholding it incorrectly decays as `O(exp(-g / scale))`
+/// up to constants from the discrete/continuous Laplace tail bounds.
+///
 /// # Arguments
 /// * `input_domain` - Domain of the input.
 /// * `input_metric` - Metric for the input domain.

--- a/rust/src/measurements/noise_threshold/distribution/mod.rs
+++ b/rust/src/measurements/noise_threshold/distribution/mod.rs
@@ -34,6 +34,26 @@ mod test;
 /// Larger granularities are more computationally efficient, but have a looser privacy map.
 /// If k is not set, k defaults to the smallest granularity.
 ///
+/// # Citations
+/// * [Rogers23 A Unifying Privacy Analysis Framework for Unknown Domain Algorithms in Differential Privacy](https://arxiv.org/abs/2309.09170)
+/// * [CKS20 The Discrete Gaussian for Differential Privacy](https://arxiv.org/abs/2004.00010)
+///
+/// # Proof Navigation
+/// * [`make_laplace_threshold`] and [`make_gaussian_threshold`] are the distribution-specific entry points.
+/// * [`MakeNoiseThreshold`] covers distribution-specific measurement construction.
+/// * [`NoiseThresholdPrivacyMap`] covers threshold-specific privacy accounting.
+///
+/// # Runtime
+/// For an input map with `m` entries, each release performs `O(m)` wrapper work
+/// plus one draw from the underlying thresholded noise sampler per entry.
+///
+/// # Utility
+/// Utility is governed by the tail of the chosen noise distribution.
+/// If an item is separated from the threshold by a margin `g`,
+/// false-positive and false-negative probabilities decay according to that tail:
+/// exponentially in `g / scale` for Laplace-like tails and
+/// subgaussianly in `(g / scale)^2` for Gaussian-like tails.
+///
 /// # Arguments
 /// * `input_domain` - Domain of the input.
 /// * `input_metric` - Metric for the input domain.

--- a/rust/src/measurements/noisy_max/mod.rs
+++ b/rust/src/measurements/noisy_max/mod.rs
@@ -28,6 +28,16 @@ mod test;
 )]
 /// Make a Measurement that takes a vector of scores and privately selects the index of the highest score.
 ///
+/// # Citations
+/// * [MS20 Permute-and-Flip: A New Mechanism for Differentially Private Selection](https://arxiv.org/abs/2010.12603)
+///
+/// # Runtime
+/// Per release, worst-case runtime is `O(n)`, where `n` is the number of scores.
+///
+/// # Utility
+/// When `scale = 0`, the mechanism returns the exact maximizing index.
+/// For positive `scale`, utility improves as score gaps grow relative to `scale`.
+///
 /// # Arguments
 /// * `input_domain` - Domain of the input vector. Must be a non-nullable `VectorDomain`
 /// * `input_metric` - Metric on the input domain. Must be `LInfDistance`
@@ -68,6 +78,12 @@ where
     note = "Use :py:func:`~opendp.measurements.make_noisy_max` instead."
 )]
 /// Make a Measurement that takes a vector of scores and privately selects the index of the highest score.
+///
+/// # Citations
+/// * [MS20 Permute-and-Flip: A New Mechanism for Differentially Private Selection](https://arxiv.org/abs/2010.12603)
+///
+/// # Runtime
+/// Per release, worst-case runtime is `O(n)`, where `n` is the number of scores.
 ///
 /// # Arguments
 /// * `input_domain` - Domain of the input vector. Must be a non-nullable `VectorDomain`

--- a/rust/src/measurements/noisy_top_k/mod.rs
+++ b/rust/src/measurements/noisy_top_k/mod.rs
@@ -29,6 +29,19 @@ mod test;
 )]
 /// Make a Measurement that takes a vector of scores and privately selects the index of the highest score.
 ///
+/// # Citations
+/// * [MS20 Permute-and-Flip: A New Mechanism for Differentially Private Selection](https://arxiv.org/abs/2010.12603)
+///
+/// # Runtime
+/// Per release, worst-case runtime is `O(k n)`, where `n` is the number of scores.
+/// For `k = 1`, this reduces to `O(n)`.
+///
+/// # Utility
+/// When `scale = 0`, the mechanism returns the exact top-`k` indices.
+/// For positive `scale`, utility improves as score gaps grow relative to `scale`;
+/// for a fixed gap parameter `g`, the failure probability decays exponentially in `g / scale`
+/// up to constants from the selection mechanism analysis.
+///
 /// # Arguments
 /// * `input_domain` - Domain of the input vector. Must be a non-nullable VectorDomain.
 /// * `input_metric` - Metric on the input domain. Must be LInfDistance

--- a/rust/src/measurements/private_quantile/mod.rs
+++ b/rust/src/measurements/private_quantile/mod.rs
@@ -24,7 +24,20 @@ mod ffi;
     generics(MI(suppress), MO(suppress), T(suppress)),
     derived_types(T = "$get_atom(get_type(input_domain))")
 )]
-/// Makes a Measurement the computes the quantile of a dataset.
+/// Make a Measurement that computes the quantile of a dataset.
+///
+/// # Citations
+/// * [Smith11 Privacy-Preserving Statistical Estimation with Optimal Convergence Rates](https://doi.org/10.1145/1993636.1993743)
+/// * [MS20 Permute-and-Flip: A New Mechanism for Differentially Private Selection](https://arxiv.org/abs/2010.12603)
+///
+/// # Runtime
+/// Construction time is `O(c log c)` to sort `c` candidates.
+/// For a dataset of size `n`, each release then runs in `O(n log c + c)`.
+///
+/// # Utility
+/// The release is always one of the supplied `candidates`.
+/// If the input domain size is known, the scoring sensitivity is reduced by a factor of 2
+/// relative to the unknown-size case, which can improve utility.
 ///
 /// # Arguments
 /// * `input_domain` - Uses a tighter sensitivity when the size of vectors in the input domain is known.

--- a/rust/src/measurements/randomized_response/mod.rs
+++ b/rust/src/measurements/randomized_response/mod.rs
@@ -28,6 +28,16 @@ use crate::traits::{ExactIntCast, Hashable, InfDiv, InfLn, InfMul, InfSub};
 #[bootstrap(features("contrib"), arguments(constant_time(default = false)))]
 /// Make a Measurement that implements randomized response on a boolean value.
 ///
+/// # Citations
+/// * [Warner65 Randomized Response: A Survey Technique for Eliminating Evasive Answer Bias](https://doi.org/10.1080/01621459.1965.10480775)
+///
+/// # Runtime
+/// Per release, runtime is `O(1)`.
+///
+/// # Utility
+/// The released bit matches the input with probability `prob`,
+/// so the expected 0-1 loss is `O(1 - prob)`.
+///
 /// # Arguments
 /// * `prob` - Probability of returning the correct answer. Must be in `[0.5, 1]`
 /// * `constant_time` - Set to true to enable constant time. Slower.
@@ -66,6 +76,19 @@ pub fn make_randomized_response_bool(
     generics(T(example = "$get_first(categories)"))
 )]
 /// Make a Measurement that implements randomized response on a categorical value.
+///
+/// # Citations
+/// * [Warner65 Randomized Response: A Survey Technique for Eliminating Evasive Answer Bias](https://doi.org/10.1080/01621459.1965.10480775)
+///
+/// # Runtime
+/// Per release, runtime is `O(t)`, where `t` is the number of categories,
+/// because the implementation linearly searches for the input in `categories`.
+///
+/// # Utility
+/// If the input is a member of `categories`,
+/// the mechanism returns the truthful category with probability `prob`,
+/// so the expected 0-1 loss is `O(1 - prob)`.
+/// Otherwise, the output is sampled uniformly from `categories`.
 ///
 /// # Arguments
 /// * `categories` - Set of valid outcomes

--- a/rust/src/transformations/quantile_score_candidates/mod.rs
+++ b/rust/src/transformations/quantile_score_candidates/mod.rs
@@ -26,6 +26,16 @@ mod test;
 )]
 /// Makes a Transformation that scores how similar each candidate is to the given `alpha`-quantile on the input dataset.
 ///
+/// # Citations
+/// * [Smith11 Privacy-Preserving Statistical Estimation with Optimal Convergence Rates](https://doi.org/10.1145/1993636.1993743)
+///
+/// # Runtime
+/// For a dataset of size `n` and `c` candidates, runtime is `O(n log c + c)`.
+///
+/// # Utility
+/// If the input domain size is known, the score sensitivity is reduced by a factor of 2
+/// relative to the unknown-size case, which can improve downstream utility.
+///
 /// # Arguments
 /// * `input_domain` - Uses a smaller sensitivity when the size of vectors in the input domain is known.
 /// * `input_metric` - Either SymmetricDistance or InsertDeleteDistance.


### PR DESCRIPTION
This PR also makes some internal polars expr parsers pub(crate) instead of pub. Users only realistically need to know about/access the make_(stable|private)_(expr|lazyframe) APIs.