### PR TITLE
docs: Add known 403 URLs

### DIFF
--- a/docs/linkchecker-external.cfg
+++ b/docs/linkchecker-external.cfg
@@ -16,14 +16,14 @@ ignore=
   # JS sniffing is involved? Easiest just to leave this ignore in place.
   https://crates.io/crates/opendp
 
-  # 403 Forbidden:
+  # "curl -IL" get 403 Forbidden, or redirects to 403, but works in browser.
   https://www.unhcr.org
-
-  # 403 Forbidden:
-  # In source:
   https://join.slack.com/t/opendp/shared_invite/zt-1t8rrbqhd-z8LiZiP06vVE422HJd6ciQ
-  # In linkchecker log:
-  https://opendp.slack.com/join/shared_invite/zt-1t8rrbqhd-z8LiZiP06vVE422HJd6ciQ
+  https://www.gesis.org/missy/files/documents/EU-LFS/EULFS_Database_UserGuide_2021-3.pdf
+  https://doi.org/10.1080/01621459.1965.10480775
+  https://doi.org/10.1145/1993636.1993743
+  http://dx.doi.org/10.1145/3564246.3585241
+
 
 
   # On main, `make_sequential_composition` is deprecated,
@@ -34,6 +34,8 @@ ignore=
   # 
   # 404 Not found:
   https://docs.rs/opendp/latest/opendp/combinators/fn.make_adaptive_composition.html
+  https://docs.rs/opendp/latest/opendp/domains/struct.SeriesDomain.html
+  https://docs.rs/opendp/latest/opendp/domains/struct.DatetimeDomain.html
 
   # TODO: Re-enable? Hopefully the site is down temporarily.
   #

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,7 +44,7 @@ Some of the applications of OpenDP in healthcare, government, and tech include:
 * `OpenMined <https://openmined.org>`_ used OpenDP as part of PySyft deployments with Microsoft and DailyMotion, with pilots at multiple national statistical organizations.
 * Researchers at `Microsoft <https://microsoft.com>`_ used OpenDP to construct a `United States Broadband Percentages Database <https://github.com/microsoft/USBroadbandUsagePercentages>`_.
 * Researchers at `Harvard Business School <https://www.hbs.edu/>`_ and `Microsoft <https://microsoft.com>`_ used OpenDP to create `a detailed atlas of internet usage in the US <https://www.nber.org/papers/w32932>`_ and found substantial disparities between urban and rural areas, and even within cities.
-* `LiveRamp <https://liveramp.com>`_ used OpenDP to `support COVID research <https://liveramp.uk/developers/blog/two-liveramp-engineers-named-harvard-opendp-fellows/>`_.
+* `LiveRamp <https://liveramp.com>`_ used OpenDP to `support COVID research <https://www.linkedin.com/posts/keng-he_activity-6789741749498605568-Y3hW/>`_.
 * Researchers with the `Christchurch Call Initiative on Algorithmic Outcomes <https://www.christchurchcall.org/christchurch-call-initiative-on-algorithmic-outcomes/>`_ used OpenDP to `audit recommender algorithms <https://www.christchurchcall.org/content/files/2024/11/Christchurch-Call-AI-Transparency-in-Practice-Report-October-2024-1.pdf>`_.
 
 Let us know if you have an example to add!


### PR DESCRIPTION
For liveramp, I can't find anything on their site that mentions this, but we could use the wayback machine, if that would be better.