### PR TITLE
docs: add tab wrapping where missing

### DIFF
--- a/docs/source/getting-started/statistical-modeling/synthetic-data.rst
+++ b/docs/source/getting-started/statistical-modeling/synthetic-data.rst
@@ -19,62 +19,77 @@ All algorithms for differentially private contingency table estimation inherit f
 
 Let's get started by setting up the context for the Labor Force dataset.
 
-.. code:: pycon
+.. tab-set::
 
-    >>> import opendp.prelude as dp
-    >>> import polars as pl
+    .. tab-item:: Python
+        :sync: python
 
-    >>> dp.enable_features("contrib")
+        .. code:: pycon
 
-    >>> context = dp.Context.compositor(
-    ...     data=pl.scan_csv(
-    ...         dp.examples.get_france_lfs_path(),
-    ...         ignore_errors=True,
-    ...     ),
-    ...     privacy_unit=dp.unit_of(contributions=36),
-    ...     privacy_loss=dp.loss_of(rho=0.2, delta=2e-7),
-    ... )
+            >>> import opendp.prelude as dp
+            >>> import polars as pl
+
+            >>> dp.enable_features("contrib")
+
+            >>> context = dp.Context.compositor(
+            ...     data=pl.scan_csv(
+            ...         dp.examples.get_france_lfs_path(),
+            ...         ignore_errors=True,
+            ...     ),
+            ...     privacy_unit=dp.unit_of(contributions=36),
+            ...     privacy_loss=dp.loss_of(rho=0.2, delta=2e-7),
+            ... )
 
 We now release a contingency table via the :py:class:`~opendp.extras.mbi.AIM` algorithm.
 
-.. code:: pycon
+.. tab-set::
 
-    >>> table_aim = (
-    ...     context.query(rho=0.1, delta=1e-7)
-    ...     # transformations/truncation may be applied here
-    ...     .select("SEX", "AGE", "HWUSUAL", "ILOSTAT")
-    ...     .contingency_table(
-    ...         keys={"SEX": [1, 2]},
-    ...         cuts={"AGE": [20, 40, 60], "HWUSUAL": [1, 20, 40]},
-    ...         algorithm=dp.mbi.AIM(),
-    ...     )
-    ...     .release()
-    ... )
+    .. tab-item:: Python
+        :sync: python
+
+        .. code:: pycon
+
+            >>> table_aim = (
+            ...     context.query(rho=0.1, delta=1e-7)
+            ...     # transformations/truncation may be applied here
+            ...     .select("SEX", "AGE", "HWUSUAL", "ILOSTAT")
+            ...     .contingency_table(
+            ...         keys={"SEX": [1, 2]},
+            ...         cuts={"AGE": [20, 40, 60], "HWUSUAL": [1, 20, 40]},
+            ...         algorithm=dp.mbi.AIM(),
+            ...     )
+            ...     .release()
+            ... )
 
 Generation of synthetic data from a DP contingency table is considered postprocessing, 
 and thus does not affect the privacy budget.
 
-.. code:: pycon
+.. tab-set::
 
