### PR TITLE
maintenance: ruff format two top-level files

### DIFF
--- a/python/conftest.py
+++ b/python/conftest.py
@@ -7,11 +7,11 @@ import opendp.prelude as dp
 
 @pytest.fixture(autouse=True)
 def add_dp(doctest_namespace):
-    doctest_namespace['dp'] = dp
+    doctest_namespace["dp"] = dp
 
 
-FUZZY_DF = doctest.register_optionflag('FUZZY_DF')
-IGNORE = doctest.register_optionflag('IGNORE')
+FUZZY_DF = doctest.register_optionflag("FUZZY_DF")
+IGNORE = doctest.register_optionflag("IGNORE")
 
 # Related doctest flags:
 # - NUMBER (https://docs.pytest.org/en/7.1.x/how-to/doctest.html?highlight=NUMBER#using-doctest-options)
@@ -21,12 +21,18 @@ IGNORE = doctest.register_optionflag('IGNORE')
 # - FUZZY (https://github.com/opendp/opendp/pull/2249#issuecomment-2667132750)
 #   Just ignores a number preceded by "~", while still checking the rest of the output.
 
+
 def _norm_df(df):
-    df = re.sub(r'╞.*', '', df, flags=re.DOTALL)  # Ignore everything after the header.
-    df = re.sub(r'\s+', ' ', df)  # Data in the table can change width of columns, so ignore whitespace.
-    df = re.sub(r'─+', '─', df)  # Similarly, ignore changes in the special character used in box.
-    df = re.sub(r'shape: \(\d+,', 'shape: (#', df)
+    df = re.sub(r"╞.*", "", df, flags=re.DOTALL)  # Ignore everything after the header.
+    df = re.sub(
+        r"\s+", " ", df
+    )  # Data in the table can change width of columns, so ignore whitespace.
+    df = re.sub(
+        r"─+", "─", df
+    )  # Similarly, ignore changes in the special character used in box.
+    df = re.sub(r"shape: \(\d+,", "shape: (#", df)
     return df
+
 
 class CustomOutputChecker(doctest.OutputChecker):
     def check_output(self, want, got, optionflags):
@@ -37,13 +43,14 @@ class CustomOutputChecker(doctest.OutputChecker):
         if FUZZY_DF & my_options:
             others = my_options - FUZZY_DF
             if others:
-                raise Exception(f'FUZZY_DF can not be used with other flags: {others}')
+                raise Exception(f"FUZZY_DF can not be used with other flags: {others}")
             return _norm_df(want) == _norm_df(got)
         if IGNORE & my_options:
             others = my_options - IGNORE
             if others:
-                raise Exception(f'IGNORE can not be used with other flags: {others}')
-            return 'Traceback' not in got and bool(len(want)) == bool(len(got))
+                raise Exception(f"IGNORE can not be used with other flags: {others}")
+            return "Traceback" not in got and bool(len(want)) == bool(len(got))
         return super().check_output(want, got, optionflags)
+
 
 doctest.OutputChecker = CustomOutputChecker  # type: ignore

--- a/python/setup.py
+++ b/python/setup.py
@@ -18,7 +18,7 @@ if not os.path.isdir("src/opendp/lib") and os.path.isdir("src/opendp/rust"):
                 args=["--color", "always"],
                 features=["untrusted", "polars-ffi"],
                 binding=Binding.NoBinding,
-                env={**os.environ, "PYO3_BUILD_EXTENSION_MODULE": "1"}
+                env={**os.environ, "PYO3_BUILD_EXTENSION_MODULE": "1"},
             )
         ]
     )


### PR DESCRIPTION
- Toward #2787: Ruff format two files.

(Splitting into a couple PRs to minimize conflicts.)