### PR TITLE
Maintenance: Just run nightly once a week

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,7 +3,8 @@ name: Nightly
 on:
   schedule:
     # 03:45 UTC = 22:45 EST/23:45 EDT (i.e., always before midnight), so nightlies will have a sensible date
-    - cron: '45 3 * * *'
+    # 0 = Sunday: Run just once a week.
+    - cron: '45 3 * * 0'
 
 jobs:
   release:


### PR DESCRIPTION
- Fix #2635

This is a proposal. Alternatives:
- Also rename to `weekly` instead of `nightly`.
- Invest, plan to automate PyPI cleaning.
- Accept the status quo, and close #2635 as won't-fix.

Since we usually haven't responded to failures within a week, I don't think we're losing any important information by just running less frequently.