-    >>> table_aim.synthesize()  # doctest: +SKIP
-    shape: (3_807_732, 4)
-    ┌─────┬───────────┬───────────┬─────────┐
-    │ SEX ┆ AGE       ┆ HWUSUAL   ┆ ILOSTAT │
-    │ --- ┆ ---       ┆ ---       ┆ ---     │
-    │ i64 ┆ f64       ┆ f64       ┆ i64     │
-    ╞═════╪═══════════╪═══════════╪═════════╡
-    │ 1   ┆ 55.446336 ┆ 20.776579 ┆ 1       │
-    │ 1   ┆ 28.21838  ┆ 40.53348  ┆ 1       │
-    │ 2   ┆ 43.291215 ┆ 34.406155 ┆ 1       │
-    │ 1   ┆ 55.106615 ┆ 22.413161 ┆ 1       │
-    │ 2   ┆ 42.585227 ┆ 40.11279  ┆ 3       │
-    │ …   ┆ …         ┆ …         ┆ …       │
-    │ 1   ┆ 58.197292 ┆ 40.139579 ┆ 1       │
-    │ 1   ┆ 59.371221 ┆ 19.671153 ┆ 1       │
-    │ 2   ┆ 19.862917 ┆ 40.339046 ┆ 9       │
-    │ 1   ┆ 19.492355 ┆ 32.233661 ┆ 1       │
-    │ 2   ┆ 60.863244 ┆ 40.737908 ┆ 3       │
-    └─────┴───────────┴───────────┴─────────┘
+    .. tab-item:: Python
+        :sync: python
+
+        .. code:: pycon
+
+            >>> table_aim.synthesize()  # doctest: +SKIP
+            shape: (3_807_732, 4)
+            ┌─────┬───────────┬───────────┬─────────┐
+            │ SEX ┆ AGE       ┆ HWUSUAL   ┆ ILOSTAT │
+            │ --- ┆ ---       ┆ ---       ┆ ---     │
+            │ i64 ┆ f64       ┆ f64       ┆ i64     │
+            ╞═════╪═══════════╪═══════════╪═════════╡
+            │ 1   ┆ 55.446336 ┆ 20.776579 ┆ 1       │
+            │ 1   ┆ 28.21838  ┆ 40.53348  ┆ 1       │
+            │ 2   ┆ 43.291215 ┆ 34.406155 ┆ 1       │
+            │ 1   ┆ 55.106615 ┆ 22.413161 ┆ 1       │
+            │ 2   ┆ 42.585227 ┆ 40.11279  ┆ 3       │
+            │ …   ┆ …         ┆ …         ┆ …       │
+            │ 1   ┆ 58.197292 ┆ 40.139579 ┆ 1       │
+            │ 1   ┆ 59.371221 ┆ 19.671153 ┆ 1       │
+            │ 2   ┆ 19.862917 ┆ 40.339046 ┆ 9       │
+            │ 1   ┆ 19.492355 ┆ 32.233661 ┆ 1       │
+            │ 2   ┆ 60.863244 ┆ 40.737908 ┆ 3       │
+            └─────┴───────────┴───────────┴─────────┘
 
 Numerical columns with cuts are sampled uniformly from between the bin edges,
 in a manner consistent with the input data types.

--- a/docs/source/getting-started/tabular-data/contingency-tables.rst
+++ b/docs/source/getting-started/tabular-data/contingency-tables.rst
@@ -44,21 +44,26 @@ This functionality is not enabled by default.
 
 Let's get started by setting up the context for the Labor Force dataset.
 
-.. code:: pycon
+.. tab-set::
 
-    >>> import opendp.prelude as dp
-    >>> import polars as pl
+    .. tab-item:: Python
+        :sync: python
 
-    >>> dp.enable_features("contrib")
+        .. code:: pycon
 
-    >>> context = dp.Context.compositor(
-    ...     data=pl.scan_csv(
-    ...         dp.examples.get_france_lfs_path(),
-    ...         ignore_errors=True,
-    ...     ),
-    ...     privacy_unit=dp.unit_of(contributions=36),
-    ...     privacy_loss=dp.loss_of(rho=0.2, delta=1e-7),
-    ... )
+            >>> import opendp.prelude as dp
+            >>> import polars as pl
+
+            >>> dp.enable_features("contrib")
+
+            >>> context = dp.Context.compositor(
+            ...     data=pl.scan_csv(
+            ...         dp.examples.get_france_lfs_path(),
+            ...         ignore_errors=True,
+            ...     ),
+            ...     privacy_unit=dp.unit_of(contributions=36),
+            ...     privacy_loss=dp.loss_of(rho=0.2, delta=1e-7),
+            ... )
 
 ``.contingency_table`` releases an approximation to a contingency table over all columns
 by estimating lower order marginals.
