### PR TITLE
feat: support one-sided binary-search bounds

### DIFF
--- a/R/opendp/R/mod.R
+++ b/R/opendp/R/mod.R
@@ -599,8 +599,10 @@ unbox2 <- function(x) {
 #' @param make_chain a function that takes a number and returns a Transformation or Measurement
 #' @param d_in how far apart input datasets can be
 #' @param d_out how far apart output datasets or distributions can be
-#' @param bounds a 2-tuple of the lower and upper bounds on the input of `make_chain`
-#' @param .T type of argument to `make_chain`, either "float" or "int"
+#' @param bounds a two-element list of optional lower and upper bounds on the input
+#'   of `make_chain`; use `NULL` for either bound to infer it
+#' @param .T type of argument to `make_chain`, either "float" or "int"; when set,
+#'   takes precedence over the type inferred from `bounds`
 #' @return a Transformation or Measurement (chain) that is (`d_in`, `d_out`)-close.
 #' @export
 #' @examples
@@ -625,8 +627,10 @@ binary_search_chain <- function(make_chain, d_in, d_out, bounds = NULL, .T = NUL
 #' @param make_chain a function that takes a number and returns a Transformation or Measurement
 #' @param d_in how far apart input datasets can be
 #' @param d_out how far apart output datasets or distributions can be
-#' @param bounds a 2-tuple of the lower and upper bounds on the input of `make_chain`
-#' @param .T type of argument to `make_chain`, either "float" or "int"
+#' @param bounds a two-element list of optional lower and upper bounds on the input
+#'   of `make_chain`; use `NULL` for either bound to infer it
+#' @param .T type of argument to `make_chain`, either "float" or "int"; when set,
+#'   takes precedence over the type inferred from `bounds`
 #' @return the parameter to `make_chain` that results in a (`d_in`, `d_out`)-close Transformation or Measurement
 #' @export
 binary_search_param <- function(make_chain, d_in, d_out, bounds = NULL, .T = NULL) {
@@ -684,18 +688,21 @@ binary_search_param <- function(make_chain, d_in, d_out, bounds = NULL, .T = NUL
 }
 
 .infer_search_type <- function(predicate, .T = NULL, bounds = NULL) {
-  if (!is.null(bounds)) {
-    if (inherits(bounds, "integer")) {
-      return(rt_parse("int"))
-    }
-    if (inherits(bounds, "numeric")) {
-      return(rt_parse("float"))
-    }
-    stop("bounds must be either float or int", call. = FALSE)
-  }
-
   if (!is.null(.T)) {
     return(rt_parse(.T))
+  }
+
+  if (!is.null(bounds)) {
+    present_bounds <- Filter(Negate(is.null), as.list(bounds))
+    if (length(present_bounds) > 0) {
+      if (all(vapply(present_bounds, inherits, logical(1), "integer"))) {
+        return(rt_parse("int"))
+      } else if (all(vapply(present_bounds, inherits, logical(1), "numeric"))) {
+        return(rt_parse("float"))
+      } else {
+        stop("bounds must be either float or int", call. = FALSE)
+      }
+    }
   }
 
   check_type <- function(v) {
@@ -714,16 +721,34 @@ binary_search_param <- function(make_chain, d_in, d_out, bounds = NULL, .T = NUL
 
 #' Find the closest passing value to the decision boundary of `predicate`
 #'
-#' If bounds are not passed, conducts an exponential search.
+#' Missing bounds are inferred. Use `NULL` for either element of `bounds` to
+#' conduct a one-sided search, or omit `bounds` to conduct an exponential search.
 #'
 #' @concept mod
 #' @param predicate a monotonic unary function from a number to a boolean
-#' @param bounds a 2-tuple of the lower and upper bounds on the input of `make_chain`
-#' @param .T type of argument to `predicate`, one of float or int
+#' @param bounds a two-element list of optional lower and upper bounds on the input
+#'   of `predicate`; use `NULL` for either bound to infer it
+#' @param .T type of argument to `predicate`, one of float or int; when set,
+#'   takes precedence over the type inferred from `bounds`
 #' @param return_sign if True, also return the direction away from the decision boundary
 #' @return the discovered parameter within the bounds
 #' @export
+#' @examples
+#' binary_search(\(x) x <= -5L, bounds = list(-10L, NULL))
 binary_search <- function(predicate, bounds = NULL, .T = NULL, return_sign = FALSE) {
+  if (is.null(bounds)) {
+    lower <- NULL
+    upper <- NULL
+  } else {
+    if (length(bounds) != 2) {
+      stop(
+        "bounds must contain exactly two elements; use list(lower, NULL) or list(NULL, upper) for a one-sided search",
+        call. = FALSE
+      )
+    }
+    lower <- bounds[[1]]
+    upper <- bounds[[2]]
+  }
   .T <- .infer_search_type(predicate, .T, bounds)
 
   result <- .call_search_callback(
@@ -731,7 +756,7 @@ binary_search <- function(predicate, bounds = NULL, .T = NULL, return_sign = FAL
     .T = .T,
     bounds = bounds,
     call_expr = function(wrapped) {
-      `_binary_search`(wrapped, bounds = bounds, .T = .T, return_sign = return_sign)
+      `_binary_search`(wrapped, lower = lower, upper = upper, .T = .T, return_sign = return_sign)
     }
   )
 

--- a/R/opendp/R/typing.R
+++ b/R/opendp/R/typing.R
@@ -329,6 +329,12 @@ get_first <- function(x) {
   }
 }
 
+get_first_non_null <- function(...) {
+  values <- list(...)
+  present <- Filter(Negate(is.null), values)
+  if (length(present) == 0) NULL else present[[1]]
+}
+
 #' Parse a runtime type or infer it from an example
 #'
 #' Mirrors Python's public `RuntimeType.parse_or_infer(...)` entrypoint.

--- a/R/opendp/tests/testthat/test-mod.R
+++ b/R/opendp/tests/testthat/test-mod.R
@@ -6,6 +6,28 @@ test_that("binary search", {
   m_sum <- binary_search_chain(\(s) t_sum |> then_laplace(s), d_in = 1L, d_out = 1., .T = "float")
 })
 
+test_that("binary search honors explicit integer type without bounds", {
+  expect_equal(binary_search(\(x) x > 5L, .T = "int"), 6L)
+  expect_equal(binary_search(\(x) x < 5L, .T = "int"), 4L)
+})
+
+test_that("binary search supports one-sided bounds", {
+  expect_equal(binary_search(\(x) x <= -5L, list(-10L, NULL)), -5L)
+  expect_equal(binary_search(\(x) x <= -5L, list(NULL, -1L)), -5L)
+  expect_error(
+    binary_search(\(x) x <= -5L, list(0L, NULL)),
+    "decision boundary is below the lower bound"
+  )
+  expect_error(
+    binary_search(\(x) x <= -5L, list(NULL, -10L)),
+    "decision boundary is above the upper bound"
+  )
+  expect_error(
+    binary_search(\(x) x <= -5L, c(-10L, NULL)),
+    paste0("use list", "\\(lower, NULL\\)")
+  )
+})
+
 test_that("floating-point aliases to idealized-numerics", {
   disable_features("floating-point", "idealized-numerics")
 

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -1314,7 +1314,7 @@ M = TypeVar("M", Transformation, Measurement)
 def binary_search_chain(
         make_chain: Callable[[float], M],
         d_in: Any, d_out: Any,
-        bounds: tuple[float, float] | None = None,
+        bounds: tuple[float | None, float | None] | None = (None, None),
         T=None) -> M:
     """Find the highest-utility (`d_in`, `d_out`)-close Transformation or Measurement.
     
@@ -1327,7 +1327,7 @@ def binary_search_chain(
     :param make_chain: a function that takes a number and returns a Transformation or Measurement
     :param d_in: how far apart input datasets can be
     :param d_out: how far apart output datasets or distributions can be
-    :param bounds: a 2-tuple of the lower and upper bounds on the input of `make_chain`
+    :param bounds: a 2-tuple of optional lower and upper bounds on the input of `make_chain`; use `None` for either bound to infer it
     :param T: type of argument to `make_chain`, one of {float, int}
     :return: a chain parameterized at the nearest passing value to the decision point of the relation
     :rtype: Union[Transformation, Measurement]
@@ -1379,7 +1379,7 @@ def binary_search_chain(
 def binary_search_param(
         make_chain: Callable[[float], Union[Transformation, Measurement]],
         d_in: Any, d_out: Any,
-        bounds: tuple[float, float] | None = None,
+        bounds: tuple[float | None, float | None] | None = (None, None),
         T=None) -> float:
     """Solve for the ideal constructor argument to `make_chain`.
     
@@ -1389,7 +1389,7 @@ def binary_search_param(
     :param make_chain: a function that takes a number and returns a Transformation or Measurement
     :param d_in: how far apart input datasets can be
     :param d_out: how far apart output datasets or distributions can be
-    :param bounds: a 2-tuple of the lower and upper bounds on the input of `make_chain`
+    :param bounds: a 2-tuple of optional lower and upper bounds on the input of `make_chain`; use `None` for either bound to infer it
     :param T: type of argument to `make_chain`, one of {float, int}
     :return: the nearest passing value to the decision point of the relation
     :raises TypeError: if the type is not inferrable (pass T) or the type is invalid
@@ -1448,7 +1448,7 @@ def _call_rust_search(
     predicate: Callable[[float], bool],
     T: "RuntimeType | str",
     search: Callable[[Callable[[float], bool]], Any],
-    bounds: tuple[float, float] | None = None,
+    bounds: tuple[float | None, float | None] | None = (None, None),
 ) -> Any:
     first_exception = None
     had_success = False
@@ -1470,7 +1470,7 @@ def _call_rust_search(
     except OpenDPException as err:
         if first_exception is not None:
             exc = first_exception
-            if bounds is None and not had_success and hasattr(exc, "add_note"):
+            if (bounds is None or bounds == (None, None)) and not had_success and hasattr(exc, "add_note"):
                 center = 0.0 if T in {"f32", "f64"} else 0
                 exc.add_note(
                     "Predicate in binary search always raises an exception. "
@@ -1488,7 +1488,7 @@ def _call_rust_search(
 @overload
 def binary_search(
         predicate: Callable[[float], bool],
-        bounds: tuple[float, float] | None = ...,
+        bounds: tuple[float | None, float | None] | None = ...,
         T: Type[float] | None = ...,
         return_sign: Literal[False] = False) -> float:
     ...
@@ -1498,7 +1498,7 @@ def binary_search(
 @overload
 def binary_search(
         predicate: Callable[[float], bool],
-        bounds: tuple[float, float] | None = ...,
+        bounds: tuple[float | None, float | None] | None = ...,
         T: Type[float] | None = ...,
         *, # see https://stackoverflow.com/questions/66435480/overload-following-optional-argument
         return_sign: Literal[True]) -> tuple[float, int]:
@@ -1508,7 +1508,7 @@ def binary_search(
 @overload
 def binary_search(
         predicate: Callable[[float], bool],
-        bounds: tuple[float, float] | None,
+        bounds: tuple[float | None, float | None] | None,
         T: Type[float] | None,
         return_sign: Literal[True]) -> tuple[float, int]:
     ...
@@ -1516,15 +1516,16 @@ def binary_search(
 
 def binary_search(
         predicate: Callable[[float], bool],
-        bounds: tuple[float, float] | None = None,
+        bounds: tuple[float | None, float | None] | None = (None, None),
         T: Type[float] | None = None,
         return_sign: bool = False) -> float | tuple[float, int]:
     """Find the closest passing value to the decision boundary of `predicate`.
 
-    If bounds are not passed, conducts an exponential search.
+    Missing bounds are inferred. Pass `None` for either element of `bounds` to
+    conduct a one-sided search, or omit `bounds` to conduct an exponential search.
     
     :param predicate: a monotonic unary function from a number to a boolean
-    :param bounds: a 2-tuple of the lower and upper bounds to the input of `predicate`
+    :param bounds: a 2-tuple of optional lower and upper bounds to the input of `predicate`; use `None` for either bound to infer it
     :param T: type of argument to `predicate`, one of {float, int}
     :param return_sign: if True, also return the direction away from the decision boundary
     :return: the discovered parameter within the bounds
@@ -1542,6 +1543,8 @@ def binary_search(
     6
     >>> dp.binary_search(lambda x: x < 5, T=int)
     4
+    >>> dp.binary_search(lambda x: x <= 5, bounds=(0, None))
+    5
 
     Find epsilon usage of the gaussian(scale=1.) mechanism applied on a dp mean.
     Assume neighboring datasets differ by up to three additions/removals, and fix delta to 1e-8.
@@ -1572,15 +1575,31 @@ def binary_search(
     from opendp._internal import _binary_search
     from opendp.typing import RuntimeType
 
-    if bounds is not None and len(set(map(type, bounds))) != 1:
-        raise TypeError("bounds must share the same type")  # pragma: no cover
+    if bounds is not None:
+        if len(bounds) != 2:
+            raise ValueError(
+                "bounds must contain exactly two elements; "
+                "use (lower, None) or (None, upper) for a one-sided search"
+            )
+        lower, upper = bounds
+        if lower is not None and upper is not None and type(lower) is not type(upper):
+            raise TypeError("bounds must share the same type")
+    else:
+        lower, upper = None, None
 
-    runtime_T = RuntimeType.infer(bounds[0]) if bounds is not None else RuntimeType.parse(T or _infer_type(predicate))
+    if T is not None:
+        runtime_T = RuntimeType.parse(T)
+    elif lower is not None:
+        runtime_T = RuntimeType.infer(lower)
+    elif upper is not None:
+        runtime_T = RuntimeType.infer(upper)
+    else:
+        runtime_T = RuntimeType.parse(_infer_type(predicate))
 
     return _call_rust_search(
         predicate,
         runtime_T,
-        lambda wrapped: _binary_search(wrapped, bounds=bounds, return_sign=return_sign, T=runtime_T),
+        lambda wrapped: _binary_search(wrapped, lower=lower, upper=upper, return_sign=return_sign, T=runtime_T),
         bounds=bounds,
     )
 

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -470,6 +470,15 @@ def get_first(value):
         return None
     return next(iter(value))
 
+
+def get_first_non_null(*values):
+    """Get the first non-null value."""
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
 def parse_or_infer(type_name: RuntimeTypeDescriptor | None, example) -> Union[RuntimeType, str]:
     '''
     Given a ``RuntimeTypeDescriptor``, returns a ``RuntimeType`` or ``str``.

--- a/python/test/test_binary_search.py
+++ b/python/test/test_binary_search.py
@@ -55,6 +55,33 @@ def test_binary_search():
     assert dp.binary_search(lambda x: x >= 5, T=int) == 5
 
 
+@pytest.mark.parametrize("bounds", [(0, None), (None, 10)])
+def test_binary_search_one_sided(bounds):
+    assert dp.binary_search(lambda x: x <= 5, bounds=bounds) == 5
+
+
+@pytest.mark.parametrize("bounds", [(0,), (0, 10, 20)])
+def test_binary_search_rejects_malformed_bounds(bounds):
+    with pytest.raises(ValueError, match="bounds must contain exactly two elements"):
+        dp.binary_search(lambda x: x <= 5, bounds=bounds)
+
+
+@pytest.mark.parametrize(
+    ("bounds", "message"),
+    [
+        ((10, None), "decision boundary is below the lower bound"),
+        ((None, 0), "decision boundary is above the upper bound"),
+    ],
+)
+def test_binary_search_one_sided_errors(bounds, message):
+    with pytest.raises(ValueError, match=message):
+        dp.binary_search(lambda x: x <= 5, bounds=bounds)
+
+
+def test_mixed_type_bounds():
+    with pytest.raises(TypeError, match="bounds must share the same type"):
+        dp.binary_search(lambda x: x <= -5, bounds=(-10, 20.))
+
 def test_binary_search_inferred_int():
     def predicate(v):
         if not isinstance(v, int):

--- a/rust/src/internal/mod.rs
+++ b/rust/src/internal/mod.rs
@@ -1,7 +1,7 @@
 /// This code is used to generate a hidden `_internal` module in Python
 /// containing APIs that allow for the construction of library primitives like Transformations and Measurements
 /// that do not require the "honest-but-curious" flag to be set.
-use std::ffi::c_char;
+use std::{ffi::c_char, os::raw::c_void};
 
 use opendp_derive::bootstrap;
 
@@ -252,10 +252,11 @@ where
     name = "_binary_search",
     arguments(
         predicate(rust_type = "bool"),
-        bounds(default = b"null", rust_type = "Option<(T, T)>"),
+        lower(default = b"null", c_type = "void *"),
+        upper(default = b"null", c_type = "void *"),
         return_sign(default = false),
     ),
-    generics(T(example = "$get_first(bounds)"))
+    generics(T(example = "$get_first_non_null(lower, upper)"))
 )]
 /// Find the closest passing value to the decision boundary of `predicate`.
 ///
@@ -263,7 +264,8 @@ where
 ///
 /// # Arguments
 /// * `predicate` - A monotonic unary function from a number to a boolean.
-/// * `bounds` - Optional lower and upper bounds on the input to `predicate`.
+/// * `lower` - Optional lower bound on the input to `predicate`.
+/// * `upper` - Optional upper bound on the input to `predicate`.
 /// * `return_sign` - If true, also return the direction away from the decision boundary.
 ///
 /// # Generics
@@ -271,32 +273,35 @@ where
 #[allow(dead_code)]
 fn _binary_search<T>(
     predicate: CallbackFn,
-    bounds: Option<(T, T)>,
+    lower: Option<T>,
+    upper: Option<T>,
     return_sign: bool,
 ) -> Fallible<AnyObject> {
-    let _ = (predicate, bounds, return_sign);
+    let _ = (predicate, lower, upper, return_sign);
     panic!("this signature only exists for code generation")
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn opendp_internal___binary_search(
     predicate: *const CallbackFn,
-    bounds: *const AnyObject,
+    lower: *const c_void,
+    upper: *const c_void,
     return_sign: bool,
     T: *const c_char,
 ) -> FfiResult<*mut AnyObject> {
     fn monomorphize<T>(
         predicate: *const CallbackFn,
-        bounds: *const AnyObject,
+        lower: *const c_void,
+        upper: *const c_void,
         return_sign: bool,
     ) -> Fallible<AnyObject>
     where
         T: BinarySearchable + 'static + Send + Sync,
     {
         let predicate = wrap_search_predicate::<T>(predicate)?;
-        let bounds = as_ref(bounds)
-            .map(|obj| obj.downcast_ref::<(T, T)>().cloned())
-            .transpose()?;
+        let lower = as_ref(lower as *const T).cloned();
+        let upper = as_ref(upper as *const T).cloned();
+        let bounds = (lower, upper);
 
         if return_sign {
             signed_fallible_binary_search(predicate, bounds)
@@ -313,7 +318,7 @@ pub extern "C" fn opendp_internal___binary_search(
             T,
             [u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64]
         )],
-        (predicate, bounds, return_sign)
+        (predicate, lower, upper, return_sign)
     )
     .into()
 }

--- a/rust/src/utilities/search/mod.rs
+++ b/rust/src/utilities/search/mod.rs
@@ -1,11 +1,15 @@
 use std::{
+    iter::{once, successors},
     mem::swap,
     ops::{Add, Div, Sub},
 };
 
-use num::{One, Zero};
+use num::{CheckedAdd, CheckedSub, One, Zero};
 
-use crate::error::Fallible;
+use crate::{
+    error::Fallible,
+    traits::{ExactIntCast, FiniteBounds},
+};
 
 #[cfg(test)]
 mod test;
@@ -21,7 +25,11 @@ macro_rules! impl_binary_searchable_float {
     ($($ty:ty),+ $(,)?) => {
         $(impl BinarySearchable for $ty {
             fn midpoint(lower: &Self, upper: &Self) -> Self {
-                lower + (upper - lower).halve()
+                if lower.is_sign_negative() != upper.is_sign_negative() {
+                    lower / 2.0 + upper / 2.0
+                } else {
+                    lower + (upper - lower).halve()
+                }
             }
         })+
     };
@@ -59,10 +67,70 @@ where
     }
 }
 
+mod private {
+    use super::{Above, Below};
+    pub trait Sealed<T> {}
+
+    impl<T> Sealed<T> for () {}
+    impl<T> Sealed<T> for (T, T) {}
+    impl<T> Sealed<T> for Above<T> {}
+    impl<T> Sealed<T> for Below<T> {}
+    impl<T> Sealed<T> for (Option<T>, Option<T>) {}
+    impl<T> Sealed<T> for Option<(T, T)> {}
+}
+
+pub trait BoundSpec<T>: private::Sealed<T> {
+    fn resolve(self) -> (Option<T>, Option<T>);
+}
+
+pub struct Above<T>(pub T);
+pub struct Below<T>(pub T);
+
+impl<T> BoundSpec<T> for () {
+    fn resolve(self) -> (Option<T>, Option<T>) {
+        (None, None)
+    }
+}
+
+impl<T> BoundSpec<T> for (T, T) {
+    fn resolve(self) -> (Option<T>, Option<T>) {
+        (Some(self.0), Some(self.1))
+    }
+}
+
+impl<T> BoundSpec<T> for Above<T> {
+    fn resolve(self) -> (Option<T>, Option<T>) {
+        (Some(self.0), None)
+    }
+}
+
+impl<T> BoundSpec<T> for Below<T> {
+    fn resolve(self) -> (Option<T>, Option<T>) {
+        (None, Some(self.0))
+    }
+}
+impl<T> BoundSpec<T> for (Option<T>, Option<T>) {
+    fn resolve(self) -> (Option<T>, Option<T>) {
+        self
+    }
+}
+
+impl<T> BoundSpec<T> for Option<(T, T)> {
+    fn resolve(self) -> (Option<T>, Option<T>) {
+        match self {
+            Some((lower, upper)) => (Some(lower), Some(upper)),
+            None => (None, None),
+        }
+    }
+}
+
 /// Find the closest passing value to the decision boundary of `predicate`.
 ///
-/// If `bounds` are not passed, conducts an exponential search to infer them first.
-pub fn binary_search<T>(predicate: impl Fn(&T) -> bool, bounds: Option<(T, T)>) -> Fallible<T>
+/// Missing bounds are inferred:
+/// - if neither bound is passed, an exponential search infers both bounds
+/// - if only `lower` is passed, a band search infers `upper`
+/// - if only `upper` is passed, a band search infers `lower`
+pub fn binary_search<T>(predicate: impl Fn(&T) -> bool, bounds: impl BoundSpec<T>) -> Fallible<T>
 where
     T: BinarySearchable,
 {
@@ -74,7 +142,7 @@ where
 /// A returned sign of `1` means the passing side is above the boundary, and `-1` means it is below.
 pub fn signed_binary_search<T>(
     predicate: impl Fn(&T) -> bool,
-    bounds: Option<(T, T)>,
+    bounds: impl BoundSpec<T>,
 ) -> Fallible<(T, i8)>
 where
     T: BinarySearchable,
@@ -86,7 +154,7 @@ where
 /// Fallible version of [`binary_search`].
 pub fn fallible_binary_search<T>(
     predicate: impl Fn(&T) -> Fallible<bool>,
-    bounds: Option<(T, T)>,
+    bounds: impl BoundSpec<T>,
 ) -> Fallible<T>
 where
     T: BinarySearchable,
@@ -97,17 +165,47 @@ where
 /// Fallible version of [`signed_binary_search`].
 pub fn signed_fallible_binary_search<T>(
     predicate: impl Fn(&T) -> Fallible<bool>,
-    bounds: Option<(T, T)>,
+    bounds: impl BoundSpec<T>,
 ) -> Fallible<(T, i8)>
 where
     T: BinarySearchable,
 {
-    let bounds = match bounds {
-        Some(bounds) => bounds,
-        None => fallible_exponential_bounds_search(&predicate)?
-            .ok_or_else(|| err!(Search, "unable to infer bounds"))?,
-    };
+    let bounds = resolve_bounds(&predicate, bounds)?;
     signed_fallible_binary_search_with_bounds(predicate, bounds)
+}
+
+fn resolve_bounds<T>(
+    predicate: &impl Fn(&T) -> Fallible<bool>,
+    bounds: impl BoundSpec<T>,
+) -> Fallible<(T, T)>
+where
+    T: BinarySearchable,
+{
+    match bounds.resolve() {
+        (Some(lower), Some(upper)) => Ok((lower, upper)),
+        (Some(lower), None) => {
+            let at_lower = predicate(&lower)?;
+            fallible_signed_band_search(predicate, lower.clone(), at_lower, 1)?
+                .ok_or_else(|| {
+                    err!(
+                        Search,
+                        "the decision boundary is below the lower bound or the predicate does not change above it"
+                    )
+                })
+        }
+        (None, Some(upper)) => {
+            let at_upper = predicate(&upper)?;
+            fallible_signed_band_search(predicate, upper.clone(), at_upper, -1)?
+                .ok_or_else(|| {
+                    err!(
+                        Search,
+                        "the decision boundary is above the upper bound or the predicate does not change below it"
+                    )
+                })
+        }
+        (None, None) => fallible_exponential_bounds_search(predicate)?
+            .ok_or_else(|| err!(Search, "unable to infer bounds")),
+    }
 }
 
 fn signed_fallible_binary_search_with_bounds<T>(
@@ -180,82 +278,54 @@ macro_rules! impl_bands_float {
 }
 impl_bands_float!(f32, f64);
 
-macro_rules! impl_bands_signed_int {
+fn band_offsets() -> impl Iterator<Item = u128> {
+    once(1u128).chain(successors(Some(16u128), |x| x.checked_mul(16)))
+}
+
+fn bands_int<T>(center: T, sign: i8) -> Vec<T>
+where
+    T: Copy + PartialEq + FiniteBounds + CheckedAdd + CheckedSub + ExactIntCast<u128>,
+{
+    let upward = sign > 0;
+    let mut bands = vec![center];
+
+    for offset in band_offsets() {
+        let Ok(offset) = T::exact_int_cast(offset) else {
+            break;
+        };
+
+        let candidate = if upward {
+            center.checked_add(&offset)
+        } else {
+            center.checked_sub(&offset)
+        };
+
+        let Some(candidate) = candidate else {
+            break;
+        };
+
+        bands.push(candidate);
+    }
+
+    let extreme = if upward { T::MAX_FINITE } else { T::MIN_FINITE };
+    if bands.last() != Some(&extreme) {
+        bands.push(extreme);
+    }
+
+    bands
+}
+
+macro_rules! impl_bands_int {
     ($($ty:ty),+ $(,)?) => {
         $(impl Bands for $ty {
             fn bands(center: Self, sign: i8) -> Vec<Self> {
-                let mut bands = vec![center];
-
-                if sign > 0 {
-                    if let Some(next) = center.checked_add(1) {
-                        bands.push(next);
-                    }
-                } else if let Some(next) = center.checked_sub(1) {
-                    bands.push(next);
-                }
-
-                for k in 1..=8 {
-                    let offset = match <$ty>::try_from(2i128.pow(16) * k) {
-                        Ok(offset) => offset,
-                        Err(_) => break,
-                    };
-                    let candidate = if sign > 0 {
-                        center.checked_add(offset)
-                    } else {
-                        center.checked_sub(offset)
-                    };
-                    let Some(candidate) = candidate else {
-                        break;
-                    };
-                    bands.push(candidate);
-                }
-
-                let extreme = if sign > 0 { <$ty>::MAX } else { <$ty>::MIN };
-                if bands.last() != Some(&extreme) {
-                    bands.push(extreme);
-                }
-
-                bands
+                bands_int(center, sign)
             }
         })+
     };
 }
-impl_bands_signed_int!(i8, i16, i32, i64, i128);
 
-macro_rules! impl_bands_unsigned_int {
-    ($($ty:ty),+ $(,)?) => {
-        $(impl Bands for $ty {
-            fn bands(center: Self, sign: i8) -> Vec<Self> {
-                if sign < 0 {
-                    return Vec::new();
-                }
-
-                let mut bands = vec![center];
-                if let Some(next) = center.checked_add(1) {
-                    bands.push(next);
-                }
-
-                for k in 1..=8 {
-                    let offset = match <$ty>::try_from(2i128.pow(16) * k) {
-                        Ok(offset) => offset,
-                        Err(_) => break,
-                    };
-                    let Some(candidate) = center.checked_add(offset) else {
-                        break;
-                    };
-                    bands.push(candidate);
-                }
-
-                if bands.last() != Some(&<$ty>::MAX) {
-                    bands.push(<$ty>::MAX);
-                }
-
-                bands
-            }
-        })+
-    };
-}
-impl_bands_unsigned_int!(u8, u16, u32, u64, u128);
+impl_bands_int!(i8, i16, i32, i64, i128, u8, u16, u32, u64, u128);
 
 pub fn exponential_bounds_search<T>(predicate: &impl Fn(&T) -> bool) -> Option<(T, T)>
 where

--- a/rust/src/utilities/search/test.rs
+++ b/rust/src/utilities/search/test.rs
@@ -3,39 +3,75 @@ use crate::error::ErrorVariant;
 
 #[test]
 fn test_binary_search() -> Fallible<()> {
-    assert_eq!(binary_search::<i32>(|x| *x <= -5, None)?, -5);
-    assert_eq!(binary_search::<i32>(|x| *x <= 5, None)?, 5);
-    assert_eq!(binary_search::<i32>(|x| *x >= -5, None)?, -5);
-    assert_eq!(binary_search::<i32>(|x| *x >= 5, None)?, 5);
+    assert_eq!(binary_search::<i32>(|x| *x <= -5, ())?, -5);
+    assert_eq!(binary_search::<i32>(|x| *x <= 5, ())?, 5);
+    assert_eq!(binary_search::<i32>(|x| *x >= -5, ())?, -5);
+    assert_eq!(binary_search::<i32>(|x| *x >= 5, ())?, 5);
     Ok(())
 }
 
 #[test]
 fn test_binary_search_sorts_bounds() -> Fallible<()> {
-    assert_eq!(binary_search(|x: &i32| *x > 5, Some((10, 0)))?, 6);
-    assert_eq!(binary_search(|x: &i32| *x < 5, Some((10, 0)))?, 4);
+    assert_eq!(binary_search(|x: &i32| *x > 5, (10, 0))?, 6);
+    assert_eq!(binary_search(|x: &i32| *x < 5, (10, 0))?, 4);
+    Ok(())
+}
+
+#[test]
+fn test_bound_specs_resolve() {
+    assert_eq!(BoundSpec::<i32>::resolve(()), (None, None));
+    assert_eq!(BoundSpec::resolve((0, 10)), (Some(0), Some(10)));
+    assert_eq!(BoundSpec::resolve(Above(0)), (Some(0), None));
+    assert_eq!(BoundSpec::resolve(Below(10)), (None, Some(10)));
+    assert_eq!(BoundSpec::resolve((Some(0), None)), (Some(0), None::<i32>));
+    assert_eq!(
+        BoundSpec::resolve((None, Some(10))),
+        (None::<i32>, Some(10))
+    );
+    assert_eq!(BoundSpec::<i32>::resolve(None), (None, None));
+    assert_eq!(BoundSpec::resolve(Some((0, 10))), (Some(0), Some(10)));
+}
+
+#[test]
+fn test_binary_search_one_sided_bounds() -> Fallible<()> {
+    let predicate = |x: &i32| *x <= -5;
+
+    assert_eq!(binary_search(predicate, Above(-10))?, -5);
+    assert_eq!(binary_search(predicate, Below(-1))?, -5);
+    assert_eq!(binary_search(predicate, (Some(-10), None))?, -5);
+    assert_eq!(binary_search(predicate, (None, Some(-1)))?, -5);
+
+    let err = binary_search(predicate, Above(0)).unwrap_err();
+    assert_eq!(
+        err.message.as_deref(),
+        Some(
+            "the decision boundary is below the lower bound or the predicate does not change above it"
+        )
+    );
+
+    let err = binary_search(predicate, Below(-10)).unwrap_err();
+    assert_eq!(
+        err.message.as_deref(),
+        Some(
+            "the decision boundary is above the upper bound or the predicate does not change below it"
+        )
+    );
+    assert_eq!(binary_search::<i32>(|x| *x >= 5, None)?, 5);
+    assert_eq!(binary_search(|x: &i32| *x >= 5, Some((0, 10)))?, 5);
+    assert_eq!(binary_search(|x: &u32| *x >= 5, Below(10))?, 5);
     Ok(())
 }
 
 #[test]
 fn test_signed_binary_search_reports_direction() -> Fallible<()> {
-    assert_eq!(
-        signed_binary_search(|x: &i32| *x >= 5, Some((0, 10)))?,
-        (5, 1)
-    );
-    assert_eq!(
-        signed_binary_search(|x: &i32| *x <= 5, Some((0, 10)))?,
-        (5, -1)
-    );
+    assert_eq!(signed_binary_search(|x: &i32| *x >= 5, (0, 10))?, (5, 1));
+    assert_eq!(signed_binary_search(|x: &i32| *x <= 5, (0, 10))?, (5, -1));
     Ok(())
 }
 
 #[test]
 fn test_exponential_bounds_search_bands() {
-    assert_eq!(
-        exponential_bounds_search::<i32>(&|x| *x > 5),
-        Some((1, 65_536))
-    );
+    assert_eq!(exponential_bounds_search::<i32>(&|x| *x > 5), Some((1, 16)));
     assert_eq!(
         exponential_bounds_search::<f64>(&|x| *x > 5.0),
         Some((2.0, 16.0))
@@ -51,7 +87,7 @@ fn test_fallible_binary_search_recovers_from_exception_boundary() -> Fallible<()
             }
             Ok(*x >= 5)
         },
-        None,
+        (),
     )?;
 
     assert_eq!(discovered, 5);
@@ -60,20 +96,34 @@ fn test_fallible_binary_search_recovers_from_exception_boundary() -> Fallible<()
 
 #[test]
 fn test_binary_search_handles_full_signed_ranges() -> Fallible<()> {
-    assert_eq!(
-        binary_search(|x: &i32| *x >= 0, Some((i32::MIN, i32::MAX)))?,
-        0
-    );
-    assert_eq!(
-        binary_search(|x: &i8| *x <= 0, Some((i8::MIN, i8::MAX)))?,
-        0
-    );
+    assert_eq!(binary_search(|x: &i32| *x >= 0, (i32::MIN, i32::MAX))?, 0);
+    assert_eq!(binary_search(|x: &i8| *x <= 0, (i8::MIN, i8::MAX))?, 0);
     Ok(())
 }
 
 #[test]
+fn test_binary_search_one_sided_float_ranges() -> Fallible<()> {
+    assert_eq!(binary_search(|x: &f32| *x <= 5.0, Above(0.0))?, 5.0);
+    assert_eq!(binary_search(|x: &f64| *x <= 5.0, Above(1.0))?, 5.0);
+    assert_eq!(binary_search(|x: &f64| *x >= -5.0, Below(-1.0))?, -5.0);
+    assert_eq!(binary_search(|x: &f64| *x >= 5.0, Above(0.0))?, 5.0);
+    Ok(())
+}
+
+#[test]
+fn test_float_midpoint_handles_opposite_sign_extremes() {
+    let midpoint = <f64 as BinarySearchable>::midpoint(&f64::MIN, &f64::MAX);
+    assert!(midpoint.is_finite());
+    assert!(!midpoint.is_nan());
+
+    let midpoint = <f32 as BinarySearchable>::midpoint(&f32::MIN, &f32::MAX);
+    assert!(midpoint.is_finite());
+    assert!(!midpoint.is_nan());
+}
+
+#[test]
 fn test_binary_search_uses_search_error_variant() {
-    let err = binary_search(|x: &i32| *x < 0, Some((0, 10))).unwrap_err();
+    let err = binary_search(|x: &i32| *x < 0, (0, 10)).unwrap_err();
     assert_eq!(err.variant, ErrorVariant::Search);
     assert_eq!(
         err.message.as_deref(),


### PR DESCRIPTION
Adds support for one-sided binary-search bounds, allowing callers to provide only a known lower or upper endpoint while the other is inferred. Used by other `PrivacyCurve` PRs to invert monotone δ(ε) and log-δ profiles where the lower bound is known (ε = 0).
