### PR TITLE
maintenance: Ruff format python psuedocode in rust directory

### DIFF
--- a/rust/src/combinators/measure_cast/zCDP_to_approxDP/cdp_delta/pseudocode/cdp_delta.py
+++ b/rust/src/combinators/measure_cast/zCDP_to_approxDP/cdp_delta/pseudocode/cdp_delta.py
@@ -41,7 +41,6 @@ def cdp_delta(rho: float, eps: float) -> float:
         t1 = a_1.inf_mul(ar_e)
 
     except OpenDPException:
-
         # if t1 is negative, then handle negative overflow by making t1 larger: the most negative finite float
         # making t1 larger makes delta larger, so it's still a valid upper bound
         if a_1.is_sign_negative() != ar_e.is_sign_negative():

--- a/rust/src/combinators/privacy_filter/pseudocode/new_continuation_rule.py
+++ b/rust/src/combinators/privacy_filter/pseudocode/new_continuation_rule.py
@@ -14,7 +14,9 @@ def new_continuation_rule(d_in: MI_Distance, d_out: MO_Distance) -> Wrapper:
 
             answer = queryable.eval_query(query)
 
-            match queryable.eval_poly(OdometerQuery.PrivacyLoss(d_in.clone())):  # `\label{external}`
+            match queryable.eval_poly(
+                OdometerQuery.PrivacyLoss(d_in.clone())
+            ):  # `\label{external}`
                 case OdometerAnswer.PrivacyLoss(pending_d_out):
                     pass
                 case _:
@@ -24,8 +26,8 @@ def new_continuation_rule(d_in: MI_Distance, d_out: MO_Distance) -> Wrapper:
                 state.take()  # `\label{free}`
                 raise "filter is now exhausted"
 
-            return answer   # `\label{return}`
-            
+            return answer  # `\label{return}`
+
         return Queryable.new_raw(transition)
 
     return Wrapper.new(wrapper)  # `\label{wrapper}`

--- a/rust/src/combinators/select_private_candidate/pseudocode/make_select_private_candidate.py
+++ b/rust/src/combinators/select_private_candidate/pseudocode/make_select_private_candidate.py
@@ -1,25 +1,27 @@
 # type: ignore
 def make_select_private_candidate(
-    measurement: Measurement, 
-    stop_probability: float, 
+    measurement: Measurement,
+    stop_probability: float,
     threshold: float,
 ) -> Measurement:
-    if not 0 <= stop_probability < 1: # |\label{stop-prob}|
+    if not 0 <= stop_probability < 1:  # |\label{stop-prob}|
         raise "stop_probability must be in [0, 1)"
 
     if not threshold.is_finite():
         raise "threshold must be finite"
-    
+
     scale = None
     if stop_probability > 0.0:
         ln_cp = (1.0).neg_inf_sub(stop_probability).inf_ln()
-        scale = ln_cp.recip().neg().into_rational() # |\label{scale}|
+        scale = ln_cp.recip().neg().into_rational()  # |\label{scale}|
 
     def function(arg):
         remaining_iterations = None
         if scale is not None:
-            remaining_iterations = UBig.ONE + sample_geometric_exp_fast(scale) # |\label{sample-geometric}|
-        
+            remaining_iterations = UBig.ONE + sample_geometric_exp_fast(
+                scale
+            )  # |\label{sample-geometric}|
+
         while True:
             score, output = measurement(arg)
 

--- a/rust/src/combinators/sequential_composition/fully_adaptive/pseudocode/new_fully_adaptive_composition_queryable.py
+++ b/rust/src/combinators/sequential_composition/fully_adaptive/pseudocode/new_fully_adaptive_composition_queryable.py
@@ -7,8 +7,7 @@ def new_fully_adaptive_composition_queryable(
 ) -> OdometerQueryable[Measurement[DI, MI, MO, TO], TO, MO_Distance]:
 
     require_sequentiality = matches(
-        output_measure.composability(Adaptivity.FullyAdaptive),
-        Composability.Sequential
+        output_measure.composability(Adaptivity.FullyAdaptive), Composability.Sequential
     )
 
     privacy_maps = []  # Vec<PrivacyMap<MI, MO>> `\label{mutable-state}`
