### PR TITLE
fix: multiversion conf.py references invalid git state

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,8 +75,18 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+          echo "Select recent version tags."
+          export OPENDP_SMV_TAG_WHITELIST="$(python tools/select_smv_versions.py)"
+          echo "Using tag whitelist: ${OPENDP_SMV_TAG_WHITELIST}"
+
           echo "Create docs."
           make versions
+
+          if [ ! -f build/html/en/stable/index.html ]; then
+            echo "Missing build/html/en/stable/index.html; refusing to deploy partial docs build."
+            exit 1
+          fi
+
           # Sphinx caches parsed sources in .doctrees, but the published site does not need them.
           rm -rf build/html/en/*/.doctrees
           cp -r build /tmp

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,17 +75,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-          echo "Select recent version tags."
-          export OPENDP_SMV_TAG_WHITELIST="$(python tools/select_smv_versions.py)"
-          echo "Using tag whitelist: ${OPENDP_SMV_TAG_WHITELIST}"
-
           echo "Create docs."
           make versions
-
-          if [ ! -f build/html/en/stable/index.html ]; then
-            echo "Missing build/html/en/stable/index.html; refusing to deploy partial docs build."
-            exit 1
-          fi
 
           # Sphinx caches parsed sources in .doctrees, but the published site does not need them.
           rm -rf build/html/en/*/.doctrees

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,6 +14,7 @@ SPHINXMULTI   = sphinx-multiversion
 PAPER         =
 BUILDDIR      = build
 VERSION       = $(shell cat ../VERSION)
+SMV_TAG_WHITELIST ?= $(shell python3 tools/select_smv_versions.py)
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
@@ -46,7 +47,7 @@ doctest-rust:
 
 versions:
 	# "/en" is the default, but someday we might have translations
-	$(SPHINXMULTI) $(SPHINXOPTS) source $(BUILDDIR)/html/en
+	OPENDP_SMV_TAG_WHITELIST='$(SMV_TAG_WHITELIST)' $(SPHINXMULTI) $(SPHINXOPTS) source $(BUILDDIR)/html/en
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 	cp redirect.html $(BUILDDIR)/html/index.html

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,3 +96,7 @@ Otherwise, you will get an error that includes:
 
     /docs/source/api/index.rst:4:toctree contains reference to nonexisting document 'api/python/index'
 
+Version selection for `make versions` is computed before Sphinx starts by
+`docs/tools/select_smv_versions.py`, then passed into `conf.py` via
+`OPENDP_SMV_TAG_WHITELIST`. This keeps `conf.py` static when
+`sphinx-multiversion` re-evaluates it inside per-ref temporary build directories.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -190,9 +190,7 @@ html_context = {
 
 # Whitelist pattern for tags (set to None to ignore all tags)
 smv_tag_whitelist = os.environ.get("OPENDP_SMV_TAG_WHITELIST", r"^$")
-# # keep all released versions, as well as prereleases for the stable version. Doesn't work, because version != stable
-# import re
-# smv_tag_whitelist = rf'(^v\d+\.\d+\.\d+$)|(^v{re.escape(version.split("-")[0])}.+$)'
+
 
 # Whitelist pattern for branches (set to None to ignore all branches)
 smv_branch_whitelist = r'(stable|beta|nightly)'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,8 +5,6 @@ import os
 from datetime import datetime
 import semver
 import pypandoc
-import re
-import subprocess
 from sphinx.ext import autodoc
 
 # docs should be built without needing import the library binary for the specified version
@@ -190,46 +188,8 @@ html_context = {
     # 'current_version': 'some-old-version'
 }
 
-# SPHINX-MULTIVERSION STUFF
-def _list_release_tags():
-    return subprocess.check_output(["git", "tag", "--list", "v*"], text=True).splitlines()
-
-
-# With a quarterly release cadence (not counting patches),
-# this will generate API docs just for the past year.
-def _select_recent_release_tags(tags):
-    """
-    Return a regex matching the latest patch release from the most recent release lines.
-
-    >>> _select_recent_release_tags(
-    ...     ["v0.11.0", "v0.11.1", "v0.12.0", "v0.12.0-rc.1", "not-a-tag"],
-    ...     number_to_keep=2,
-    ... )
-    '^(v0\\\\.11\\\\.1|v0\\\\.12\\\\.0)$'
-    """
-    # assuming quarterly release cadence
-    number_to_keep = 8
-    
-    latest_patch_for_major_minor = {}
-    for tag in tags:
-        match = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)", tag)
-        if match is None:
-            continue
-        major, minor, patch = map(int, match.groups())
-        major_minor = (major, minor)
-        current = latest_patch_for_major_minor.get(major_minor)
-        if current is None or patch > current[0]:
-            latest_patch_for_major_minor[major_minor] = (patch, tag)
-
-    selected_major_minors = sorted(latest_patch_for_major_minor, reverse=True)[:number_to_keep]
-    selected_tags = sorted(
-        latest_patch_for_major_minor[major_minor][1] for major_minor in selected_major_minors
-    )
-    return r"^(%s)$" % "|".join(re.escape(tag) for tag in selected_tags)
-
-
 # Whitelist pattern for tags (set to None to ignore all tags)
