### PR TITLE
Remove WIP warning from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 <img src="https://docs.opendp.org/en/stable/_static/opendp-logo.png" width="200" alt="OpenDP logo">
 
-[![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/license/MIT)
 
 [![Python](https://img.shields.io/badge/Python-3.10%20%E2%80%93%203.13-blue)](https://docs.opendp.org/en/stable/api/python/index.html)

--- a/docs/source/api/user-guide/index.rst
+++ b/docs/source/api/user-guide/index.rst
@@ -50,7 +50,7 @@ Features that are available from Python and R:
    * - Name
      - Description
    * - ``contrib``
-     - Enable to include constructors that have not passed the vetting process.
+     - Enable to include constructors that have not completed the vetting process.
    * - ``honest-but-curious``
      - Enable to include constructors whose differential privacy (or stability) properties
        rely on the constructor arguments being correct.


### PR DESCRIPTION
- Fix #2727
- Change from "passed" to "completed the vetting process".

It's a minor change, but if something hasn't "passed" it might seemed like it has failed. Changing to "completed" emphasizes that the process itself gives us something, even if we haven't gotten over the finish line.

(Another direction would be to have a separate flag for proved but not-yet-vetted functions: I think that would add process complexity that we can't afford.)
