### PR TITLE
docs: Prune lists-of-links

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,13 +10,10 @@ The algorithm is differentially private if by looking at the output,
 you cannot tell whether any individual's data was included in the original dataset or not.
 Differential privacy achieves this by carefully injecting random noise into the released statistics to hide the effects of each individual. 
 
-For more background on differential privacy and its applications:
-
-* "`Designing Access with Differential Privacy <https://admindatahandbook.mit.edu/book/v1.0/diffpriv.html>`_" from *Handbook on Using Administrative Data for Research and Evidence-based Policy*
-* The `Resources list <https://differentialprivacy.org/resources/>`_ from *differentialprivacy.org*
-* A shorter list of `Educational Resources <https://opendp.github.io/learning/>`_
-* OpenDP's own :doc:`theory/resources`
-* `Hand-On Differential Privacy <https://www.oreilly.com/library/view/hands-on-differential-privacy/9781492097730/>`_ is co-authored by the OpenDP Library architect
+For more background on differential privacy and its applications
+see the OpenDP Project's `Educational Resources <https://opendp.github.io/learning/>`_,
+and `Hands-On Differential Privacy <https://www.oreilly.com/library/view/hands-on-differential-privacy/9781492097730/>`_,
+which is co-authored by the OpenDP Library architect
 
 Why OpenDP?
 -----------

--- a/docs/source/theory/index.rst
+++ b/docs/source/theory/index.rst
@@ -15,4 +15,3 @@ For that, see :doc:`../getting-started/index` or :doc:`../api/index`.
   accuracy-pitfalls
   attacks/index
   mechanisms/index
-  resources

--- a/docs/source/theory/resources.rst
+++ b/docs/source/theory/resources.rst
@@ -1,5 +1,13 @@
+:orphan:
+
 Resources List
 ==============
+
+.. note::
+
+    We are not actively maintaining this list.
+    Instead see the OpenDP Project's `Educational Resources <https://opendp.github.io/learning/>`_ page.
+
 
 Foundations
 -----------


### PR DESCRIPTION
- Fix #2471

Sphinx will warn if unlinked pages are included in the source, unless explicitly marked as `:orphan:`. I think we do want to keep the orphan page around, to keep any inbound links from breaking.

The education page doesn't have all of these links, but I don't think we should be trying to create a bibliography.