### PR TITLE
CI: Enable compiler caching with sccache

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -60,8 +60,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run sccache-cache
-        # Enables caching of compilation results.
-        #   Link to action doc: https://github.com/marketplace/actions/sccache-action
+        # Enables caching of compilation results via:
+        #   https://github.com/marketplace/actions/sccache-action
         uses: mozilla-actions/sccache-action@v0.0.10
         with:
           version: "v0.15.0"  # Ensure sccache binary supports cache v2 API

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Run sccache-cache
         # Enables caching of compilation results.
-        #   For more info: https://github.com/marketplace/actions/sccache-action
+        #   Link to action doc: https://github.com/marketplace/actions/sccache-action
         uses: mozilla-actions/sccache-action@v0.0.10
         with:
           version: "v0.15.0"  # Ensure sccache binary supports cache v2 API

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -49,7 +49,7 @@ jobs:
 
         # Add rust caching following example:
         #   https://github.com/actions/cache/blob/main/examples.md#rust---cargo
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin
@@ -59,7 +59,13 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.7
+
       - name: Build
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: "sccache"
         run: cargo build --verbose --all-features
       
       - name: Check --no-default-features

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -69,7 +69,12 @@ jobs:
       - name: Build
         env:
           RUSTC_WRAPPER: "sccache"
+          SCCACHE_GHA_ENABLED: "true"
         run: cargo build --verbose --all-features
+
+      - name: Check sccache stats
+        shell: bash
+        run: sccache --show-stats
       
       - name: Check --no-default-features
         run: cargo check --verbose --no-default-features --features untrusted,bindings

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -49,7 +49,7 @@ jobs:
 
         # Add rust caching following example:
         #   https://github.com/actions/cache/blob/main/examples.md#rust---cargo
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin
@@ -62,11 +62,12 @@ jobs:
       - name: Run sccache-cache
         # Enables caching of compilation results.
         #   For more info: https://github.com/marketplace/actions/sccache-action
-        uses: mozilla-actions/sccache-action@v0.0.7
+        uses: mozilla-actions/sccache-action@v0.0.10
+        with:
+          version: "v0.15.0"  # Ensure sccache binary supports cache v2 API
 
       - name: Build
         env:
-          SCCACHE_GHA_ENABLED: "true"
           RUSTC_WRAPPER: "sccache"
         run: cargo build --verbose --all-features
       

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -60,6 +60,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run sccache-cache
+        # Enables caching of compilation results.
+        #   For more info: https://github.com/marketplace/actions/sccache-action
         uses: mozilla-actions/sccache-action@v0.0.7
 
       - name: Build

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -49,7 +49,7 @@ jobs:
 
         # Add rust caching following example:
         #   https://github.com/actions/cache/blob/main/examples.md#rust---cargo
-      - uses: actions/cache@v5
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -59,9 +59,9 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+      # Enables caching of compilation results via:
+      #   https://github.com/marketplace/actions/sccache-action
       - name: Run sccache-cache
-        # Enables caching of compilation results via:
-        #   https://github.com/marketplace/actions/sccache-action
         uses: mozilla-actions/sccache-action@v0.0.10
         with:
           version: "v0.15.0"  # Ensure sccache binary supports cache v2 API


### PR DESCRIPTION
Verified local builds are sped up significantly with sccache. 

Previous cache only saved 40 seconds off of the builds.

Reduces rust build to ~3 minutes from 6.5. ~50% improvement.

Follow up run ran in < 2 minutes