### PR TITLE
feat: model stable oneway marginals as linear constraints (synthetic data)

### DIFF
--- a/python/src/opendp/extras/mbi/__init__.py
+++ b/python/src/opendp/extras/mbi/__init__.py
@@ -20,7 +20,7 @@ from ._fixed import Fixed
 from ._mst import MST
 from ._sequential import Sequential
 from ._table import make_contingency_table, ContingencyTable
-from ._utilities import Algorithm, Count, mirror_descent
+from ._utilities import Algorithm, Count, Marginals, mirror_descent
 
 __all__ = [
     "AIM",
@@ -31,5 +31,6 @@ __all__ = [
     "ContingencyTable",
     "Algorithm",
     "Count",
+    "Marginals",
     "mirror_descent",
 ]

--- a/python/src/opendp/extras/mbi/_aim/__init__.py
+++ b/python/src/opendp/extras/mbi/_aim/__init__.py
@@ -17,9 +17,9 @@ from opendp.extras.mbi._utilities import (
     make_noise_marginal,
     make_stable_marginals,
     prior,
-    weight_marginals,
     Count,
     Algorithm,
+    Marginals,
 )
 from opendp.measurements import then_noisy_max
 from opendp.measures import max_divergence, zero_concentrated_divergence
@@ -49,10 +49,10 @@ class AIM(Algorithm):
     """AIM mechanism from `MMSM22 <https://arxiv.org/abs/2201.12677>`_.
 
     Adaptively chooses and estimates the least-well-approximated marginal.
-    The stronger the correlation amongst a clique of columns, 
+    The stronger the correlation amongst a clique of columns,
     the more likely AIM is to select the clique.
 
-    The algorithm starts with a small per-step privacy budget, 
+    The algorithm starts with a small per-step privacy budget,
     and in each step increases the budget if the last measured marginal doesn't sufficiently improve the model.
 
     ..
@@ -77,7 +77,7 @@ class AIM(Algorithm):
         ...     # transformations/truncation may be applied here
         ...     .select("SEX", "AGE", "HWUSUAL", "ILOSTAT")
         ...     .contingency_table(
-        ...         keys={"SEX": [1, 2]}, 
+        ...         keys={"SEX": [1, 2]},
         ...         cuts={"AGE": [20, 40, 60], "HWUSUAL": [1, 20, 40]},
         ...         algorithm=dp.mbi.AIM()
         ...     )
@@ -146,7 +146,7 @@ class AIM(Algorithm):
         d_in: list["Bound"],
         d_out: float,
         *,
-        marginals: dict[tuple[str, ...], Any],
+        marginals: Marginals,
         model,  # MarkovRandomField
     ) -> Measurement:
         """Implements AIM (Adaptive Iterative Mechanism) for ordinal data.
@@ -180,7 +180,7 @@ class AIM(Algorithm):
 
         def function(
             qbl: OdometerQueryable,
-        ) -> tuple[dict[tuple[str, ...], Any], MarkovRandomField]:
+        ) -> tuple[Marginals, MarkovRandomField]:
             # mutable state
             current_model = model
             current_marginals = marginals.copy()
@@ -201,9 +201,7 @@ class AIM(Algorithm):
                 if not m_step:
                     break
 
-                R: TypeAlias = tuple[
-                    dict[tuple[str, ...], Any], MarkovRandomField, bool
-                ]
+                R: TypeAlias = tuple[Marginals, MarkovRandomField, bool]
                 current_marginals, current_model, is_significant = cast(R, qbl(m_step))
 
                 if not is_significant:
@@ -233,7 +231,7 @@ def _make_aim_marginal(
     output_measure: Measure,
     d_in: int,
     d_out: float,
-    marginals: dict[tuple[str, ...], Any],
+    marginals: Marginals,
     model,  # MarkovRandomField
     max_size: float,
     algorithm: AIM,
@@ -275,7 +273,7 @@ def _make_aim_marginal(
 
     def function(
         qbl: Queryable,
-    ) -> tuple[dict[tuple[str, ...], Any], MarkovRandomField, bool]:
+    ) -> tuple[Marginals, MarkovRandomField, bool]:
         # SELECT a query that best reduces the error
         selected_clique = qbl(m_select)
 
@@ -298,12 +296,12 @@ def _make_aim_marginal(
         # GENERATE an updated probability distribution
         prev_tab = model.project(selected_clique).values
 
-        all_marginals = weight_marginals(marginals, new_marginal)
+        all_marginals = marginals.add(new_marginal)
 
         new_model: MarkovRandomField = algorithm.estimator(
             model.domain,
-            list(all_marginals.values()),
-            potentials=model.potentials.expand(list(all_marginals.keys())),
+            all_marginals.flatten(),
+            potentials=model.potentials,
         )
 
         next_tab = new_model.project(selected_clique).values

--- a/python/src/opendp/extras/mbi/_fixed/__init__.py
+++ b/python/src/opendp/extras/mbi/_fixed/__init__.py
@@ -8,10 +8,10 @@ from opendp._lib import import_optional_dependency
 from opendp.extras.mbi._utilities import (
     get_associated_metric,
     then_noise_marginals,
-    weight_marginals,
     make_stable_marginals,
     Algorithm,
     Count,
+    Marginals,
     OnewayType,
     ONEWAY_UNKEYED
 )
@@ -58,7 +58,7 @@ class Fixed(Algorithm):
         d_in: list["Bound"],
         d_out: float,
         *,
-        marginals: dict[tuple[str, ...], Any],
+        marginals: Marginals,
         model: Any,  # MarkovRandomField
     ):
         """Implements a "Fixed" algorithm over ordinal data.
@@ -94,13 +94,13 @@ class Fixed(Algorithm):
 
         def function(
             new_releases: list,
-        ) -> tuple[dict[tuple[str, ...], Any], MarkovRandomField]:
-            all_marginals = weight_marginals(marginals, *new_releases)
+        ) -> tuple[Marginals, MarkovRandomField]:
+            all_marginals = marginals.add(*new_releases)
 
             new_model = self.estimator(
                 model.domain,
-                list(all_marginals.values()),
-                potentials=model.potentials.expand(list(all_marginals.keys())),
+                all_marginals.flatten(),
+                potentials=model.potentials,
             )
             return all_marginals, new_model
 

--- a/python/src/opendp/extras/mbi/_mst/__init__.py
+++ b/python/src/opendp/extras/mbi/_mst/__init__.py
@@ -15,8 +15,8 @@ from opendp.extras.mbi._utilities import (
     make_noise_marginals,
     prior,
     make_stable_marginals,
-    weight_marginals,
     Algorithm,
+    Marginals,
 )
 from opendp.measurements import make_noisy_max
 from opendp.metrics import linf_distance
@@ -120,7 +120,7 @@ class MST(Algorithm):
         d_in: list["Bound"],
         d_out: float,
         *,
-        marginals: dict[tuple[str, ...], Any],
+        marginals: Marginals,
         model: Any,  # MarkovRandomField
     ) -> Measurement:
         """Implements MST (Minimum Spanning Tree) over ordinal data.
@@ -150,7 +150,7 @@ class MST(Algorithm):
 
         def function(
             qbl: Queryable,
-        ) -> tuple[dict[tuple[str, ...], Any], MarkovRandomField]:
+        ) -> tuple[Marginals, MarkovRandomField]:
 
             # SELECT a set of queries that best reduces the error
             m_select = _make_mst_select(
@@ -178,13 +178,13 @@ class MST(Algorithm):
                 T=float,
             )
 
