### PR TITLE
fix: clip counts before casting u32 to i32 in make_stable_marginals

### DIFF
--- a/python/src/opendp/extras/mbi/_utilities/__init__.py
+++ b/python/src/opendp/extras/mbi/_utilities/__init__.py
@@ -238,7 +238,11 @@ def make_stable_marginals(
 
     def pivot(x, clique: tuple[str, ...]):
         y = np.zeros(shape(clique), dtype=np.int32)
-        y[tuple(x[clique].to_numpy().T)] = x["len"].to_numpy()
+        # u32 counts are clipped before narrowing to i32: numpy treats
+        # uint32->int32 as a same-kind cast and silently wraps instead of erroring.
+        y[tuple(x[clique].to_numpy().T)] = (
+            x["len"].clip(upper_bound=np.iinfo(np.int32).max).cast(pl.Int32).to_numpy()
+        )
         return y
 
     def function(data):

--- a/python/test/mbi/test_utilities.py
+++ b/python/test/mbi/test_utilities.py
@@ -116,6 +116,35 @@ def test_make_stable_marginals():
         )
 
 
+def test_make_stable_marginals_clips_u32_counts(monkeypatch):
+    pytest.importorskip("mbi")
+    import numpy as np  # type: ignore[import-not-found]
+    import polars as pl  # type: ignore[import-not-found]
+
+    domain = dp.lazyframe_domain(
+        [dp.series_domain("A", dp.atom_domain(T="u32", bounds=(0, 0)))]
+    )
+    transformation = make_stable_marginals(
+        domain,
+        dp.frame_distance(dp.symmetric_distance()),
+        dp.l1_distance(T="u32"),
+        cliques=[("A",)],
+    )
+
+    # Avoid materializing more than i32::MAX rows while still exercising the
+    # UInt32-to-Int32 conversion performed by the marginal transformation.
+    counts = pl.DataFrame(
+        {
+            "A": pl.Series("A", [0], dtype=pl.UInt32),
+            "len": pl.Series("len", [np.iinfo(np.uint32).max], dtype=pl.UInt32),
+        }
+    )
+    monkeypatch.setattr(pl, "collect_all", lambda _: [counts])
+
+    marginals = transformation(pl.LazyFrame({"A": [0]}))
+    assert marginals[("A",)].tolist() == [np.iinfo(np.int32).max]
+
+
 def test_make_noise_marginal():
     pytest.importorskip("mbi")
     kwargs = dict(


### PR DESCRIPTION
Assigning a numpy u32 into an i32 array causes counts above i32::MAX (2^31) to silently wrap, resulting in sensitivity of 2^32 (although unlikely to be reached, unless you're dealing with a very large dataset!

Clip to i32::MAX before cast so any potentially overflowing count saturates instead.