### PR TITLE
fix: dashu to_f32/to_f64 round to nearest semantics

### DIFF
--- a/rust/src/measurements/noise/nature/float/test.rs
+++ b/rust/src/measurements/noise/nature/float/test.rs
@@ -1,4 +1,4 @@
-use crate::{measurements::make_laplace, metrics::AbsoluteDistance};
+use crate::{measurements::make_laplace, metrics::AbsoluteDistance, traits::CastInternalRational};
 
 use super::*;
 
@@ -47,7 +47,7 @@ fn test_make_noise_floatexpfamily() -> Fallible<()> {
 fn test_then_deintegerize_vec() -> Fallible<()> {
     // rationals with greater magnitude than MAX saturate to infinity
     let q = RBig::try_from(f64::MAX).unwrap();
-    assert!((q * IBig::from(2u8)).to_f64().value().is_infinite());
+    assert!(f64::from_rational(q * IBig::from(2u8)).is_infinite());
 
     assert!(then_deintegerize_vec::<f64>(i32::MIN).is_err());
     assert!(then_deintegerize_vec::<f64>(i32::MAX).is_ok());

--- a/rust/src/measurements/noisy_top_k/test.rs
+++ b/rust/src/measurements/noisy_top_k/test.rs
@@ -1,4 +1,7 @@
-use crate::traits::samplers::{Shuffle, test::check_chi_square};
+use crate::traits::{
+    CastInternalRational,
+    samplers::{Shuffle, test::check_chi_square},
+};
 use crate::{error::Fallible, measures::ZeroConcentratedDivergence};
 use dashu::rbig;
 use std::array::from_fn;
@@ -186,7 +189,7 @@ fn test_permute_and_flip_distribution_varied() -> Fallible<()> {
     let expected: Vec<f64> = permute_and_flip_pmf(
         &scores
             .into_iter()
-            .map(|r| r.to_f64().value())
+            .map(f64::from_rational)
             .collect::<Vec<_>>(),
         1.0,
     )

--- a/rust/src/traits/cast/mod.rs
+++ b/rust/src/traits/cast/mod.rs
@@ -16,6 +16,8 @@ use num::{NumCast, One, Zero};
 
 use crate::error::Fallible;
 
+mod to_float;
+
 // general overview of casters:
 // https://docs.google.com/spreadsheets/d/1DJohiOI3EVHjwj8g4IEdFZVf7MMyFk_4oaSyjTfkO_0/edit?usp=sharing
 
@@ -254,7 +256,7 @@ impl ExactIntBounds for f32 {
     const MIN_CONSECUTIVE: Self = -16_777_216.0;
 }
 
-pub(crate) trait NextFloat {
+pub trait NextFloat {
     // naming has a trailing underscore so as not to conflict with stabilization of the corresponding methods in Rust STD
     fn next_up_(self) -> Self;
     fn next_down_(self) -> Self;
@@ -371,7 +373,7 @@ impl NextFloat for f32 {
     }
 }
 
-/// Wrapper around Dashu's FBig::to_f32 and FBig::to_f32 that guarantees correct rounding, even in edge cases
+/// Wrapper around Dashu's FBig::to_f32 and FBig::to_f64 that guarantees correct rounding, even in edge cases.
 pub trait ToFloatRounded {
     fn to_f32_rounded(self) -> f32;
     fn to_f64_rounded(self) -> f64;
@@ -410,6 +412,36 @@ impl ToFloatRounded for FBig<Down> {
             Approximation::Inexact(v, Rounding::AddOne)
             | Approximation::Inexact(v, Rounding::NoOp) => v.next_down_(),
         }
+    }
+}
+
+impl ToFloatRounded for RBig {
+    fn to_f32_rounded(self) -> f32 {
+        to_float::to_f32_rounded(self)
+    }
+
+    fn to_f64_rounded(self) -> f64 {
+        to_float::to_f64_rounded(self)
+    }
+}
+
+impl ToFloatRounded for UBig {
+    fn to_f32_rounded(self) -> f32 {
+        RBig::from(self).to_f32_rounded()
+    }
+
+    fn to_f64_rounded(self) -> f64 {
+        RBig::from(self).to_f64_rounded()
+    }
+}
+
+impl ToFloatRounded for IBig {
+    fn to_f32_rounded(self) -> f32 {
+        RBig::from(self).to_f32_rounded()
+    }
+
+    fn to_f64_rounded(self) -> f64 {
+        RBig::from(self).to_f64_rounded()
     }
 }
 
@@ -625,25 +657,25 @@ impl<R: Round> RoundCast<f64> for FBig<R> {
 
 impl<R: Round> RoundCast<FBig<R>> for f32 {
     fn round_cast(v: FBig<R>) -> Fallible<Self> {
-        Ok(v.with_rounding::<HalfEven>().to_f32().value())
+        Ok(RBig::try_from(v.with_rounding::<HalfEven>())?.to_f32_rounded())
     }
 }
 
 impl<R: Round> RoundCast<FBig<R>> for f64 {
     fn round_cast(v: FBig<R>) -> Fallible<Self> {
-        Ok(v.with_rounding::<HalfEven>().to_f64().value())
+        Ok(RBig::try_from(v.with_rounding::<HalfEven>())?.to_f64_rounded())
     }
 }
 
 impl RoundCast<RBig> for f32 {
     fn round_cast(v: RBig) -> Fallible<Self> {
-        Ok(v.to_f32().value())
+        Ok(v.to_f32_rounded())
     }
 }
 
 impl RoundCast<RBig> for f64 {
     fn round_cast(v: RBig) -> Fallible<Self> {
-        Ok(v.to_f64().value())
+        Ok(v.to_f64_rounded())
     }
 }
 
@@ -687,30 +719,53 @@ impl<R: Round> InfCast<FBig<R>> for f64 {
     }
 }
 
-macro_rules! impl_InfCast_dashu {
-    ($($TI:ty),+; $TO:ty, $to:ident) => {
-        $(impl InfCast<$TI> for $TO {
-            fn inf_cast(v: $TI) -> Fallible<Self> {
-                use Approximation::*;
-                Ok(match v.$to() {
-                    Exact(v) | Inexact(v, Sign::Positive) => v,
-                    Inexact(v, _) => v.next_up_(),
+macro_rules! impl_inf_cast_rational_float {
+    ($from:ty, f32) => {
+        impl InfCast<$from> for f32 {
+            fn inf_cast(v: $from) -> Fallible<Self> {
+                Ok(match to_float::to_f32_approx(RBig::from(v)) {
+                    Approximation::Exact(v) | Approximation::Inexact(v, Sign::Positive) => v,
+                    Approximation::Inexact(f32::NEG_INFINITY, Sign::Negative) => f32::MIN,
+                    Approximation::Inexact(v, Sign::Negative) => v.next_up_(),
                 })
             }
 
-            fn neg_inf_cast(v: $TI) -> Fallible<Self> {
-                use Approximation::*;
-                Ok(match v.$to() {
-                    Exact(v) | Inexact(v, Sign::Negative) => v,
-                    Inexact(v, _) => v.next_down_(),
+            fn neg_inf_cast(v: $from) -> Fallible<Self> {
+                Ok(match to_float::to_f32_approx(RBig::from(v)) {
+                    Approximation::Exact(v) | Approximation::Inexact(v, Sign::Negative) => v,
+                    Approximation::Inexact(f32::INFINITY, Sign::Positive) => f32::MAX,
+                    Approximation::Inexact(v, Sign::Positive) => v.next_down_(),
                 })
             }
-        })+
-    }
+        }
+    };
+    ($from:ty, f64) => {
+        impl InfCast<$from> for f64 {
+            fn inf_cast(v: $from) -> Fallible<Self> {
+                Ok(match to_float::to_f64_approx(RBig::from(v)) {
+                    Approximation::Exact(v) | Approximation::Inexact(v, Sign::Positive) => v,
+                    Approximation::Inexact(f64::NEG_INFINITY, Sign::Negative) => f64::MIN,
+                    Approximation::Inexact(v, Sign::Negative) => v.next_up_(),
+                })
+            }
+
+            fn neg_inf_cast(v: $from) -> Fallible<Self> {
+                Ok(match to_float::to_f64_approx(RBig::from(v)) {
+                    Approximation::Exact(v) | Approximation::Inexact(v, Sign::Negative) => v,
+                    Approximation::Inexact(f64::INFINITY, Sign::Positive) => f64::MAX,
+                    Approximation::Inexact(v, Sign::Positive) => v.next_down_(),
+                })
+            }
+        }
+    };
 }
 
-impl_InfCast_dashu!(RBig, UBig, IBig; f64, to_f64);
-impl_InfCast_dashu!(RBig, UBig, IBig; f32, to_f32);
+impl_inf_cast_rational_float!(RBig, f32);
+impl_inf_cast_rational_float!(UBig, f32);
+impl_inf_cast_rational_float!(IBig, f32);
+impl_inf_cast_rational_float!(RBig, f64);
+impl_inf_cast_rational_float!(UBig, f64);
+impl_inf_cast_rational_float!(IBig, f64);
 
 macro_rules! impl_saturating_cast_ubig_int {
     ($($T:ty)+) => {$(
@@ -740,7 +795,7 @@ macro_rules! impl_cast_internal_rational_float {
     ($ty:ty, $method:ident) => {
         impl CastInternalRational for $ty {
             fn from_rational(v: RBig) -> Self {
-                v.$method().value()
+                v.$method()
             }
             fn into_rational(self) -> Fallible<RBig> {
                 RBig::try_from(self).map_err(|_| {
@@ -755,8 +810,8 @@ macro_rules! impl_cast_internal_rational_float {
     };
 }
 
-impl_cast_internal_rational_float!(f32, to_f32);
-impl_cast_internal_rational_float!(f64, to_f64);
+impl_cast_internal_rational_float!(f32, to_f32_rounded);
+impl_cast_internal_rational_float!(f64, to_f64_rounded);
 
 macro_rules! impl_cast_internal_rational_int {
     ($($ty:ty)+) => {

--- a/rust/src/traits/cast/test.rs
+++ b/rust/src/traits/cast/test.rs
@@ -1,11 +1,15 @@
-use dashu::float::{
-    FBig,
-    round::mode::{Down, Up},
+use dashu::{
+    float::{
+        FBig,
+        round::mode::{Down, Up},
+    },
+    integer::UBig,
+    rational::RBig,
 };
 
 use crate::{
     error::Fallible,
-    traits::{InfCast, cast::ToFloatRounded},
+    traits::{InfCast, RoundCast, cast::ToFloatRounded},
 };
 
 #[allow(dead_code)]
@@ -145,5 +149,57 @@ fn test_to_native_inf() -> Fallible<()> {
     let double: FBig<Up> = min * 2;
     assert_eq!(double.to_f64_rounded(), f64::MIN);
 
+    Ok(())
+}
+
+#[test]
+fn test_round_cast_rbig_to_f64_corrects_dashu_double_rounding() -> Fallible<()> {
+    let input = RBig::from_parts(
+        (-10534148920556696739i128).into(),
+        73786976294838206464u128.into(),
+    );
+
+    // Documents the upstream Dashu double-rounding bug. When Dashu fixes this,
+    // this assertion should fail and the OpenDP workaround can be revisited.
+    assert_eq!(input.to_f64().value(), f64::from_bits(0xbfc2461a14309b16));
+
+    assert_eq!(f64::round_cast(input)?, f64::from_bits(0xbfc2461a14309b17));
+    Ok(())
+}
+
+#[test]
+fn test_round_cast_rbig_to_f32_subnormal_boundary() -> Fallible<()> {
+    let just_above_half_min_subnormal = RBig::from_parts(3.into(), UBig::ONE << 151);
+
+    assert_eq!(
+        f32::round_cast(just_above_half_min_subnormal)?,
+        f32::from_bits(1)
+    );
+    Ok(())
+}
+
+#[test]
+fn test_round_cast_rbig_to_f32_ties_to_even() -> Fallible<()> {
+    let tie_between_one_and_next = RBig::from_parts(16_777_217.into(), 16_777_216u32.into());
+    let tie_between_next_and_next_next = RBig::from_parts(16_777_219.into(), 16_777_216u32.into());
+
+    assert_eq!(f32::round_cast(tie_between_one_and_next)?, 1.0);
+    assert_eq!(
+        f32::round_cast(tie_between_next_and_next_next)?,
+        f32::from_bits(0x3f80_0002)
+    );
+    Ok(())
+}
+
+#[test]
+fn test_round_cast_rbig_to_f64_underflow_ties_to_even_zero() -> Fallible<()> {
+    let half_min_subnormal = RBig::from_parts(1.into(), UBig::ONE << 1075);
+    let just_above_half_min_subnormal = RBig::from_parts(3.into(), UBig::ONE << 1076);
+
+    assert_eq!(f64::round_cast(half_min_subnormal)?, 0.0);
+    assert_eq!(
+        f64::round_cast(just_above_half_min_subnormal)?,
+        f64::from_bits(1)
+    );
     Ok(())
 }

--- a/rust/src/traits/cast/to_float.rs
+++ b/rust/src/traits/cast/to_float.rs
@@ -1,0 +1,123 @@
+use dashu::{
+    base::{Approximation, BitTest, FloatEncoding, Sign},
+    integer::UBig,
+    rational::RBig,
+};
+
+fn cmp_ubig_to_scaled(numer: &UBig, denom: &UBig, exp: isize) -> std::cmp::Ordering {
+    if exp >= 0 {
+        numer.cmp(&(denom << exp as usize))
+    } else {
+        (numer << (-exp) as usize).cmp(denom)
+    }
+}
+
+fn floor_log2_ratio(numer: &UBig, denom: &UBig) -> isize {
+    let exp = numer.bit_len() as isize - denom.bit_len() as isize;
+
+    if cmp_ubig_to_scaled(numer, denom, exp).is_lt() {
+        exp - 1
+    } else {
+        exp
+    }
+}
+
+fn with_sign<T>(v: T, sign: Sign, error: Sign) -> Approximation<T, Sign> {
+    Approximation::Inexact(
+        v,
+        if sign == Sign::Positive {
+            error
+        } else {
+            -error
+        },
+    )
+}
+
+fn round_scaled_ratio_to_ubig(numer: &UBig, denom: &UBig, exp: isize) -> Approximation<UBig, Sign> {
+    let (scaled_num, scaled_den) = if exp >= 0 {
+        (numer.clone(), denom << exp as usize)
+    } else {
+        (numer << (-exp) as usize, denom.clone())
+    };
+
+    let q = &scaled_num / &scaled_den;
+    let r = scaled_num - &q * &scaled_den;
+
+    if r.is_zero() {
+        return Approximation::Exact(q);
+    }
+
+    let twice_r = r << 1;
+    if twice_r > scaled_den || (twice_r == scaled_den && (&q & UBig::ONE).is_one()) {
+        Approximation::Inexact(q + UBig::ONE, Sign::Positive)
+    } else {
+        Approximation::Inexact(q, Sign::Negative)
+    }
+}
+
+macro_rules! impl_rbig_to_float {
+    ($approx_fn:ident, $ty:ty, $mantissa:ty, $precision:expr, $emin:expr, $emax:expr) => {
+        pub(super) fn $approx_fn(v: RBig) -> Approximation<$ty, Sign> {
+            let (signed_numer, denom) = v.into_parts();
+            let (sign, numer) = signed_numer.into_parts();
+
+            if numer.is_zero() {
+                return Approximation::Exact(0.0);
+            }
+
+            let value_exp = floor_log2_ratio(&numer, &denom);
+            let min_subnormal_exp = $emin - ($precision - 1);
+
+            if value_exp > $emax {
+                let value = if sign == Sign::Negative {
+                    <$ty>::NEG_INFINITY
+                } else {
+                    <$ty>::INFINITY
+                };
+                return with_sign(value, sign, Sign::Positive);
+            }
+
+            if value_exp < min_subnormal_exp - 1 {
+                let value = if sign == Sign::Negative { -0.0 } else { 0.0 };
+                return with_sign(value, sign, Sign::Negative);
+            }
+
+            let mantissa_exp = if value_exp < $emin {
+                min_subnormal_exp
+            } else {
+                value_exp - ($precision - 1)
+            };
+
+            let (mantissa, error) = match round_scaled_ratio_to_ubig(&numer, &denom, mantissa_exp) {
+                Approximation::Exact(mantissa) => (mantissa, None),
+                Approximation::Inexact(mantissa, error) => (mantissa, Some(error)),
+            };
+            let mantissa: $mantissa = mantissa
+                .try_into()
+                .expect("rounded mantissa fits native float encoding");
+            let mantissa = if sign == Sign::Negative {
+                -mantissa
+            } else {
+                mantissa
+            };
+
+            let value = <$ty>::encode(mantissa, mantissa_exp as i16).value();
+            if let Some(error) = error {
+                with_sign(value, sign, error)
+            } else {
+                Approximation::Exact(value)
+            }
+        }
+    };
+}
+
+impl_rbig_to_float!(to_f32_approx, f32, i32, 24, -126, 127);
+impl_rbig_to_float!(to_f64_approx, f64, i64, 53, -1022, 1023);
+
+pub(super) fn to_f32_rounded(v: RBig) -> f32 {
+    to_f32_approx(v).value()
+}
+
+pub(super) fn to_f64_rounded(v: RBig) -> f64 {
+    to_f64_approx(v).value()
+}

--- a/rust/src/traits/samplers/bernoulli/test.rs
+++ b/rust/src/traits/samplers/bernoulli/test.rs
@@ -1,5 +1,6 @@
-use crate::traits::samplers::test::{
-    ALPHA, BASE_N, assert_close_normal, run_wilson_test, sample_mean_bool,
+use crate::traits::{
+    CastInternalRational,
+    samplers::test::{ALPHA, BASE_N, assert_close_normal, run_wilson_test, sample_mean_bool},
 };
 
 use super::*;
@@ -32,7 +33,7 @@ fn wilson_rational_fixed_points() {
     ];
 
     for p in ps {
-        let p0 = p.to_f64().value();
+        let p0 = f64::from_rational(p.clone());
         run_wilson_test(
             || sample_bernoulli_rational(p.clone()).unwrap(),
             p0,

--- a/rust/src/traits/samplers/cks20/test/mod.rs
+++ b/rust/src/traits/samplers/cks20/test/mod.rs
@@ -5,7 +5,7 @@ mod symmetric;
 
 use dashu::rational::RBig;
 
-use crate::traits::samplers::test::BASE_N;
+use crate::traits::{CastInternalRational, samplers::test::BASE_N};
 
 pub const N_BERNOULLI: usize = 2 * BASE_N;
 pub const N_GEOM_FAST: usize = 2 * BASE_N;
@@ -14,5 +14,5 @@ pub const N_LAPLACE: usize = 2 * BASE_N;
 pub const N_GAUSS: usize = 2 * BASE_N;
 
 pub fn p_exp_neg(x: &RBig) -> f64 {
-    (-x.to_f64().value()).exp()
+    (-f64::from_rational(x.clone())).exp()
 }

--- a/rust/src/traits/samplers/cks20/test/symmetric.rs
+++ b/rust/src/traits/samplers/cks20/test/symmetric.rs
@@ -3,9 +3,12 @@ use std::convert::TryFrom;
 use dashu::integer::IBig;
 use dashu::rbig;
 
-use crate::traits::samplers::{
-    sample_discrete_gaussian,
-    test::{assert_close_binomial_mean, assert_close_normal},
+use crate::traits::{
+    CastInternalRational,
+    samplers::{
+        sample_discrete_gaussian,
+        test::{assert_close_binomial_mean, assert_close_normal},
+    },
 };
 
 use super::*;
@@ -166,7 +169,7 @@ mod laplace {
             if s.is_zero() {
                 continue;
             }
-            let th = LaplaceTheory::build(s.to_f64().value());
+            let th = LaplaceTheory::build(f64::from_rational(s.clone()));
 
             let mut sum: i128 = 0;
 
@@ -186,7 +189,7 @@ mod laplace {
     #[test]
     fn per_k_symmetry_matches_theory() {
         let s = rbig!(1);
-        let th = LaplaceTheory::build(s.to_f64().value());
+        let th = LaplaceTheory::build(f64::from_rational(s.clone()));
         let kmax = 8usize;
 
         let mut pos = vec![0u64; kmax + 1];
@@ -220,7 +223,7 @@ mod laplace {
     #[test]
     fn goodness_of_fit_chi_square_binned() {
         let s = rbig!(1);
-        let th = LaplaceTheory::build(s.to_f64().value());
+        let th = LaplaceTheory::build(f64::from_rational(s.clone()));
 
         let kmax = 9usize;
         let hist = SignedHist::sample(N_LAPLACE, kmax, || {
@@ -248,7 +251,7 @@ mod laplace {
             if s.is_zero() {
                 continue;
             }
-            let th = LaplaceTheory::build(s.to_f64().value());
+            let th = LaplaceTheory::build(f64::from_rational(s.clone()));
 
             let hist = SignedHist::sample(N_LAPLACE, kmax, || {
                 sample_discrete_laplace(s.clone()).unwrap()
@@ -392,7 +395,7 @@ mod gaussian {
             if s.is_zero() {
                 continue;
             }
-            let th = GaussTheory::build(s.to_f64().value());
+            let th = GaussTheory::build(f64::from_rational(s.clone()));
 
             // empirical mean + m2 in one pass
             let mut sum: i128 = 0;
@@ -420,7 +423,7 @@ mod gaussian {
     #[test]
     fn per_k_symmetry_matches_theory() {
         let s = rbig!(1);
-        let th = GaussTheory::build(s.to_f64().value());
+        let th = GaussTheory::build(f64::from_rational(s.clone()));
         let kmax = th.choose_kmax_for_expected(N_GAUSS, 10.0, 25).min(10);
 
         let mut pos = vec![0u64; kmax + 1];
@@ -454,7 +457,7 @@ mod gaussian {
     #[test]
     fn discrete_gaussian_goodness_of_fit_binned_chi_square() {
         let s = rbig!(2);
-        let th = GaussTheory::build(s.to_f64().value());
+        let th = GaussTheory::build(f64::from_rational(s.clone()));
 
         // Choose kmax so edge expected counts are >= 10 (very safe).
         let kmax = th.choose_kmax_for_expected(N_GAUSS, 10.0, 60);
@@ -493,7 +496,7 @@ mod gaussian {
             if s.is_zero() {
                 continue;
             }
-            let th = GaussTheory::build(s.to_f64().value());
+            let th = GaussTheory::build(f64::from_rational(s.clone()));
 
             let hist = SignedHist::sample(N_GAUSS, kmax, || {
                 sample_discrete_gaussian(s.clone()).unwrap()

--- a/rust/src/traits/samplers/psrn/canonical/test.rs
+++ b/rust/src/traits/samplers/psrn/canonical/test.rs
@@ -3,8 +3,11 @@ use num::FromPrimitive;
 use crate::{
     error::Fallible,
     measurements::approximate_to_tradeoff,
-    traits::samplers::{
-        PartialSample, psrn::test::assert_ordered_progression, test::check_kolmogorov_smirnov,
+    traits::{
+        CastInternalRational,
+        samplers::{
+            PartialSample, psrn::test::assert_ordered_progression, test::check_kolmogorov_smirnov,
+        },
     },
 };
 
@@ -21,7 +24,7 @@ fn test_sample_cnd_interval_progression() -> Fallible<()> {
         fixed_point: &c,
     });
     let (l, r) = assert_ordered_progression(&mut cnd, 20);
-    let (l, r) = (l.to_f64().value(), r.to_f64().value());
+    let (l, r) = (f64::from_rational(l), f64::from_rational(r));
     println!("{l:?}, {r:?}, {}", cnd.refinements);
     Ok(())
 }
@@ -54,8 +57,8 @@ fn test_cnd_psrn() -> Fallible<()> {
 
     let samples = <[f64; 5000]>::try_from(samples).unwrap();
 
-    let f_tradeoff = |x: f64| -> f64 { tradeoff(RBig::from_f64(x).unwrap()).to_f64().value() };
-    let f_c = c.to_f64().value();
+    let f_tradeoff = |x: f64| -> f64 { f64::from_rational(tradeoff(RBig::from_f64(x).unwrap())) };
+    let f_c = f64::from_rational(c);
     check_kolmogorov_smirnov(samples, |x| F_f(x, f_tradeoff, f_c))?;
     Ok(())
 }


### PR DESCRIPTION
Dashu’s rational-to-float conversion can double-round: it first rounds the scaled rational to an oversized intermediate mantissa, then FloatEncoding::encode normalizes and rounds again, which can choose the adjacent wrong float instead of the nearest-even result.