### PR TITLE
bug: add alp fix and test for regression to scale.exp

### DIFF
--- a/rust/src/measurements/alp/mod.rs
+++ b/rust/src/measurements/alp/mod.rs
@@ -14,7 +14,7 @@ use crate::interactive::Queryable;
 use crate::measures::MaxDivergence;
 use crate::metrics::{AbsoluteDistance, L01InfDistance};
 use crate::traits::samplers::{fill_bytes, sample_bernoulli_float};
-use crate::traits::{Hashable, InfCast, InfMul, Integer, ToFloatRounded};
+use crate::traits::{Hashable, InfCast, InfMul, Integer};
 use std::collections::hash_map::DefaultHasher;
 
 #[cfg(test)]
@@ -95,14 +95,12 @@ where
     let mut scale = FBig::<Down>::neg_inf_cast(scale)?;
     scale /= FBig::<Down>::inf_cast(alpha)?;
 
-    // Truncate bits that represents values below 2^-53
+    // Truncate bits that represents values below 2^-53.
+    // exp is the MSB position (scale in [2^(exp-1), 2^exp)), matching MPFR's get_exp
+    let exp = scale.repr().exponent() + scale.repr().digits() as isize;
     scale = scale
         .clone()
-        .with_precision(
-            (f64::MANTISSA_DIGITS as i32 - scale.exp())
-                .max(FBig::ONE)
-                .to_f64_rounded() as usize,
-        )
+        .with_precision((f64::MANTISSA_DIGITS as isize - exp).max(1) as usize)
         .value();
 
     let r = FBig::from(x.max(CI::zero()).to_u64().unwrap_or_else(|| u64::MAX))

--- a/rust/src/measurements/alp/test.rs
+++ b/rust/src/measurements/alp/test.rs
@@ -183,6 +183,48 @@ fn test_construct_and_post_process() -> Fallible<()> {
     Ok(())
 }
 