-            all_marginals = weight_marginals(marginals, *qbl(m_measure))
+            all_marginals = marginals.add(*qbl(m_measure))
 
             # GENERATE (fit a MarkovRandomField)
             new_model = self.estimator(
                 model.domain,
-                list(all_marginals.values()),
-                potentials=model.potentials.expand(model.cliques + selected_cliques),
+                all_marginals.flatten(),
+                potentials=model.potentials,
             )
             return all_marginals, new_model
 

--- a/python/src/opendp/extras/mbi/_sequential/__init__.py
+++ b/python/src/opendp/extras/mbi/_sequential/__init__.py
@@ -10,6 +10,7 @@ from opendp.extras.mbi._utilities import (
     Algorithm,
     get_associated_metric,
     get_cardinalities,
+    Marginals,
 )
 from opendp.metrics import frame_distance, symmetric_distance
 from opendp.mod import (
@@ -63,7 +64,7 @@ class Sequential(Algorithm):
         d_in: list["Bound"],
         d_out: float,
         *,
-        marginals: dict[tuple[str, ...], Any],
+        marginals: Marginals,
         model: Any,  # MarkovRandomField
     ):
         """Implements a "Sequential" algorithm over ordinal data.
@@ -105,7 +106,7 @@ class Sequential(Algorithm):
 
         def function(
             qbl: Queryable,
-        ) -> tuple[dict[tuple[str, ...], Any], MarkovRandomField]:
+        ) -> tuple[Marginals, MarkovRandomField]:
             all_marginals = marginals.copy()
             current_model = model
             for algo, d_mid in zip(self.algorithms, d_mids):

--- a/python/src/opendp/extras/mbi/_table/__init__.py
+++ b/python/src/opendp/extras/mbi/_table/__init__.py
@@ -25,9 +25,11 @@ from opendp.extras.mbi._aim import AIM
 from opendp.extras.mbi._utilities import (
     prior,
     get_std,
+    identity_query_precision,
     row_major_order,
-    weight_marginals,
+    SelectPrefixQuery,
     Algorithm,
+    Marginals,
     ONEWAY_UNKEYED,
 )
 from opendp.measurements import make_private_lazyframe
@@ -59,8 +61,8 @@ class ContingencyTable:
     """Unique keys for each column"""
     cuts: dict[str, Any]  # dict[str, Series]
     """Cut points (left-open) for each numeric column"""
-    marginals: dict[tuple[str, ...], Any]  # dict[tuple[str, ...], LinearMeasurement]
-    """Mapping from clique name to LinearMeasurement used to fit the model"""
+    marginals: Marginals
+    """Measurements used to fit the model, keyed by clique"""
     model: Any  # MarkovRandomField
     """MarkovRandomField spanning the same columns as keys"""
     thresholds: dict[str, int] = field(default_factory=dict)
@@ -93,6 +95,12 @@ class ContingencyTable:
             if len(self.keys[col]) - 1 != len(cutset):
                 msg = f'"{col}" keyset length ({len(self.keys[col])}) must be one greater than the number of cuts ({len(cutset)})'
                 raise ValueError(msg)
+
+        if isinstance(self.marginals, dict):
+            self.marginals = Marginals({
+                tuple(clique): [measurement]
+                for clique, measurement in self.marginals.items()
+            })
 
     def synthesize(
         self, rows: Optional[int] = None, method: Literal["round", "sample"] = "round"
@@ -156,6 +164,10 @@ class ContingencyTable:
         use :py:func:`~opendp.accuracy.gaussian_scale_to_accuracy`
         to construct a confidence interval.
 
+        Marginals released via a partial (prefix) query, or the zero-way total,
+        don't contribute a per-cell precision, so this may raise
+        if ``attrs`` is only covered by such measurements.
+
         :param attrs: attributes to preserve in uncertainty estimate
         """
         from mbi import MarkovRandomField  # type: ignore[import-untyped,import-not-found]
@@ -168,11 +180,17 @@ class ContingencyTable:
         attrs_clique = set(attrs)
         size = model.domain.size
 
