### PR TITLE
Maintenance: Run doctests on conf.py

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -32,6 +32,7 @@ clean:
 
 html:
 	@set -e
+	@cd source && python -m doctest conf.py && cd ..
 	# If sphinx-apidoc options change, also update conf.py!
 	$(SPHINXAPIDOC) -f -F -e -d 3 -H "OpenDP" -A "The OpenDP Project" -V $(VERSION) -o source/api/python ../python/src/opendp --templatedir source/_templates
 	OPENDP_SPHINX_LOCAL=1 $(SPHINXBUILD) $(SPHINXOPTS) -D version=$(VERSION) source $(BUILDDIR)/html

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -195,19 +195,17 @@ def _list_release_tags():
     return subprocess.check_output(["git", "tag", "--list", "v*"], text=True).splitlines()
 
 
-# With a quarterly release cadence (not counting patches),
-# this will generate API docs just for the past year.
 def _select_recent_release_tags(tags):
     """
     Return a regex matching the latest patch release from the most recent release lines.
 
-    >>> _select_recent_release_tags(
+    >>> print(_select_recent_release_tags(
     ...     ["v0.11.0", "v0.11.1", "v0.12.0", "v0.12.0-rc.1", "not-a-tag"],
-    ...     number_to_keep=2,
-    ... )
-    '^(v0\\\\.11\\\\.1|v0\\\\.12\\\\.0)$'
+    ... ))
+    ^(v0\.11\.1|v0\.12\.0)$
     """
-    # assuming quarterly release cadence
+    # With a quarterly release cadence (not counting patches),
+    # this will generate API docs just for the past two years.
     number_to_keep = 8
     
     latest_patch_for_major_minor = {}


### PR DESCRIPTION
- Fix #2706
- Update existing doctest to reflect current kwargs
- Run the doctests as part of `make html`, which is covered by the smoketest.