@@ -66,28 +71,32 @@ To improve the utility of the mechanism,
 specify the key-sets for categorical data, and cut-sets for numerical data.
 The mechanism will release stable keys for any columns that don't have key- or cut-sets.
 
+.. tab-set::
 
-.. code:: pycon
+    .. tab-item:: Python
+        :sync: python
 
-    >>> query = (
-    ...     context.query(rho=0.1, delta=1e-7)
-    ...     # transformations/truncation may be applied here
-    ...     .select(
-    ...         "SEX", "AGE", "HWUSUAL", "ILOSTAT"
-    ...     ).contingency_table(
-    ...         keys={"SEX": [1, 2]},
-    ...         cuts={"AGE": [20, 40, 60], "HWUSUAL": [1, 20, 40]},
-    ...         algorithm=dp.mbi.Fixed(
-    ...             queries=[
-    ...                 dp.mbi.Count(("AGE", "HWUSUAL")),
-    ...                 dp.mbi.Count(("HWUSUAL", "ILOSTAT")),
-    ...             ],
-    ...             # proportion of budget to spend estimating one-way marginal key-sets
-    ...             #   (defaults to num_unknown / num_columns / 2)
-    ...             oneway_split=1 / 8,
-    ...         ),
-    ...     )
-    ... )
+        .. code:: pycon
+
+            >>> query = (
+            ...     context.query(rho=0.1, delta=1e-7)
+            ...     # transformations/truncation may be applied here
+            ...     .select(
+            ...         "SEX", "AGE", "HWUSUAL", "ILOSTAT"
+            ...     ).contingency_table(
+            ...         keys={"SEX": [1, 2]},
+            ...         cuts={"AGE": [20, 40, 60], "HWUSUAL": [1, 20, 40]},
+            ...         algorithm=dp.mbi.Fixed(
+            ...             queries=[
+            ...                 dp.mbi.Count(("AGE", "HWUSUAL")),
+            ...                 dp.mbi.Count(("HWUSUAL", "ILOSTAT")),
+            ...             ],
+            ...             # proportion of budget to spend estimating one-way marginal key-sets
+            ...             #   (defaults to num_unknown / num_columns / 2)
+            ...             oneway_split=1 / 8,
+            ...         ),
+            ...     )
+            ... )
 
 By default, up to half of the privacy budget is used to estimate one-way marginals and their keys.
 The privacy budget used depends on the proportion of columns with unknown keys or cuts.
@@ -98,13 +107,18 @@ via the ``oneway_split`` attribute on the algorithm.
 
 Before releasing, you can view the noise scale and threshold to be used when estimating one-way key-sets.
 
-.. code:: pycon
+.. tab-set::
 
-    >>> query.oneway_scale
-    227.68399153212334
+    .. tab-item:: Python
+        :sync: python
 
-    >>> query.oneway_threshold
-    1364
+        .. code:: pycon
+
+            >>> query.oneway_scale
+            227.68399153212334
+
+            >>> query.oneway_threshold
+            1364
 
 In this setting, the scale and threshold are reasonably small.
 To make the threshold smaller, consider adding more key-sets 
@@ -113,27 +127,37 @@ or bounding the number of groups a user may contribute.
 When you release, all marginals are estimated and stored inside a :py:class:`~opendp.extras.mbi.ContingencyTable`.
 The contingency table supports counting queries over arbitrary sets of grouping columns.
 
-.. code:: pycon
+.. tab-set::
 
-    >>> table: dp.mbi.ContingencyTable = query.release()
+    .. tab-item:: Python
+        :sync: python
+
+        .. code:: pycon
+
+            >>> table: dp.mbi.ContingencyTable = query.release()
 
 Any keys in the data that are not present in the key-set,
 either because they are missing from the key-set (like a third category for ``SEX``)
 or because they had frequencies too low to meet the threshold (like the uncommon ``ILOSTAT`` category ``5``),
 are replaced with ``null`` when estimating higher-order marginals.
 
-.. code:: pycon
+.. tab-set::
 