@@ -65,7 +64,7 @@ def new_fully_adaptive_composition_queryable(
                 answer = meas.invoke_wrap(data, seq_wrapper)  # `\label{invoke}`
 
                 enforce_sequentiality = True
-                
+
                 # We've now increased our privacy spend.
                 # This is our only state modification
                 privacy_maps.push(meas.privacy_map)  # `\label{child-privacy-map}`

--- a/rust/src/combinators/sequential_composition/pseudocode/CompositionMeasure_for_RenyiDivergence.py
+++ b/rust/src/combinators/sequential_composition/pseudocode/CompositionMeasure_for_RenyiDivergence.py
@@ -6,7 +6,7 @@ class CompositionMeasure(RenyiDivergence):
         return Composability.Concurrent
 
     def compose(self, d_mids: Vec[Self_Distance]) -> Self_Distance:
-        def curve(alpha: float) -> float: # |\label{line:curve}|
+        def curve(alpha: float) -> float:  # |\label{line:curve}|
             epsilons = [d_mid(alpha) for d_mid in d_mids]
 
             d_out = 0.0
@@ -15,4 +15,3 @@ class CompositionMeasure(RenyiDivergence):
             return d_out
 
         return Function.new_fallible(curve)
-        

--- a/rust/src/domains/polars/frame/pseudocode/find_min_covering.py
+++ b/rust/src/domains/polars/frame/pseudocode/find_min_covering.py
@@ -2,7 +2,7 @@
 def find_min_covering(
     must_cover: set[T], sets: list[set[T], u32]
 ) -> list[tuple[set[T], u32]] | None:
-    
+
     covered = list()  # `\label{covered}`
 
     while must_cover:  # `\label{loop}`

--- a/rust/src/domains/polars/frame/pseudocode/get_margin.py
+++ b/rust/src/domains/polars/frame/pseudocode/get_margin.py
@@ -1,37 +1,29 @@
 # type: ignore
 from math import prod
 
+
 def get_margin(domain: FrameDomain, by: set[Expr]) -> Margin:
     margin = next(  # |\label{let-margin}|
-        (m for m in domain.margins if m.by == by), 
-        Margin.by(by)
+        (m for m in domain.margins if m.by == by), Margin.by(by)
     )
 
     subset_margins = [  # |\label{let-subset-margins}|
-        margin
-        for margin in domain.margins
-        if margin.by.issubset(by)
+        margin for margin in domain.margins if margin.by.issubset(by)
     ]
 
     margin.max_length = min(  # |\label{let-max-length}|
-        m.max_length
-        for m in subset_margins
-        if m.max_length is not None
+        m.max_length for m in subset_margins if m.max_length is not None
     )
 
     all_max_groups = [  # |\label{all-max-groups}|
-        (m.by, m.max_groups)
-        for m in domain.margins
-        if m.max_groups is not None
+        (m.by, m.max_groups) for m in domain.margins if m.max_groups is not None
     ]
     max_groups_covering = find_min_covering(grouping_columns, all_max_groups)
     if max_groups_covering is not None:
         margin.max_groups = prod(v for _, v in max_groups_covering)
 
     all_invariants = (  # |\label{all-invariants}|
-        m.invariant
-        for m in domain.margins
-        if by.issubset(m.by)
+        m.invariant for m in domain.margins if by.issubset(m.by)
     )
     margin.invariant = max(all_invariants, key={None: 0, "Keys": 1, "Lengths": 2}.get)
 

--- a/rust/src/measurements/canonical_noise/pseudocode/approximate_to_tradeoff.py
+++ b/rust/src/measurements/canonical_noise/pseudocode/approximate_to_tradeoff.py
@@ -1,6 +1,6 @@
 # type: ignore
 def appproximate_to_tradeoff(
-    param: tuple[f64, f64]
+    param: tuple[f64, f64],
 ) -> tuple[Callable[[RBig], RBig], RBig]:
     epsilon, delta = param
 

--- a/rust/src/measurements/canonical_noise/pseudocode/make_canonical_noise.py
+++ b/rust/src/measurements/canonical_noise/pseudocode/make_canonical_noise.py
@@ -5,8 +5,10 @@ def make_canonical_noise(
     d_in: f64,
     d_out: tuple[f64, f64],
 ):
-    assert not input_domain.nan(), "input data must be non-nan" # `\label{non-nan}`
-    assert not d_in.is_sign_negative() and d_in.is_finite() # `\label{sensitivity-check}`
+    assert not input_domain.nan(), "input data must be non-nan"  # `\label{non-nan}`
+    assert (
+        not d_in.is_sign_negative() and d_in.is_finite()
+    )  # `\label{sensitivity-check}`
 
     tradeoff, fixed_point = approximate_to_tradeoff(d_out)
     r_d_in = RBig.try_from(d_in)
@@ -16,7 +18,7 @@ def make_canonical_noise(
             arg = RBig.try_from(arg)
         except Exception:
             arg = RBig(0)
-        
+
         canonical_rv = CanonicalRV(  # `\label{canonical-rv}`
             shift=arg, scale=r_d_in, tradeoff=tradeoff, fixed_point=fixed_point
         )

--- a/rust/src/measurements/make_private_lazyframe/group_by/pseudocode/make_private_group_by.py
+++ b/rust/src/measurements/make_private_lazyframe/group_by/pseudocode/make_private_group_by.py
@@ -7,13 +7,15 @@ def make_private_group_by(
     global_scale: Optional[f64],
     threshold: Optional[u32],
 ):
-    input, group_by, aggs, key_sanitizer = match_group_by(plan) # |\label{line:match-group-by}|
+    input, group_by, aggs, key_sanitizer = match_group_by(
+        plan
+    )  # |\label{line:match-group-by}|
 
     # 1: establish stability of `group_by` |\label{line:input_stability}|
     t_prior = input.make_stable(input_domain, input_metric)  # |\label{line:tprior}|
     middle_domain, middle_metric = t_prior.output_space()
 
-    for expr in group_by: # |\label{line:group-by-stability}|
+    for expr in group_by:  # |\label{line:group-by-stability}|
         # grouping keys must be stable
         t_group_by = expr.make_stable(
             WildExprDomain(
@@ -28,7 +30,7 @@ def make_private_group_by(
             domain = series_domain.element_domain(CategoricalDomain)
         except Exception:
             pass
-            
+
         if domain is not None and domain.categories() is None:
             raise "Categories are data-dependent, which may reveal sensitive record ordering."
 
@@ -39,7 +41,9 @@ def make_private_group_by(
     match key_sanitizer:
         case KeySanitizer.Join(keys):
             num_keys = LazyFrame.from_(keys).select([len()]).collect()
-            margin.max_num_partitions = num_keys.column("len").u32().last()  # |\label{line:keys-len}|
+            margin.max_num_partitions = (
+                num_keys.column("len").u32().last()
+            )  # |\label{line:keys-len}|
             is_join = True
         case _:
             is_join = False
@@ -54,7 +58,8 @@ def make_private_group_by(
             output_measure,
             expr,
             global_scale,
-        ) for expr in aggs
+        )
+        for expr in aggs
     ]
     m_aggs = make_composition(m_expr_aggs)
 
@@ -62,7 +67,9 @@ def make_private_group_by(
     f_privacy_map = m_aggs.privacy_map
 
     # 3: prepare for release of `keys` |\label{line:prep-release-keys}|
-    dp_exprs, null_exprs = zip(*((plan.expr, plan.fill) for plan in m_aggs.invoke(input)))
+    dp_exprs, null_exprs = zip(
+        *((plan.expr, plan.fill) for plan in m_aggs.invoke(input))
+    )
 
     # 3.2: reconcile information about the threshold |\label{line:reconcile-threshold}|
     if margin.invariant is not None or is_join:  # |\label{line:no-thresholding}|
@@ -81,12 +88,16 @@ def make_private_group_by(
     if threshold_info is not None:  # |\label{line:incorporate-threshold}|
         name, _, threshold_value, is_present = threshold_info
         threshold_expr = col(name).gt(lit(threshold_value))
-        if not is_present and predicate is not None:  # |\label{line:new-threshold-sanitizer}|
+        if (
+            not is_present and predicate is not None
+        ):  # |\label{line:new-threshold-sanitizer}|
             key_sanitizer = KeySanitizer.Filter(threshold_expr.and_(predicate))
         else:
             key_sanitizer = KeySanitizer.Filter(threshold_expr)
 
-    elif isinstance(key_sanitizer, KeySanitizer.Join):  # |\label{line:incorporate-join-fill}|
+    elif isinstance(
+        key_sanitizer, KeySanitizer.Join
+    ):  # |\label{line:incorporate-join-fill}|
         key_sanitizer.fill_null = []
         for dp_expr, null_expr in zip(dp_exprs, null_exprs):
             name = dp_expr.meta().output_name()
@@ -94,7 +105,7 @@ def make_private_group_by(
                 raise f"fill expression for {name} is unknown"
 
             key_sanitizer.fill_null.append(col(name).fill_null(null_expr))
-    
+
     # 4: build final measurement |\label{line:build-meas}|
     def function(arg: DslPlan) -> DslPlan:  # |\label{line:function}|
         output = DslPlan.GroupBy(
@@ -149,27 +160,29 @@ def make_private_group_by(
         if l0 is not None and l1 is not None and li is not None:
             pass
         elif l1 is not None:
-            l0 = l0 or l1 # |\label{line:l0-from-l1}|
-            li = li or l1 # |\label{line:li-from-l1}|
+            l0 = l0 or l1  # |\label{line:l0-from-l1}|
+            li = li or l1  # |\label{line:li-from-l1}|
         elif l0 is not None and li is not None:
-            l1 = l0.inf_mul(li) # |\label{line:l1-from-l0-li}|
-        else: # |\label{line: helpful_error_message}|            
+            l1 = l0.inf_mul(li)  # |\label{line:l1-from-l0-li}|
+        else:  # |\label{line: helpful_error_message}|
             raise f"num_groups ({l0}), total contributions ({l1}), and per_group ({li}) are not sufficiently well-defined."
 
         # tighten the concrete bounds via identities that always hold
-        l0 = min(l0, l1) # |\label{line:l0-tighten}|
-        li = min(li, l1) # |\label{line:li-tighten}|
-        l1 = min(l1, l0.inf_mul(li)) # |\label{line:l1-tighten}|
+        l0 = min(l0, l1)  # |\label{line:l0-tighten}|
+        li = min(li, l1)  # |\label{line:li-tighten}|
+        l1 = min(l1, l0.inf_mul(li))  # |\label{line:l1-tighten}|
 
         d_out = f_privacy_map.eval((l0, l1, li))
 
-        if margin.invariant is not None or is_join:  # |\label{line:privacy-map-static-keys}|
+        if (
+            margin.invariant is not None or is_join
+        ):  # |\label{line:privacy-map-static-keys}|
             pass
         elif threshold_info is not None:  # |\label{line:privacy-map-threshold}|
             _, noise, threshold_value, _ = threshold_info
             if li >= threshold_value:
                 raise f"Threshold must be greater than {li}."
-            
+
             d_instability = threshold_value.neg_inf_sub(li)
             delta_single = integrate_discrete_noise_tail(
                 noise.distribution, noise.scale, d_instability

--- a/rust/src/measurements/noise/distribution/gaussian/pseudocode/MakeNoise_for_DiscreteGaussian.py
+++ b/rust/src/measurements/noise/distribution/gaussian/pseudocode/MakeNoise_for_DiscreteGaussian.py
@@ -1,8 +1,12 @@
 # type: ignore
 # analogous to impl MakeNoise<DI, MI, MO> for DiscreteGaussian in Rust
 class DiscreteGaussian:
-    def make_noise(self, input_space: tuple[DI, MI]) -> Measurement[DI, DI_Carrier, MI, MO]:
+    def make_noise(
+        self, input_space: tuple[DI, MI]
+    ) -> Measurement[DI, DI_Carrier, MI, MO]:
         # an equivalent random variable specific to the atom dtype
-        rv_nature = DI_Atom.new_distribution(self.scale, self.k) # |\label{line:rv-nature}|
+        rv_nature = DI_Atom.new_distribution(
+            self.scale, self.k
+        )  # |\label{line:rv-nature}|
         # build a measurement sampling from this equivalent distribution
-        return rv_nature.make_noise(input_space) # |\label{line:make-noise}|
+        return rv_nature.make_noise(input_space)  # |\label{line:make-noise}|

--- a/rust/src/measurements/noise/distribution/gaussian/pseudocode/NoisePrivacyMap_for_ZExpFamily2.py
+++ b/rust/src/measurements/noise/distribution/gaussian/pseudocode/NoisePrivacyMap_for_ZExpFamily2.py
@@ -2,7 +2,9 @@
 # analogous to impl NoisePrivacyMap<L2Distance<RBig>, ZeroConcentratedDivergence> for ZExpFamily<1> in Rust
 class ZExpFamily2:
     def noise_privacy_map(
-        self, _input_metric: L2Distance[RBig], _output_measure: ZeroConcentratedDivergence
+        self,
+        _input_metric: L2Distance[RBig],
+        _output_measure: ZeroConcentratedDivergence,
     ) -> PrivacyMap[L2Distance[RBig], ZeroConcentratedDivergence]:
         scale = self.scale
         if scale < RBig.ZERO:  # |\label{line:neg-scale}|

--- a/rust/src/measurements/noise/distribution/geometric/pseudocode/MakeNoise_VectorDomain_for_ConstantTimeGeometric.py
+++ b/rust/src/measurements/noise/distribution/geometric/pseudocode/MakeNoise_VectorDomain_for_ConstantTimeGeometric.py
@@ -6,7 +6,7 @@ class ConstantTimeGeometric:
     ) -> Measurement[DI, DI_Carrier, MI, MO]:
         input_domain, input_metric = input_space
         scale, (lower, upper) = self.scale, self.bounds
-        if lower > upper: # |\label{line:check-bounds}|
+        if lower > upper:  # |\label{line:check-bounds}|
             raise "lower may not be greater than upper"
 
         distribution = ZExpFamily(scale=RBig.from_f64(scale))
@@ -16,7 +16,7 @@ class ConstantTimeGeometric:
             L1Distance.default(), output_measure
         )
 
-        p = (1.0).neg_inf_sub((-scale.recip()).inf_exp()) # |\label{line:prob-check}|
+        p = (1.0).neg_inf_sub((-scale.recip()).inf_exp())  # |\label{line:prob-check}|
         if not (0.0 < p <= 1.0):
             raise f"Probability of termination p ({p}) must be in (0, 1]. This is likely because the noise scale is so large that conservative arithmetic causes p to go negative"
 

--- a/rust/src/measurements/noise/distribution/laplace/pseudocode/MakeNoise_for_DiscreteLaplace.py
+++ b/rust/src/measurements/noise/distribution/laplace/pseudocode/MakeNoise_for_DiscreteLaplace.py
@@ -1,8 +1,12 @@
 # type: ignore
 # analogous to impl MakeNoise<DI, MI, MO> for DiscreteLaplace in Rust
 class DiscreteLaplace:
-    def make_noise(self, input_space: tuple[DI, MI]) -> Measurement[DI, DI_Carrier, MI, MO]:
+    def make_noise(
+        self, input_space: tuple[DI, MI]
+    ) -> Measurement[DI, DI_Carrier, MI, MO]:
         # an equivalent random variable specific to the atom dtype
-        rv_nature = DI_Atom.new_distribution(self.scale, self.k) # |\label{line:rv-nature}|
+        rv_nature = DI_Atom.new_distribution(
+            self.scale, self.k
+        )  # |\label{line:rv-nature}|
         # build a measurement sampling from this equivalent distribution
-        return rv_nature.make_noise(input_space) # |\label{line:make-noise}|
+        return rv_nature.make_noise(input_space)  # |\label{line:make-noise}|

--- a/rust/src/measurements/noise/nature/float/pseudocode/MakeNoise_AtomDomain_for_FloatExpFamily.py
+++ b/rust/src/measurements/noise/nature/float/pseudocode/MakeNoise_AtomDomain_for_FloatExpFamily.py
@@ -1,8 +1,9 @@
 # type: ignore
 class FloatExpFamily:
-    def make_noise(self, input_space) -> Measurement[AtomDomain[T], T, AbsoluteDistance[QI], MO]:
-        t_vec = make_vec(input_space) # |\label{line:make-vec}|
-        m_noise = self.make_noise(t_vec.output_space()) # |\label{line:make-noise}|
+    def make_noise(
+        self, input_space
+    ) -> Measurement[AtomDomain[T], T, AbsoluteDistance[QI], MO]:
+        t_vec = make_vec(input_space)  # |\label{line:make-vec}|
+        m_noise = self.make_noise(t_vec.output_space())  # |\label{line:make-noise}|
 
-        return t_vec >> m_noise >> then_index_or_default(0) # |\label{line:post}|
-    
+        return t_vec >> m_noise >> then_index_or_default(0)  # |\label{line:post}|

--- a/rust/src/measurements/noise/nature/float/pseudocode/MakeNoise_VectorDomain_for_FloatExpFamily.py
+++ b/rust/src/measurements/noise/nature/float/pseudocode/MakeNoise_VectorDomain_for_FloatExpFamily.py
@@ -1,10 +1,13 @@
 # type: ignore
 class FloatExpFamily:
-    def make_noise(self, input_space) -> Measurement[AtomDomain[T], T, AbsoluteDistance[QI], MO]:
+    def make_noise(
+        self, input_space
+    ) -> Measurement[AtomDomain[T], T, AbsoluteDistance[QI], MO]:
         scale, k = self.scale, self.k
-        distribution = ZExpFamily(scale=integerize_scale(scale, k)) # |\label{line:dist}|
+        distribution = ZExpFamily(
+            scale=integerize_scale(scale, k)
+        )  # |\label{line:dist}|
 
         t_int = make_float_to_bigint(input_space)
         m_noise = distribution.make_noise(t_int.output_space())
         return t_int >> m_noise >> then_deintegerize_vec(k)
-    

--- a/rust/src/measurements/noise/nature/float/pseudocode/make_float_to_bigint.py
+++ b/rust/src/measurements/noise/nature/float/pseudocode/make_float_to_bigint.py
@@ -12,7 +12,9 @@ def make_float_to_bigint(
         raise "input_domain may not contain NaN elements"
 
     size = input_domain.size
-    rounding_distance = get_rounding_distance(k, size, T) # |\label{line:rounding-distance}|
+    rounding_distance = get_rounding_distance(
+        k, size, T
+    )  # |\label{line:rounding-distance}|
 
     def elementwise_function(x_i):  # |\label{line:elementwise-function}|
         x_i = RBig.try_from(x_i).unwrap_or(RBig.ZERO)  # |\label{line:try-from}|

--- a/rust/src/measurements/noise/nature/float/pseudocode/then_deintegerize_vec.py
+++ b/rust/src/measurements/noise/nature/float/pseudocode/then_deintegerize_vec.py
@@ -1,10 +1,10 @@
 # type: ignore
 def then_deintegerize_vec(k: i32) -> Function[Vec[IBig], Vec[TO]]:
 
-    if k == i32.MIN: # |\label{line:check-k}|
+    if k == i32.MIN:  # |\label{line:check-k}|
         raise ValueError("k must be greater than i32.MIN")
-    
+
     def element_function(x_i):
         return TO.from_rational(x_mul_2k(RBig.from_(x_i), k))
-    
+
     return Function.new(lambda x: [element_function(x_i) for x_i in x])

--- a/rust/src/measurements/noise/nature/float/utilities/pseudocode/find_nearest_multiple_of_2k.py
+++ b/rust/src/measurements/noise/nature/float/utilities/pseudocode/find_nearest_multiple_of_2k.py
@@ -1,7 +1,7 @@
 # type: ignore
 def find_nearest_multiple_of_2k(x: RBig, k: i32) -> IBig:
     # exactly compute x/2^k and break into fractional parts
-    num, den = x_mul_2k(x, -k).into_parts() # `\label{line:into-parts}`
+    num, den = x_mul_2k(x, -k).into_parts()  # `\label{line:into-parts}`
 
     # argmin_i |i * 2^k - x|, the index of nearest multiple of 2^k
-    return (floor_div(num << 1, den) + 1) >> 1 # `\label{line:return}`
+    return (floor_div(num << 1, den) + 1) >> 1  # `\label{line:return}`

--- a/rust/src/measurements/noise/nature/float/utilities/pseudocode/get_min_k.py
+++ b/rust/src/measurements/noise/nature/float/utilities/pseudocode/get_min_k.py
@@ -1,3 +1,5 @@
 # type: ignore
 def get_min_k() -> i32:
-    return -i32.exact_int_cast(T.EXPONENT_BIAS) - i32.exact_int_cast(T.MANTISSA_BITS) + 1
+    return (
+        -i32.exact_int_cast(T.EXPONENT_BIAS) - i32.exact_int_cast(T.MANTISSA_BITS) + 1
+    )

--- a/rust/src/measurements/noise/nature/float/utilities/pseudocode/get_rounding_distance.py
+++ b/rust/src/measurements/noise/nature/float/utilities/pseudocode/get_rounding_distance.py
@@ -1,24 +1,24 @@
 # type: ignore
 def get_rounding_distance() -> RBig:
-    k_min = get_min_k(T) # |\label{line:get-min-k}|
-    if k < k_min: # |\label{line:check-k}|
+    k_min = get_min_k(T)  # |\label{line:get-min-k}|
+    if k < k_min:  # |\label{line:check-k}|
         raise f"k ({k}) must not be smaller than {k_min}"
 
     # input has granularity 2^{k_min} (subnormal float precision)
-    input_gran = x_mul_2k(RBig.ONE, k_min) # |\label{line:input-gran}|
+    input_gran = x_mul_2k(RBig.ONE, k_min)  # |\label{line:input-gran}|
 
     # discretization rounds to the nearest 2^k
-    output_gran = x_mul_2k(RBig.ONE, k) # |\label{line:output-gran}|
+    output_gran = x_mul_2k(RBig.ONE, k)  # |\label{line:output-gran}|
 
     # the worst-case increase in sensitivity due to discretization is
     #     the range, minus the smallest step in the range
-    distance = output_gran - input_gran # |\label{line:distance}|
+    distance = output_gran - input_gran  # |\label{line:distance}|
 
     # rounding may occur on all vector elements
-    if not distance.is_zero(): # |\label{line:zero-distance}|
-        if size is None: # |\label{line:unknown-size}|
+    if not distance.is_zero():  # |\label{line:zero-distance}|
+        if size is None:  # |\label{line:unknown-size}|
             raise "domain size must be known if discretization is not exact"
-        
+
         match P:
             case 1:
                 distance *= RBig.from_(size)
@@ -26,5 +26,5 @@ def get_rounding_distance() -> RBig:
                 distance *= RBig.try_from(f64.inf_cast(size).inf_sqrt())
             case _:
                 raise f"norm ({P}) must be one or two"
-        
+
     return distance

--- a/rust/src/measurements/noise/pseudocode/MakeNoise_IBig_for_RV.py
+++ b/rust/src/measurements/noise/pseudocode/MakeNoise_IBig_for_RV.py
@@ -1,13 +1,16 @@
 # type: ignore
 # analogous to impl MakeNoise<VectorDomain<AtomDomain<IBig>>, MI, MO> for RV in Rust
 class RV:
-    def make_noise(self, input_space) -> Measurement[VectorDomain[AtomDomain[IBig]], Vec[IBig], MI, MO]:
+    def make_noise(
+        self, input_space
+    ) -> Measurement[VectorDomain[AtomDomain[IBig]], Vec[IBig], MI, MO]:
         input_domain, input_metric = input_space
         return Measurement.new(
             input_domain,
             Function.new_fallible(
-                lambda x: [self.sample(x_i) for x_i in x]), # |\label{line:sample}|
+                lambda x: [self.sample(x_i) for x_i in x]
+            ),  # |\label{line:sample}|
             input_metric,
             MO.default(),
             self.noise_privacy_map(),  # |\label{line:privacy-map}|
-        ) 
+        )

--- a/rust/src/measurements/noise/pseudocode/Sample_for_ZExpFamily1.py
+++ b/rust/src/measurements/noise/pseudocode/Sample_for_ZExpFamily1.py
@@ -1,4 +1,4 @@
 # type: ignore
-class ZExpFamily1: # analogous to impl Sample for ZExpFamily<1> in Rust
+class ZExpFamily1:  # analogous to impl Sample for ZExpFamily<1> in Rust
     def sample(self, shift):
-        return shift + sample_discrete_laplace(self.scale) # |\label{line:add}|
+        return shift + sample_discrete_laplace(self.scale)  # |\label{line:add}|

--- a/rust/src/measurements/noise/pseudocode/Sample_for_ZExpFamily2.py
+++ b/rust/src/measurements/noise/pseudocode/Sample_for_ZExpFamily2.py
@@ -1,4 +1,4 @@
 # type: ignore
-class ZExpFamily2: # analogous to impl Sample for ZExpFamily<1> in Rust
+class ZExpFamily2:  # analogous to impl Sample for ZExpFamily<1> in Rust
     def sample(self, shift):
-        return shift + sample_discrete_gaussian(self.scale) # |\label{line:add}|
+        return shift + sample_discrete_gaussian(self.scale)  # |\label{line:add}|

--- a/rust/src/measurements/noise_threshold/distribution/gaussian/pseudocode/MakeNoiseThreshold_for_DiscreteGaussian.py
+++ b/rust/src/measurements/noise_threshold/distribution/gaussian/pseudocode/MakeNoiseThreshold_for_DiscreteGaussian.py
@@ -1,8 +1,14 @@
 # type: ignore
 # analogous to impl MakeNoiseThreshold<DI, MI, MO> for DiscreteGaussian in Rust
 class DiscreteGaussian:
-    def make_noise_threshold(self, input_space, threshold) -> Measurement[DI, DI_Carrier, MI, MO]:
+    def make_noise_threshold(
+        self, input_space, threshold
+    ) -> Measurement[DI, DI_Carrier, MI, MO]:
         # an equivalent random variable specific to the atom dtype
-        rv_nature = DI_Atom.new_distribution(self.scale, self.k) # |\label{line:rv-nature}|
+        rv_nature = DI_Atom.new_distribution(
+            self.scale, self.k
+        )  # |\label{line:rv-nature}|
         # build a measurement sampling from this equivalent distribution
-        return rv_nature.make_noise_threshold(input_space, threshold) # |\label{line:make-noise}|
+        return rv_nature.make_noise_threshold(
+            input_space, threshold
+        )  # |\label{line:make-noise}|

--- a/rust/src/measurements/noise_threshold/distribution/gaussian/pseudocode/NoiseThresholdPrivacyMap_for_ZExpFamily2.py
+++ b/rust/src/measurements/noise_threshold/distribution/gaussian/pseudocode/NoiseThresholdPrivacyMap_for_ZExpFamily2.py
@@ -6,33 +6,39 @@ class ZExpFamily2:
         _input_metric: L02InfDistance[AbsoluteDistance[RBig]],
         output_measure: Approximate[ZeroConcentratedDivergence],
         threshold: UBig,
-    ) -> PrivacyMap[L02InfDistance[AbsoluteDistance[RBig]], Approximate[ZeroConcentratedDivergence]]:
+    ) -> PrivacyMap[
+        L02InfDistance[AbsoluteDistance[RBig]], Approximate[ZeroConcentratedDivergence]
+    ]:
         # |\label{line:noise-privacy-map}|
-        noise_privacy_map = self.noise_privacy_map(L2Distance.default(), output_measure[0])
+        noise_privacy_map = self.noise_privacy_map(
+            L2Distance.default(), output_measure[0]
+        )
         scale = self.scale
 
         def privacy_map(d_in: tuple[u32, RBig, RBig]):
             l0, l2, li = d_in
 
-            li_sign, li = li.floor().into_parts() # |\label{line:li-floor}|
-            if li_sign != Sign.Positive: # |\label{line:li-check}|
+            li_sign, li = li.floor().into_parts()  # |\label{line:li-floor}|
+            if li_sign != Sign.Positive:  # |\label{line:li-check}|
                 raise f"l-infinity sensitivity ({li}) must be non-negative"
-            
-            l2 = l2.min(li * RBig.try_from(f64.from_(l0).inf_sqrt()))  # |\label{line:l2}|
+
+            l2 = l2.min(
+                li * RBig.try_from(f64.from_(l0).inf_sqrt())
+            )  # |\label{line:l2}|
             li = li.min(l2.floor())  # |\label{line:li}|
 
             if l2.is_zero():  # |\label{line:zero-sens}|
                 return 0.0, 0.0
 
-            if scale.is_zero(): # |\label{line:zero-scale}|
+            if scale.is_zero():  # |\label{line:zero-scale}|
                 return f64.INFINITY, 1.0
 
-            rho = noise_privacy_map.eval(l2) # |\label{line:rho}|
-            
-            if li > threshold: # |\label{line:threshold-check}|
+            rho = noise_privacy_map.eval(l2)  # |\label{line:rho}|
+
+            if li > threshold:  # |\label{line:threshold-check}|
                 raise f"threshold must not be smaller than {li}"
-            
-            d_instability = threshold - li # |\label{line:distance-to-instability}|
+
+            d_instability = threshold - li  # |\label{line:distance-to-instability}|
 
             delta_single = conservative_discrete_gaussian_tail_to_alpha(
                 scale,

--- a/rust/src/measurements/noise_threshold/distribution/laplace/pseudocode/MakeNoiseThreshold_for_DiscreteLaplace.py
+++ b/rust/src/measurements/noise_threshold/distribution/laplace/pseudocode/MakeNoiseThreshold_for_DiscreteLaplace.py
@@ -1,8 +1,14 @@
 # type: ignore
 # analogous to impl MakeNoiseThreshold<DI, MI, MO> for DiscreteLaplace in Rust
 class DiscreteLaplace:
-    def make_noise_threshold(self, input_space, threshold) -> Measurement[DI, DI_Carrier, MI, MO]:
+    def make_noise_threshold(
+        self, input_space, threshold
+    ) -> Measurement[DI, DI_Carrier, MI, MO]:
         # an equivalent random variable specific to the atom dtype
-        rv_nature = DI_Atom.new_distribution(self.scale, self.k) # |\label{line:rv-nature}|
+        rv_nature = DI_Atom.new_distribution(
+            self.scale, self.k
+        )  # |\label{line:rv-nature}|
         # build a measurement sampling from this equivalent distribution
-        return rv_nature.make_noise_threshold(input_space, threshold) # |\label{line:make-noise}|
+        return rv_nature.make_noise_threshold(
+            input_space, threshold
+        )  # |\label{line:make-noise}|

--- a/rust/src/measurements/noise_threshold/distribution/laplace/pseudocode/NoiseThresholdPrivacyMap_for_ZExpFamily1.py
+++ b/rust/src/measurements/noise_threshold/distribution/laplace/pseudocode/NoiseThresholdPrivacyMap_for_ZExpFamily1.py
@@ -8,44 +8,45 @@ class ZExpFamily1:
         threshold: UBig,
     ) -> PrivacyMap[L01InfDistance[AbsoluteDistance[RBig]], Approximate[MaxDivergence]]:
         # |\label{line:noise-privacy-map}|
-        noise_privacy_map = self.noise_privacy_map(L1Distance.default(), output_measure[0])
+        noise_privacy_map = self.noise_privacy_map(
+            L1Distance.default(), output_measure[0]
+        )
         scale = self.scale
 
         def privacy_map(d_in: tuple[u32, RBig, RBig]):
             l0, l1, li = d_in
 
-            l1_sign, l1 = l1.floor().into_parts() # |\label{line:l1-floor}|
-            if l1_sign != Sign.Positive: # |\label{line:l1-check}|
+            l1_sign, l1 = l1.floor().into_parts()  # |\label{line:l1-floor}|
+            if l1_sign != Sign.Positive:  # |\label{line:l1-check}|
                 raise f"l1 sensitivity ({l1}) must be non-negative"
 
-            li_sign, li = li.floor().into_parts() # |\label{line:li-floor}|
-            if li_sign != Sign.Positive: # |\label{line:li-check}|
+            li_sign, li = li.floor().into_parts()  # |\label{line:li-floor}|
+            if li_sign != Sign.Positive:  # |\label{line:li-check}|
                 raise f"l-infinity sensitivity ({li}) must be non-negative"
-            
+
             l1 = l1.min(li * l0)  # |\label{line:l1}|
             li = li.min(l1)  # |\label{line:li}|
 
             if l1.is_zero():  # |\label{line:zero-sens}|
                 return 0.0, 0.0
 
-            if scale.is_zero(): # |\label{line:zero-scale}|
+            if scale.is_zero():  # |\label{line:zero-scale}|
                 return f64.INFINITY, 1.0
 
-            epsilon = noise_privacy_map.eval(l1) # |\label{line:epsilon}|
-            
-            if li > threshold: # |\label{line:threshold-check}|
+            epsilon = noise_privacy_map.eval(l1)  # |\label{line:epsilon}|
+
+            if li > threshold:  # |\label{line:threshold-check}|
                 raise f"threshold must not be smaller than {li}"
-            
-            d_instability = threshold - li # |\label{line:distance-to-instability}|
+
+            d_instability = threshold - li  # |\label{line:distance-to-instability}|
 
             try:
                 alpha_disc = conservative_discrete_laplacian_tail_to_alpha(
-                    scale,
-                    d_instability
+                    scale, d_instability
                 )
             except Exception:
                 alpha_disc = None
-            
+
             try:
                 alpha_cont = conservative_continuous_laplacian_tail_to_alpha(
                     scale,

--- a/rust/src/measurements/noise_threshold/nature/float/pseudocode/MakeNoiseThreshold_MapDomain_for_FloatExpFamily.py
+++ b/rust/src/measurements/noise_threshold/nature/float/pseudocode/MakeNoiseThreshold_MapDomain_for_FloatExpFamily.py
@@ -3,7 +3,8 @@ class FloatExpFamily:
     def make_noise_threshold(
         self,
         input_space: tuple[
-            MapDomain[AtomDomain[TK], MapDomain[TV]], L0PInfDistance[P, AbsoluteDistance[QI]]
+            MapDomain[AtomDomain[TK], MapDomain[TV]],
+            L0PInfDistance[P, AbsoluteDistance[QI]],
         ],
         threshold: TV,
     ) -> Measurement[

--- a/rust/src/measurements/noise_threshold/nature/float/pseudocode/make_float_to_bigint_threshold.py
+++ b/rust/src/measurements/noise_threshold/nature/float/pseudocode/make_float_to_bigint_threshold.py
@@ -1,7 +1,8 @@
 # type: ignore
 def make_float_to_bigint_threshold(
     input_space: tuple[
-        MapDomain[AtomDomain[TK], MapDomain[TV]], L0PInfDistance[P, AbsoluteDistance[QI]]
+        MapDomain[AtomDomain[TK], MapDomain[TV]],
+        L0PInfDistance[P, AbsoluteDistance[QI]],
     ],
     threshold: TV,
     k: i32,
@@ -37,7 +38,7 @@ def make_float_to_bigint_threshold(
         r_lp = x_mul_2k(r_lp + r_lp_round, -k)  # |\label{line:lp-x-mul-2k}|
 
         r_li = RBig.try_from(li)
-        if r_li > x_mul_2k(r_threshold, -k): # |\label{line:check-li}|
+        if r_li > x_mul_2k(r_threshold, -k):  # |\label{line:check-li}|
             raise f"li ({li}) must not be larger than threshold ({threshold})"
         r_li_round = get_rounding_distance(k, 1, P)
         r_li = x_mul_2k(r_li + r_li_round, -k)  # |\label{line:li-x-mul-2k}|

--- a/rust/src/measurements/noise_threshold/nature/float/pseudocode/then_deintegerize_hashmap.py
+++ b/rust/src/measurements/noise_threshold/nature/float/pseudocode/then_deintegerize_hashmap.py
@@ -1,6 +1,6 @@
 # type: ignore
 def then_deintegerize_hashmap(k: i32) -> Function[HashMap[TK, IBig], HashMap[TK, TV]]:
-    if k == i32.MIN: # |\label{line:check-k}|
+    if k == i32.MIN:  # |\label{line:check-k}|
         raise ValueError("k must not be i32.MIN")
 
     def value_function(v_i):

--- a/rust/src/measurements/noise_threshold/nature/integer/pseudocode/MakeNoiseThreshold_MapDomain_for_IntExpFamily.py
+++ b/rust/src/measurements/noise_threshold/nature/integer/pseudocode/MakeNoiseThreshold_MapDomain_for_IntExpFamily.py
@@ -3,7 +3,8 @@ class IntExpFamily:
     def make_noise_threshold(
         self,
         input_space: tuple[
-            MapDomain[AtomDomain[TK], AtomDomain[TV]], L0PInfDistance[P, AbsoluteDistance[QI]]
+            MapDomain[AtomDomain[TK], AtomDomain[TV]],
+            L0PInfDistance[P, AbsoluteDistance[QI]],
         ],
         threshold: TV,
     ) -> Measurement[

--- a/rust/src/measurements/noise_threshold/nature/integer/pseudocode/make_int_to_bigint_threshold.py
+++ b/rust/src/measurements/noise_threshold/nature/integer/pseudocode/make_int_to_bigint_threshold.py
@@ -1,7 +1,8 @@
 # type: ignore
 def make_int_to_bigint_threshold(
     input_space: tuple[
-        MapDomain[AtomDomain[TK], AtomDomain[TV]], L0PInfDistance[P, AbsoluteDistance[QI]]
+        MapDomain[AtomDomain[TK], AtomDomain[TV]],
+        L0PInfDistance[P, AbsoluteDistance[QI]],
     ],
 ) -> Transformation[
     MapDomain[AtomDomain[TK], AtomDomain[TV]],
@@ -19,11 +20,13 @@ def make_int_to_bigint_threshold(
 
     return Transformation.new(
         input_domain,
-        MapDomain( # |\label{line:output-domain}|
+        MapDomain(  # |\label{line:output-domain}|
             key_domain=input_domain.key_domain,
             value_domain=AtomDomain.default(IBig),
         ),
-        Function.new(lambda x: {k: IBig.from_(v) for k, v in x.items()}), # |\label{line:function}|
+        Function.new(
+            lambda x: {k: IBig.from_(v) for k, v in x.items()}
+        ),  # |\label{line:function}|
         input_metric,
         L0PI.default(),
         StabilityMap.new_fallible(stability_map),

--- a/rust/src/measurements/noise_threshold/pseudocode/MakeNoiseThreshold_IBig_for_RV.py
+++ b/rust/src/measurements/noise_threshold/pseudocode/MakeNoiseThreshold_IBig_for_RV.py
@@ -10,8 +10,8 @@ class RV:
     ]:
         input_domain, input_metric = input_space
         output_measure = MO.default()
-        threshold_magnitude = threshold.into_parts()[1] # |\label{line:threshold-mag}|
-        privacy_map = self.noise_threshold_privacy_map( # |\label{line:privacy-map}|
+        threshold_magnitude = threshold.into_parts()[1]  # |\label{line:threshold-mag}|
+        privacy_map = self.noise_threshold_privacy_map(  # |\label{line:privacy-map}|
             input_metric, output_measure, threshold_magnitude
         )
 
@@ -24,12 +24,12 @@ class RV:
         def function(data: HashMap[TK, IBig]) -> HashMap[TK, IBig]:
             out = []
             for k, v in data.items():
-                v = self.sample(v) # |\label{line:sample}|
+                v = self.sample(v)  # |\label{line:sample}|
 
                 if v.cmp(threshold) != inner:
                     out.append((k, v))
             # shuffle the output to avoid leaking the order of the input
-            random.shuffle(out) # |\label{line:shuffle}|
+            random.shuffle(out)  # |\label{line:shuffle}|
             return dict(out)
 
         return Measurement.new(

--- a/rust/src/measurements/noisy_top_k/pseudocode/TopKMeasure_MaxDivergence.py
+++ b/rust/src/measurements/noisy_top_k/pseudocode/TopKMeasure_MaxDivergence.py
@@ -2,5 +2,6 @@
 # MaxDivergence
 REPLACEMENT = False
 
+
 def privacy_map(d_in: f64, scale: f64) -> f64:
     return d_in.inf_div(scale)

--- a/rust/src/measurements/noisy_top_k/pseudocode/TopKMeasure_ZeroConcentratedDivergence.py
+++ b/rust/src/measurements/noisy_top_k/pseudocode/TopKMeasure_ZeroConcentratedDivergence.py
@@ -2,5 +2,6 @@
 # ZeroConcentratedDivergence
 REPLACEMENT = True
 
+
 def privacy_map(d_in: f64, scale: f64) -> f64:
     return d_in.inf_div(scale).inf_powi(ibig(2)).inf_div(8.0)

--- a/rust/src/measurements/noisy_top_k/pseudocode/make_noisy_top_k.py
+++ b/rust/src/measurements/noisy_top_k/pseudocode/make_noisy_top_k.py
@@ -14,7 +14,9 @@ def make_noisy_top_k(
         if k > input_domain.size:
             raise "k must not exceed the number of candidates"
 
-    if not scale.is_finite() or scale.is_sign_negative():  # |\label{check-non-negative-scale}|
+    if (
+        not scale.is_finite() or scale.is_sign_negative()
+    ):  # |\label{check-non-negative-scale}|
         raise "scale must be finite and non-negative"
 
     monotonic = input_metric.monotonic

--- a/rust/src/measurements/randomized_response/pseudocode/make_randomized_response.py
+++ b/rust/src/measurements/randomized_response/pseudocode/make_randomized_response.py
@@ -8,38 +8,39 @@ def make_randomized_response(categories: set[T], prob: f64):
 
     if len(categories) < 2:  # |\label{line:num_cats}|
         raise ValueError("expected at least two categories")
-    
+
     num_categories = len(categories)
 
     if not (1 / num_categories <= prob <= 1):  # |\label{line:range}|
         raise ValueError("probability must be within [1/num_categories, 1]")
-    
+
     # prepare constant: |\label{line:map}|
     if prob == 1.0:
         c = float("inf")
     else:
-        c = p.inf_div((1).neg_inf_sub(prob)) \
-            .inf_mul(num_categories.inf_sub(1)) \
-            .inf_ln()
-    
+        c = p.inf_div((1).neg_inf_sub(prob)).inf_mul(num_categories.inf_sub(1)).inf_ln()
+
     def privacy_map(d_in: u32) -> QO:
         if d_in == 0:
             return 0
-        else: 
+        else:
             return c
 
     def function(truth: bool) -> bool:  # |\label{line:fn}|
         index = categories.index(truth)
         sample = usize.sample_uniform_int_below(
-            len(num_categories) - (0 if index == -1 else 1))
-        
+            len(num_categories) - (0 if index == -1 else 1)
+        )
+
         if index != -1 and sample >= index:
             sample += 1
-        
+
         lie = categories[sample]
 
         be_honest = sample_bernoulli_float(prob, false)
         is_member = index != -1
         return truth if be_honest and is_member else lie
-    
-    return Measurement(input_domain, function, input_metric, output_measure, privacy_map)
+
+    return Measurement(
+        input_domain, function, input_metric, output_measure, privacy_map
+    )

--- a/rust/src/measurements/randomized_response/pseudocode/make_randomized_response_bool.py
+++ b/rust/src/measurements/randomized_response/pseudocode/make_randomized_response_bool.py
@@ -3,15 +3,15 @@ def make_randomized_response_bool(prob: f64, constant_time: bool):
     input_domain = AtomDomain(bool)
     input_metric = DiscreteMetric()
     output_measure = MaxDivergence()
-    
-    if (prob < 0.5 or prob > 1):  # |\label{line:range}|
+
+    if prob < 0.5 or prob > 1:  # |\label{line:range}|
         raise Exception("probability must be in [0.5, 1]")
 
     if prob == 1.0:
         c = float("inf")
     else:
         c = prob.inf_div((1).neg_inf_sub(prob)).inf_ln()
-    
+
     def privacy_map(d_in: u32) -> f64:  # |\label{line:map}|
         if d_in == 0:
             return 0
@@ -22,5 +22,7 @@ def make_randomized_response_bool(prob: f64, constant_time: bool):
         sample = not sample_bernoulli_float(prob, constant_time)
 
         return arg ^ sample
-    
-    return Measurement(input_domain, function, input_metric, output_measure, privacy_map)
+
+    return Measurement(
+        input_domain, function, input_metric, output_measure, privacy_map
+    )

--- a/rust/src/measurements/randomized_response_bitvec/pseudocode/make_randomized_response_bitvec.py
+++ b/rust/src/measurements/randomized_response_bitvec/pseudocode/make_randomized_response_bitvec.py
@@ -1,27 +1,36 @@
 # type: ignore
 def make_randomized_response_bitvec(
-        input_domain: BitVectorDomain, 
-        input_metric: DiscreteDistance, 
-        f: f64, 
-        constant_time: bool):
+    input_domain: BitVectorDomain,
+    input_metric: DiscreteDistance,
+    f: f64,
+    constant_time: bool,
+):
     output_measure = MaxDivergence(f64)
-    
-    if f <= 0.0 or f > 1: # |\label{line:range}|
+
+    if f <= 0.0 or f > 1:  # |\label{line:range}|
         raise Exception("Probability must be in (0.0, 1]")
-    
+
     m = input_domain.max_weight
-    if m is None: 
-        raise Exception("make_randomized_response_bitvec requires a max_weight on the input_domain")
-    
+    if m is None:
+        raise Exception(
+            "make_randomized_response_bitvec requires a max_weight on the input_domain"
+        )
+
     epsilon = 2 * m * log((2 - f) / f)
-    def privacy_map(d_in: IntDistance): # |\label{line:map}|
+
+    def privacy_map(d_in: IntDistance):  # |\label{line:map}|
         if d_in == 0:
-            return 0.
+            return 0.0
         if d_in > 1:
             raise ValueError("d_in must be 0 or 1.")
         return epsilon
-    def function(arg: BitVector) -> BitVector: # |\label{line:fn}|
-        noise_vector = [bool.sample_bernoulli(f/2, constant_time) for _ in range(len(arg))]
+
+    def function(arg: BitVector) -> BitVector:  # |\label{line:fn}|
+        noise_vector = [
+            bool.sample_bernoulli(f / 2, constant_time) for _ in range(len(arg))
+        ]
         return xor(arg, noise_vector)
-    
-    return Measurement(input_domain, function, input_metric, output_measure, privacy_map)
+
+    return Measurement(
+        input_domain, function, input_metric, output_measure, privacy_map
+    )

--- a/rust/src/traits/samplers/cks20/pseudocode/sample_bernoulli_exp.py
+++ b/rust/src/traits/samplers/cks20/pseudocode/sample_bernoulli_exp.py
@@ -1,8 +1,8 @@
-# type: ignore 
-def sample_bernoulli_exp(x) -> bool: 
-    while x > 1: 
-        if sample_bernoulli_exp1(1):  # |\label{line:B_i}| 
-            x -= 1 
-        else:  
-            return False 
-    return sample_bernoulli_exp1(x)   # |\label{line:C}| 
+# type: ignore
+def sample_bernoulli_exp(x) -> bool:
+    while x > 1:
+        if sample_bernoulli_exp1(1):  # |\label{line:B_i}|
+            x -= 1
+        else:
+            return False
+    return sample_bernoulli_exp1(x)  # |\label{line:C}|

--- a/rust/src/traits/samplers/cks20/pseudocode/sample_bernoulli_exp1.py
+++ b/rust/src/traits/samplers/cks20/pseudocode/sample_bernoulli_exp1.py
@@ -2,7 +2,7 @@
 def sample_bernoulli_exp1(x) -> bool:
     k = 1
     while True:
-        if sample_bernoulli_rational(x / k, false): # |\label{line:B_i}|
+        if sample_bernoulli_rational(x / k, false):  # |\label{line:B_i}|
             k += 1
-        else: 
-            return is_odd(k) # |\label{line:K}|
+        else:
+            return is_odd(k)  # |\label{line:K}|

--- a/rust/src/traits/samplers/cks20/pseudocode/sample_discrete_gaussian.py
+++ b/rust/src/traits/samplers/cks20/pseudocode/sample_discrete_gaussian.py
@@ -1,17 +1,17 @@
-# type: ignore 
-def sample_discrete_gaussian(scale: RBig) -> int: 
-    if scale == 0: 
+# type: ignore
+def sample_discrete_gaussian(scale: RBig) -> int:
+    if scale == 0:
         return 0
 
-    t = floor(scale) + 1 # |\label{line:t}| 
-    sigma2 = scale**2 
+    t = floor(scale) + 1  # |\label{line:t}|
+    sigma2 = scale**2
 
-    while True: 
-        candidate = sample_discrete_laplace(t) # |\label{line:candidate}| 
+    while True:
+        candidate = sample_discrete_laplace(t)  # |\label{line:candidate}|
 
         # prepare rejection probability: "bias"
-        x = abs(candidate) - sigma2 / t 
-        bias = x**2 / (2 * sigma2)  # |\label{line:bias}| 
-        
-        if sample_bernoulli_exp(bias): # |\label{line:bern}| 
-            return candidate 
+        x = abs(candidate) - sigma2 / t
+        bias = x**2 / (2 * sigma2)  # |\label{line:bias}|
+
+        if sample_bernoulli_exp(bias):  # |\label{line:bern}|
+            return candidate

--- a/rust/src/traits/samplers/cks20/pseudocode/sample_discrete_laplace.py
+++ b/rust/src/traits/samplers/cks20/pseudocode/sample_discrete_laplace.py
@@ -2,14 +2,14 @@
 def sample_discrete_laplace(scale) -> int:
     if scale == 0:
         return 0
-        
+
     inv_scale = recip(scale)
-    
+
     while True:
         sign = sample_standard_bernoulli()
-        magnitude = sample_geometric_exp_fast(inv_scale) # |\label{line:magnitude}|
-        
-        if sign or magnitude != 0: # |\label{line:branching}|
+        magnitude = sample_geometric_exp_fast(inv_scale)  # |\label{line:magnitude}|
+
+        if sign or magnitude != 0:  # |\label{line:branching}|
             if sign:
                 return magnitude
             else:

--- a/rust/src/traits/samplers/cks20/pseudocode/sample_geometric_exp_fast.py
+++ b/rust/src/traits/samplers/cks20/pseudocode/sample_geometric_exp_fast.py
@@ -1,16 +1,16 @@
-# type: ignore 
-def sample_geometric_exp_fast(x: RBig) -> int: 
-    if x == 0: 
-        return 0 
+# type: ignore
+def sample_geometric_exp_fast(x: RBig) -> int:
+    if x == 0:
+        return 0
 
-    s, t = x.into_parts() 
+    s, t = x.into_parts()
 
-    while True: 
-        u = sample_uniform_ubig_below(t) # |\label{line:U}| 
-        d = sample_bernoulli_exp(Rational(u, t)) # |\label{line:D}| 
-        if d: 
-            break 
+    while True:
+        u = sample_uniform_ubig_below(t)  # |\label{line:U}|
+        d = sample_bernoulli_exp(Rational(u, t))  # |\label{line:D}|
+        if d:
+            break
 
-    v = sample_geometric_exp_slow(1) # |\label{line:V}| 
-    z = u + t * v 
-    return z // s 
+    v = sample_geometric_exp_slow(1)  # |\label{line:V}|
+    z = u + t * v
+    return z // s

--- a/rust/src/traits/samplers/cks20/pseudocode/sample_geometric_exp_slow.py
+++ b/rust/src/traits/samplers/cks20/pseudocode/sample_geometric_exp_slow.py
@@ -1,8 +1,8 @@
-# type: ignore 
-def sample_geometric_exp_slow(x) -> int: 
-    k = 0 
-    while True: 
-        if sample_bernoulli_exp(x): # |\label{line:B}| 
-            k += 1 
-        else: 
-            return k 
+# type: ignore
+def sample_geometric_exp_slow(x) -> int:
+    k = 0
+    while True:
+        if sample_bernoulli_exp(x):  # |\label{line:B}|
+            k += 1
+        else:
+            return k

--- a/rust/src/traits/samplers/psrn/canonical/pseudocode/InverseCDF_for_CanonicalRV.py
+++ b/rust/src/traits/samplers/psrn/canonical/pseudocode/InverseCDF_for_CanonicalRV.py
@@ -3,5 +3,7 @@ class InverseCDF(CanonicalRV):
     # type Edge = RBig
 
     def inverse_cdf(self, uniform: RBig, _refinements: usize, _R) -> RBig | None:
-        f_inv = quantile_cnd(uniform, self.tradeoff, self.fixed_point)  # `\label{f_inv}`
+        f_inv = quantile_cnd(
+            uniform, self.tradeoff, self.fixed_point
+        )  # `\label{f_inv}`
         return f_inv * self.scale + self.shift

--- a/rust/src/traits/samplers/psrn/canonical/pseudocode/quantile_cnd.py
+++ b/rust/src/traits/samplers/psrn/canonical/pseudocode/quantile_cnd.py
@@ -1,7 +1,5 @@
 # type: ignore
-def quantile_cnd(
-    uniform: RBig, f: Callable[[RBig], RBig], c: RBig
-) -> RBig | None:
+def quantile_cnd(uniform: RBig, f: Callable[[RBig], RBig], c: RBig) -> RBig | None:
     if uniform < c:
         return quantile_cnd(RBig(1) - f(uniform), f, c) - RBig(1)
     elif uniform <= RBig(1) - c:  # the linear function

--- a/rust/src/transformations/clamp/pseudocode/make_clamp.py
+++ b/rust/src/transformations/clamp/pseudocode/make_clamp.py
@@ -1,21 +1,16 @@
 # type: ignore
 def make_clamp(
-    input_domain: VectorDomain[AtomDomain[TA]], 
-    input_metric: M, 
-    bounds: tuple[TA, TA]
-): # |\label{line:def}|
-    input_domain.element_domain.assert_non_null() # |\label{line:assert-non-null}|
+    input_domain: VectorDomain[AtomDomain[TA]], input_metric: M, bounds: tuple[TA, TA]
+):  # |\label{line:def}|
+    input_domain.element_domain.assert_non_null()  # |\label{line:assert-non-null}|
 
     # clone to make it explicit that we are not mutating the input domain
     output_row_domain = input_domain.element_domain.clone()
     output_row_domain.bounds = Bounds.new_closed(bounds)
 
-    def clamper(value: TA) -> TA: # |\label{line:clamper}|
+    def clamper(value: TA) -> TA:  # |\label{line:clamper}|
         return value.total_clamp(bounds[0], bounds[1])
-    
-    return make_row_by_row_fallible( # |\label{line:row-by-row}|
-        input_domain, 
-        input_metric, 
-        output_row_domain, 
-        clamper
+
+    return make_row_by_row_fallible(  # |\label{line:row-by-row}|
+        input_domain, input_metric, output_row_domain, clamper
     )

--- a/rust/src/transformations/count/pseudocode/make_count.py
+++ b/rust/src/transformations/count/pseudocode/make_count.py
@@ -1,21 +1,27 @@
 # type: ignore
 def make_count(
-    input_domain: VectorDomain[AtomDomain[TIA]],
-    input_metric: SymmetricDistance
+    input_domain: VectorDomain[AtomDomain[TIA]], input_metric: SymmetricDistance
 ):
-    output_domain = AtomDomain.default(TO) # |\label{line:output-domain}|
+    output_domain = AtomDomain.default(TO)  # |\label{line:output-domain}|
 
-    def function(arg: Vec[TIA]) -> TO: # |\label{line:TO-output}|
-        size = arg.len() # |\label{line:size}|
-        try: # |\label{line:try-catch}|
-            return TO.exact_int_cast(size) # |\label{line:exact-int-cast}|
+    def function(arg: Vec[TIA]) -> TO:  # |\label{line:TO-output}|
+        size = arg.len()  # |\label{line:size}|
+        try:  # |\label{line:try-catch}|
+            return TO.exact_int_cast(size)  # |\label{line:exact-int-cast}|
         except FailedCast:
-            return TO.MAX_CONSECUTIVE # |\label{line:except-return}|
+            return TO.MAX_CONSECUTIVE  # |\label{line:except-return}|
 
     output_metric = AbsoluteDistance(TO)
 
-    stability_map = StabilityMap.new_from_constant(TO.one()) # |\label{line:stability-map}|
+    stability_map = StabilityMap.new_from_constant(
+        TO.one()
+    )  # |\label{line:stability-map}|
 
     return Transformation(
-        input_domain, output_domain, function,
-        input_metric, output_metric, stability_map)
+        input_domain,
+        output_domain,
+        function,
+        input_metric,
+        output_metric,
+        stability_map,
+    )

--- a/rust/src/transformations/make_stable_expr/expr_count/pseudocode/counting_query_stability_map.py
+++ b/rust/src/transformations/make_stable_expr/expr_count/pseudocode/counting_query_stability_map.py
@@ -4,15 +4,15 @@ def counting_query_stability_map(
 ) -> StabilityMap[PartitionDistance[M], LpDistance[P, f64]]:
 
     if public_info == "Lengths":  # `\label{public-info}`
-        return StabilityMap.new(lambda _: 0.)
-        
+        return StabilityMap.new(lambda _: 0.0)
+
     def norm_map(d_in: f64) -> f64:  # `\label{norm-map}`
         if P == 1:
             return d_in
         if P == 2:
             return d_in.inf_sqrt()
         raise ValueError("unsupported Lp norm. Must be an L1 or L2 norm.")
-    
+
     def stability_map(d_in: tuple[u32, u32, u32]) -> f64:
         l0, l1, l_inf = d_in  # `\label{l01i}`
         l0_p = norm_map(f64.from_(l0))  # `\label{l0-p}`

--- a/rust/src/transformations/make_stable_expr/expr_count/pseudocode/make_expr_count.py
+++ b/rust/src/transformations/make_stable_expr/expr_count/pseudocode/make_expr_count.py
@@ -20,7 +20,9 @@ def make_expr_count(
             raise ValueError("expected count, null_count, len, or n_unique expression")
 
     # check if input is row-by-row
-    is_row_by_row = input.make_stable(input_domain.as_row_by_row(), input_metric).is_ok()  # `\label{is-row-by-row}`
+    is_row_by_row = input.make_stable(
+        input_domain.as_row_by_row(), input_metric
+    ).is_ok()  # `\label{is-row-by-row}`
 
     # construct prior transformation
     t_prior = input.make_stable(input_domain, input_metric)  # `\label{t-prior}`
@@ -42,7 +44,7 @@ def make_expr_count(
                 max_influenced_partitions=margin.max_influenced_partitions,
                 public_info=margin.public_info,
             ),
-        )
+        ),
     )
 
     match strategy:  # `\label{will-count-all}`
@@ -53,8 +55,10 @@ def make_expr_count(
         case _:
             will_count_all = False
 
-    public_info = margin.public_info if will_count_all else None  # `\label{public-info}`
-    
+    public_info = (
+        margin.public_info if will_count_all else None
+    )  # `\label{public-info}`
+
     def function(e: Expr) -> Expr:  # `\label{function}`
         match strategy:
             case Strategy.Count:

--- a/rust/src/transformations/make_stable_expr/namespace_dt/expr_datetime_component/pseudocode/make_expr_datetime_component.py
+++ b/rust/src/transformations/make_stable_expr/namespace_dt/expr_datetime_component/pseudocode/make_expr_datetime_component.py
@@ -5,25 +5,31 @@ def make_expr_datetime_component(
     expr: Expr,
 ) -> Transformation:
     match expr:  # `\label{match-strategy}`
-        case Expr.Function(input=inputs, function=FunctionExpr.TemporalExpr(temporal_function)):
+        case Expr.Function(
+            input=inputs, function=FunctionExpr.TemporalExpr(temporal_function)
+        ):
             pass
         case _:
             raise ValueError("expected datetime component expression")
-    
+
     to_dtype, _ = match_datetime_component(temporal_function)  # `\label{match-dt}`
 
     # raises an error if there is not exactly one input
-    input, = inputs  # `\label{one-input}`
+    (input,) = inputs  # `\label{one-input}`
 
     t_prior = input.make_stable(input_domain, input_metric)  # `\label{t-prior}`
     middle_domain, middle_metric = t_prior.output_space()
 
     in_dtype = middle_domain.column.dtype
-    if in_dtype not in {DataType.Time, DataType.Datetime, DataType.Date}:  # `\label{check-dtype}`
+    if in_dtype not in {
+        DataType.Time,
+        DataType.Datetime,
+        DataType.Date,
+    }:  # `\label{check-dtype}`
         raise ValueError("expected a temporal input type")
-    
+
     output_domain = middle_domain.clone()  # `\label{output-domain}`
-    output_domain.column.set_dtype(to_dtype) # `\label{domain-dtype}`
+    output_domain.column.set_dtype(to_dtype)  # `\label{domain-dtype}`
 
     def function(expr: Expr) -> Expr:
         return Expr.Function(

--- a/rust/src/transformations/make_stable_expr/namespace_dt/expr_datetime_component/pseudocode/match_datetime_component.py
+++ b/rust/src/transformations/make_stable_expr/namespace_dt/expr_datetime_component/pseudocode/match_datetime_component.py
@@ -2,22 +2,23 @@
 def match_datetime_component(
     temporal_function: TemporalFunction,
 ) -> DataType | None:
-    return ({
-        Millennium: DataType.UInt32,
-        Century: DataType.Int32,
-        Year: DataType.Int32,
-        IsoYear: DataType.Int32,
-        Quarter: DataType.Int8,
-        Month: DataType.Int8,
-        Week: DataType.Int8,
-        WeekDay: DataType.Int8,
-        Day: DataType.Int8,
-        OrdinalDay: DataType.Int16,
-        Hour: DataType.Int8,
-        Minute: DataType.Int8,
-        Second: DataType.Int8,
-        Millisecond: DataType.Int32,
-        Microsecond: DataType.Int32,
-        Nanosecond: DataType.Int32,
-    }).get(temporal_function)
-
+    return (
+        {
+            Millennium: DataType.UInt32,
+            Century: DataType.Int32,
+            Year: DataType.Int32,
+            IsoYear: DataType.Int32,
+            Quarter: DataType.Int8,
+            Month: DataType.Int8,
+            Week: DataType.Int8,
+            WeekDay: DataType.Int8,
+            Day: DataType.Int8,
+            OrdinalDay: DataType.Int16,
+            Hour: DataType.Int8,
+            Minute: DataType.Int8,
+            Second: DataType.Int8,
+            Millisecond: DataType.Int32,
+            Microsecond: DataType.Int32,
+            Nanosecond: DataType.Int32,
+        }
+    ).get(temporal_function)

--- a/rust/src/transformations/make_stable_expr/namespace_str/expr_strptime/pseudocode/make_expr_strptime.py
+++ b/rust/src/transformations/make_stable_expr/namespace_str/expr_strptime/pseudocode/make_expr_strptime.py
@@ -30,7 +30,7 @@ def make_expr_strptime(
         ambig_value = literal_value_of(ambiguous)
     except Exception:
         ambig_value = None
-    ambiguous = lit(ambig_value if ambig_value in {"earliest" "latest"} else "null")
+    ambiguous = lit(ambig_value if ambig_value in {"earliestlatest"} else "null")
 
     output_domain = middle_domain.clone()
     series_domain = output_domain.column
@@ -38,8 +38,12 @@ def make_expr_strptime(
     # check input and output types
     if series_domain.dtype() != DataType.String:  # `\label{string-check}`
         raise ValueError("str.strptime input dtype must be String")
-    
-    if to_type not in {DataType.Time, DataType.Datetime, DataType.Date}:  # `\label{to-type-check}`
+
+    if to_type not in {
+        DataType.Time,
+        DataType.Datetime,
+        DataType.Date,
+    }:  # `\label{to-type-check}`
         raise ValueError("str.strptime output dtype must be Time, Datetime or Date")
 
     # in Rust, this assigns to the series domain in output_domain

--- a/rust/src/transformations/make_stable_lazyframe/group_by/pseudocode/make_stable_group_by.py
+++ b/rust/src/transformations/make_stable_lazyframe/group_by/pseudocode/make_stable_group_by.py
@@ -61,13 +61,15 @@ def make_stable_group_by(
 
         influenced_groups = option_min(contributed_rows, contributed_groups)
         if influenced_groups.is_none():
-            return "an upper bound on the number of contributed rows or groups is required"
+            return (
+                "an upper bound on the number of contributed rows or groups is required"
+            )
 
-        if per_group is not None: # |\label{line:double}|
+        if per_group is not None:  # |\label{line:double}|
             per_group = per_group.inf_mul(2)
 
         bound = Bound(by=set(), per_group=per_group, num_groups=None)
-        return Bounds([bound]) # |\label{line:bound}|
+        return Bounds([bound])  # |\label{line:bound}|
 
     t_group_agg = Transformation.new(
         middle_domain,

--- a/rust/src/transformations/make_stable_lazyframe/truncate/matching/pseudocode/match_group_by_truncation.py
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/matching/pseudocode/match_group_by_truncation.py
@@ -2,7 +2,7 @@
 def match_group_by_truncation(
     plan: DslPlan, identifier: Expr
 ) -> Optional[Tuple[DslPlan, Truncation, Bound]]:
-    if not isinstance(plan, DslPlan.GroupBy): # |\label{line:check_groupby}|
+    if not isinstance(plan, DslPlan.GroupBy):  # |\label{line:check_groupby}|
         return None
 
     input = plan.input
@@ -12,17 +12,19 @@ def match_group_by_truncation(
     options = plan.options
 
     if apply is not None or options != GroupbyOptions.default():
-        return None # |\label{line:check_apply}|
+        return None  # |\label{line:check_apply}|
 
-    ids, by = partition(lambda expr: expr == identifier, keys) # |\label{line:partition}|
+    ids, by = partition(
+        lambda expr: expr == identifier, keys
+    )  # |\label{line:partition}|
 
-    if not ids: # |\label{line:check_ids}|
+    if not ids:  # |\label{line:check_ids}|
         return None
 
     return (
         input,
         Truncation.GroupBy(keys, aggs),
-        Bound(by=by, per_group=1, num_groups=None), # |\label{line:bound}|
+        Bound(by=by, per_group=1, num_groups=None),  # |\label{line:bound}|
     )
 
 

--- a/rust/src/transformations/make_stable_lazyframe/truncate/matching/pseudocode/match_num_groups_predicate.py
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/matching/pseudocode/match_num_groups_predicate.py
@@ -29,7 +29,6 @@ def match_num_groups_predicate(
     if isinstance(input_item, Expr.Function) and isinstance(
         input_item.function, FunctionExpr.AsStruct
     ):  # |\label{line:extract_grouping_columns}|
-
         # If the first field is a hash of the second field,
         # then interpret the grouping columns as the hash input.
         # The second field disambiguates hash collisions when ranking.

--- a/rust/src/transformations/make_stable_lazyframe/truncate/matching/pseudocode/match_per_group_predicate.py
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/matching/pseudocode/match_per_group_predicate.py
@@ -6,7 +6,9 @@ def match_per_group_predicate(
     threshold: u32,
 ) -> Optional[Bound]:
     # reorderings of an enumeration are still enumerations
-    if isinstance(enumeration, Expr.Function) and isinstance( # |\label{line:reordering_start}|
+    if isinstance(
+        enumeration, Expr.Function
+    ) and isinstance(  # |\label{line:reordering_start}|
         enumeration.options.collect_groups, ApplyOptions.GroupWise
     ):
         input = enumeration.input
@@ -20,26 +22,30 @@ def match_per_group_predicate(
             is_reorder = method == "shuffle"
         else:
             is_reorder = False
-        
+
         if is_reorder:
             enumeration = input[0]
 
     elif isinstance(enumeration, Expr.SortBy):
         for key in enumeration.by:
             check_infallible(key, Resize.Ban)
-        enumeration = enumeration.expr# |\label{line:reordering_end}|
+        enumeration = enumeration.expr  # |\label{line:reordering_end}|
 
     # in Rust, the != results in a boolean comparison, not a "ne" expression
-    if enumeration != int_range(lit(0), len(partition_by), 1, DataType.Int64): # |\label{line:check_enumeration}|
+    if enumeration != int_range(
+        lit(0), len(partition_by), 1, DataType.Int64
+    ):  # |\label{line:check_enumeration}|
         return None
 
     # we now know this is a per group predicate,
     # and can raise more informative error messages
 
     # check if the function is limiting partition contributions
-    ids, by = partition(lambda expr: expr == identifier, partition_by) # |\label{line:partition}|
+    ids, by = partition(
+        lambda expr: expr == identifier, partition_by
+    )  # |\label{line:partition}|
 
     if not ids:
         raise "failed to find identifier column in per_group predicate condition"
 
-    return Bound(by=by, per_group=threshold, num_groups=None) # |\label{line:bound}|
+    return Bound(by=by, per_group=threshold, num_groups=None)  # |\label{line:bound}|

--- a/rust/src/transformations/make_stable_lazyframe/truncate/matching/pseudocode/match_truncation_predicate.py
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/matching/pseudocode/match_truncation_predicate.py
@@ -12,10 +12,10 @@ def match_truncation_predicate(
         ]
 
         # propagate nones
-        if not all(bounds): # |\label{line:check_all}|
+        if not all(bounds):  # |\label{line:check_all}|
             return None
-        
-        # appears to differ from Rust, but is equivalent 
+
+        # appears to differ from Rust, but is equivalent
         # because options don't need to be flattened in Python
         return bounds
 
@@ -39,7 +39,7 @@ def match_truncation_predicate(
         else:
             return None
 
-        if not isinstance(over, Expr.Window): # |\label{line:check_over}|
+        if not isinstance(over, Expr.Window):  # |\label{line:check_over}|
             return None
 
         threshold_value = literal_value_of(threshold, u32)
@@ -49,7 +49,9 @@ def match_truncation_predicate(
             )
 
         # account for distinction between gt and ge
-        threshold_value = threshold_value.inf_add(offset) # |\label{line:threshold_value}|
+        threshold_value = threshold_value.inf_add(
+            offset
+        )  # |\label{line:threshold_value}|
 
         num_groups = match_num_groups_predicate(
             over.function, over.partition_by, identifier, threshold_value
@@ -58,9 +60,9 @@ def match_truncation_predicate(
             over.function, over.partition_by, identifier, threshold_value
         )
 
-        if num_groups is None and per_group is None: # |\label{line:check_bounds}|
+        if num_groups is None and per_group is None:  # |\label{line:check_bounds}|
             raise ValueError(
                 f"expected a predicate that limits per_group contributions (via int_range) or num_groups contributions (via rank). Found {over.function}"
             )
 
-        return [num_groups or per_group] # |\label{line:return}|
+        return [num_groups or per_group]  # |\label{line:return}|

--- a/rust/src/transformations/make_stable_lazyframe/truncate/matching/pseudocode/match_truncations.py
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/matching/pseudocode/match_truncations.py
@@ -5,18 +5,22 @@ def match_truncations(
     truncations = []
     bounds = []
 
-    allowed_keys = match_group_by_truncation(plan, identifier) # |\label{line:match_group_by_truncation}|
+    allowed_keys = match_group_by_truncation(
+        plan, identifier
+    )  # |\label{line:match_group_by_truncation}|
     if allowed_keys:
         input, truncate, new_bound = allowed_keys
-        plan = input # |\label{line:match_group_by_truncation_start}|
+        plan = input  # |\label{line:match_group_by_truncation_start}|
         truncations.append(truncate)
-        bounds.append(new_bound) # |\label{line:match_group_by_truncation_end}|
-        allowed_keys = new_bound.by # |\label{line:allowed_keys}|
+        bounds.append(new_bound)  # |\label{line:match_group_by_truncation_end}|
+        allowed_keys = new_bound.by  # |\label{line:allowed_keys}|
 
     # match until not a filter truncation
-    while isinstance(plan, Truncation.Filter): # |\label{line:match_filter_truncation}|
+    while isinstance(plan, Truncation.Filter):  # |\label{line:match_filter_truncation}|
         input, predicate = plan.input, plan.predicate
-        new_bounds = match_truncation_predicate(predicate, identifier) # |\label{line:match_truncation_predicate}|
+        new_bounds = match_truncation_predicate(
+            predicate, identifier
+        )  # |\label{line:match_truncation_predicate}|
         if new_bounds is None:
             break
 
@@ -24,22 +28,24 @@ def match_truncations(
         # if the groupby group keys don't cover the filter truncation keys,
         # then the groupby aggs can overwrite the filter truncation keys,
         # invalidating the filter truncation bounds.
-        if allowed_keys is not None: # |\label{line:allowed_keys_check}|
+        if allowed_keys is not None:  # |\label{line:allowed_keys_check}|
             for bound in new_bounds:
                 if not bound.by.is_subset(allowed_keys):
                     raise f"Filter truncation keys ({bound.by}) must be a subset of groupby truncation keys ({allowed_keys})."
 
-        plan = input # |\label{line:match_filter_truncation_start}|
+        plan = input  # |\label{line:match_filter_truncation_start}|
         truncations.append(Truncation.Filter(predicate))
-        bounds.extend(new_bounds) # |\label{line:match_filter_truncation_end}|
+        bounds.extend(new_bounds)  # |\label{line:match_filter_truncation_end}|
 
     # just for better error messages, no privacy implications
-    if match_group_by_truncation(plan, identifier) is not None: # |\label{line:match_group_by_truncation_check}|
+    if (
+        match_group_by_truncation(plan, identifier) is not None
+    ):  # |\label{line:match_group_by_truncation_check}|
         raise Exception("groupby truncation must be the last truncation in the plan.")
 
     # since the parse descends to the source,
     # truncations and bounds are in reverse order
-    truncations.reverse() # |\label{line:truncations_reverse}|
-    bounds.reverse() # |\label{line:bounds_reverse}|
+    truncations.reverse()  # |\label{line:truncations_reverse}|
+    bounds.reverse()  # |\label{line:bounds_reverse}|
 
     return plan, truncations, bounds

--- a/rust/src/transformations/make_stable_lazyframe/truncate/pseudocode/make_stable_truncate.py
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/pseudocode/make_stable_truncate.py
@@ -34,7 +34,7 @@ def make_stable_truncate(
             )
 
     output_domain = middle_domain.clone()
-    for truncation in truncations: # |\label{line:truncation}|
+    for truncation in truncations:  # |\label{line:truncation}|
         output_domain = truncate_domain(output_domain, truncation)
 
     def function(plan: DslPlan) -> DslPlan:
@@ -63,11 +63,13 @@ def make_stable_truncate(
 
         # each truncation is used to derive row bounds
         new_bounds = []
-        for truncation_bound in truncation_bounds: # |\label{line:truncation-bound}|
+        for truncation_bound in truncation_bounds:  # |\label{line:truncation-bound}|
             # each truncation is used to derive row bounds
             new_bounds.append(
-                truncate_id_bound( # |\label{line:truncate-id-bound}|
-                    id_bounds.get_bound(truncation_bound.by), # |\label{line:id-bound-by}|
+                truncate_id_bound(  # |\label{line:truncate-id-bound}|
+                    id_bounds.get_bound(
+                        truncation_bound.by
+                    ),  # |\label{line:id-bound-by}|
                     truncation_bound,
                     total_num_ids,
                 )

--- a/rust/src/transformations/make_stable_lazyframe/truncate/pseudocode/truncate_id_bound.py
+++ b/rust/src/transformations/make_stable_lazyframe/truncate/pseudocode/truncate_id_bound.py
@@ -12,7 +12,9 @@ def truncate_id_bound(
     # times the number of rows contributed under each id (known from truncation),
     num_ids, num_rows = id_bound.per_group, truncation.per_group
     if num_ids is not None and num_rows is not None:
-        row_bound = row_bound.with_per_group(num_ids.inf_mul(num_rows)) # |\label{line:per-group}|
+        row_bound = row_bound.with_per_group(
+            num_ids.inf_mul(num_rows)
+        )  # |\label{line:per-group}|
 
     # Worst case number of groups contributed is the
     # total number of ids contributed (total_ids)
@@ -25,6 +27,6 @@ def truncate_id_bound(
     # Use the smaller of the two if both are known.
     num_groups = option_min(num_groups_via_truncation, id_bound.num_groups)
     if num_groups is not None:
-        row_bound = row_bound.with_num_groups(num_groups) # |\label{line:num-groups}|
+        row_bound = row_bound.with_num_groups(num_groups)  # |\label{line:num-groups}|
 
     return row_bound

--- a/rust/src/transformations/manipulation/pseudocode/make_is_equal.py
+++ b/rust/src/transformations/manipulation/pseudocode/make_is_equal.py
@@ -1,17 +1,12 @@
 # type: ignore
 def make_is_equal(
-    input_domain: VectorDomain[AtomDomain[TIA]], 
-    input_metric: M, 
-    value: TIA
-): # |\label{line:def}|
+    input_domain: VectorDomain[AtomDomain[TIA]], input_metric: M, value: TIA
+):  # |\label{line:def}|
     output_row_domain = atom_domain(T=bool)
 
-    def is_equal(arg: TA) -> TA: # |\label{line:function}|
+    def is_equal(arg: TA) -> TA:  # |\label{line:function}|
         return value == arg
 
-    return make_row_by_row( # |\label{line:row-by-row}|
-        input_domain, 
-        input_metric, 
-        output_row_domain, 
-        is_equal
+    return make_row_by_row(  # |\label{line:row-by-row}|
+        input_domain, input_metric, output_row_domain, is_equal
     )

--- a/rust/src/transformations/manipulation/pseudocode/make_row_by_row.py
+++ b/rust/src/transformations/manipulation/pseudocode/make_row_by_row.py
@@ -1,12 +1,12 @@
 # type: ignore
 def make_row_by_row(
-    input_domain: DI, 
-    input_metric: M, 
-    output_row_domain: DO, 
+    input_domain: DI,
+    input_metric: M,
+    output_row_domain: DO,
     # a function from input domain's row type to output domain's row type
-    row_function: Callable([[DI_RowDomain_Carrier], DO_RowDomain_Carrier])
+    row_function: Callable([[DI_RowDomain_Carrier], DO_RowDomain_Carrier]),
 ) -> Transformation:
-    
+
     return make_row_by_row_fallible(
         input_domain, input_metric, output_row_domain, row_function
     )

--- a/rust/src/transformations/manipulation/pseudocode/make_row_by_row_fallible.py
+++ b/rust/src/transformations/manipulation/pseudocode/make_row_by_row_fallible.py
@@ -1,12 +1,12 @@
 # type: ignore
 def make_row_by_row_fallible(
-    input_domain: DI, 
-    input_metric: M, 
-    output_row_domain: DO, 
+    input_domain: DI,
+    input_metric: M,
+    output_row_domain: DO,
     # a function from input domain's row type to output domain's row type
-    row_function: Callable([[DI_RowDomain_Carrier], DO_RowDomain_Carrier])
+    row_function: Callable([[DI_RowDomain_Carrier], DO_RowDomain_Carrier]),
 ) -> Transformation:
-    
+
     # where .translate is defined by the RowByRowDomain trait
     output_domain = input_domain.translate(output_row_domain)
 
@@ -14,8 +14,8 @@ def make_row_by_row_fallible(
         # where .apply_rows is defined by the RowByRowDomain trait
         return DI.apply_rows(data, row_function)
 
-    stability_map = new_stability_map_from_constant(1) # |\label{line:stability-map}|
+    stability_map = new_stability_map_from_constant(1)  # |\label{line:stability-map}|
 
     return Transformation(
-        input_domain, output_domain, function,
-        input_metric, input_metric, stability_map)
+        input_domain, output_domain, function, input_metric, input_metric, stability_map
+    )

--- a/rust/src/transformations/quantile_score_candidates/pseudocode/check_candidates.py
+++ b/rust/src/transformations/quantile_score_candidates/pseudocode/check_candidates.py
@@ -1,13 +1,13 @@
 # type: ignore
 def validate_candidates(candidates: list[T]):
-    if not candidates: # `\label{empty}`
+    if not candidates:  # `\label{empty}`
         raise ValueError("candidates must not be empty")
-    
+
     i1 = iter(candidates)
     i2 = iter(candidates)
     next(i1)
 
-    for c1, c2 in zip(i1, i2): # `\label{windows}`
+    for c1, c2 in zip(i1, i2):  # `\label{windows}`
         cmp = c1.partial_cmp(c2)
         if cmp is None or cmp != Ordering.Less:
             raise ValueError("candidates must be non-null and strictly increasing")

--- a/rust/src/transformations/quantile_score_candidates/pseudocode/make_quantile_score_candidates.py
+++ b/rust/src/transformations/quantile_score_candidates/pseudocode/make_quantile_score_candidates.py
@@ -28,7 +28,7 @@ def make_quantile_score_candidates(
         function=function,
         input_metric=input_metric,
         output_metric=LInfDistance.default(T=u64),
-        stability_map=StabilityMap.new_fallible( # `\label{map}`
+        stability_map=StabilityMap.new_fallible(  # `\label{map}`
             score_candidates_map(
                 alpha_num,
                 alpha_den,

--- a/rust/src/transformations/quantile_score_candidates/pseudocode/score_candidates.py
+++ b/rust/src/transformations/quantile_score_candidates/pseudocode/score_candidates.py
@@ -1,16 +1,16 @@
 # type: ignore
 def score_candidates(
-    x: Iterator[TIA], 
-    candidates: list[TIA], 
+    x: Iterator[TIA],
+    candidates: list[TIA],
     alpha_num: u64,
     alpha_den: u64,
-    size_limit: u64
+    size_limit: u64,
 ) -> Iterator[usize]:
     # count of the number of records between...
     #  (-inf, c1), [c1, c2), [c2, c3), ..., [ck, inf)
-    hist_ro = [0] * candidates.len() + 1 # histogram of right-open intervals
+    hist_ro = [0] * candidates.len() + 1  # histogram of right-open intervals
     #  (-inf, c1], (c1, c2], (c2, c3], ..., (ck, inf)
-    hist_lo = [0] * candidates.len() + 1 # histogram of left-open intervals
+    hist_lo = [0] * candidates.len() + 1  # histogram of left-open intervals
 
     for x_i in x:
         idx_lt = candidates.partition_point(lambda c: c < x_i)
@@ -32,10 +32,12 @@ def score_candidates(
         # cumsum the right-open histogram to get the total number of records lt or equal to the candidate
         le += lo  # `\label{le-cumsum}`
 
-        gt = n - le # `\label{gt}`
+        gt = n - le  # `\label{gt}`
 
         # the number of records equal to the candidate is the difference between the two cumsums
         lt_lim, gt_lim = lt.min(size_limit), gt.min(size_limit)  # `\label{lt-gt-lim}`
 
         # a_den * |    (1 - a)         * #(x < c)    -            a * #(x > c)|
-        yield ((alpha_den - alpha_num) * lt_lim).abs_diff(alpha_num * gt_lim)  # `\label{score}`
+        yield ((alpha_den - alpha_num) * lt_lim).abs_diff(
+            alpha_num * gt_lim
+        )  # `\label{score}`


### PR DESCRIPTION
- Toward #2787: Ruff format the rust directory: Python pseudocode included in proofs.

(Splitting into a couple PRs to minimize conflicts.)