### PR TITLE
docs: fix misleading fill_null(35) explanation in essential-statistics

### DIFF
--- a/docs/source/api/user-guide/polars/expressions/manipulation.rst
+++ b/docs/source/api/user-guide/polars/expressions/manipulation.rst
@@ -402,6 +402,8 @@ Just like ``.fill_nan``, even if you are in an aggregation context like
 ``.select`` or ``.agg``, OpenDP enforces that inputs to ``.fill_nan``
 are row-by-row.
 
+.. _polars-filter-null-handling:
+
 Filter
 ------
 

--- a/docs/source/getting-started/tabular-data/essential-statistics.rst
+++ b/docs/source/getting-started/tabular-data/essential-statistics.rst
@@ -292,6 +292,43 @@ of weekly work hours in France. Your choice of imputation value will
 vary depending on how you want to use the statistic.
 
 .. note::
+   Looking at the query above, you might expect ``.fill_null(35)`` to be
+   the step that imputes the survey's "blank" / no-answer ``HWUSUAL``
+   responses (see the codebook above) with 35 hours. It isn't: the
+   preceding ``.filter(pl.col("HWUSUAL") != 99.0)`` already removes those
+   rows. Polars comparisons against a null value themselves evaluate to
+   null rather than ``False``, and ``.filter`` drops any row whose
+   predicate is null, so the blank responses are filtered out right
+   alongside the ``99`` ("not applicable") ones, before ``.fill_null``
+   ever runs. In this particular query, ``.fill_null(35)`` doesn't
+   actually impute anything at runtime.
+
+   ``.fill_null`` is still required here regardless, because OpenDP
+   doesn't infer non-null guarantees from filtering criteria, so it has
+   no way to know that this data happens to already be null-free by this
+   point in the query. See :ref:`polars-filter-null-handling` for more on
+   this distinction. If you instead want ``.fill_null`` to impute the
+   blank responses rather than have the filter silently discard them,
+   adjust the filter condition to retain nulls, for example with
+   ``(pl.col("HWUSUAL") != 99.0) | pl.col("HWUSUAL").is_null()``.
+
+   You can see the underlying Polars behavior directly, independent of
+   OpenDP, on a small sample frame with a mix of ``99``, a blank
+   (``None``), and an ordinary response:
+
+   .. tab-set::
+
+       .. tab-item:: Python
+           :sync: python
+
+           .. code:: pycon
+
+               >>> pl.LazyFrame({"HWUSUAL": [40.0, 99.0, None]}).filter(
+               ...     pl.col("HWUSUAL") != 99.0
+               ... ).collect()["HWUSUAL"].null_count()
+               0
+
+.. note::
    Do not use private data to calculate imputed values or bounds: This
    could leak private information, reducing the integrity of the privacy
    guarantee. Instead, choose bounds and imputed values based on prior


### PR DESCRIPTION
Closes #2788

## What was wrong

In the "Sum" section of the essential-statistics tutorial, there's a query like:

```python
context.query().filter(pl.col("HWUSUAL") != 99.0)
    .select(pl.col.HWUSUAL.cast(int).fill_null(35).dp.sum(bounds=(0, 80)))
```

The prose right after it says `.fill_null(35)` imputes the missing survey responses with 35 (the average French work week), based on public info. Reading that, I assumed the blank/no-answer rows for `HWUSUAL` (see the codebook: `99` means "not applicable", but there's also a separate *blank* code for "no answer") would flow through the filter and get filled with 35.

They don't. `pl.col("HWUSUAL") != 99.0` is a null-propagating comparison in Polars: when `HWUSUAL` is null, the comparison itself evaluates to null, not `False`, and `.filter()` drops any row whose predicate is null. So the blank rows get dropped by the filter step, same as the `99` rows, before `.fill_null(35)` ever sees them. By the time `.fill_null` runs, there's nothing left to impute in this particular query.

I want to be clear this isn't a library bug, just an inaccurate docs claim, the issue author (a maintainer) flagged this exact thing.

## How I traced it

I checked the codebook for `HWUSUAL` in `docs/source/getting-started/tabular-data/index.rst`, which confirmed there's a real distinction between `99` ("not applicable") and blank ("no answer"), so this isn't just a semantic quibble, they're genuinely different codes meant to be handled differently. Then I found the exact mechanism already documented elsewhere in the repo, in `manipulation.rst`'s Filter section: "OpenDP doesn't infer descriptors from the filtering criteria, so the filtered data is not considered non-null (or non-NaN) even if you filter nulls." That's also why `.fill_null(35)` is still required in the query even though it turns out to be a no-op at runtime here, OpenDP's non-null requirement is a static, type-level thing, it doesn't know the filter already removed every null.

```mermaid
flowchart LR
    A["HWUSUAL column<br/>values: 40, 99, null"] --> B{".filter(col != 99.0)"}
    B -->|"40 != 99.0 → True"| C["kept"]
    B -->|"99 != 99.0 → False"| D["dropped"]
    B -->|"null != 99.0 → null"| E["dropped<br/>(filter drops null predicates too)"]
    C --> F[".fill_null(35)<br/>nothing left to fill"]
    F --> G[".dp.sum(bounds=(0,80))"]
```

## What I changed

- Added a note in `essential-statistics.rst` explaining what's actually happening at that point in the query, why `.fill_null` is still needed regardless, and how to adjust the filter (`(pl.col("HWUSUAL") != 99.0) | pl.col("HWUSUAL").is_null()`) if someone actually wants to retain and impute the blank rows instead of dropping them.
- Added a small self-contained doctest right in that note, on a synthetic 3-row frame, that pins down the underlying Polars behavior (`null_count()` is `0` after the filter). It's plain Polars, not going through the `Context`, so it doesn't touch the tutorial's privacy budget.
- Added a `.. _polars-filter-null-handling:` anchor next to the existing explanation in `manipulation.rst` and cross-referenced it, since this is the same underlying behavior, no need to explain it twice from scratch.
- Deliberately did not change the example query itself or any of its `.summarize()`/`.release()` output shown later on the page. Changing the filter to actually retain nulls would change the DP sum's downstream numbers, and I didn't want to touch verified doctest output I can't fully re-execute against a built OpenDP binary in this environment.

## Test plan

- [x] New doctest verified independently: I ran the exact `pl.LazyFrame(...).filter(...).collect()["HWUSUAL"].null_count()` snippet in a throwaway virtualenv with just `polars` installed, confirmed it returns `0` before adding it to the docs.
- [x] Ran a plain docutils parse over both modified `.rst` files as a structural sanity check, no new syntax errors beyond the expected "unknown directive" noise from `tab-set`/`:ref:`, which come from Sphinx extensions bare docutils doesn't know about (same noise appears throughout the rest of the file, not introduced by this change).
- [ ] Did not run the full `pytest --doctest-glob '*.rst'` suite locally (this repo's docs doctests need a built OpenDP binary via `cargo build --all-features`, which is a heavy build I didn't want to run just for a docs prose fix). This should get picked up by CI, the new doctest lives in a file already collected via `testpaths` + `--doctest-glob '*.rst'` in `python/.pytest.ini`.

Let me know if you'd rather I take a different approach, e.g. just simplifying the prose without adding the extra doctest, or if there's a preferred spot elsewhere in the docs for this kind of note.