-    >>> table.keys["ILOSTAT"]  # doctest: +NORMALIZE_WHITESPACE
-    shape: (5,)
-    Series: 'ILOSTAT' [i64]
-    [
-        1
-        2
-        3
-        9
-        null
-    ]
+    .. tab-item:: Python
+        :sync: python
+
+        .. code:: pycon
+
+            >>> table.keys["ILOSTAT"]  # doctest: +NORMALIZE_WHITESPACE
+            shape: (5,)
+            Series: 'ILOSTAT' [i64]
+            [
+                1
+                2
+                3
+                9
+                null
+            ]
 
 In this example, infrequent ``ILOSTAT`` categories of ``4`` and ``5`` were absorbed into the ``null`` key.
 Preserve true nulls in your data by preprocessing them into another key via ``.select`` or ``.with_columns``.
@@ -141,28 +165,38 @@ Preserve true nulls in your data by preprocessing them into another key via ``.s
 To see counts of the number of records corresponding to each key,
 project the contingency table down to just ``ILOSTAT``.
 
-.. code:: pycon
+.. tab-set::
 
-    >>> table.project(("ILOSTAT",)).astype(int)  # doctest: +SKIP
-    Array([1515729,  155912, 1450748,  689452,     109], dtype=int64)
+    .. tab-item:: Python
+        :sync: python
+
+        .. code:: pycon
+
+            >>> table.project(("ILOSTAT",)).astype(int)  # doctest: +SKIP
+            Array([1515729,  155912, 1450748,  689452,     109], dtype=int64)
 
 The same projection can be viewed in a melted dataframe form:
 
-.. code:: pycon
+.. tab-set::
 
-    >>> table.project_melted(("ILOSTAT",))  # doctest: +SKIP
-    shape: (5, 2)
-    ┌─────────┬──────────────┐
-    │ ILOSTAT ┆ len          │
-    │ ---     ┆ ---          │
-    │ i64     ┆ f64          │
-    ╞═════════╪══════════════╡
-    │ 1       ┆ 1.5157e6     │
-    │ 2       ┆ 156011.15206 │
-    │ 3       ┆ 1.4509e6     │
-    │ 9       ┆ 689551.39267 │
-    │ null    ┆ 119.022842   │
-    └─────────┴──────────────┘
+    .. tab-item:: Python
+        :sync: python
+
+        .. code:: pycon
+
+            >>> table.project_melted(("ILOSTAT",))  # doctest: +SKIP
+            shape: (5, 2)
+            ┌─────────┬──────────────┐
+            │ ILOSTAT ┆ len          │
+            │ ---     ┆ ---          │
+            │ i64     ┆ f64          │
+            ╞═════════╪══════════════╡
+            │ 1       ┆ 1.5157e6     │
+            │ 2       ┆ 156011.15206 │
+            │ 3       ┆ 1.4509e6     │
+            │ 9       ┆ 689551.39267 │
+            │ null    ┆ 119.022842   │
+            └─────────┴──────────────┘
 
 Since ``("ILOSTAT",)`` is covered by the query workload,
 an estimate of the standard deviation can be derived.
@@ -170,11 +204,16 @@ Since all noise added is gaussian-distributed,
 the resulting noise distribution remains approximately gaussian-distributed,
 so it is possible to construct a confidence interval for each scalar in the projection.
 
-.. code:: pycon
+.. tab-set::
 
-    >>> scale = table.std(("ILOSTAT",))
-    >>> dp.gaussian_scale_to_accuracy(scale, alpha=0.05)
-    446.2524232592843
+    .. tab-item:: Python
+        :sync: python
+
+        .. code:: pycon
+
+            >>> scale = table.std(("ILOSTAT",))
+            >>> dp.gaussian_scale_to_accuracy(scale, alpha=0.05)
+            446.2524232592843
 
 That is, the true count differs from the estimate by no more than the accuracy estimate,
 with ``(1 - alpha)100%`` confidence.
