### PR TITLE
chore: skip polars in docs.rs build

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -51,6 +51,8 @@ bitvec = "1.0"
 #
 # The features track the features enabled in the Rust build for the Polars Python crate.
 # Having matching features is necessary for cross-binary DSL compatibility.
+#
+# TODO: re-enable docs.rs polars once https://github.com/pola-rs/polars/issues/27105 is released
 polars = { version = "=0.52.0", features = ["full", "meta", "cutqcut", "row_hash"], optional = true }
 polars-python = { version = "=0.52.0", optional = true }
 
@@ -145,7 +147,7 @@ crate-type = ["rlib", "cdylib", "staticlib"]
 
 [package.metadata.docs.rs]
 no-default-features = true
-features = ["use-openssl", "derive", "untrusted", "polars"]
+features = ["use-openssl", "derive", "untrusted"]
 rustdoc-args = [
     # so that latex renders
     "--html-in-header", "katex.html",


### PR DESCRIPTION
Polars has fixed upstream, but it is not part of a public release yet. Could do some feature magic to just carve out strings from polars, but I think simpler is better.