### PR TITLE
docs: update banner / fix dates in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This file documents the version history of OpenDP. The links on each version num
 
 
 
-## [0.15.0](https://github.com/opendp/opendp/compare/v1.14.2...v0.15.0) - 2026-05-19
+## [0.15.0](https://github.com/opendp/opendp/compare/v0.14.2...v0.15.0) - 2026-05-19
 
 
 ### Migration
@@ -88,7 +88,7 @@ There are a few changes in feature names to be aware of:
 
 #### Fill gaps
 
-- Fill in migration notes back to v12 [#2541](https://github.com/opendp/opendp/pull/2541)
+- Fill in migration notes back to v0.12 [#2541](https://github.com/opendp/opendp/pull/2541)
 - Clarify commitments for OpenDP Commons [#2661](https://github.com/opendp/opendp/pull/2661)
 - Add citations and utility/runtime information in Rust code [#2702](https://github.com/opendp/opendp/pull/2702)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file documents the version history of OpenDP. The links on each version num
 
 
 
-## [0.15.1-dev](https://github.com/opendp/opendp/compare/v0.15.0...HEAD) - TBD
+## [0.15.1](https://github.com/opendp/opendp/compare/v0.15.0...v0.15.1) - 2026-05-28
 
 
 ### Fix
@@ -25,7 +25,7 @@ This file documents the version history of OpenDP. The links on each version num
 
 
 
-## [0.15.0](https://github.com/opendp/opendp/compare/v1.14.2...v0.15.0) - 2026-05-28
+## [0.15.0](https://github.com/opendp/opendp/compare/v1.14.2...v0.15.0) - 2026-05-19
 
 
 ### Migration
@@ -116,7 +116,7 @@ There are a few changes in feature names to be aware of:
 
 
 
-## [0.14.2](https://github.com/opendp/opendp/compare/v0.14.1...v0.14.2) - 2026-05-08
+## [0.14.2](https://github.com/opendp/opendp/compare/v0.14.1...v0.14.2) - 2026-03-11
 
 
 ### Features

--- a/docs/source/announcement.html
+++ b/docs/source/announcement.html
@@ -3,5 +3,5 @@
     Changes here only need to be pushed to main: Full release not needed!
 -->
 <div>
-    <a href="https://github.com/opendp/opendp/blob/main/CHANGELOG.md#0142---2026-03-10">Announcing OpenDP v0.14.2!</a>
+    <a href="https://opendp.org/2026/05/29/announcing-opendp-library-0-15/">Announcing OpenDP v0.15!</a>
 </div>


### PR DESCRIPTION
- Update the docs banner.
- Related to #2741, fix recent dates in the changelog.

I think part of the problem is that the date is set when the changelog is generated, which can come some time before the release hits PyPI. I'm not entirely sure about the expected state of the changelog, but I don't think I want to try to dig into it right now, either.