### PR TITLE
feat: model stable oneway marginals as linear constraints (synthetic data)

### DIFF
--- a/docs/source/getting-started/tabular-data/contingency-tables.rst
+++ b/docs/source/getting-started/tabular-data/contingency-tables.rst
@@ -210,7 +210,7 @@ so it is possible to construct a confidence interval for each scalar in the proj
 
             >>> scale = table.std(("ILOSTAT",))
             >>> dp.gaussian_scale_to_accuracy(scale, alpha=0.05)
-            446.2524232592843
+            477.06390738682074
 
 That is, the true count differs from the estimate by no more than the accuracy estimate,
 with ``(1 - alpha)100%`` confidence.

--- a/python/src/opendp/extras/mbi/__init__.py
+++ b/python/src/opendp/extras/mbi/__init__.py
@@ -20,7 +20,7 @@ from ._fixed import Fixed
 from ._mst import MST
 from ._sequential import Sequential
 from ._table import make_contingency_table, ContingencyTable
-from ._utilities import Algorithm, Count, mirror_descent
+from ._utilities import Algorithm, Count, Marginals, mirror_descent
 
 __all__ = [
     "AIM",
@@ -31,5 +31,6 @@ __all__ = [
     "ContingencyTable",
     "Algorithm",
     "Count",
+    "Marginals",
     "mirror_descent",
 ]

--- a/python/src/opendp/extras/mbi/_aim/__init__.py
+++ b/python/src/opendp/extras/mbi/_aim/__init__.py
@@ -17,9 +17,9 @@ from opendp.extras.mbi._utilities import (
     make_noise_marginal,
     make_stable_marginals,
     prior,
-    weight_marginals,
     Count,
     Algorithm,
+    Marginals,
 )
 from opendp.measurements import then_noisy_max
 from opendp.measures import max_divergence, zero_concentrated_divergence
@@ -49,10 +49,10 @@ class AIM(Algorithm):
     """AIM mechanism from `MMSM22 <https://arxiv.org/abs/2201.12677>`_.
 
     Adaptively chooses and estimates the least-well-approximated marginal.
-    The stronger the correlation amongst a clique of columns, 
+    The stronger the correlation amongst a clique of columns,
     the more likely AIM is to select the clique.
 
-    The algorithm starts with a small per-step privacy budget, 
+    The algorithm starts with a small per-step privacy budget,
     and in each step increases the budget if the last measured marginal doesn't sufficiently improve the model.
 
     ..
@@ -77,7 +77,7 @@ class AIM(Algorithm):
         ...     # transformations/truncation may be applied here
         ...     .select("SEX", "AGE", "HWUSUAL", "ILOSTAT")
         ...     .contingency_table(
-        ...         keys={"SEX": [1, 2]}, 
+        ...         keys={"SEX": [1, 2]},
         ...         cuts={"AGE": [20, 40, 60], "HWUSUAL": [1, 20, 40]},
         ...         algorithm=dp.mbi.AIM()
         ...     )
@@ -146,7 +146,7 @@ class AIM(Algorithm):
         d_in: list["Bound"],
         d_out: float,
         *,
-        marginals: dict[tuple[str, ...], Any],
+        marginals: Marginals,
         model,  # MarkovRandomField
     ) -> Measurement:
         """Implements AIM (Adaptive Iterative Mechanism) for ordinal data.
@@ -180,7 +180,7 @@ class AIM(Algorithm):
 
         def function(
             qbl: OdometerQueryable,
-        ) -> tuple[dict[tuple[str, ...], Any], MarkovRandomField]:
+        ) -> tuple[Marginals, MarkovRandomField]:
             # mutable state
             current_model = model
             current_marginals = marginals.copy()
@@ -201,9 +201,7 @@ class AIM(Algorithm):
                 if not m_step:
                     break
 
-                R: TypeAlias = tuple[
-                    dict[tuple[str, ...], Any], MarkovRandomField, bool
-                ]
+                R: TypeAlias = tuple[Marginals, MarkovRandomField, bool]
                 current_marginals, current_model, is_significant = cast(R, qbl(m_step))
 
                 if not is_significant:
