### PR TITLE
feat: Adjusts Minimum Threshold Check from ApproxDP Queries

### DIFF
--- a/python/test/mbi/test_table.py
+++ b/python/test/mbi/test_table.py
@@ -29,7 +29,7 @@ def test_fit_effectiveness(algorithm, privacy_loss, approximate):
     cuts = {"A": [-2, -1, 0, 1, 2]}
     keys: dict[str, list] = {"B": ["a", "b", "c", "d", "e", "f"]}
     if approximate:
-        privacy_loss["delta"] = 0.5
+        privacy_loss["delta"] = 1e-8
     else:
         keys["C"] = [0, 1, 2, 3, 4, 5, 6, 7]
 

--- a/python/test/mbi/test_table.py
+++ b/python/test/mbi/test_table.py
@@ -29,7 +29,7 @@ def test_fit_effectiveness(algorithm, privacy_loss, approximate):
     cuts = {"A": [-2, -1, 0, 1, 2]}
     keys: dict[str, list] = {"B": ["a", "b", "c", "d", "e", "f"]}
     if approximate:
-        privacy_loss["delta"] = 1e-8
+        privacy_loss["delta"] = 0.5
     else:
         keys["C"] = [0, 1, 2, 3, 4, 5, 6, 7]
 

--- a/rust/src/measurements/make_private_lazyframe/group_by/mod.rs
+++ b/rust/src/measurements/make_private_lazyframe/group_by/mod.rs
@@ -286,13 +286,6 @@ where
         if margin.invariant.is_some() || is_join {
             ()
         } else if let Some((_, noise, threshold_value, _)) = &threshold_info {
-            if *threshold_value <= 0 {
-                return fallible!(
-                    FailedMap,
-                    "This algorithm requires a threshold greater than 0."
-                );
-            }
-
             let d_instability = threshold_value.neg_inf_sub(&li)?;
             let delta_single =
                 integrate_discrete_noise_tail(noise.distribution, noise.scale, d_instability)?;

--- a/rust/src/measurements/make_private_lazyframe/group_by/mod.rs
+++ b/rust/src/measurements/make_private_lazyframe/group_by/mod.rs
@@ -286,8 +286,8 @@ where
         if margin.invariant.is_some() || is_join {
             ()
         } else if let Some((_, noise, threshold_value, _)) = &threshold_info {
-            if li >= *threshold_value {
-                return fallible!(FailedMap, "threshold must be greater than {:?}", li);
+            if threshold_value <= 0.0 {
+                return fallible!(FailedMap, "This algorithm requires a threshold greater than 0");
             }
 
             let d_instability = threshold_value.neg_inf_sub(&li)?;

--- a/rust/src/measurements/make_private_lazyframe/group_by/mod.rs
+++ b/rust/src/measurements/make_private_lazyframe/group_by/mod.rs
@@ -286,8 +286,11 @@ where
         if margin.invariant.is_some() || is_join {
             ()
         } else if let Some((_, noise, threshold_value, _)) = &threshold_info {
-            if threshold_value <= 0.0 {
-                return fallible!(FailedMap, "This algorithm requires a threshold greater than 0");
+            if *threshold_value <= 0 {
+                return fallible!(
+                    FailedMap,
+                    "This algorithm requires a threshold greater than 0."
+                );
             }
 
             let d_instability = threshold_value.neg_inf_sub(&li)?;

--- a/rust/src/measurements/make_private_lazyframe/group_by/pseudocode/make_private_group_by.py
+++ b/rust/src/measurements/make_private_lazyframe/group_by/pseudocode/make_private_group_by.py
@@ -180,7 +180,7 @@ def make_private_group_by(
             pass
         elif threshold_info is not None:  # |\label{line:privacy-map-threshold}|
             _, noise, threshold_value, _ = threshold_info
-            if 0 >= threshold_value:
+            if 0 > threshold_value:
                 raise f"Threshold must be greater than 0."
 
             d_instability = threshold_value.neg_inf_sub(li)

--- a/rust/src/measurements/make_private_lazyframe/group_by/pseudocode/make_private_group_by.py
+++ b/rust/src/measurements/make_private_lazyframe/group_by/pseudocode/make_private_group_by.py
@@ -180,8 +180,8 @@ def make_private_group_by(
             pass
         elif threshold_info is not None:  # |\label{line:privacy-map-threshold}|
             _, noise, threshold_value, _ = threshold_info
-            if li >= threshold_value:
-                raise f"Threshold must be greater than {li}."
+            if 0 >= threshold_value:
+                raise f"Threshold must be greater than 0."
 
             d_instability = threshold_value.neg_inf_sub(li)
             delta_single = integrate_discrete_noise_tail(

--- a/rust/src/measurements/make_private_lazyframe/group_by/pseudocode/make_private_group_by.py
+++ b/rust/src/measurements/make_private_lazyframe/group_by/pseudocode/make_private_group_by.py
@@ -180,7 +180,7 @@ def make_private_group_by(
             pass
         elif threshold_info is not None:  # |\label{line:privacy-map-threshold}|
             _, noise, threshold_value, _ = threshold_info
-            if 0 > threshold_value:
+            if 0 >= threshold_value:
                 raise f"Threshold must be greater than 0."
 
             d_instability = threshold_value.neg_inf_sub(li)

--- a/rust/src/measurements/make_private_lazyframe/group_by/pseudocode/make_private_group_by.py
+++ b/rust/src/measurements/make_private_lazyframe/group_by/pseudocode/make_private_group_by.py
@@ -181,7 +181,7 @@ def make_private_group_by(
         elif threshold_info is not None:  # |\label{line:privacy-map-threshold}|
             _, noise, threshold_value, _ = threshold_info
             if 0 > threshold_value:
-                raise f"Threshold must be greater than 0."
+                raise "Threshold must be greater than 0."
 
             d_instability = threshold_value.neg_inf_sub(li)
             delta_single = integrate_discrete_noise_tail(


### PR DESCRIPTION
This adjusts the minimum value that the threshold can be in an Approx DP query - dropping it from 1 to 0.

In Line with Algorithm 1 in this [paper](https://arxiv.org/pdf/2309.09170).
R. Rogers, “A Unifying Privacy Analysis Framework for Unknown Domain Algorithms in Differential Privacy,” 2024. Accessed: July 31, 2026. [Online]. Available: https://arxiv.org/pdf/2309.09170