-smv_tag_whitelist = _select_recent_release_tags(_list_release_tags())
+smv_tag_whitelist = os.environ.get("OPENDP_SMV_TAG_WHITELIST", r"^$")
 # # keep all released versions, as well as prereleases for the stable version. Doesn't work, because version != stable
 # import re
 # smv_tag_whitelist = rf'(^v\d+\.\d+\.\d+$)|(^v{re.escape(version.split("-")[0])}.+$)'

--- a/docs/tools/select_smv_versions.py
+++ b/docs/tools/select_smv_versions.py
@@ -18,11 +18,12 @@ def select_recent_release_tags(tags: list[str]) -> str:
     """
     Return a regex matching the latest patch release from the most recent release lines.
 
-    >>> select_recent_release_tags(
+    >>> print(select_recent_release_tags(
     ...     ["v0.11.0", "v0.11.1", "v0.12.0", "v0.12.0-rc.1", "not-a-tag"],
-    ... )
-    '^(v0\\\\.11\\\\.1|v0\\\\.12\\\\.0)$'
+    ... ))
+    ^(v0\\.11\\.1|v0\\.12\\.0)$
     """
+    # latest patch for each minor version
     pareto_versions: dict[tuple[int, int], tuple[int, str]] = {}
     for tag in tags:
         match = TAG_PATTERN.fullmatch(tag)

--- a/docs/tools/select_smv_versions.py
+++ b/docs/tools/select_smv_versions.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Prepare a sphinx-multiversion tag whitelist for recent OpenDP releases."""
+
+import re
+import subprocess
+from pathlib import Path
+
+DEFAULT_NUM_RELEASES = 8
+TAG_PATTERN = re.compile(r"v(\d+)\.(\d+)\.(\d+)$")
+
+
+def list_release_tags(repo_root: Path) -> list[str]:
+    args = "git tag --list v*".split()
+    return subprocess.check_output(args, cwd=repo_root, text=True).splitlines()
+
+
+def select_recent_release_tags(tags: list[str]) -> str:
+    """
+    Return a regex matching the latest patch release from the most recent release lines.
+
+    >>> select_recent_release_tags(
+    ...     ["v0.11.0", "v0.11.1", "v0.12.0", "v0.12.0-rc.1", "not-a-tag"],
+    ... )
+    '^(v0\\\\.11\\\\.1|v0\\\\.12\\\\.0)$'
+    """
+    pareto_versions: dict[tuple[int, int], tuple[int, str]] = {}
+    for tag in tags:
+        match = TAG_PATTERN.fullmatch(tag)
+        if match is None:
+            continue
+
+        major, minor, patch = map(int, match.groups())
+        current = pareto_versions.get((major, minor))
+        if current is None or patch > current[0]:
+            pareto_versions[(major, minor)] = (patch, tag)
+
+    selected_versions = sorted(pareto_versions, reverse=True)[:DEFAULT_NUM_RELEASES]
+    selected_tags = sorted(pareto_versions[v][1] for v in selected_versions)
+    return r"^(%s)$" % "|".join(re.escape(tag) for tag in selected_tags)
+
+
+if __name__ == "__main__":
+    repo_root = Path(__file__).resolve().parents[2]
+    print(select_recent_release_tags(list_release_tags(repo_root)))


### PR DESCRIPTION
In #2679 I adjusted the CI to build docs from only the last two years. In the multiversion build, conf.py is run once, creating a refs list. Then for each ref, sphinx multiversion prepares a folder with the contents of that ref, and builds, thus loading that ref's conf.py. 0.15 was the first version to have a newer conf.py that tries to read git state to determine which versions to build. 0.15 (and similarly stable/beta/nightly) fail because the temporary folder provisioned by multiversion isn't a git repository.

This PR:
* moves the ref selection logic out of conf.py, instead passing it in as an env var
* adds a check to avoid a bogus docs publish again