### PR TITLE
Docs: Add slack URL to the linkchecker ignore list

### DIFF
--- a/docs/linkchecker-external.cfg
+++ b/docs/linkchecker-external.cfg
@@ -18,7 +18,8 @@ ignore=
 
   # 403 Forbidden:
   https://www.unhcr.org
-
+  https://join.slack.com/t/opendp/shared_invite/zt-1t8rrbqhd-z8LiZiP06vVE422HJd6ciQ
+  
   # On main, `make_sequential_composition` is deprecated,
   # and has been replaced by `make_adaptive_composition`,
   # but until there is a release, docs.rs will not have the new name.


### PR DESCRIPTION
- Fix #2752 
- (Warnings in the workflow will be addressed by #2753.)