-        inv_var_sum = sum(
-            1 / (lm.stddev**2 * size(clique) / size(attrs_clique))
-            for clique, lm in self.marginals.items()
-            if attrs_clique.issuperset(clique)
-        )
+        inv_var_sum = 0.0
+        for measurement in self.marginals.flatten():
+            clique = measurement.clique
+            if not attrs_clique.issuperset(clique):
+                continue
+            # a total constrains the sum of cells, not each cell directly
+            if clique == () and attrs_clique:
+                continue
+            inv_var_sum += identity_query_precision(measurement) / (
+                size(clique) / size(attrs_clique)
+            )
 
         if inv_var_sum == 0:
             raise ValueError(f"attrs ({attrs}) are not covered by the query set")
@@ -241,7 +259,7 @@ def make_contingency_table(
         thresholds = table.thresholds.copy()
     else:
         model = None
-        marginals = {}
+        marginals = Marginals()
         thresholds = {}
 
     if cuts_pl:
@@ -283,6 +301,10 @@ def make_contingency_table(
             d_oneway = d_oneway, delta  # type: ignore[assignment]
 
         d_mids = [d_oneway, d_multiway if delta is None else (d_multiway, 0.0)]  # type: ignore[has-type]
+        has_prior_total = any(
+            identity_query_precision(measurement) > 0
+            for measurement in marginals.flatten()
+        )
         m_oneway, scale, threshold = _make_oneway_marginals(
             input_domain,
             input_metric,
@@ -292,6 +314,7 @@ def make_contingency_table(
             keys=keys_pl,
             plan=plan,
             unknown_only=algorithm.oneway == ONEWAY_UNKEYED,
+            has_prior_total=has_prior_total
         )
         if threshold is not None:
             thresholds |= {
@@ -317,7 +340,7 @@ def make_contingency_table(
         if m_oneway:
             new_keys, oneway_releases = qbl(m_oneway)
             stable_keys |= new_keys
-            current_marginals = weight_marginals(current_marginals, *oneway_releases)
+            current_marginals = current_marginals.add(*oneway_releases)
 
         mbi_domain = mbi.Domain.fromdict({c: len(k) for c, k in stable_keys.items()})
 
@@ -325,11 +348,10 @@ def make_contingency_table(
         if isinstance(model, mbi.MarkovRandomField):
             import attr  # type: ignore[import-not-found]
 
-            potential_factor = attr.evolve(model.potentials, domain=mbi_domain)
-            potentials = potential_factor.expand(list(current_marginals.keys()))
+            potentials = attr.evolve(model.potentials, domain=mbi_domain)
 
         current_model = algorithm.estimator(
-            mbi_domain, list(current_marginals.values()), potentials=potentials
+            mbi_domain, current_marginals.flatten(), potentials=potentials
         )
 
         t_index = make_stable_lazyframe(
@@ -363,7 +385,7 @@ def make_contingency_table(
         if delta is not None:
             m_index_marginals = make_approximate(m_index_marginals)
 
-        T: TypeAlias = tuple[dict[tuple[str, ...], Any], mbi.MarkovRandomField]
+        T: TypeAlias = tuple[Marginals, mbi.MarkovRandomField]
         current_marginals, current_model = cast(T, qbl(m_index_marginals))
 
         ordered_keys = {c: stable_keys[c] for c in input_domain.columns}
@@ -422,13 +444,13 @@ def _make_oneway_marginals(
     keys: dict[str, Any],
     plan: Any,
     unknown_only: bool,
+    has_prior_total: bool,
 ) -> tuple[Measurement, float, Optional[int]]:
     """Returns a measurement that releases keys and counts for one-way marginals,
     as well as the discovered scale and threshold."""
     from opendp.extras.polars import dp_len
     import polars as pl  # type: ignore[import-not-found]
     from mbi import LinearMeasurement  # type: ignore[import-not-found]
-    from mbi.estimation import minimum_variance_unbiased_total  # type: ignore[import-untyped,import-not-found]
     import numpy as np  # type: ignore[import-not-found]
 
     def group_by_agg(plan: pl.LazyFrame, name: str) -> pl.LazyFrame:
@@ -458,8 +480,18 @@ def _make_oneway_marginals(
             for name in input_domain.columns
             if name not in keys or not unknown_only
         ]
-        # estimating the total is necessary if there are no keyed columns
-        should_total = all(name not in keys for name in input_domain.columns)
+
+        will_release_full_identity = any(
+            name in keys
+            for name in names
+        )
+
+        should_total = not (has_prior_total or will_release_full_identity)
+
+        # estimating the total from an identity marginal requires a queried
+        # column with known keys; when `unknown_only`, keyed columns are
+        # excluded from `names`, so no such marginal is ever available.
+        should_total = not any(name in keys for name in names)
 
         one_way_measurements = [
             make_private_lazyframe(
@@ -489,11 +521,10 @@ def _make_oneway_marginals(
 
             if should_total:
                 total = counts.pop().item()
-            else:
-                total = minimum_variance_unbiased_total(
-                    LinearMeasurement(count["len"].to_numpy(), [name], stddev=std)
-                    for name, count in zip(names, counts)
-                    if name in keys
+                lm_counts.append(
+                    LinearMeasurement(
+                        np.asarray([total], dtype=float), clique=(), stddev=std
+                    )
                 )
 
             for name, count in zip(names, counts):
@@ -502,16 +533,32 @@ def _make_oneway_marginals(
 
                 if name in keys:
                     values_iter: Iterator[int] = (lookup[k] for k in keys[name])
+                    values = np.fromiter(values_iter, dtype=np.int64)
+                    lm_counts.append(
+                        LinearMeasurement(values, clique=[name], stddev=std)
+                    )
                 else:
-                    lookup.setdefault(None, 0)
-                    lookup[None] += total - count["len"].sum()
                     dtype = count[name].dtype
+                    observed_keys = [key for key in lookup if key is not None]
 
-                    new_keys[name] = pl.Series(name, lookup.keys(), dtype=dtype)
-                    values_iter = lookup.values()  # type: ignore[assignment]
+                    # Null represents both actual nulls and values omitted by
+                    # private key discovery. Keep it as a latent final cell.
+                    new_keys[name] = pl.Series(
+                        name, [*observed_keys, None], dtype=dtype
+                    )
 
-                values = np.fromiter(values_iter, dtype=np.int64)
-                lm_counts.append(LinearMeasurement(values, clique=[name], stddev=std))
+                    if observed_keys:
+                        values = np.fromiter(
+                            (lookup[key] for key in observed_keys), dtype=np.int64
+                        )
+                        lm_counts.append(
+                            LinearMeasurement(
+                                values,
+                                clique=[name],
+                                stddev=std,
+                                query=SelectPrefixQuery(len(observed_keys)),
+                            )
+                        )
 
             return new_keys, lm_counts
 

--- a/python/src/opendp/extras/mbi/_utilities/__init__.py
+++ b/python/src/opendp/extras/mbi/_utilities/__init__.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Callable, Literal, Optional, Any, Iterator, cast, get_args, TYPE_CHECKING
+from typing import Callable, Literal, Optional, Any, Iterator, get_args, TYPE_CHECKING
 from functools import reduce
 from math import sqrt
 from opendp._internal import (
@@ -35,8 +35,10 @@ from opendp.mod import (
     Metric,
     Transformation,
 )
+
 if TYPE_CHECKING:  # pragma: no cover
     from opendp.extras.polars import Bound
+
 
 @dataclass
 class Count:
@@ -64,15 +66,17 @@ def mirror_descent(
     potentials=None,  # CliqueVector | None
 ):  # MarkovRandomField
     """Fit a MarkovRandomField over the domain and loss function using mirror descent.
-    
+
     If you want to use a custom estimator, consider this a contract/example.
     Your function can then close over configuration for any MBI estimator."""
     from mbi.estimation import mirror_descent as _mirror_descent  # type: ignore
 
     return _mirror_descent(domain, loss_fn, potentials=potentials)
 
+
 OnewayType = Literal["all", "unkeyed"]
 ONEWAY_ALL, ONEWAY_UNKEYED = get_args(OnewayType)
+
 
 @dataclass(kw_only=True, frozen=True)
 class Algorithm(ABC):
@@ -100,7 +104,9 @@ class Algorithm(ABC):
 
     def __post_init__(self):
         if self.oneway not in get_args(OnewayType):
-            raise ValueError(f'oneway ({self.oneway}) must be in {get_args(OnewayType)}')
+            raise ValueError(
+                f"oneway ({self.oneway}) must be in {get_args(OnewayType)}"
+            )
 
         if self.oneway_split is not None and not (0 <= self.oneway_split < 1):
             raise ValueError(f"oneway_split ({self.oneway_split}) must be in [0, 1)")
@@ -114,7 +120,7 @@ class Algorithm(ABC):
         d_in: list["Bound"],
         d_out: float,
         *,
-        marginals: dict[tuple[str, ...], Any],
+        marginals: "Marginals",
         model,  # MarkovRandomField
     ) -> Measurement: ...
 
@@ -238,7 +244,11 @@ def make_stable_marginals(
 
     def pivot(x, clique: tuple[str, ...]):
         y = np.zeros(shape(clique), dtype=np.int32)
-        y[tuple(x[clique].to_numpy().T)] = x["len"].to_numpy()
+        # u32 counts are clipped before narrowing to i32: numpy treats
+        # uint32->int32 as a same-kind cast and silently wraps instead of erroring.
+        y[tuple(x[clique].to_numpy().T)] = (
+            x["len"].clip(upper_bound=np.iinfo(np.int32).max).cast(pl.Int32).to_numpy()
+        )
         return y
 
     def function(data):
@@ -342,35 +352,129 @@ def row_major_order(keys: Iterator):
     return reduce(reducer, (keyset.to_frame() for keyset in keys))
 
 
-def weight_marginals(
-    marginals: dict[tuple[str, ...], Any], *new_marginals
-) -> dict[tuple[str, ...], Any]:
-    from mbi import LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+@dataclass(frozen=True)
+class SelectPrefixQuery:
+    """Select a prefix of a flattened MBI marginal.
 
-    marginals = marginals.copy()
+    Used when the final cell is a latent synthetic ``other`` bucket rather than
+    a directly measured count.
+    """
 
-    for new_marginal in new_marginals:
-        if not isinstance(new_marginal, LinearMeasurement):
-            raise ValueError("each new marginal must be of type LinearMeasurement")
+    length: int
 
-        clique = new_marginal.clique
-        old_marginal = cast(Optional[LinearMeasurement], marginals.get(clique))
+    def __call__(self, factor):
+        return factor.datavector()[: self.length]
 
-        if old_marginal is None:
-            marginals[clique] = new_marginal
-            continue
 
-        old_var = old_marginal.stddev**2
-        old = old_marginal.noisy_measurement
+def _queries_equal(left: Callable, right: Callable) -> bool:
+    if left is right:
+        return True
+    try:
+        result = left == right
+        return result if isinstance(result, bool) else False
+    except Exception:  # pragma: no cover - defensive for user-defined queries
+        return False
 
-        new_var = new_marginal.stddev**2
-        new = new_marginal.noisy_measurement
 
-        weighted_var = 1 / (1 / old_var + 1 / new_var)
-        weighted = (old / old_var + new / new_var) * weighted_var
+def _same_shape(left, right) -> bool:
+    import numpy as np  # type: ignore[import-not-found]
 
-        marginals[clique] = LinearMeasurement(
-            weighted, clique, stddev=sqrt(weighted_var)
-        )
+    left_shape = np.asarray(left.noisy_measurement).shape
+    right_shape = np.asarray(right.noisy_measurement).shape
+    return left_shape == right_shape
 
-    return marginals
+
+def _inverse_variance_combine(old, new):
+    from mbi import LinearMeasurement
+
+    old_var = old.stddev**2
+    new_var = new.stddev**2
+    combined_var = 1 / (1 / old_var + 1 / new_var)
+
+    combined = (
+        old.noisy_measurement / old_var + new.noisy_measurement / new_var
+    ) * combined_var
+
+    return LinearMeasurement(
+        combined,
+        old.clique,
+        stddev=sqrt(combined_var),
+        query=old.query,
+    )
+
+
+def identity_query_precision(measurement) -> float:
+    """Return precision contributed by a full-datavector observation.
+
+    Partial queries do not provide a uniform uncertainty estimate for every
+    cell in a marginal, so they contribute zero precision.
+    """
+    from mbi import Factor  # type: ignore[import-untyped,import-not-found]
+
+    if _queries_equal(measurement.query, Factor.datavector):
+        return 1 / measurement.stddev**2
+    return 0.0
+
+
+class Marginals:
+    """A multimap from clique to independent :py:class:`mbi.LinearMeasurement`.
+
+    A clique identifies the marginal a query operates on; it does not
+    uniquely identify the observation. Several independent measurements can
+    legitimately share a clique: an initial partial (prefix) release, a later
+    full release, a zero-way total, or any other linear query over the same
+    marginal. Distinct query operators are kept as separate observations,
+    even when their cliques match.
+    """
+
+    def __init__(self, by_clique: Optional[dict[tuple[str, ...], list]] = None):
+        self.by_clique: dict[tuple[str, ...], list] = {
+            clique: list(group) for clique, group in (by_clique or {}).items()
+        }
+
+    def cliques(self) -> list[tuple[str, ...]]:
+        """Unique cliques with at least one measurement."""
+        return list(self.by_clique)
+
+    def flatten(self) -> list:
+        """All measurements, across all cliques."""
+        return [
+            measurement for group in self.by_clique.values() for measurement in group
+        ]
+
+    def copy(self) -> "Marginals":
+        return Marginals(self.by_clique)
+
+    def add(self, *new_measurements) -> "Marginals":
+        """Return a new collection with `new_measurements` merged in.
+
+        A new measurement is combined with an existing one under the same
+        clique only if they share a query and output shape; otherwise it is
+        kept as an independent observation."""
+        from mbi import LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+
+        result = self.copy()
+
+        for new in new_measurements:
+            if not isinstance(new, LinearMeasurement):
+                raise ValueError("each new marginal must be of type LinearMeasurement")
+
+            group = result.by_clique.setdefault(new.clique, [])
+
+            for index, old in enumerate(group):
+                if not _queries_equal(old.query, new.query):
+                    continue
+
+                # should be impossible to reach
+                if old.noisy_measurement.shape != new.noisy_measurement.shape:
+                    raise ValueError(
+                        "equal queries over the same clique have "
+                        "incompatible measurement shapes"
+                    )
+
+                group[index] = _inverse_variance_combine(old, new)
+                break
+            else:
+                group.append(new)
+
+        return result

--- a/python/test/mbi/test_algorithms.py
+++ b/python/test/mbi/test_algorithms.py
@@ -4,6 +4,7 @@ from opendp.extras.mbi import (
     Count,
     AIM,
     MST,
+    Marginals,
     Sequential,
 )
 import opendp.prelude as dp
@@ -43,7 +44,7 @@ def test_algorithm_err_elements(algorithm):
             dp.zero_concentrated_divergence(),
             d_in=[dp.polars.Bound(per_group=1)],
             d_out=0.5,
-            marginals={},
+            measurements=Marginals(),
             model=model,
         )
 
@@ -57,7 +58,7 @@ def test_algorithm_err_elements(algorithm):
             dp.zero_concentrated_divergence(),
             d_in=[dp.polars.Bound(per_group=1)],
             d_out=0.5,
-            marginals={},
+            measurements=Marginals(),
             model=model,
         )
 
@@ -71,7 +72,7 @@ def test_algorithm_err_elements(algorithm):
             dp.renyi_divergence(),
             d_in=[dp.polars.Bound(per_group=1)],
             d_out=0.5,
-            marginals={},
+            measurements=Marginals(),
             model=model,
         )
 
@@ -84,7 +85,7 @@ def test_algorithm_err_elements(algorithm):
             dp.max_divergence(),
             d_in=[dp.polars.Bound(per_group=1)],
             d_out=1.0,
-            marginals={},
+            measurements=Marginals(),
             model=None,
         )
 
@@ -118,7 +119,7 @@ def test_aim_exhaustion():
         dp.max_divergence(),
         d_in=[dp.polars.Bound(per_group=1)],
         d_out=1.0,
-        marginals={},
+        marginals=Marginals(),
         model=dp.mbi.mirror_descent(mbi.Domain(("A",), (2,)), []),
     )
 

--- a/python/test/mbi/test_table.py
+++ b/python/test/mbi/test_table.py
@@ -1,7 +1,15 @@
 import re
-from opendp.extras.mbi import Fixed, AIM, MST, ContingencyTable, Count, Sequential
+from opendp.extras.mbi import (
+    Fixed,
+    AIM,
+    MST,
+    ContingencyTable,
+    Count,
+    Marginals,
+    Sequential,
+)
 from opendp.extras.mbi._table import _get_null_index, _increasing, _unique, _with_null
-from opendp.extras.mbi._utilities import mirror_descent
+from opendp.extras.mbi._utilities import mirror_descent, SelectPrefixQuery
 import pytest
 import opendp.prelude as dp
 import warnings
@@ -98,16 +106,15 @@ def test_fit_effectiveness(algorithm, privacy_loss, approximate):
     def test_cov(clique):
         idx = {"A": 0, "B": 1, "C": 2}
         i, j = idx[clique[0]], idx[clique[-1]]
-        assert 0 == pytest.approx(abs(cov[i, j] - cov_syn[i, j]), abs=0.2), (
+        assert abs(cov[i, j] - cov_syn[i, j]) < 0.2, (
             f"{clique} cov drifted: {cov[i, j]=:.3f}, {cov_syn[i, j]=:.3f}"
         )
 
     # in an MRF, a missing 2-way marginal does not imply independence
     # max-entropy does not guarantee spurious correlations won't be formed on undetermined pairs
-    if not approximate:
-        test_cov(("A", "B"))
-        for clique in (cl for cl in table.marginals if len(cl) <= 2):
-            test_cov(clique)
+    test_cov(("A", "B"))
+    for clique in (cl for cl in table.marginals.cliques() if 0 < len(cl) <= 2):
+        test_cov(clique)
 
 
 def test_contingency_table_int_cuts():
@@ -124,7 +131,7 @@ def test_contingency_table_int_cuts():
     table = ContingencyTable(
         keys={"A": pl.Series("A", ["a", "b", "c", "d", "e"])},
         cuts={"A": A_cuts},
-        marginals={("A",): lm},
+        marginals=Marginals({("A",): [lm]}),
         model=model,
     )
 
@@ -156,7 +163,7 @@ def test_contingency_table_project():
     table = ContingencyTable(
         keys={"A": A_keys, "B": B_keys},
         cuts={},
-        marginals={("A",): A_lm, ("B",): B_lm},
+        marginals=Marginals({("A",): [A_lm], ("B",): [B_lm]}),
         model=model,
     )
 
@@ -208,6 +215,8 @@ def test_make_contingency_table_multi_fit():
         .release()
     )
 
+    cliques_before = set(table.marginals.cliques())
+
     # expand the contingency table to also include ("B", "C")
     table2: ContingencyTable = (
         context.query(rho=0.05)
@@ -217,6 +226,10 @@ def test_make_contingency_table_multi_fit():
     )
 
     assert table2.schema == {"A": pl.Int64, "B": pl.Int64, "C": pl.Int64}
+
+    # reusing `table` as input to a later query must not mutate it
+    assert set(table.marginals.cliques()) == cliques_before
+    assert set(table2.marginals.cliques()) > cliques_before
 
 
 def test_make_contingency_table_invalid_d_out():
@@ -247,7 +260,7 @@ def test_contingency_table_invalid_shape():
         ContingencyTable(
             keys={},
             cuts={},
-            marginals={},
+            marginals=Marginals(),
             model=get_model({"A": 3}),
         )
 
@@ -258,7 +271,7 @@ def test_contingency_table_missing_cut():
         ContingencyTable(
             keys={"A": [1, 2, 3]},
             cuts={"B": [1, 2, 3]},
-            marginals={},
+            marginals=Marginals(),
             model=get_model({"A": 3}),
         )
 
@@ -270,7 +283,7 @@ def test_contingency_table_misshapen_cut():
         ContingencyTable(
             keys={"A": [1, 2, 3], "B": ["a", "b", "c"]},
             cuts={"B": [1, 2, 3]},
-            marginals={},
+            marginals=Marginals(),
             model=get_model({"A": 3, "B": 3}),
         )
 
@@ -345,6 +358,65 @@ def test_contingency_table_minimum_variance_weighted_total():
     )
 
     assert 950 < table.project([]) < 1050
+
+
+def test_contingency_table_std_ignores_zero_way_total():
+    pytest.importorskip("mbi")
+    from mbi import Domain, LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+    import numpy as np  # type: ignore[import-not-found]
+    import polars as pl  # type: ignore[import-not-found]
+
+    A_lm = LinearMeasurement(np.array([3.0, 5.0]), clique=("A",), stddev=1.0)
+    total_lm = LinearMeasurement(np.array([8.0]), clique=(), stddev=0.01)
+
+    model = mirror_descent(Domain(("A",), (2,)), [A_lm, total_lm])
+    table = ContingencyTable(
+        keys={"A": pl.Series("A", ["a1", "a2"])},
+        cuts={},
+        marginals=Marginals({("A",): [A_lm], (): [total_lm]}),
+        model=model,
+    )
+
+    # a total constrains the sum of cells, not each cell directly,
+    # so its precision shouldn't count towards the std of an individual cell
+    assert table.std(("A",)) == pytest.approx(1.0)
+
+
+def test_contingency_table_std_sums_independent_identity_measurements():
+    pytest.importorskip("mbi")
+    from mbi import Domain, LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+    import numpy as np  # type: ignore[import-not-found]
+    import polars as pl  # type: ignore[import-not-found]
+
+    # a partial (prefix) query contributes no per-cell precision, so only
+    # `full`'s precision should count -- this is only reachable now that a
+    # clique can hold more than one independent measurement
+    prefix = LinearMeasurement(
+        np.array([3.0]), clique=("A",), stddev=1.0, query=SelectPrefixQuery(1)
+    )
+    full = LinearMeasurement(np.array([3.0, 5.0]), clique=("A",), stddev=2.0)
+
+    model = mirror_descent(Domain(("A",), (2,)), [prefix, full])
+    table = ContingencyTable(
+        keys={"A": pl.Series("A", ["a1", "a2"])},
+        cuts={},
+        marginals=Marginals({("A",): [prefix, full]}),
+        model=model,
+    )
+    assert table.std(("A",)) == pytest.approx(full.stddev)
+
+    # two independent full identity measurements over the same clique each
+    # contribute precision independently, summing by inverse variance
+    full2 = LinearMeasurement(np.array([3.0, 5.0]), clique=("A",), stddev=4.0)
+    model2 = mirror_descent(Domain(("A",), (2,)), [full, full2])
+    table2 = ContingencyTable(
+        keys={"A": pl.Series("A", ["a1", "a2"])},
+        cuts={},
+        marginals=Marginals({("A",): [full, full2]}),
+        model=model2,
+    )
+    expected_std = (1 / full.stddev**2 + 1 / full2.stddev**2) ** -0.5
+    assert table2.std(("A",)) == pytest.approx(expected_std)
 
 
 def test_unique():

--- a/python/test/mbi/test_utilities.py
+++ b/python/test/mbi/test_utilities.py
@@ -5,13 +5,16 @@ import re
 from opendp._internal import _extrinsic_distance
 import opendp.prelude as dp
 from opendp.extras.mbi._utilities import (
+    Marginals,
+    SelectPrefixQuery,
     get_cardinalities,
     get_std,
+    identity_query_precision,
     make_noise_marginal,
     make_stable_marginals,
+    mirror_descent,
     typed_dict_distance,
     typed_dict_domain,
-    weight_marginals,
 )
 
 from ..helpers import ids
@@ -162,7 +165,7 @@ def test_make_noise_marginal():
     assert m_noise.map({("A",): 1}) == 1.0
 
 
-def test_weight_marginals():
+def test_marginal_measurements_add_combines_same_query():
     pytest.importorskip("mbi")
     import numpy as np  # type: ignore[import-not-found]
     from mbi import LinearMeasurement  # type: ignore[import-untyped,import-not-found]
@@ -170,12 +173,183 @@ def test_weight_marginals():
     with pytest.raises(
         ValueError, match="each new marginal must be of type LinearMeasurement"
     ):
-        weight_marginals({}, False)
+        Marginals().add(False)
 
     lm1 = LinearMeasurement(np.array([1]), clique=("A",), stddev=1.0)
     lm2 = LinearMeasurement(np.array([2]), clique=("A",), stddev=1.0)
-    marginals = weight_marginals({("A",): lm1}, lm2)
-    weighted: LinearMeasurement = marginals[("A",)]
+    measurements = Marginals({("A",): [lm1]}).add(lm2)
+    [weighted] = measurements.by_clique[("A",)]
     assert weighted.stddev == sqrt(1 / 2)
 
     assert np.array_equal(weighted.noisy_measurement, [1.5])
+
+
+def test_marginal_measurements_add_keeps_distinct_queries_independent():
+    pytest.importorskip("mbi")
+    import numpy as np  # type: ignore[import-not-found]
+    from mbi import LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+
+    partial = LinearMeasurement(
+        np.array([1.0]),
+        clique=("A",),
+        stddev=2.0,
+        query=SelectPrefixQuery(1),
+    )
+    full = LinearMeasurement(
+        np.array([2.0, 3.0]), clique=("A",), stddev=1.0
+    )
+
+    measurements = Marginals({("A",): [partial]}).add(full)
+
+    # a clique only groups measurements for indexing and model structure --
+    # distinct query operators remain independent observations, even when
+    # their cliques match, rather than being silently combined
+    group = measurements.by_clique[("A",)]
+    assert len(group) == 2
+    assert group[0] is partial
+    assert group[1] is full
+    assert measurements.cliques() == [("A",)]
+
+    assert identity_query_precision(full) == 1.0
+    assert identity_query_precision(partial) == 0.0
+
+
+def test_marginal_measurements_add_does_not_mutate():
+    pytest.importorskip("mbi")
+    import numpy as np  # type: ignore[import-not-found]
+    from mbi import LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+
+    lm = LinearMeasurement(np.array([1.0]), clique=("A",), stddev=1.0)
+    original = Marginals({("A",): [lm]})
+
+    new_lm = LinearMeasurement(np.array([5.0, 6.0]), clique=("B",), stddev=1.0)
+    updated = original.add(new_lm)
+
+    assert original.cliques() == [("A",)]
+    assert updated.cliques() == [("A",), ("B",)]
+
+
+def test_latent_remainder_linear_measurement():
+    pytest.importorskip("mbi")
+    import numpy as np  # type: ignore[import-not-found]
+    from mbi import Domain, LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+
+    measurement = LinearMeasurement(
+        np.array([30.0]),
+        clique=("A",),
+        stddev=0.01,
+        query=SelectPrefixQuery(1),
+    )
+    total = LinearMeasurement(np.array([100.0]), clique=(), stddev=0.01)
+    model = mirror_descent(Domain(("A",), (2,)), [measurement, total])
+
+    assert np.allclose(model.project(("A",)).values, [30.0, 70.0], atol=0.1)
+
+
+def test_marginal_measurements_add_merges_zero_way_totals():
+    pytest.importorskip("mbi")
+    import numpy as np  # type: ignore[import-not-found]
+    from mbi import LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+
+    early = LinearMeasurement(np.array([90.0]), clique=(), stddev=10.0)
+    late = LinearMeasurement(np.array([120.0]), clique=(), stddev=5.0)
+
+    measurements = Marginals({(): [early]}).add(late)
+    [combined] = measurements.by_clique[()]
+
+    expected_var = 1 / (1 / 10.0**2 + 1 / 5.0**2)
+    expected_mean = (90.0 / 10.0**2 + 120.0 / 5.0**2) * expected_var
+
+    assert combined.stddev == pytest.approx(sqrt(expected_var))
+    assert np.allclose(combined.noisy_measurement, [expected_mean])
+    # a later, noisier total does not overwrite a precise earlier one
+    assert combined.stddev < late.stddev
+
+
+def test_zero_way_measurement_retains_nonpositive_value():
+    pytest.importorskip("mbi")
+    import numpy as np  # type: ignore[import-not-found]
+    from mbi import Domain, LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+    from mbi.estimation import minimum_variance_unbiased_total  # type: ignore[import-untyped,import-not-found]
+
+    total = LinearMeasurement(np.array([-5.0]), clique=(), stddev=10.0)
+
+    # the raw noisy measurement is preserved, even though it's implausible
+    assert total.noisy_measurement.item() == -5.0
+
+    # but the model mass supplied to the optimizer is floored to be positive
+    assert minimum_variance_unbiased_total([total]) >= 1.0
+
+    # a zero-way measurement is always accompanied by at least one marginal
+    # that covers every domain attribute, as it is in practice
+    oneway = LinearMeasurement(np.array([1.0, 2.0]), clique=("A",), stddev=1.0)
+    model = mirror_descent(Domain(("A",), (2,)), [total, oneway])
+    assert float(model.total) >= 1.0
+
+
+def test_atomic_measurements_sum_losses():
+    """Passing two atomic measurements over the same clique to MBI is
+    equivalent to summing their individual losses -- the invariant that
+    justifies keeping independent observations atomic instead of stacking
+    them into a single composite query."""
+    pytest.importorskip("mbi")
+    import numpy as np  # type: ignore[import-not-found]
+    from mbi import (  # type: ignore[import-untyped,import-not-found]
+        CliqueVector,
+        Domain,
+        Factor,
+        LinearMeasurement,
+        marginal_loss,
+    )
+
+    dom = Domain(("A",), (2,))
+    m1 = LinearMeasurement(np.array([1.0, 2.0]), clique=("A",), stddev=1.0)
+    m2 = LinearMeasurement(np.array([3.0, 4.0]), clique=("A",), stddev=2.0)
+
+    mu = CliqueVector(dom, [("A",)], {("A",): Factor(dom, np.array([1.5, 2.5]))})
+
+    loss_both = marginal_loss.from_linear_measurements([m1, m2], domain=dom)
+    loss1 = marginal_loss.from_linear_measurements([m1], domain=dom)
+    loss2 = marginal_loss.from_linear_measurements([m2], domain=dom)
+
+    assert float(loss_both(mu)) == pytest.approx(float(loss1(mu)) + float(loss2(mu)))
+
+
+def test_repeated_fit_preserves_prior_and_later_observations():
+    """A later full marginal over a previously-partial clique remains visible
+    to MBI's total estimator, and doesn't overwrite the earlier prefix
+    observation -- the scenario that motivated the measurement multimap."""
+    pytest.importorskip("mbi")
+    import numpy as np  # type: ignore[import-not-found]
+    from mbi import Domain, LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+    from mbi.estimation import minimum_variance_unbiased_total  # type: ignore[import-untyped,import-not-found]
+
+    # 1. initial unknown-key prefix release
+    prefix = LinearMeasurement(
+        np.array([30.0]), clique=("A",), stddev=1.0, query=SelectPrefixQuery(1)
+    )
+    measurements = Marginals({("A",): [prefix]})
+
+    # 2. explicit zero-way total release
+    total = LinearMeasurement(np.array([100.0]), clique=(), stddev=1.0)
+    measurements = measurements.add(total)
+
+    # 3. later full marginal over the same clique
+    full = LinearMeasurement(np.array([30.0, 70.0]), clique=("A",), stddev=1.0)
+    measurements = measurements.add(full)
+
+    # both prefix and full observations remain present
+    group = measurements.by_clique[("A",)]
+    assert len(group) == 2
+    assert any(m is prefix for m in group)
+    assert any(m is full for m in group)
+
+    # the later full marginal contributes to total estimation, alongside the
+    # zero-way total; the earlier partial observation is correctly ignored
+    flattened = measurements.flatten()
+    estimated_total = minimum_variance_unbiased_total(flattened)
+    assert estimated_total == pytest.approx(minimum_variance_unbiased_total([total, full]))
+
+    # 4. refit from all accumulated measurements
+    model = mirror_descent(Domain(("A",), (2,)), flattened)
+    assert float(model.total) >= 1.0

--- a/rust/src/measurements/make_private_lazyframe/group_by/matching.rs
+++ b/rust/src/measurements/make_private_lazyframe/group_by/matching.rs
@@ -1,8 +1,11 @@
 use std::{collections::BTreeSet, sync::Arc};
 
-use polars::prelude::{DslPlan, JoinOptions, JoinType, PlSmallStr, Selector};
+use polars::{
+    datatypes::DataType,
+    prelude::{DslPlan, JoinOptions, JoinType, PlSmallStr, Selector},
+};
 use polars_plan::{
-    dsl::{Expr, Operator},
+    dsl::{DataTypeExpr, Expr, Operator},
     prelude::GroupbyOptions,
     utils::expr_output_name,
 };
@@ -221,10 +224,14 @@ pub(super) fn is_len_expr(expr: &Expr, name: Option<&str>) -> Option<(String, No
 
     let (inputs, args) = match_trusted_plugin::<NoisePlugin>(&expr).ok().flatten()?;
 
-    // If it is a cast, unwrap to get the len expr.
+    // Signed frame lengths are represented as a stable widening cast from u32.
     let input = match &inputs[0] {
-        Expr::Cast { expr, .. } => expr.as_ref(),
-        x => x,
+        Expr::Cast {
+            expr,
+            dtype: DataTypeExpr::Literal(DataType::Int64),
+            ..
+        } => expr.as_ref(),
+        input => input,
     };
 
     if let Expr::Len = input {


### PR DESCRIPTION
The synthetic data implementation releases one-way marginals over unknown keysets via stability histograms. The tricky bit is that stability histograms don't sum to total, which breaks the symmetry in MBI. The current implementation inserts a synthetic bin for null counts based on best-known information about the total count. This "works", but the cell is correlated and has much higher variance, which improperly influences MBI's variance weighting.  

This PR adjusts the corresponding LinearMeasurements to ignore the synthetic bin, which keeps it out of the variance calculations.