### PR TITLE
feat(r): expose PrivacyCurve

### DIFF
--- a/R/opendp/src/convert.c
+++ b/R/opendp/src/convert.c
@@ -675,7 +675,7 @@ SEXP slice_to_sexp(FfiSlice *raw, SEXP type_name)
 
     if (str_equal(c_origin, "Vec"))
         result = slice_to_vector(raw, type_name);
-    
+
     else if (str_equal(c_origin, "BitVector"))
         result = slice_to_bitvector(raw, type_name);
 


### PR DESCRIPTION
Superseded by #2862. This branch now contains only a whitespace-only R formatting change and is no longer a logical stack layer.