@@ -233,7 +231,7 @@ def _make_aim_marginal(
     output_measure: Measure,
     d_in: int,
     d_out: float,
-    marginals: dict[tuple[str, ...], Any],
+    marginals: Marginals,
     model,  # MarkovRandomField
     max_size: float,
     algorithm: AIM,
@@ -275,7 +273,7 @@ def _make_aim_marginal(
 
     def function(
         qbl: Queryable,
-    ) -> tuple[dict[tuple[str, ...], Any], MarkovRandomField, bool]:
+    ) -> tuple[Marginals, MarkovRandomField, bool]:
         # SELECT a query that best reduces the error
         selected_clique = qbl(m_select)
 
@@ -298,12 +296,12 @@ def _make_aim_marginal(
         # GENERATE an updated probability distribution
         prev_tab = model.project(selected_clique).values
 
-        all_marginals = weight_marginals(marginals, new_marginal)
+        all_marginals = marginals.add(new_marginal)
 
         new_model: MarkovRandomField = algorithm.estimator(
             model.domain,
-            list(all_marginals.values()),
-            potentials=model.potentials.expand(list(all_marginals.keys())),
+            all_marginals.flatten(),
+            potentials=model.potentials,
         )
 
         next_tab = new_model.project(selected_clique).values

--- a/python/src/opendp/extras/mbi/_fixed/__init__.py
+++ b/python/src/opendp/extras/mbi/_fixed/__init__.py
@@ -7,11 +7,12 @@ from opendp._internal import _new_pure_function
 from opendp._lib import import_optional_dependency
 from opendp.extras.mbi._utilities import (
     get_associated_metric,
+    get_cardinalities,
     then_noise_marginals,
-    weight_marginals,
     make_stable_marginals,
     Algorithm,
     Count,
+    Marginals,
     OnewayType,
     ONEWAY_UNKEYED
 )
@@ -41,6 +42,13 @@ class Fixed(Algorithm):
     not all unknown first-order marginals.
     """
 
+    @property
+    def needs_model(self) -> bool:
+        # Fixed workloads are predetermined and do not need a model for
+        # workload selection. The fixed release supplies the constraint used
+        # to fit the final model.
+        return False
+
     def __post_init__(self):
         super().__post_init__()
 
@@ -58,7 +66,7 @@ class Fixed(Algorithm):
         d_in: list["Bound"],
         d_out: float,
         *,
-        marginals: dict[tuple[str, ...], Any],
+        marginals: Marginals,
         model: Any,  # MarkovRandomField
     ):
         """Implements a "Fixed" algorithm over ordinal data.
@@ -74,9 +82,9 @@ class Fixed(Algorithm):
         :param model: warm-start fit of MarkovRandomField
         """
         import_optional_dependency("mbi")
-        from mbi import MarkovRandomField  # type: ignore[import-untyped,import-not-found]
+        from mbi import Domain, MarkovRandomField  # type: ignore[import-untyped,import-not-found]
 
-        if not isinstance(model, MarkovRandomField):
+        if model is not None and not isinstance(model, MarkovRandomField):
             raise ValueError("model must be a MarkovRandomField")
 
         lp_metric = get_associated_metric(output_measure)
@@ -94,13 +102,20 @@ class Fixed(Algorithm):
 
         def function(
             new_releases: list,
-        ) -> tuple[dict[tuple[str, ...], Any], MarkovRandomField]:
-            all_marginals = weight_marginals(marginals, *new_releases)
+        ) -> tuple[Marginals, MarkovRandomField]:
+            all_marginals = marginals.add(*new_releases)
+
+            if model is None:
+                model_domain = Domain.fromdict(get_cardinalities(input_domain))
+                potentials = None
+            else:
+                model_domain = model.domain
+                potentials = model.potentials
 
             new_model = self.estimator(
-                model.domain,
-                list(all_marginals.values()),
-                potentials=model.potentials.expand(list(all_marginals.keys())),
+                model_domain,
+                all_marginals.flatten(),
+                potentials=potentials,
             )
             return all_marginals, new_model
 

--- a/python/src/opendp/extras/mbi/_mst/__init__.py
+++ b/python/src/opendp/extras/mbi/_mst/__init__.py
@@ -15,8 +15,8 @@ from opendp.extras.mbi._utilities import (
     make_noise_marginals,
     prior,
     make_stable_marginals,
-    weight_marginals,
     Algorithm,
+    Marginals,
 )
 from opendp.measurements import make_noisy_max
 from opendp.metrics import linf_distance
@@ -120,7 +120,7 @@ class MST(Algorithm):
         d_in: list["Bound"],
         d_out: float,
         *,
-        marginals: dict[tuple[str, ...], Any],
+        marginals: Marginals,
         model: Any,  # MarkovRandomField
     ) -> Measurement:
         """Implements MST (Minimum Spanning Tree) over ordinal data.
@@ -150,7 +150,7 @@ class MST(Algorithm):
 
         def function(
             qbl: Queryable,
-        ) -> tuple[dict[tuple[str, ...], Any], MarkovRandomField]:
+        ) -> tuple[Marginals, MarkovRandomField]:
 
             # SELECT a set of queries that best reduces the error
             m_select = _make_mst_select(
@@ -178,13 +178,13 @@ class MST(Algorithm):
                 T=float,
             )
 
-            all_marginals = weight_marginals(marginals, *qbl(m_measure))
+            all_marginals = marginals.add(*qbl(m_measure))
 
             # GENERATE (fit a MarkovRandomField)
             new_model = self.estimator(
                 model.domain,
-                list(all_marginals.values()),
-                potentials=model.potentials.expand(model.cliques + selected_cliques),
+                all_marginals.flatten(),
+                potentials=model.potentials,
             )
             return all_marginals, new_model
 

--- a/python/src/opendp/extras/mbi/_sequential/__init__.py
+++ b/python/src/opendp/extras/mbi/_sequential/__init__.py
@@ -10,6 +10,7 @@ from opendp.extras.mbi._utilities import (
     Algorithm,
     get_associated_metric,
     get_cardinalities,
+    Marginals,
 )
 from opendp.metrics import frame_distance, symmetric_distance
 from opendp.mod import (
@@ -63,7 +64,7 @@ class Sequential(Algorithm):
         d_in: list["Bound"],
         d_out: float,
         *,
-        marginals: dict[tuple[str, ...], Any],
+        marginals: Marginals,
         model: Any,  # MarkovRandomField
     ):
         """Implements a "Sequential" algorithm over ordinal data.
@@ -105,7 +106,7 @@ class Sequential(Algorithm):
 
         def function(
             qbl: Queryable,
-        ) -> tuple[dict[tuple[str, ...], Any], MarkovRandomField]:
+        ) -> tuple[Marginals, MarkovRandomField]:
             all_marginals = marginals.copy()
             current_model = model
             for algo, d_mid in zip(self.algorithms, d_mids):

--- a/python/src/opendp/extras/mbi/_table/__init__.py
+++ b/python/src/opendp/extras/mbi/_table/__init__.py
@@ -25,9 +25,11 @@ from opendp.extras.mbi._aim import AIM
 from opendp.extras.mbi._utilities import (
     prior,
     get_std,
+    identity_query_precision,
     row_major_order,
-    weight_marginals,
+    SelectPrefixQuery,
     Algorithm,
+    Marginals,
     ONEWAY_UNKEYED,
 )
 from opendp.measurements import make_private_lazyframe
@@ -59,8 +61,8 @@ class ContingencyTable:
     """Unique keys for each column"""
     cuts: dict[str, Any]  # dict[str, Series]
     """Cut points (left-open) for each numeric column"""
-    marginals: dict[tuple[str, ...], Any]  # dict[tuple[str, ...], LinearMeasurement]
-    """Mapping from clique name to LinearMeasurement used to fit the model"""
+    marginals: Marginals
+    """Measurements used to fit the model, keyed by clique"""
     model: Any  # MarkovRandomField
     """MarkovRandomField spanning the same columns as keys"""
     thresholds: dict[str, int] = field(default_factory=dict)
@@ -93,6 +95,12 @@ class ContingencyTable:
             if len(self.keys[col]) - 1 != len(cutset):
                 msg = f'"{col}" keyset length ({len(self.keys[col])}) must be one greater than the number of cuts ({len(cutset)})'
                 raise ValueError(msg)
+
+        if isinstance(self.marginals, dict):
+            self.marginals = Marginals({
+                tuple(clique): [measurement]
+                for clique, measurement in self.marginals.items()
+            })
 
     def synthesize(
         self, rows: Optional[int] = None, method: Literal["round", "sample"] = "round"
@@ -156,6 +164,11 @@ class ContingencyTable:
         use :py:func:`~opendp.accuracy.gaussian_scale_to_accuracy`
         to construct a confidence interval.
 
+        Only complete identity measurements over a clique that covers
+        ``attrs`` contribute precision. Marginals released via a partial
+        (prefix) query don't contribute a per-cell precision, so this may
+        raise if ``attrs`` is only covered by such measurements.
+
         :param attrs: attributes to preserve in uncertainty estimate
         """
         from mbi import MarkovRandomField  # type: ignore[import-untyped,import-not-found]
@@ -168,11 +181,17 @@ class ContingencyTable:
         attrs_clique = set(attrs)
         size = model.domain.size
 
-        inv_var_sum = sum(
-            1 / (lm.stddev**2 * size(clique) / size(attrs_clique))
-            for clique, lm in self.marginals.items()
-            if attrs_clique.issuperset(clique)
-        )
+        inv_var_sum = 0.0
+        for measurement in self.marginals.flatten():
+            clique = measurement.clique
+            # a measurement informs a projection only if it was taken over a
+            # clique that covers (is a superset of) the requested attrs --
+            # marginalizing down sums independent noisy cells together
+            if not attrs_clique.issubset(clique):
+                continue
+            inv_var_sum += identity_query_precision(measurement) / (
+                size(clique) / size(attrs_clique)
+            )
 
         if inv_var_sum == 0:
             raise ValueError(f"attrs ({attrs}) are not covered by the query set")
@@ -241,7 +260,7 @@ def make_contingency_table(
         thresholds = table.thresholds.copy()
     else:
         model = None
-        marginals = {}
+        marginals = Marginals()
         thresholds = {}
 
     if cuts_pl:
@@ -283,6 +302,10 @@ def make_contingency_table(
             d_oneway = d_oneway, delta  # type: ignore[assignment]
 
         d_mids = [d_oneway, d_multiway if delta is None else (d_multiway, 0.0)]  # type: ignore[has-type]
+        has_prior_total = any(
+            identity_query_precision(measurement) > 0
+            for measurement in marginals.flatten()
+        )
         m_oneway, scale, threshold = _make_oneway_marginals(
             input_domain,
             input_metric,
@@ -292,6 +315,8 @@ def make_contingency_table(
             keys=keys_pl,
             plan=plan,
             unknown_only=algorithm.oneway == ONEWAY_UNKEYED,
+            has_prior_total=has_prior_total,
+            release_total=algorithm.needs_model,
         )
         if threshold is not None:
             thresholds |= {
@@ -317,7 +342,7 @@ def make_contingency_table(
         if m_oneway:
             new_keys, oneway_releases = qbl(m_oneway)
             stable_keys |= new_keys
-            current_marginals = weight_marginals(current_marginals, *oneway_releases)
+            current_marginals = current_marginals.add(*oneway_releases)
 
         mbi_domain = mbi.Domain.fromdict({c: len(k) for c, k in stable_keys.items()})
 
@@ -325,11 +350,14 @@ def make_contingency_table(
         if isinstance(model, mbi.MarkovRandomField):
             import attr  # type: ignore[import-not-found]
 
-            potential_factor = attr.evolve(model.potentials, domain=mbi_domain)
-            potentials = potential_factor.expand(list(current_marginals.keys()))
+            potentials = attr.evolve(model.potentials, domain=mbi_domain)
 
-        current_model = algorithm.estimator(
-            mbi_domain, list(current_marginals.values()), potentials=potentials
+        current_model = (
+            algorithm.estimator(
+                mbi_domain, current_marginals.flatten(), potentials=potentials
+            )
+            if algorithm.needs_model
+            else model
         )
 
         t_index = make_stable_lazyframe(
@@ -363,7 +391,7 @@ def make_contingency_table(
         if delta is not None:
             m_index_marginals = make_approximate(m_index_marginals)
 
-        T: TypeAlias = tuple[dict[tuple[str, ...], Any], mbi.MarkovRandomField]
+        T: TypeAlias = tuple[Marginals, mbi.MarkovRandomField]
         current_marginals, current_model = cast(T, qbl(m_index_marginals))
 
         ordered_keys = {c: stable_keys[c] for c in input_domain.columns}
@@ -422,13 +450,18 @@ def _make_oneway_marginals(
     keys: dict[str, Any],
     plan: Any,
     unknown_only: bool,
+    has_prior_total: bool,
+    release_total: bool = True,
 ) -> tuple[Measurement, float, Optional[int]]:
     """Returns a measurement that releases keys and counts for one-way marginals,
-    as well as the discovered scale and threshold."""
+    as well as the discovered scale and threshold.
+
+    ``release_total`` is only needed when the next algorithm needs a fitted
+    model to select its workload; a fixed workload can use its own identity
+    marginal to constrain the total."""
     from opendp.extras.polars import dp_len
     import polars as pl  # type: ignore[import-not-found]
     from mbi import LinearMeasurement  # type: ignore[import-not-found]
-    from mbi.estimation import minimum_variance_unbiased_total  # type: ignore[import-untyped,import-not-found]
     import numpy as np  # type: ignore[import-not-found]
 
     def group_by_agg(plan: pl.LazyFrame, name: str) -> pl.LazyFrame:
@@ -458,8 +491,20 @@ def _make_oneway_marginals(
             for name in input_domain.columns
             if name not in keys or not unknown_only
         ]
-        # estimating the total is necessary if there are no keyed columns
-        should_total = all(name not in keys for name in input_domain.columns)
+
+        will_release_full_identity = any(
+            name in keys
+            for name in names
+        )
+
+        # An algorithm that selects its workload needs a total constraint
+        # before that selection. A fixed workload does not: its own identity
+        # marginal will constrain the total after it is released.
+        # When `unknown_only`, keyed columns are excluded from `names`, so a
+        # one-way identity marginal is not available for model selection.
+        should_total = release_total and not (
+            has_prior_total or will_release_full_identity
+        )
 
         one_way_measurements = [
             make_private_lazyframe(
@@ -489,11 +534,10 @@ def _make_oneway_marginals(
 
             if should_total:
                 total = counts.pop().item()
-            else:
-                total = minimum_variance_unbiased_total(
-                    LinearMeasurement(count["len"].to_numpy(), [name], stddev=std)
-                    for name, count in zip(names, counts)
-                    if name in keys
+                lm_counts.append(
+                    LinearMeasurement(
+                        np.asarray([total], dtype=float), clique=(), stddev=std
+                    )
                 )
 
             for name, count in zip(names, counts):
@@ -502,16 +546,32 @@ def _make_oneway_marginals(
 
                 if name in keys:
                     values_iter: Iterator[int] = (lookup[k] for k in keys[name])
+                    values = np.fromiter(values_iter, dtype=np.int64)
+                    lm_counts.append(
+                        LinearMeasurement(values, clique=[name], stddev=std)
+                    )
                 else:
-                    lookup.setdefault(None, 0)
-                    lookup[None] += total - count["len"].sum()
                     dtype = count[name].dtype
+                    observed_keys = [key for key in lookup if key is not None]
 
-                    new_keys[name] = pl.Series(name, lookup.keys(), dtype=dtype)
-                    values_iter = lookup.values()  # type: ignore[assignment]
+                    # Null represents both actual nulls and values omitted by
+                    # private key discovery. Keep it as a latent final cell.
+                    new_keys[name] = pl.Series(
+                        name, [*observed_keys, None], dtype=dtype
+                    )
 
-                values = np.fromiter(values_iter, dtype=np.int64)
-                lm_counts.append(LinearMeasurement(values, clique=[name], stddev=std))
+                    if observed_keys:
+                        values = np.fromiter(
+                            (lookup[key] for key in observed_keys), dtype=np.int64
+                        )
+                        lm_counts.append(
+                            LinearMeasurement(
+                                values,
+                                clique=[name],
+                                stddev=std,
+                                query=SelectPrefixQuery(len(observed_keys)),
+                            )
+                        )
 
             return new_keys, lm_counts
 

--- a/python/src/opendp/extras/mbi/_utilities/__init__.py
+++ b/python/src/opendp/extras/mbi/_utilities/__init__.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Callable, Literal, Optional, Any, Iterator, cast, get_args, TYPE_CHECKING
+from typing import Callable, Literal, Optional, Any, Iterator, get_args, TYPE_CHECKING
 from functools import reduce
 from math import sqrt
 from opendp._internal import (
@@ -35,8 +35,10 @@ from opendp.mod import (
     Metric,
     Transformation,
 )
+
 if TYPE_CHECKING:  # pragma: no cover
     from opendp.extras.polars import Bound
+
 
 @dataclass
 class Count:
@@ -64,15 +66,17 @@ def mirror_descent(
     potentials=None,  # CliqueVector | None
 ):  # MarkovRandomField
     """Fit a MarkovRandomField over the domain and loss function using mirror descent.
-    
+
     If you want to use a custom estimator, consider this a contract/example.
     Your function can then close over configuration for any MBI estimator."""
     from mbi.estimation import mirror_descent as _mirror_descent  # type: ignore
 
     return _mirror_descent(domain, loss_fn, potentials=potentials)
 
+
 OnewayType = Literal["all", "unkeyed"]
 ONEWAY_ALL, ONEWAY_UNKEYED = get_args(OnewayType)
+
 
 @dataclass(kw_only=True, frozen=True)
 class Algorithm(ABC):
@@ -98,9 +102,16 @@ class Algorithm(ABC):
     and when no columns have keys, then ``oneway_split`` is one-half.
     """
 
+    @property
+    def needs_model(self) -> bool:
+        """Whether a fitted model is needed to select the workload."""
+        return True
+
     def __post_init__(self):
         if self.oneway not in get_args(OnewayType):
-            raise ValueError(f'oneway ({self.oneway}) must be in {get_args(OnewayType)}')
+            raise ValueError(
+                f"oneway ({self.oneway}) must be in {get_args(OnewayType)}"
+            )
 
         if self.oneway_split is not None and not (0 <= self.oneway_split < 1):
             raise ValueError(f"oneway_split ({self.oneway_split}) must be in [0, 1)")
@@ -114,7 +125,7 @@ class Algorithm(ABC):
         d_in: list["Bound"],
         d_out: float,
         *,
-        marginals: dict[tuple[str, ...], Any],
+        marginals: "Marginals",
         model,  # MarkovRandomField
     ) -> Measurement: ...
 
@@ -346,35 +357,92 @@ def row_major_order(keys: Iterator):
     return reduce(reducer, (keyset.to_frame() for keyset in keys))
 
 
-def weight_marginals(
-    marginals: dict[tuple[str, ...], Any], *new_marginals
-) -> dict[tuple[str, ...], Any]:
-    from mbi import LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+@dataclass(frozen=True)
+class SelectPrefixQuery:
+    """Select a prefix of a flattened MBI marginal.
 
-    marginals = marginals.copy()
+    Used when the final cell is a latent synthetic ``other`` bucket rather than
+    a directly measured count.
+    """
 
-    for new_marginal in new_marginals:
-        if not isinstance(new_marginal, LinearMeasurement):
-            raise ValueError("each new marginal must be of type LinearMeasurement")
+    length: int
 
-        clique = new_marginal.clique
-        old_marginal = cast(Optional[LinearMeasurement], marginals.get(clique))
+    def __call__(self, factor):
+        return factor.datavector()[: self.length]
 
-        if old_marginal is None:
-            marginals[clique] = new_marginal
-            continue
 
-        old_var = old_marginal.stddev**2
-        old = old_marginal.noisy_measurement
+def _queries_equal(left: Callable, right: Callable) -> bool:
+    if left is right:
+        return True
+    try:
+        result = left == right
+        return result if isinstance(result, bool) else False
+    except Exception:  # pragma: no cover - defensive for user-defined queries
+        return False
 
-        new_var = new_marginal.stddev**2
-        new = new_marginal.noisy_measurement
 
-        weighted_var = 1 / (1 / old_var + 1 / new_var)
-        weighted = (old / old_var + new / new_var) * weighted_var
+def identity_query_precision(measurement) -> float:
+    """Return precision contributed by a full-datavector observation.
 
-        marginals[clique] = LinearMeasurement(
-            weighted, clique, stddev=sqrt(weighted_var)
-        )
+    Partial queries do not provide a uniform uncertainty estimate for every
+    cell in a marginal, so they contribute zero precision.
+    """
+    from mbi import Factor  # type: ignore[import-untyped,import-not-found]
 
-    return marginals
+    if _queries_equal(measurement.query, Factor.datavector):
+        return 1 / measurement.stddev**2
+    return 0.0
+
+
+class Marginals:
+    """A multimap from clique to independent :py:class:`mbi.LinearMeasurement`.
+
+    A clique identifies the marginal a query operates on; it does not
+    uniquely identify the observation. Several independent measurements can
+    legitimately share a clique: an initial partial (prefix) release, a later
+    full release, a zero-way total, or any other linear query over the same
+    marginal. Distinct query operators are kept as separate observations,
+    even when their cliques match.
+    """
+
+    def __init__(self, by_clique: Optional[dict[tuple[str, ...], list]] = None):
+        self.by_clique: dict[tuple[str, ...], list] = {
+            clique: list(group) for clique, group in (by_clique or {}).items()
+        }
+
+    def cliques(self) -> list[tuple[str, ...]]:
+        """Unique cliques with at least one measurement."""
+        return list(self.by_clique)
+
+    def flatten(self) -> list:
+        """All measurements, across all cliques."""
+        return [
+            measurement for group in self.by_clique.values() for measurement in group
+        ]
+
+    def copy(self) -> "Marginals":
+        return Marginals(self.by_clique)
+
+    def add(self, *new_measurements) -> "Marginals":
+        """Return a new collection with `new_measurements` appended.
+
+        Each measurement is kept atomic: independent observations sharing a
+        clique (a repeated identity release, a prefix release alongside a
+        later full release, a repeated zero-way total, ...) are never
+        combined. Inverse-variance coalescing is exact only for the default
+        quadratic loss, and `Algorithm.estimator` is a public extension point
+        that may use an L1 or other custom loss, so combining measurements
+        here would silently change the meaning of the supplied collection
+        for such an estimator. MBI already sums losses across atomic
+        measurements, so keeping them separate is correct for any loss."""
+        from mbi import LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+
+        result = self.copy()
+
+        for new in new_measurements:
+            if not isinstance(new, LinearMeasurement):
+                raise ValueError("each new marginal must be of type LinearMeasurement")
+
+            result.by_clique.setdefault(new.clique, []).append(new)
+
+        return result

--- a/python/src/opendp/extras/mbi/_utilities/__init__.py
+++ b/python/src/opendp/extras/mbi/_utilities/__init__.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Callable, Literal, Optional, Any, Iterator, cast, get_args, TYPE_CHECKING
+from typing import Callable, Literal, Optional, Any, Iterator, get_args, TYPE_CHECKING
 from functools import reduce
 from math import sqrt
 from opendp._internal import (
@@ -35,8 +35,10 @@ from opendp.mod import (
     Metric,
     Transformation,
 )
+
 if TYPE_CHECKING:  # pragma: no cover
     from opendp.extras.polars import Bound
+
 
 @dataclass
 class Count:
@@ -64,15 +66,17 @@ def mirror_descent(
     potentials=None,  # CliqueVector | None
 ):  # MarkovRandomField
     """Fit a MarkovRandomField over the domain and loss function using mirror descent.
-    
+
     If you want to use a custom estimator, consider this a contract/example.
     Your function can then close over configuration for any MBI estimator."""
     from mbi.estimation import mirror_descent as _mirror_descent  # type: ignore
 
     return _mirror_descent(domain, loss_fn, potentials=potentials)
 
+
 OnewayType = Literal["all", "unkeyed"]
 ONEWAY_ALL, ONEWAY_UNKEYED = get_args(OnewayType)
+
 
 @dataclass(kw_only=True, frozen=True)
 class Algorithm(ABC):
@@ -98,9 +102,16 @@ class Algorithm(ABC):
     and when no columns have keys, then ``oneway_split`` is one-half.
     """
 
+    @property
+    def needs_model(self) -> bool:
+        """Whether a fitted model is needed to select the workload."""
+        return True
+
     def __post_init__(self):
         if self.oneway not in get_args(OnewayType):
-            raise ValueError(f'oneway ({self.oneway}) must be in {get_args(OnewayType)}')
+            raise ValueError(
+                f"oneway ({self.oneway}) must be in {get_args(OnewayType)}"
+            )
 
         if self.oneway_split is not None and not (0 <= self.oneway_split < 1):
             raise ValueError(f"oneway_split ({self.oneway_split}) must be in [0, 1)")
@@ -114,7 +125,7 @@ class Algorithm(ABC):
         d_in: list["Bound"],
         d_out: float,
         *,
-        marginals: dict[tuple[str, ...], Any],
+        marginals: "Marginals",
         model,  # MarkovRandomField
     ) -> Measurement: ...
 
@@ -342,35 +353,92 @@ def row_major_order(keys: Iterator):
     return reduce(reducer, (keyset.to_frame() for keyset in keys))
 
 
-def weight_marginals(
-    marginals: dict[tuple[str, ...], Any], *new_marginals
-) -> dict[tuple[str, ...], Any]:
-    from mbi import LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+@dataclass(frozen=True)
+class SelectPrefixQuery:
+    """Select a prefix of a flattened MBI marginal.
 
-    marginals = marginals.copy()
+    Used when the final cell is a latent synthetic ``other`` bucket rather than
+    a directly measured count.
+    """
 
-    for new_marginal in new_marginals:
-        if not isinstance(new_marginal, LinearMeasurement):
-            raise ValueError("each new marginal must be of type LinearMeasurement")
+    length: int
 
-        clique = new_marginal.clique
-        old_marginal = cast(Optional[LinearMeasurement], marginals.get(clique))
+    def __call__(self, factor):
+        return factor.datavector()[: self.length]
 
-        if old_marginal is None:
-            marginals[clique] = new_marginal
-            continue
 
-        old_var = old_marginal.stddev**2
-        old = old_marginal.noisy_measurement
+def _queries_equal(left: Callable, right: Callable) -> bool:
+    if left is right:
+        return True
+    try:
+        result = left == right
+        return result if isinstance(result, bool) else False
+    except Exception:  # pragma: no cover - defensive for user-defined queries
+        return False
 
-        new_var = new_marginal.stddev**2
-        new = new_marginal.noisy_measurement
 
-        weighted_var = 1 / (1 / old_var + 1 / new_var)
-        weighted = (old / old_var + new / new_var) * weighted_var
+def identity_query_precision(measurement) -> float:
+    """Return precision contributed by a full-datavector observation.
 
-        marginals[clique] = LinearMeasurement(
-            weighted, clique, stddev=sqrt(weighted_var)
-        )
+    Partial queries do not provide a uniform uncertainty estimate for every
+    cell in a marginal, so they contribute zero precision.
+    """
+    from mbi import Factor  # type: ignore[import-untyped,import-not-found]
 
-    return marginals
+    if _queries_equal(measurement.query, Factor.datavector):
+        return 1 / measurement.stddev**2
+    return 0.0
+
+
+class Marginals:
+    """A multimap from clique to independent :py:class:`mbi.LinearMeasurement`.
+
+    A clique identifies the marginal a query operates on; it does not
+    uniquely identify the observation. Several independent measurements can
+    legitimately share a clique: an initial partial (prefix) release, a later
+    full release, a zero-way total, or any other linear query over the same
+    marginal. Distinct query operators are kept as separate observations,
+    even when their cliques match.
+    """
+
+    def __init__(self, by_clique: Optional[dict[tuple[str, ...], list]] = None):
+        self.by_clique: dict[tuple[str, ...], list] = {
+            clique: list(group) for clique, group in (by_clique or {}).items()
+        }
+
+    def cliques(self) -> list[tuple[str, ...]]:
+        """Unique cliques with at least one measurement."""
+        return list(self.by_clique)
+
+    def flatten(self) -> list:
+        """All measurements, across all cliques."""
+        return [
+            measurement for group in self.by_clique.values() for measurement in group
+        ]
+
+    def copy(self) -> "Marginals":
+        return Marginals(self.by_clique)
+
+    def add(self, *new_measurements) -> "Marginals":
+        """Return a new collection with `new_measurements` appended.
+
+        Each measurement is kept atomic: independent observations sharing a
+        clique (a repeated identity release, a prefix release alongside a
+        later full release, a repeated zero-way total, ...) are never
+        combined. Inverse-variance coalescing is exact only for the default
+        quadratic loss, and `Algorithm.estimator` is a public extension point
+        that may use an L1 or other custom loss, so combining measurements
+        here would silently change the meaning of the supplied collection
+        for such an estimator. MBI already sums losses across atomic
+        measurements, so keeping them separate is correct for any loss."""
+        from mbi import LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+
+        result = self.copy()
+
+        for new in new_measurements:
+            if not isinstance(new, LinearMeasurement):
+                raise ValueError("each new marginal must be of type LinearMeasurement")
+
+            result.by_clique.setdefault(new.clique, []).append(new)
+
+        return result

--- a/python/test/mbi/test_algorithms.py
+++ b/python/test/mbi/test_algorithms.py
@@ -4,6 +4,7 @@ from opendp.extras.mbi import (
     Count,
     AIM,
     MST,
+    Marginals,
     Sequential,
 )
 import opendp.prelude as dp
@@ -43,7 +44,7 @@ def test_algorithm_err_elements(algorithm):
             dp.zero_concentrated_divergence(),
             d_in=[dp.polars.Bound(per_group=1)],
             d_out=0.5,
-            marginals={},
+            marginals=Marginals(),
             model=model,
         )
 
@@ -57,7 +58,7 @@ def test_algorithm_err_elements(algorithm):
             dp.zero_concentrated_divergence(),
             d_in=[dp.polars.Bound(per_group=1)],
             d_out=0.5,
-            marginals={},
+            marginals=Marginals(),
             model=model,
         )
 
@@ -71,7 +72,7 @@ def test_algorithm_err_elements(algorithm):
             dp.renyi_divergence(),
             d_in=[dp.polars.Bound(per_group=1)],
             d_out=0.5,
-            marginals={},
+            marginals=Marginals(),
             model=model,
         )
 
@@ -84,8 +85,11 @@ def test_algorithm_err_elements(algorithm):
             dp.max_divergence(),
             d_in=[dp.polars.Bound(per_group=1)],
             d_out=1.0,
-            marginals={},
-            model=None,
+            marginals=Marginals(),
+            # Fixed can intentionally start without a model because its fixed
+            # workload provides the first model constraint. Pass an invalid
+            # non-None value so every algorithm still exercises validation.
+            model=object(),
         )
 
 
@@ -118,7 +122,7 @@ def test_aim_exhaustion():
         dp.max_divergence(),
         d_in=[dp.polars.Bound(per_group=1)],
         d_out=1.0,
-        marginals={},
+        marginals=Marginals(),
         model=dp.mbi.mirror_descent(mbi.Domain(("A",), (2,)), []),
     )
 

--- a/python/test/mbi/test_table.py
+++ b/python/test/mbi/test_table.py
@@ -1,7 +1,21 @@
 import re
-from opendp.extras.mbi import Fixed, AIM, MST, ContingencyTable, Count, Sequential
-from opendp.extras.mbi._table import _get_null_index, _increasing, _unique, _with_null
-from opendp.extras.mbi._utilities import mirror_descent
+from opendp.extras.mbi import (
+    Fixed,
+    AIM,
+    MST,
+    ContingencyTable,
+    Count,
+    Marginals,
+    Sequential,
+)
+from opendp.extras.mbi._table import (
+    _get_null_index,
+    _increasing,
+    _make_oneway_marginals,
+    _unique,
+    _with_null,
+)
+from opendp.extras.mbi._utilities import mirror_descent, SelectPrefixQuery
 import pytest
 import opendp.prelude as dp
 import warnings
@@ -80,7 +94,10 @@ def test_fit_effectiveness(algorithm, privacy_loss, approximate):
     try:
         std = table.std(("A",))
         assert isinstance(std, float)
-        assert 1 < std < 5
+        # a coarser marginal that covers "A" (e.g. ("A", "B")) can now
+        # legitimately inform this estimate, not just a direct ("A",) release,
+        # so this is a loose sanity bound rather than a tight calibration
+        assert 0 < std < 20
     except ValueError:
         pass
 
@@ -98,16 +115,15 @@ def test_fit_effectiveness(algorithm, privacy_loss, approximate):
     def test_cov(clique):
         idx = {"A": 0, "B": 1, "C": 2}
         i, j = idx[clique[0]], idx[clique[-1]]
-        assert 0 == pytest.approx(abs(cov[i, j] - cov_syn[i, j]), abs=0.2), (
+        assert abs(cov[i, j] - cov_syn[i, j]) < 0.2, (
             f"{clique} cov drifted: {cov[i, j]=:.3f}, {cov_syn[i, j]=:.3f}"
         )
 
     # in an MRF, a missing 2-way marginal does not imply independence
     # max-entropy does not guarantee spurious correlations won't be formed on undetermined pairs
-    if not approximate:
-        test_cov(("A", "B"))
-        for clique in (cl for cl in table.marginals if len(cl) <= 2):
-            test_cov(clique)
+    test_cov(("A", "B"))
+    for clique in (cl for cl in table.marginals.cliques() if 0 < len(cl) <= 2):
+        test_cov(clique)
 
 
 def test_contingency_table_int_cuts():
@@ -124,7 +140,8 @@ def test_contingency_table_int_cuts():
     table = ContingencyTable(
         keys={"A": pl.Series("A", ["a", "b", "c", "d", "e"])},
         cuts={"A": A_cuts},
-        marginals={("A",): lm},
+        # Exercise the backwards-compatible dict-to-Marginals conversion.
+        marginals={("A",): lm},  # type: ignore[arg-type]
         model=model,
     )
 
@@ -156,7 +173,7 @@ def test_contingency_table_project():
     table = ContingencyTable(
         keys={"A": A_keys, "B": B_keys},
         cuts={},
-        marginals={("A",): A_lm, ("B",): B_lm},
+        marginals=Marginals({("A",): [A_lm], ("B",): [B_lm]}),
         model=model,
     )
 
@@ -208,6 +225,8 @@ def test_make_contingency_table_multi_fit():
         .release()
     )
 
+    cliques_before = set(table.marginals.cliques())
+
     # expand the contingency table to also include ("B", "C")
     table2: ContingencyTable = (
         context.query(rho=0.05)
@@ -217,6 +236,10 @@ def test_make_contingency_table_multi_fit():
     )
 
     assert table2.schema == {"A": pl.Int64, "B": pl.Int64, "C": pl.Int64}
+
+    # reusing `table` as input to a later query must not mutate it
+    assert set(table.marginals.cliques()) == cliques_before
+    assert set(table2.marginals.cliques()) > cliques_before
 
 
 def test_make_contingency_table_invalid_d_out():
@@ -247,7 +270,7 @@ def test_contingency_table_invalid_shape():
         ContingencyTable(
             keys={},
             cuts={},
-            marginals={},
+            marginals=Marginals(),
             model=get_model({"A": 3}),
         )
 
@@ -258,7 +281,7 @@ def test_contingency_table_missing_cut():
         ContingencyTable(
             keys={"A": [1, 2, 3]},
             cuts={"B": [1, 2, 3]},
-            marginals={},
+            marginals=Marginals(),
             model=get_model({"A": 3}),
         )
 
@@ -270,7 +293,7 @@ def test_contingency_table_misshapen_cut():
         ContingencyTable(
             keys={"A": [1, 2, 3], "B": ["a", "b", "c"]},
             cuts={"B": [1, 2, 3]},
-            marginals={},
+            marginals=Marginals(),
             model=get_model({"A": 3, "B": 3}),
         )
 
@@ -312,6 +335,31 @@ def test_contingency_table_delta():
     )
 
 
+def test_make_oneway_marginals_releases_total():
+    pytest.importorskip("mbi")
+    import polars as pl  # type: ignore[import-not-found]
+    from opendp.domains import _lazyframe_from_domain
+
+    input_domain = dp.lazyframe_domain(
+        [dp.series_domain("A", dp.atom_domain(T="u32", bounds=(0, 1)))]
+    )
+    m_oneway, _, _ = _make_oneway_marginals(
+        input_domain,
+        dp.frame_distance(dp.symmetric_distance()),
+        dp.approximate(dp.max_divergence()),
+        d_in=[dp.polars.Bound(per_group=1)],
+        d_out=(0.5, 1e-8),
+        keys={},
+        plan=_lazyframe_from_domain(input_domain),
+        unknown_only=False,
+        has_prior_total=False,
+        release_total=True,
+    )
+
+    _, releases = m_oneway(pl.LazyFrame({"A": [0]}))
+    assert any(release.clique == () for release in releases)
+
+
 def test_contingency_table_len():
     pytest.importorskip("mbi")
     import polars as pl  # type: ignore[import-not-found]
@@ -337,7 +385,8 @@ def test_contingency_table_minimum_variance_weighted_total():
         privacy_loss=dp.loss_of(epsilon=1.0, delta=1e-8),
     )
 
-    # tests fit when no columns have keys, so total is estimated directly
+    # tests fit when no columns have keys, using the fixed identity marginal
+    # to constrain the total
     table: ContingencyTable = (
         context.query(epsilon=1.0, delta=1e-8)
         .contingency_table(algorithm=Fixed(queries=[Count(("A",))], oneway_split=0.9))
@@ -345,6 +394,154 @@ def test_contingency_table_minimum_variance_weighted_total():
     )
 
     assert 950 < table.project([]) < 1050
+
+
+def test_fixed_unkeyed_does_not_release_zero_way_total():
+    pytest.importorskip("mbi")
+    import polars as pl  # type: ignore[import-not-found]
+
+    context = dp.Context.compositor(
+        data=pl.LazyFrame({"A": [1] * 1000}),
+        privacy_unit=dp.unit_of(contributions=1),
+        privacy_loss=dp.loss_of(epsilon=1.0, delta=1e-8),
+    )
+
+    table: ContingencyTable = (
+        context.query(epsilon=1.0, delta=1e-8)
+        .contingency_table(algorithm=Fixed(queries=[Count(("A",))], oneway_split=0.9))
+        .release()
+    )
+
+    assert () not in table.marginals.by_clique
+    fixed_measurement = table.marginals.by_clique[("A",)][-1]
+    # The fixed workload receives the remaining 10% of the budget.
+    assert fixed_measurement.stddev == pytest.approx(10 * 2**0.5)
+
+
+def test_contingency_table_std_ignores_zero_way_total():
+    pytest.importorskip("mbi")
+    from mbi import Domain, LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+    import numpy as np  # type: ignore[import-not-found]
+    import polars as pl  # type: ignore[import-not-found]
+
+    A_lm = LinearMeasurement(np.array([3.0, 5.0]), clique=("A",), stddev=1.0)
+    total_lm = LinearMeasurement(np.array([8.0]), clique=(), stddev=0.01)
+
+    model = mirror_descent(Domain(("A",), (2,)), [A_lm, total_lm])
+    table = ContingencyTable(
+        keys={"A": pl.Series("A", ["a1", "a2"])},
+        cuts={},
+        marginals=Marginals({("A",): [A_lm], (): [total_lm]}),
+        model=model,
+    )
+
+    # a total constrains the sum of cells, not each cell directly,
+    # so its precision shouldn't count towards the std of an individual cell
+    assert table.std(("A",)) == pytest.approx(1.0)
+
+
+def test_contingency_table_std_sums_independent_identity_measurements():
+    pytest.importorskip("mbi")
+    from mbi import Domain, LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+    import numpy as np  # type: ignore[import-not-found]
+    import polars as pl  # type: ignore[import-not-found]
+
+    # a partial (prefix) query contributes no per-cell precision, so only
+    # `full`'s precision should count -- this is only reachable now that a
+    # clique can hold more than one independent measurement
+    prefix = LinearMeasurement(
+        np.array([3.0]), clique=("A",), stddev=1.0, query=SelectPrefixQuery(1)
+    )
+    full = LinearMeasurement(np.array([3.0, 5.0]), clique=("A",), stddev=2.0)
+
+    model = mirror_descent(Domain(("A",), (2,)), [prefix, full])
+    table = ContingencyTable(
+        keys={"A": pl.Series("A", ["a1", "a2"])},
+        cuts={},
+        marginals=Marginals({("A",): [prefix, full]}),
+        model=model,
+    )
+    assert table.std(("A",)) == pytest.approx(full.stddev)
+
+    # two independent full identity measurements over the same clique each
+    # contribute precision independently, summing by inverse variance
+    full2 = LinearMeasurement(np.array([3.0, 5.0]), clique=("A",), stddev=4.0)
+    model2 = mirror_descent(Domain(("A",), (2,)), [full, full2])
+    table2 = ContingencyTable(
+        keys={"A": pl.Series("A", ["a1", "a2"])},
+        cuts={},
+        marginals=Marginals({("A",): [full, full2]}),
+        model=model2,
+    )
+    expected_std = (1 / full.stddev**2 + 1 / full2.stddev**2) ** -0.5
+    assert table2.std(("A",)) == pytest.approx(expected_std)
+
+
+def test_contingency_table_std_larger_measurement_informs_smaller_projection():
+    pytest.importorskip("mbi")
+    from mbi import Domain, LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+    import numpy as np  # type: ignore[import-not-found]
+    import polars as pl  # type: ignore[import-not-found]
+
+    # a complete identity measurement over (A, B) informs the projection
+    # onto the smaller clique (A,), by summing independent noisy cells
+    AB_lm = LinearMeasurement(
+        np.array([1.0, 2.0, 3.0, 4.0]), clique=("A", "B"), stddev=2.0
+    )
+    domain = Domain(("A", "B"), (2, 2))
+    model = mirror_descent(domain, [AB_lm])
+    table = ContingencyTable(
+        keys={"A": pl.Series("A", ["a1", "a2"]), "B": pl.Series("B", ["b1", "b2"])},
+        cuts={},
+        marginals=Marginals({("A", "B"): [AB_lm]}),
+        model=model,
+    )
+
+    expected = AB_lm.stddev * (domain.size(("A", "B")) / domain.size(("A",))) ** 0.5
+    assert table.std(("A",)) == pytest.approx(expected)
+
+
+def test_contingency_table_std_smaller_measurement_does_not_inform_larger_projection():
+    pytest.importorskip("mbi")
+    from mbi import Domain, LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+    import numpy as np  # type: ignore[import-not-found]
+    import polars as pl  # type: ignore[import-not-found]
+
+    # a measurement over (A,) alone cannot provide per-cell uncertainty
+    # for the larger clique (A, B)
+    A_lm = LinearMeasurement(np.array([1.0, 2.0]), clique=("A",), stddev=1.0)
+    model = mirror_descent(Domain(("A", "B"), (2, 2)), [A_lm])
+    table = ContingencyTable(
+        keys={"A": pl.Series("A", ["a1", "a2"]), "B": pl.Series("B", ["b1", "b2"])},
+        cuts={},
+        marginals=Marginals({("A",): [A_lm]}),
+        model=model,
+    )
+
+    with pytest.raises(ValueError, match="are not covered by the query set"):
+        table.std(("A", "B"))
+
+
+def test_contingency_table_std_of_total():
+    pytest.importorskip("mbi")
+    from mbi import Domain, LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+    import numpy as np  # type: ignore[import-not-found]
+    import polars as pl  # type: ignore[import-not-found]
+
+    # any complete identity measurement informs the zero-way total, since
+    # a nonempty clique is always a superset of the empty attrs set
+    A_lm = LinearMeasurement(np.array([3.0, 5.0]), clique=("A",), stddev=1.0)
+    domain = Domain(("A",), (2,))
+    model = mirror_descent(domain, [A_lm])
+    table = ContingencyTable(
+        keys={"A": pl.Series("A", ["a1", "a2"])},
+        cuts={},
+        marginals=Marginals({("A",): [A_lm]}),
+        model=model,
+    )
+
+    expected = A_lm.stddev * domain.size(("A",)) ** 0.5
+    assert table.std(()) == pytest.approx(expected)
 
 
 def test_unique():

--- a/python/test/mbi/test_utilities.py
+++ b/python/test/mbi/test_utilities.py
@@ -1,17 +1,19 @@
 import pytest
 from opendp.extras.mbi import Count, AIM
-from math import sqrt
 import re
 from opendp._internal import _extrinsic_distance
 import opendp.prelude as dp
 from opendp.extras.mbi._utilities import (
+    Marginals,
+    SelectPrefixQuery,
     get_cardinalities,
     get_std,
+    identity_query_precision,
     make_noise_marginal,
     make_stable_marginals,
+    mirror_descent,
     typed_dict_distance,
     typed_dict_domain,
-    weight_marginals,
 )
 
 from ..helpers import ids
@@ -162,7 +164,7 @@ def test_make_noise_marginal():
     assert m_noise.map({("A",): 1}) == 1.0
 
 
-def test_weight_marginals():
+def test_marginal_measurements_add_preserves_atomic_queries():
     pytest.importorskip("mbi")
     import numpy as np  # type: ignore[import-not-found]
     from mbi import LinearMeasurement  # type: ignore[import-untyped,import-not-found]
@@ -170,12 +172,78 @@ def test_weight_marginals():
     with pytest.raises(
         ValueError, match="each new marginal must be of type LinearMeasurement"
     ):
-        weight_marginals({}, False)
+        Marginals().add(False)
 
-    lm1 = LinearMeasurement(np.array([1]), clique=("A",), stddev=1.0)
-    lm2 = LinearMeasurement(np.array([2]), clique=("A",), stddev=1.0)
-    marginals = weight_marginals({("A",): lm1}, lm2)
-    weighted: LinearMeasurement = marginals[("A",)]
-    assert weighted.stddev == sqrt(1 / 2)
+    partial = LinearMeasurement(
+        np.array([1.0]),
+        clique=("A",),
+        stddev=2.0,
+        query=SelectPrefixQuery(1),
+    )
+    full = LinearMeasurement(np.array([2.0, 3.0]), clique=("A",), stddev=1.0)
+    repeated = LinearMeasurement(
+        np.array([4.0, 5.0]), clique=("A",), stddev=3.0
+    )
+    measurements = Marginals({("A",): [partial]}).add(full, repeated)
 
-    assert np.array_equal(weighted.noisy_measurement, [1.5])
+    # Independent observations sharing a clique remain separate, regardless
+    # of whether their query operators are equal.
+    group = measurements.by_clique[("A",)]
+    assert len(group) == 3
+    assert group[0] is partial
+    assert group[1] is full
+    assert group[2] is repeated
+    assert measurements.cliques() == [("A",)]
+    assert identity_query_precision(full) == 1.0
+    assert identity_query_precision(partial) == 0.0
+
+
+def test_marginal_measurements_add_does_not_mutate():
+    pytest.importorskip("mbi")
+    import numpy as np  # type: ignore[import-not-found]
+    from mbi import LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+
+    lm = LinearMeasurement(np.array([1.0]), clique=("A",), stddev=1.0)
+    original = Marginals({("A",): [lm]})
+
+    new_lm = LinearMeasurement(np.array([5.0, 6.0]), clique=("B",), stddev=1.0)
+    updated = original.add(new_lm)
+
+    assert original.cliques() == [("A",)]
+    assert len(original.by_clique[("A",)]) == 1
+    assert updated.cliques() == [("A",), ("B",)]
+
+
+def test_latent_remainder_linear_measurement():
+    pytest.importorskip("mbi")
+    import numpy as np  # type: ignore[import-not-found]
+    from mbi import Domain, LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+
+    measurement = LinearMeasurement(
+        np.array([30.0]),
+        clique=("A",),
+        stddev=0.01,
+        query=SelectPrefixQuery(1),
+    )
+    total = LinearMeasurement(np.array([100.0]), clique=(), stddev=0.01)
+    model = mirror_descent(Domain(("A",), (2,)), [measurement, total])
+
+    assert np.allclose(model.project(("A",)).values, [30.0, 70.0], atol=0.1)
+
+
+def test_zero_way_measurement_retains_nonpositive_value():
+    pytest.importorskip("mbi")
+    import numpy as np  # type: ignore[import-not-found]
+    from mbi import Domain, LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+    from mbi.estimation import minimum_variance_unbiased_total  # type: ignore[import-untyped,import-not-found]
+
+    total = LinearMeasurement(np.array([-5.0]), clique=(), stddev=10.0)
+
+    # The raw noisy total may be nonpositive; only the optimizer's mass is
+    # floored to a valid positive value.
+    assert total.noisy_measurement.item() == -5.0
+    assert minimum_variance_unbiased_total([total]) >= 1.0
+
+    oneway = LinearMeasurement(np.array([1.0, 2.0]), clique=("A",), stddev=1.0)
+    model = mirror_descent(Domain(("A",), (2,)), [total, oneway])
+    assert float(model.total) >= 1.0

--- a/python/test/mbi/test_utilities.py
+++ b/python/test/mbi/test_utilities.py
@@ -1,17 +1,19 @@
 import pytest
 from opendp.extras.mbi import Count, AIM
-from math import sqrt
 import re
 from opendp._internal import _extrinsic_distance
 import opendp.prelude as dp
 from opendp.extras.mbi._utilities import (
+    Marginals,
+    SelectPrefixQuery,
     get_cardinalities,
     get_std,
+    identity_query_precision,
     make_noise_marginal,
     make_stable_marginals,
+    mirror_descent,
     typed_dict_distance,
     typed_dict_domain,
-    weight_marginals,
 )
 
 from ..helpers import ids
@@ -191,7 +193,7 @@ def test_make_noise_marginal():
     assert m_noise.map({("A",): 1}) == 1.0
 
 
-def test_weight_marginals():
+def test_marginal_measurements_add_preserves_atomic_queries():
     pytest.importorskip("mbi")
     import numpy as np  # type: ignore[import-not-found]
     from mbi import LinearMeasurement  # type: ignore[import-untyped,import-not-found]
@@ -199,12 +201,78 @@ def test_weight_marginals():
     with pytest.raises(
         ValueError, match="each new marginal must be of type LinearMeasurement"
     ):
-        weight_marginals({}, False)
+        Marginals().add(False)
 
-    lm1 = LinearMeasurement(np.array([1]), clique=("A",), stddev=1.0)
-    lm2 = LinearMeasurement(np.array([2]), clique=("A",), stddev=1.0)
-    marginals = weight_marginals({("A",): lm1}, lm2)
-    weighted: LinearMeasurement = marginals[("A",)]
-    assert weighted.stddev == sqrt(1 / 2)
+    partial = LinearMeasurement(
+        np.array([1.0]),
+        clique=("A",),
+        stddev=2.0,
+        query=SelectPrefixQuery(1),
+    )
+    full = LinearMeasurement(np.array([2.0, 3.0]), clique=("A",), stddev=1.0)
+    repeated = LinearMeasurement(
+        np.array([4.0, 5.0]), clique=("A",), stddev=3.0
+    )
+    measurements = Marginals({("A",): [partial]}).add(full, repeated)
 
-    assert np.array_equal(weighted.noisy_measurement, [1.5])
+    # Independent observations sharing a clique remain separate, regardless
+    # of whether their query operators are equal.
+    group = measurements.by_clique[("A",)]
+    assert len(group) == 3
+    assert group[0] is partial
+    assert group[1] is full
+    assert group[2] is repeated
+    assert measurements.cliques() == [("A",)]
+    assert identity_query_precision(full) == 1.0
+    assert identity_query_precision(partial) == 0.0
+
+
+def test_marginal_measurements_add_does_not_mutate():
+    pytest.importorskip("mbi")
+    import numpy as np  # type: ignore[import-not-found]
+    from mbi import LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+
+    lm = LinearMeasurement(np.array([1.0]), clique=("A",), stddev=1.0)
+    original = Marginals({("A",): [lm]})
+
+    new_lm = LinearMeasurement(np.array([5.0, 6.0]), clique=("B",), stddev=1.0)
+    updated = original.add(new_lm)
+
+    assert original.cliques() == [("A",)]
+    assert len(original.by_clique[("A",)]) == 1
+    assert updated.cliques() == [("A",), ("B",)]
+
+
+def test_latent_remainder_linear_measurement():
+    pytest.importorskip("mbi")
+    import numpy as np  # type: ignore[import-not-found]
+    from mbi import Domain, LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+
+    measurement = LinearMeasurement(
+        np.array([30.0]),
+        clique=("A",),
+        stddev=0.01,
+        query=SelectPrefixQuery(1),
+    )
+    total = LinearMeasurement(np.array([100.0]), clique=(), stddev=0.01)
+    model = mirror_descent(Domain(("A",), (2,)), [measurement, total])
+
+    assert np.allclose(model.project(("A",)).values, [30.0, 70.0], atol=0.1)
+
+
+def test_zero_way_measurement_retains_nonpositive_value():
+    pytest.importorskip("mbi")
+    import numpy as np  # type: ignore[import-not-found]
+    from mbi import Domain, LinearMeasurement  # type: ignore[import-untyped,import-not-found]
+    from mbi.estimation import minimum_variance_unbiased_total  # type: ignore[import-untyped,import-not-found]
+
+    total = LinearMeasurement(np.array([-5.0]), clique=(), stddev=10.0)
+
+    # The raw noisy total may be nonpositive; only the optimizer's mass is
+    # floored to a valid positive value.
+    assert total.noisy_measurement.item() == -5.0
+    assert minimum_variance_unbiased_total([total]) >= 1.0
+
+    oneway = LinearMeasurement(np.array([1.0, 2.0]), clique=("A",), stddev=1.0)
+    model = mirror_descent(Domain(("A",), (2,)), [total, oneway])
+    assert float(model.total) >= 1.0


### PR DESCRIPTION
The synthetic data implementation releases one-way marginals over unknown keysets via stability histograms. The tricky bit is that stability histograms don't sum to total, which breaks the symmetry in MBI. The current implementation inserts a synthetic bin for null counts based on best-known information about the total count. This "works", but the cell is correlated and has much higher variance, which improperly influences MBI's variance weighting.

This PR adjusts the corresponding LinearMeasurements to ignore the synthetic bin, which keeps it out of the variance calculations. In the process, I could no longer roll multiple releases for the same marginal into one via inverse variance weighting because multiple marginals for the same set of grouping columns can have different linear measurement queries.