### PR TITLE
maintenance: Disable R `unreachable_code_linter`

### DIFF
--- a/R/opendp/.lintr
+++ b/R/opendp/.lintr
@@ -8,6 +8,7 @@ linters: all_linters(
     object_length_linter = NULL, # Variable and function names should not be longer than 30 characters.
     object_name_linter = NULL, # Variable and function name style should match snake_case or symbols.
     # With "all_linters", these problems are also reported:
+    unreachable_code_linter = NULL,
     expect_identical_linter = NULL, # Use expect_identical(x, y) by default; resort to expect_equal() only when needed, e.g. when setting ignore_attr= or tolerance=.
     implicit_integer_linter = NULL, # Integers should not be implicit. Use the form 1L for integers or 1.0 for doubles.
     routine_registration_linter = NULL, # Register your native code routines with useDynLib and R_registerRoutines().

--- a/docs/source/.lintr
+++ b/docs/source/.lintr
@@ -3,6 +3,7 @@ linters: all_linters(
     # If "linters_with_defaults" is used then only these problems are reported:
     line_length_linter = NULL, # Lines should not be more than 80 characters.
     # With "all_linters", these problems are also reported:
+    unreachable_code_linter = NULL,
     todo_comment_linter = NULL, # TODO comments should be removed.
     undesirable_function_linter = NULL, # Function "library" is undesirable. As an alternative, use roxygen2's @importFrom statement in packages and `::` in scripts, instead of modifying the global search path.
     one_call_pipe_linter = NULL # Avoid pipe |> for expressions with only a single call.


### PR DESCRIPTION
- Fix #2796

My memory is that the R philosophy is not to pin tools, so you're getting the latest and greatest, although it's not my preference. I could double check that.