+/// The internal quotient scale/alpha must round DOWN: an over-estimate would
+/// set more projection bits per unit of sensitivity than the privacy map charges
+/// for. The quotient is unobservable, so the chain mirrors `scale_and_round`.
+#[test]
+fn test_alp_scale_and_round_rounding_direction() -> Fallible<()> {
+    use dashu::{rational::RBig, rbig};
+
+    let mut scale = FBig::<Down>::neg_inf_cast(1.0)?;
+    scale /= FBig::<Down>::inf_cast(10.0)?;
+
+    let exp = scale.repr().exponent() + scale.repr().digits() as isize;
+    let prec = (f64::MANTISSA_DIGITS as isize - exp).max(1) as usize;
+    // 1/10 lies in [2^-4, 2^-3): exp = -3, matching MPFR's 53 - get_exp = 56
+    assert_eq!(prec, 56);
+    let scale_impl = scale.with_precision(prec).value();
+
+    // below the exact quotient 1/10, but within one 53-bit division ulp, 2^-56
+    let truth = rbig!(1 / 10);
+    let impl_q = RBig::try_from(scale_impl)?;
+    assert!(impl_q < truth);
+    assert!((truth.clone() - impl_q.clone()) * RBig::from(1u64 << 56) < RBig::ONE);
+
+    // the direction-MIRRORED chain: cast UP, divide UP, truncate UP
+    let mut scale_bad = FBig::<Up>::inf_cast(1.0)?;
+    scale_bad /= FBig::<Up>::neg_inf_cast(10.0)?;
+    let scale_bad = scale_bad.with_precision(prec).value();
+    assert!(RBig::try_from(scale_bad.clone())? > truth);
+    assert!(impl_q < RBig::try_from(scale_bad)?);
+
+    // scale/alpha = 7 exercises positive exponents: MSB position 3 gives
+    // precision 50, keeping the 3-bit value 7 exact. (The pre-fix code
+    // computed e^7 here, clamping precision to a single bit: 7 became 4.)
+    let mut scale7 = FBig::<Down>::neg_inf_cast(7.0)?;
+    scale7 /= FBig::<Down>::inf_cast(1.0)?;
+    let exp7 = scale7.repr().exponent() + scale7.repr().digits() as isize;
+    let prec7 = (f64::MANTISSA_DIGITS as isize - exp7).max(1) as usize;
+    assert_eq!(prec7, 50);
+    let scale7 = scale7.with_precision(prec7).value();
+    assert_eq!(RBig::try_from(scale7)?, RBig::from(7));
+    Ok(())
+}
+
 #[test]
 fn test_post_process_measurement() -> Fallible<()> {
     let mut x = HashMap::new();

--- a/rust/src/measurements/alp/test.rs
+++ b/rust/src/measurements/alp/test.rs
@@ -183,45 +183,9 @@ fn test_construct_and_post_process() -> Fallible<()> {
     Ok(())
 }
 
-/// The internal quotient scale/alpha must round DOWN: an over-estimate would
-/// set more projection bits per unit of sensitivity than the privacy map charges
-/// for. The quotient is unobservable, so the chain mirrors `scale_and_round`.
 #[test]
-fn test_alp_scale_and_round_rounding_direction() -> Fallible<()> {
-    use dashu::{rational::RBig, rbig};
-
-    let mut scale = FBig::<Down>::neg_inf_cast(1.0)?;
-    scale /= FBig::<Down>::inf_cast(10.0)?;
-
-    let exp = scale.repr().exponent() + scale.repr().digits() as isize;
-    let prec = (f64::MANTISSA_DIGITS as isize - exp).max(1) as usize;
-    // 1/10 lies in [2^-4, 2^-3): exp = -3, matching MPFR's 53 - get_exp = 56
-    assert_eq!(prec, 56);
-    let scale_impl = scale.with_precision(prec).value();
-
-    // below the exact quotient 1/10, but within one 53-bit division ulp, 2^-56
-    let truth = rbig!(1 / 10);
-    let impl_q = RBig::try_from(scale_impl)?;
-    assert!(impl_q < truth);
-    assert!((truth.clone() - impl_q.clone()) * RBig::from(1u64 << 56) < RBig::ONE);
-
-    // the direction-MIRRORED chain: cast UP, divide UP, truncate UP
-    let mut scale_bad = FBig::<Up>::inf_cast(1.0)?;
-    scale_bad /= FBig::<Up>::neg_inf_cast(10.0)?;
-    let scale_bad = scale_bad.with_precision(prec).value();
-    assert!(RBig::try_from(scale_bad.clone())? > truth);
-    assert!(impl_q < RBig::try_from(scale_bad)?);
-
-    // scale/alpha = 7 exercises positive exponents: MSB position 3 gives
-    // precision 50, keeping the 3-bit value 7 exact. (The pre-fix code
-    // computed e^7 here, clamping precision to a single bit: 7 became 4.)
-    let mut scale7 = FBig::<Down>::neg_inf_cast(7.0)?;
-    scale7 /= FBig::<Down>::inf_cast(1.0)?;
-    let exp7 = scale7.repr().exponent() + scale7.repr().digits() as isize;
-    let prec7 = (f64::MANTISSA_DIGITS as isize - exp7).max(1) as usize;
-    assert_eq!(prec7, 50);
-    let scale7 = scale7.with_precision(prec7).value();
-    assert_eq!(RBig::try_from(scale7)?, RBig::from(7));
+fn test_scale_and_round_exponent_regression() -> Fallible<()> {
+    assert_eq!(scale_and_round(1u64, 1.0, 7.0)?, 7);
     Ok(())
 }
 


### PR DESCRIPTION
In the adoption of dashu we moved from get_exp to .exp. This introduced a bug that reduced utility. 

This fix moves back to e and adds a test for utility that would catch the previous bug.