@@ -185,58 +224,78 @@ Adaptive Estimation
 Now consider the ``SEX`` column, which contains three keys: 
 the two specified in ``keys``, as well as ``null`` for any records not in the key set.
 
-.. code:: pycon
+.. tab-set::
 
-    >>> table.keys["SEX"]  # doctest: +NORMALIZE_WHITESPACE
-    shape: (3,)
-    Series: 'SEX' [i64]
-    [
-        1
-        2
-        null
-    ]
+    .. tab-item:: Python
+        :sync: python
+
+        .. code:: pycon
+
+            >>> table.keys["SEX"]  # doctest: +NORMALIZE_WHITESPACE
+            shape: (3,)
+            Series: 'SEX' [i64]
+            [
+                1
+                2
+                null
+            ]
 
 ``SEX`` is not well-supported by the contingency table,
 because it is not included in any of the released marginals.
 As a result, the best estimate for the total number of records is distributed uniformly over the key set,
 and the standard deviation is unknown.
 
-.. code:: pycon
+.. tab-set::
 
-    >>> table.project(("SEX",)).astype(int)  # doctest: +SKIP
-    Array([1270561, 1270561, 1270561], dtype=int64)
+    .. tab-item:: Python
+        :sync: python
 
-    >>> table.std(("SEX",))  # doctest: +IGNORE_EXCEPTION_DETAIL
-    Traceback (most recent call last):
-    ...
-    ValueError: attrs (('SEX',)) are not covered by the query set
+        .. code:: pycon
+
+            >>> table.project(("SEX",)).astype(int)  # doctest: +SKIP
+            Array([1270561, 1270561, 1270561], dtype=int64)
+
+            >>> table.std(("SEX",))  # doctest: +IGNORE_EXCEPTION_DETAIL
+            Traceback (most recent call last):
+            ...
+            ValueError: attrs (('SEX',)) are not covered by the query set
 
 To improve the utility of this projection, you could release an updated contingency table with more marginals.
 
-.. code:: pycon
+.. tab-set::
 
-    >>> table2 = (
-    ...     context.query(rho=0.05, delta=0.0)
-    ...     .select("SEX")
-    ...     .contingency_table(
-    ...         table=table,
-    ...         algorithm=dp.mbi.Fixed(
-    ...             queries=[dp.mbi.Count(("SEX",))]
-    ...         ),
-    ...     )
-    ...     .release()
-    ... )
+    .. tab-item:: Python
+        :sync: python
+
+        .. code:: pycon
+
+            >>> table2 = (
+            ...     context.query(rho=0.05, delta=0.0)
+            ...     .select("SEX")
+            ...     .contingency_table(
+            ...         table=table,
+            ...         algorithm=dp.mbi.Fixed(
+            ...             queries=[dp.mbi.Count(("SEX",))]
+            ...         ),
+            ...     )
+            ...     .release()
+            ... )
 
 
 The updated table now much more accurately reflects the distribution of counts over ``SEX``.
 
-.. code:: pycon
+.. tab-set::
 
-    >>> table2.project(("SEX",)).astype(int)  # doctest: +SKIP
-    Array([1828251, 1982295,    1228], dtype=int64)
+    .. tab-item:: Python
+        :sync: python
 
-    >>> table2.std(("SEX",))
-    113.84199576606166
+        .. code:: pycon
+
+            >>> table2.project(("SEX",)).astype(int)  # doctest: +SKIP
+            Array([1828251, 1982295,    1228], dtype=int64)
+
+            >>> table2.std(("SEX",))
+            113.84199576606166
 
 The contingency table mechanism can satisfy either pure-DP (epsilon) or zCDP (rho). 
 If approximate-DP (delta) is not enabled, then the key-set and cut-set must be exhaustive.


### PR DESCRIPTION
- Fix #2481

Not essential, but
- Doing it consistently avoids having to sort out whether to add at a particular point.
- Consistent style in the documentation also looks better to readers
- A negative reason, but it highlights what's missing, and invites us to fill in the other tabs (if we had infinite time.)