### PR TITLE
docs: use feature listing rather than github discussion

### DIFF
--- a/R/opendp/R/mod.R
+++ b/R/opendp/R/mod.R
@@ -18,14 +18,14 @@ normalize_features <- function(features) {
 assert_features <- function(...) {
   for (feature in normalize_features(list(...))) {
     if (!feature %in% getOption("opendp_features")) {
-      stop("Attempted to use function that requires ", feature, " but ", feature, " is not enabled. See https://github.com/opendp/opendp/discussions/304, then call enable_features(\"", feature, "\")", call. = FALSE)
+      stop("Attempted to use function that requires ", feature, " but ", feature, " is not enabled. See https://docs.opendp.org/en/stable/api/user-guide/#feature-listing, then call enable_features(\"", feature, "\")", call. = FALSE)
     }
   }
 }
 
 #' Enable features for the opendp package.
 #'
-#' See https://github.com/opendp/opendp/discussions/304 for available features.
+#' See https://docs.opendp.org/en/stable/api/user-guide/#feature-listing for available features.
 #'
 #' @concept mod
 #' @param ... features to enable

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -1306,7 +1306,7 @@ def assert_features(*features: str) -> None:
     missing_features = [f for f in features if f not in GLOBAL_FEATURES]
     if missing_features:
         features_string = ', '.join(f'"{f}"' for f in features)
-        raise OpenDPException(f"Attempted to use function that requires {features_string}, but not enabled. See https://github.com/opendp/opendp/discussions/304, then call enable_features({features_string})")
+        raise OpenDPException(f"Attempted to use function that requires {features_string}, but not enabled. See https://docs.opendp.org/en/stable/api/user-guide/#feature-listing, then call enable_features({features_string})")
 
 
 M = TypeVar("M", Transformation, Measurement)


### PR DESCRIPTION
- Towards #1139.
- It's not obvious to me whether there is already a point in the docs which could substitute for https://github.com/opendp/opendp/discussions/298. Maybe a new trouble-shooting section?