### PR TITLE
feat: expose PrivacyCurve through FFI and Python

### DIFF
--- a/python/src/opendp/context.py
+++ b/python/src/opendp/context.py
@@ -1164,6 +1164,9 @@ def _cast_measure(chain, to_measure: Optional[Measure] = None, d_to=None):
     if from_to == ("PrivacyCurveDP", "Approximate<PureDP>"):
         return make_fix_delta(chain, d_to[1])
 
+    if from_to == ("PrivacyCurveDP", "Approximate<MaxDivergence>"):
+        return make_fix_delta(chain, d_to[1])
+
     raise ValueError(
         f"Unable to cast measure from {from_to[0]} to {from_to[1]}"
     )  # pragma: no cover


### PR DESCRIPTION
Superseded by the consolidated output-measure/public API migration in #2862. The remaining three-line compatibility case should be folded into the dedicated measure-rename commit rather than kept as a standalone stack layer.