### PR TITLE
feat: add core PrivacyCurve representations

### DIFF
--- a/rust/src/combinators/fix_delta/mod.rs
+++ b/rust/src/combinators/fix_delta/mod.rs
@@ -1,8 +1,8 @@
 use crate::{
     core::{Domain, Measure, Measurement, Metric, MetricSpace, PrivacyMap},
     error::Fallible,
-    measures::{Approximate, MaxDivergence, PrivacyProfile, SmoothedMaxDivergence},
-    traits::InfSub,
+    measures::{Approximate, MaxDivergence, PrivacyCurve, SmoothedMaxDivergence},
+    traits::DInterval,
 };
 
 #[cfg(feature = "ffi")]
@@ -78,10 +78,13 @@ impl FixDeltaMeasure for Approximate<SmoothedMaxDivergence> {
     }
     fn fix_delta(
         &self,
-        (curve, fixed_delta): &(PrivacyProfile, f64),
+        (curve, fixed_delta): &(PrivacyCurve, f64),
         delta: f64,
     ) -> Fallible<(f64, f64)> {
-        let remaining_delta = delta.neg_inf_sub(&fixed_delta)?;
+        let remaining_delta = DInterval::point(delta)?
+            .sub(DInterval::point(*fixed_delta)?)?
+            .max(DInterval::point(0.0)?)?
+            .lower_f64()?;
         curve.epsilon(remaining_delta).map(|v| (v, delta.clone()))
     }
 }

--- a/rust/src/combinators/fix_delta/test.rs
+++ b/rust/src/combinators/fix_delta/test.rs
@@ -1,4 +1,4 @@
-use crate::{core::Function, domains::AtomDomain, metrics::DiscreteDistance, traits::InfExp};
+use crate::{core::Function, domains::AtomDomain, metrics::DiscreteDistance};
 
 use super::*;
 
@@ -9,7 +9,11 @@ fn test_fix_delta_adp() -> Fallible<()> {
         DiscreteDistance,
         SmoothedMaxDivergence,
         Function::new(|&v| v),
-        PrivacyMap::new(|_d_in| PrivacyProfile::new(|eps| (-eps).inf_exp())),
+        PrivacyMap::new(|_d_in| {
+            PrivacyCurve::new()
+                .with_log_profile(|eps| Ok(-eps))
+                .unwrap()
+        }),
     )?;
     let m_fixed = make_fix_delta(&meas, 1e-7)?;
 
@@ -28,7 +32,14 @@ fn test_fix_delta_approx_adp() -> Fallible<()> {
         DiscreteDistance,
         Approximate(SmoothedMaxDivergence),
         Function::new(|&v| v),
-        PrivacyMap::new(|_d_in| (PrivacyProfile::new(|eps| (-eps).inf_exp()), 1e-7)),
+        PrivacyMap::new(|_d_in| {
+            (
+                PrivacyCurve::new()
+                    .with_log_profile(|eps| Ok(-eps))
+                    .unwrap(),
+                1e-7,
+            )
+        }),
     )?;
     let m_fixed = make_fix_delta(&meas, 2e-7)?;
 

--- a/rust/src/combinators/measure_cast/fixed_approxDP_to_approxDP/mod.rs
+++ b/rust/src/combinators/measure_cast/fixed_approxDP_to_approxDP/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     core::{Domain, Measurement, Metric, MetricSpace, PrivacyMap},
     error::Fallible,
-    measures::{Approximate, MaxDivergence, PrivacyProfile, SmoothedMaxDivergence},
+    measures::{Approximate, MaxDivergence, PrivacyCurve, SmoothedMaxDivergence},
 };
 
 #[cfg(feature = "ffi")]
@@ -33,9 +33,9 @@ where
         measurement.input_metric.clone(),
         SmoothedMaxDivergence::default(),
         PrivacyMap::new_fallible(move |d_in: &MI::Distance| {
-            privacy_map
-                .eval(d_in)
-                .map(|(eps, delta)| PrivacyProfile::new(fixed_approx_dp_privacy_curve(eps, delta)))
+            privacy_map.eval(d_in).and_then(|(eps, delta)| {
+                PrivacyCurve::new().with_profile(fixed_approx_dp_privacy_curve(eps, delta))
+            })
         }),
     )
 }

--- a/rust/src/combinators/measure_cast/fixed_approxDP_to_approxDP/test.rs
+++ b/rust/src/combinators/measure_cast/fixed_approxDP_to_approxDP/test.rs
@@ -24,8 +24,11 @@ fn test_fixed_approxDP_to_approxDP() -> Fallible<()> {
 
     assert_eq!(profile.delta(0.)?, 1.0);
     assert_eq!(profile.delta(eps.next_down_())?, 1.0);
-    assert_eq!(profile.delta(eps)?, del);
-    assert_eq!(profile.delta(eps.next_up_())?, del);
+    let profile_delta = profile.delta(eps)?;
+    assert!(profile_delta >= del);
+    assert_eq!(profile.delta(eps.next_up_())?, profile_delta);
+    assert_eq!(profile.epsilon(del)?, eps);
+    assert_eq!(profile.epsilon(del.next_down())?, f64::INFINITY);
 
     Ok(())
 }

--- a/rust/src/combinators/measure_cast/zCDP_to_approxDP/mod.rs
+++ b/rust/src/combinators/measure_cast/zCDP_to_approxDP/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     core::{Domain, Measure, Measurement, Metric, MetricSpace, PrivacyMap},
     error::Fallible,
-    measures::{Approximate, PrivacyProfile, SmoothedMaxDivergence, ZeroConcentratedDivergence},
+    measures::{Approximate, PrivacyCurve, SmoothedMaxDivergence, ZeroConcentratedDivergence},
 };
 
 use self::cdp_delta::cdp_delta;
@@ -58,9 +58,7 @@ impl ConcentratedMeasure for ZeroConcentratedDivergence {
     type ApproxMeasure = SmoothedMaxDivergence;
 
     fn convert(rho: Self::Distance) -> Fallible<<Self::ApproxMeasure as Measure>::Distance> {
-        Ok(PrivacyProfile::new(move |epsilon: f64| {
-            cdp_delta(rho, epsilon)
-        }))
+        PrivacyCurve::new().with_profile(move |epsilon: f64| cdp_delta(rho, epsilon))
     }
 }
 
@@ -71,7 +69,7 @@ impl ConcentratedMeasure for Approximate<ZeroConcentratedDivergence> {
         (rho, delta): Self::Distance,
     ) -> Fallible<<Self::ApproxMeasure as Measure>::Distance> {
         Ok((
-            PrivacyProfile::new(move |epsilon: f64| cdp_delta(rho, epsilon)),
+            PrivacyCurve::new().with_profile(move |epsilon: f64| cdp_delta(rho, epsilon))?,
             delta,
         ))
     }

--- a/rust/src/measures/curves/approxdp.rs
+++ b/rust/src/measures/curves/approxdp.rs
@@ -1,0 +1,75 @@
+use dashu::{rational::RBig, rbig};
+
+use crate::{
+    error::Fallible,
+    measures::{
+        ApproxDPPoint,
+        curves::{check_delta, check_epsilon},
+    },
+    traits::InfCast,
+    traits::{D, Interval},
+};
+
+impl ApproxDPPoint {
+    pub fn build((epsilon, delta): (f64, f64)) -> Fallible<Self> {
+        check_epsilon(epsilon)?;
+        check_delta(delta)?;
+
+        let epsilon = Interval::<D>::point(epsilon)?;
+        let exp_eps = epsilon.clone().exp()?;
+        let exp_neg_eps = epsilon.clone().neg()?.exp()?;
+
+        let (_, exp_eps_up) = exp_eps.into_endpoints();
+        let (exp_neg_eps_down, _) = exp_neg_eps.into_endpoints();
+
+        Ok(Self {
+            epsilon: epsilon.upper_f64()?,
+            delta,
+            one_minus_delta: RBig::ONE - RBig::try_from(delta)?,
+            exp_eps_up: exp_eps_up.to_rbig()?,
+            exp_neg_eps_down: exp_neg_eps_down.to_rbig()?,
+        })
+    }
+
+    #[inline]
+    pub fn beta(&self, alpha: &RBig) -> RBig {
+        let t1 = &self.one_minus_delta - &self.exp_eps_up * alpha;
+        let base = (&self.one_minus_delta - alpha).max(rbig!(0));
+        let t2 = &self.exp_neg_eps_down * base;
+
+        t1.max(t2).max(rbig!(0))
+    }
+}
+
+pub fn beta_via_approxDP(points: &[ApproxDPPoint], alpha: f64) -> Fallible<f64> {
+    let alpha = RBig::try_from(alpha)?;
+
+    let best = points
+        .iter()
+        .map(|p| p.beta(&alpha))
+        .max()
+        .unwrap_or_default();
+
+    Ok(f64::neg_inf_cast(best)?.clamp(0.0, 1.0))
+}
+
+pub fn delta_via_approxDP(points: &[ApproxDPPoint], epsilon: f64) -> Fallible<f64> {
+    let idx = points.partition_point(|point| point.epsilon <= epsilon);
+    Ok(if idx == 0 { 1.0 } else { points[idx - 1].delta })
+}
+
+pub fn epsilon_via_approxdp(points: &[ApproxDPPoint], delta: f64) -> Fallible<f64> {
+    check_delta(delta)?;
+
+    if delta == 1.0 {
+        return Ok(0.0);
+    }
+
+    let idx = points.partition_point(|point| point.delta > delta);
+
+    Ok(if idx == points.len() {
+        f64::INFINITY
+    } else {
+        points[idx].epsilon
+    })
+}

--- a/rust/src/measures/curves/approxdp_point_beta.tex
+++ b/rust/src/measures/curves/approxdp_point_beta.tex
@@ -1,0 +1,81 @@
+\documentclass{article}
+\input{../../lib.sty}
+
+\title{\texttt{ApproxDPPoint::beta}}
+\author{\AishwaryaRamasethuAuthor, \YuJuKuAuthor, \JordanAwanAuthor, \MichaelShoemateAuthor}
+\begin{document}
+
+\maketitle
+
+\contrib
+
+\section{Hoare Triple}
+
+\subsection*{Precondition}
+\subsubsection*{Compiler-verified}
+\begin{itemize}
+    \item Argument \texttt{epsilon} of type \texttt{f64}
+    \item Argument \texttt{delta} of type \texttt{f64}
+\end{itemize}
+
+\subsubsection*{Caller-verified}
+\texttt{epsilon} is finite and nonnegative, and \texttt{delta} is in $[0,1]$.
+
+\subsection*{Pseudocode}
+
+\lstinputlisting[language=Python,firstline=2,escapechar=`]{./pseudocode/approxdp_point_beta.py}
+
+\subsection*{Postcondition}
+
+\begin{theorem}
+    For all $\alpha \in [0, 1]$, the pseudocode returns
+    $\tilde{f}(\alpha) \le f_{\epsilon,\delta}(\alpha)$, where
+    $f_{\epsilon,\delta}$ is the exact approximate-DP tradeoff curve.
+\end{theorem}
+
+We start with the following standard definition of approximate DP.
+\begin{definition}
+    \label{def-2-2}
+    Let $\epsilon > 0$ and $\delta \geq 0$, and define
+    \begin{equation}
+        f_{\epsilon,\delta}(\alpha) = \max(0, 1 - \delta - \exp(\epsilon) \alpha, \exp(-\epsilon) (1 - \delta - \alpha)).
+    \end{equation}
+    Then we say that a mechanism $M$ satisfies $(\epsilon, \delta)$-DP if it satisfies $f_{\epsilon,\delta}$-DP.
+\end{definition}
+
+\begin{proof}
+The definition assumes $\alpha \in [0, 1]$, which is the domain of the returned function.
+The code clamps the base of the second affine branch at zero, as in Definition~\ref{def-2-2}.
+
+The interval upper endpoint on line \ref{exp-eps} over-estimates
+$\exp(\epsilon)$, and the interval lower endpoint on line
+\ref{exp-neg-eps} under-estimates $\exp(-\epsilon)$.
+The results of these constants are converted exactly into rationals to be used in the tradeoff function.
+
+The function defined on line \ref{tradeoff} implements the formula in Definition~\ref{def-2-2} with exact fractional arithmetic, except that it substitutes these conservative rounded constants for $\exp(\epsilon)$ and $\exp(-\epsilon)$.
+
+For $\alpha \in [0, 1]$, the first branch
+\[
+    1 - \delta - \texttt{exp\_eps} \cdot \alpha
+\]
+is no greater than
+\[
+    1 - \delta - \exp(\epsilon)\alpha,
+\]
+because $\texttt{exp\_eps} \ge \exp(\epsilon)$ and $\alpha \ge 0$.
+
+For the second branch, if $1 - \delta - \alpha \ge 0$, then
+\[
+    \texttt{exp\_neg\_eps} \cdot (1 - \delta - \alpha)
+    \le
+    \exp(-\epsilon)(1 - \delta - \alpha),
+\]
+because $\texttt{exp\_neg\_eps} \le \exp(-\epsilon)$.
+If instead $1 - \delta - \alpha < 0$, then both expressions are negative, so they do not affect the outer maximum with $0$.
+
+Therefore, for all $\alpha \in [0, 1]$, the function returned by the pseudocode is pointwise no greater than $f_{\epsilon,\delta}(\alpha)$.
+This is the required reporting behavior because a smaller $\beta$ is a weaker
+tradeoff guarantee.
+\end{proof}
+
+\end{document}

--- a/rust/src/measures/curves/mod.rs
+++ b/rust/src/measures/curves/mod.rs
@@ -1,0 +1,646 @@
+use core::f64;
+use std::sync::Arc;
+
+use crate::measures::curves::{
+    approxdp::{beta_via_approxDP, delta_via_approxDP, epsilon_via_approxdp},
+    profile::{beta_via_profile, delta_via_profile},
+    tradeoff::delta_via_tradeoff,
+};
+use dashu::rational::RBig;
+
+use crate::{
+    error::{ErrorVariant, Fallible},
+    measures::privacy_profile::{delta_to_log_lower, delta_to_log_upper},
+    traits::DInterval,
+    utilities::search::{Above, fallible_binary_search},
+};
+
+mod approxdp;
+mod profile;
+mod tradeoff;
+
+#[cfg(test)]
+mod test;
+
+#[deprecated(since = "0.15.0", note = "Use PrivacyCurve instead.")]
+#[allow(dead_code)] // compatibility alias is consumed by later stack commits
+/// Compatibility alias while callers migrate to [`PrivacyCurve`].
+pub type PrivacyProfile = PrivacyCurve;
+
+/// A unified representation of privacy guarantees that can be queried as either
+/// a privacy profile `delta(epsilon)` or an f-DP tradeoff curve `beta(alpha)`.
+#[derive(Clone, Default)]
+pub struct PrivacyCurve {
+    delta_slack: f64,
+    // invariant: order increasing in epsilon, nonincreasing in delta
+    approx_dp: Option<Arc<[ApproxDPPoint]>>,
+    profile: Option<Profile>,
+    tradeoff: Option<Tradeoff>,
+}
+
+#[derive(Clone)]
+struct Profile {
+    log_delta: Arc<ProfileFn>,
+    epsilon: Option<Arc<EpsilonFn>>,
+}
+
+type DeltaFn = dyn Fn(f64) -> Fallible<f64> + Send + Sync;
+
+impl Profile {
+    fn new(log_delta: impl Fn(f64) -> Fallible<f64> + 'static + Send + Sync) -> Self {
+        Self {
+            log_delta: Arc::new(move |epsilon| checked_log_delta_output(log_delta(epsilon)?)),
+            epsilon: None,
+        }
+    }
+
+    fn new_with_epsilon(
+        log_delta: impl Fn(f64) -> Fallible<f64> + 'static + Send + Sync,
+        epsilon: impl Fn(f64) -> Fallible<f64> + 'static + Send + Sync,
+    ) -> Self {
+        Self {
+            log_delta: Arc::new(move |value| checked_log_delta_output(log_delta(value)?)),
+            epsilon: Some(Arc::new(epsilon)),
+        }
+    }
+
+    fn new_from_delta(delta: impl Fn(f64) -> Fallible<f64> + 'static + Send + Sync) -> Self {
+        let delta: Arc<DeltaFn> = Arc::new(delta);
+        let forward = delta.clone();
+        let reverse = delta.clone();
+
+        Self::new_with_epsilon(
+            move |epsilon| delta_to_log_upper(checked_delta_output(forward(epsilon)?)?),
+            move |target_delta| invert_delta_callback(reverse.as_ref(), target_delta),
+        )
+    }
+}
+
+#[derive(Clone)]
+struct Tradeoff {
+    beta: Arc<TradeoffFn>,
+    symmetric: bool,
+}
+
+type ProfileFn = dyn Fn(f64) -> Fallible<f64> + Send + Sync;
+type EpsilonFn = dyn Fn(f64) -> Fallible<f64> + Send + Sync;
+type TradeoffFn = dyn Fn(f64) -> Fallible<f64> + Send + Sync;
+
+#[derive(Clone, Debug)]
+pub(crate) struct ApproxDPPoint {
+    epsilon: f64,
+    delta: f64,
+    // allows to cache computations that are repeated many times in tradeoff evaluation
+    one_minus_delta: RBig,
+    exp_eps_up: RBig,
+    exp_neg_eps_down: RBig,
+}
+
+impl PrivacyCurve {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Construct an (ε, δ)-DP privacy profile from epsilon-delta pairs.
+    ///
+    /// # Arguments
+    /// * `pairs` - a vector of approx-DP pairs
+    pub fn with_approxDP(mut self, mut points: Vec<(f64, f64)>) -> Fallible<Self> {
+        if points.is_empty() {
+            return fallible!(
+                FailedMap,
+                "privacy curve must be defined by at least one approximate-DP pair"
+            );
+        }
+
+        points.sort_by(|a, b| a.0.total_cmp(&b.0).then_with(|| b.1.total_cmp(&a.1)));
+        // For duplicate epsilons, keep the largest delta conservatively.
+        points.dedup_by(|a, b| a.0 == b.0);
+        // Keep the earliest epsilon for each delta plateau.
+        points.dedup_by(|later, earlier| later.1 == earlier.1);
+
+        let mut min_delta = 1.0;
+        for (epsilon, delta) in &points {
+            if !epsilon.is_finite() {
+                return fallible!(FailedMap, "epsilon values in privacy curve must be finite");
+            }
+            if *delta > min_delta {
+                return fallible!(
+                    FailedMap,
+                    "delta values must be monotonically nonincreasing as epsilon increases"
+                );
+            }
+            min_delta = min_delta.min(*delta);
+        }
+
+        self.approx_dp = Some(Arc::from(
+            points
+                .into_iter()
+                .map(ApproxDPPoint::build)
+                .collect::<Fallible<Vec<_>>>()?
+                .into_boxed_slice(),
+        ));
+
+        Ok(self)
+    }
+
+    /// Attach an additive catastrophic failure probability to the privacy curve.
+    ///
+    /// This represents a representation-independent delta slack that is added to
+    /// the privacy profile `delta(epsilon)`, allowing curves such as
+    /// approximate-zCDP to be expressed as a concentrated/privacy-profile
+    /// representation plus a fixed catastrophic failure parameter.
+    pub fn with_delta_slack(mut self, delta_slack: f64) -> Fallible<Self> {
+        check_delta(delta_slack)?;
+        self.delta_slack = delta_slack;
+        Ok(self)
+    }
+
+    /// Construct a privacy curve from a callback mapping `epsilon -> delta`.
+    ///
+    /// For tight conversion to f-DP, the profile should also preserve the
+    /// hockey-stick structure of true privacy profiles:
+    ///
+    /// * λ ↦ δ(log λ) is convex and nonincreasing for λ >= 1
+    ///
+    /// If this property is not satisfied, `beta(alpha)` remains conservative,
+    /// but may be loose because the optimizer may miss the best epsilon.
+    ///
+    /// # Arguments
+    /// * `curve` - A privacy profile mapping epsilon to delta
+    ///
+    /// # Why honest-but-curious?
+    ///
+    /// The privacy profile should implement a well-defined $\delta(\epsilon)$ curve:
+    ///
+    /// * is functionally pure
+    /// * nonincreasing
+    /// * returns delta values only within $[0, 1]$
+    /// * returned values are upward-conservative if numerically approximate
+    #[cfg(feature = "honest-but-curious")]
+    pub fn with_profile(
+        mut self,
+        delta: impl Fn(f64) -> Fallible<f64> + 'static + Send + Sync,
+    ) -> Fallible<Self> {
+        self.profile = Some(Profile::new_from_delta(delta));
+        Ok(self)
+    }
+
+    /// Construct a privacy curve from a callback mapping `epsilon -> log(delta)`.
+    ///
+    /// For tight conversion to f-DP, the profile should also preserve the
+    /// hockey-stick structure of true privacy profiles:
+    ///
+    /// * λ ↦ δ(log λ) is convex and nonincreasing for λ >= 1
+    ///
+    /// If this property is not satisfied, `beta(alpha)` remains conservative,
+    /// but may be loose because the optimizer may miss the best epsilon.
+    ///
+    /// # Arguments
+    /// * `curve` - A privacy profile mapping epsilon to delta
+    ///
+    /// # Why honest-but-curious?
+    ///
+    /// The privacy profile should implement a well-defined $\delta(\epsilon)$ curve:
+    ///
+    /// * is functionally pure
+    /// * nonincreasing
+    /// * returns log(delta), where delta is within $[0, 1]$
+    /// * returned values are upward-conservative if numerically approximate
+    #[cfg(feature = "honest-but-curious")]
+    pub fn with_log_profile(
+        mut self,
+        delta: impl Fn(f64) -> Fallible<f64> + 'static + Send + Sync,
+    ) -> Fallible<Self> {
+        self.profile = Some(Profile::new(delta));
+        Ok(self)
+    }
+
+    /// Construct a log-delta profile with an independently certified inverse.
+    #[cfg(feature = "honest-but-curious")]
+    pub(crate) fn with_log_profile_with_epsilon(
+        mut self,
+        log_delta: impl Fn(f64) -> Fallible<f64> + 'static + Send + Sync,
+        epsilon: impl Fn(f64) -> Fallible<f64> + 'static + Send + Sync,
+    ) -> Fallible<Self> {
+        self.profile = Some(Profile::new_with_epsilon(log_delta, epsilon));
+        Ok(self)
+    }
+
+    /// Construct a symmetric tradeoff function from a callback mapping `alpha -> beta`.
+    ///
+    /// # Arguments
+    /// * `curve` - An $f$-DP tradeoff curve mapping alpha to beta
+    ///
+    /// # Why honest-but-curious?
+    ///
+    /// The tradeoff curve should implement a well-defined $\beta(\alpha)$ curve.
+    ///
+    /// * is functionally pure
+    /// * returns finite beta values in [0, 1]
+    /// * satisfies β(0) = 1 and β(1) = 0
+    /// * is nonincreasing and convex on [0, 1]
+    /// * returns downward-conservative beta values if numerically approximate
+    /// * beta(beta(alpha)) = alpha
+    #[cfg(feature = "honest-but-curious")]
+    pub fn with_symmetric_tradeoff(
+        mut self,
+        beta: impl Fn(f64) -> Fallible<f64> + 'static + Send + Sync,
+    ) -> Fallible<Self> {
+        self.tradeoff = Some(Tradeoff {
+            beta: Arc::new(beta),
+            symmetric: true,
+        });
+        Ok(self)
+    }
+
+    /// Construct a tradeoff function from a callback mapping `alpha -> beta`.
+    ///
+    /// # Arguments
+    /// * `curve` - An $f$-DP tradeoff curve mapping alpha to beta
+    ///
+    /// # Why honest-but-curious?
+    ///
+    /// The tradeoff curve should implement a well-defined $\beta(\alpha)$ curve:
+    ///
+    /// * is functionally pure
+    /// * returns finite beta values in [0, 1]
+    /// * satisfies beta(0) = 1 and beta(1) = 0
+    /// * is nonincreasing and convex on [0, 1]
+    /// * returns downward-conservative beta values if numerically approximate
+    #[cfg(feature = "honest-but-curious")]
+    pub fn with_tradeoff(
+        mut self,
+        beta: impl Fn(f64) -> Fallible<f64> + 'static + Send + Sync,
+    ) -> Fallible<Self> {
+        self.tradeoff = Some(Tradeoff {
+            beta: Arc::new(beta),
+            symmetric: false,
+        });
+        Ok(self)
+    }
+
+    /// Evaluate the privacy profile at `epsilon`.
+    ///
+    /// # Arguments
+    /// * `epsilon` - What to fix epsilon to compute delta.
+    fn delta_base(&self, epsilon: f64) -> Fallible<f64> {
+        check_epsilon(epsilon)?;
+
+        if epsilon.is_infinite() {
+            return Ok(0.0);
+        }
+
+        let delta = if let Some(Profile { log_delta, .. }) = &self.profile {
+            delta_via_profile(log_delta.as_ref(), epsilon)
+        } else if let Some(points) = &self.approx_dp {
+            delta_via_approxDP(points, epsilon)
+        } else if let Some(Tradeoff { beta, symmetric }) = &self.tradeoff {
+            delta_via_tradeoff(beta.as_ref(), *symmetric, epsilon)
+        } else {
+            return fallible!(FailedFunction, "PrivacyCurve has no representation");
+        }?;
+
+        check_delta(delta)?;
+        Ok(delta)
+    }
+
+    /// Return a conservative upper bound on delta at the given nonnegative epsilon.
+    pub fn delta(&self, epsilon: f64) -> Fallible<f64> {
+        let mut delta = self.delta_base(epsilon)?;
+
+        if self.delta_slack > 0.0 {
+            delta = DInterval::point(delta)?
+                .add(DInterval::point(self.delta_slack)?)?
+                .upper_f64()?
+                .clamp(0.0, 1.0);
+        }
+
+        check_delta(delta)?;
+        Ok(delta)
+    }
+
+    /// Evaluate the f-DP tradeoff curve at `alpha`.
+    ///
+    /// # Arguments
+    /// * `alpha` - What to fix alpha to compute beta.
+    fn beta_base(&self, alpha: f64) -> Fallible<f64> {
+        check_alpha(alpha)?;
+
+        if alpha == 0.0 {
+            return Ok(1.0);
+        }
+        if alpha == 1.0 {
+            return Ok(0.0);
+        }
+
+        let beta = if let Some(Tradeoff { beta, .. }) = &self.tradeoff {
+            beta(alpha)?
+        } else if let Some(Profile { log_delta, .. }) = &self.profile {
+            beta_via_profile(log_delta.as_ref(), alpha)?
+        } else if let Some(points) = &self.approx_dp {
+            beta_via_approxDP(points, alpha)?
+        } else {
+            return fallible!(FailedFunction, "PrivacyCurve has no representation");
+        };
+
+        check_beta(beta)?;
+        Ok(beta)
+    }
+
+    /// Return a conservative lower bound on beta at the given alpha in `[0, 1]`.
+    pub fn beta(&self, alpha: f64) -> Fallible<f64> {
+        if self.delta_slack == 0.0 {
+            return self.beta_base(alpha);
+        }
+        let curve = self.clone();
+        // TODO: this could be pushed deeper into the calculation for efficiency
+        beta_via_profile(
+            &move |epsilon| delta_to_log_upper(curve.delta(epsilon)?),
+            alpha,
+        )
+    }
+
+    /// Invert the privacy curve by finding the smallest `epsilon`
+    /// such that `delta(epsilon) <= delta`.
+    ///
+    /// # Arguments
+    /// * `delta` - What to fix delta to compute epsilon.
+    pub fn epsilon(&self, delta: f64) -> Fallible<f64> {
+        check_delta(delta)?;
+
+        if delta == 1.0 {
+            return Ok(0.0);
+        }
+        if delta == 0.0 && self.profile.is_some() && self.approx_dp.is_none() {
+            return Ok(if self.delta_base(0.0)? == 0.0 {
+                0.0
+            } else {
+                f64::INFINITY
+            });
+        }
+
+        if delta < self.delta_slack {
+            return Ok(f64::INFINITY);
+        }
+        let remaining_delta = DInterval::point(delta)?
+            .sub(DInterval::point(self.delta_slack)?)?
+            .lower_f64()?
+            .clamp(0.0, 1.0);
+
+        if self.delta_slack == 0.0 {
+            if let Some(Profile { log_delta, epsilon }) = &self.profile {
+                if let Some(epsilon) = epsilon {
+                    let value = epsilon(remaining_delta)?;
+                    if value.is_nan() || value.is_sign_negative() {
+                        return fallible!(
+                            FailedMap,
+                            "epsilon ({value}) must be non-negative and not NaN"
+                        );
+                    }
+                    return Ok(value.max(0.0));
+                }
+
+                return invert_log_profile(log_delta.as_ref(), remaining_delta);
+            }
+        }
+
+        // Fast path only when ApproxDP is the preferred delta representation.
+        // If profile exists, self.delta(...) would use profile, so do not bypass it.
+        if self.profile.is_none() {
+            if let Some(points) = &self.approx_dp {
+                return epsilon_via_approxdp(points, remaining_delta);
+            }
+        }
+
+        if self.delta(0.0)? <= delta {
+            return Ok(0.0);
+        }
+        match fallible_binary_search(|epsilon| Ok(self.delta(*epsilon)? <= delta), Above(0.0)) {
+            Ok(epsilon) => Ok(epsilon),
+            Err(err) if err.variant == ErrorVariant::Search => Ok(f64::INFINITY),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Returns a conservative lower bound on the smallest alpha such that
+    /// beta(alpha) <= beta.
+    ///
+    /// # Arguments
+    /// * `beta` - What to fix beta to compute alpha.
+    pub fn alpha(&self, beta: f64) -> Fallible<f64> {
+        check_beta(beta)?;
+
+        if beta == 0.0 {
+            return Ok(1.0);
+        }
+        if beta == 1.0 {
+            return Ok(0.0);
+        }
+
+        if self.delta_slack != 0.0 {
+            return self.alpha_by_inverting_beta(beta);
+        }
+
+        let alpha = if let Some(Tradeoff {
+            beta: beta_fn,
+            symmetric,
+        }) = &self.tradeoff
+        {
+            if *symmetric {
+                // For symmetric tradeoff curves, alpha(beta) == beta(beta).
+                beta_fn(beta)?
+            } else {
+                // Non-symmetric tradeoff is still the preferred beta representation,
+                // so invert the preferred beta path instead of falling through.
+                return self.alpha_by_inverting_beta(beta);
+            }
+        } else if let Some(Profile { log_delta, .. }) = &self.profile {
+            beta_via_profile(log_delta.as_ref(), beta)?
+        } else if let Some(points) = &self.approx_dp {
+            beta_via_approxDP(points, beta)?
+        } else {
+            return fallible!(FailedFunction, "PrivacyCurve has no representation");
+        };
+
+        check_alpha(alpha)?;
+        Ok(alpha)
+    }
+
+    fn alpha_by_inverting_beta(&self, beta: f64) -> Fallible<f64> {
+        let passing = fallible_binary_search(|alpha| Ok(self.beta(*alpha)? <= beta), (0.0, 1.0))?;
+        Ok(passing.next_down().clamp(0.0, 1.0))
+    }
+
+    #[allow(dead_code)] // composition is wired into measurements later in the stack
+    pub(crate) fn compose(curves: Vec<Self>) -> Fallible<Self> {
+        let delta_slack = curves.iter().try_fold(0.0, |acc, curve| {
+            check_delta(curve.delta_slack)?;
+            DInterval::point(acc)?
+                .add(DInterval::point(curve.delta_slack)?)?
+                .upper_f64()
+                .map(|value| value.min(1.0))
+        })?;
+
+        let mut out = PrivacyCurve::new().with_delta_slack(delta_slack)?;
+        if curves.is_empty() {
+            out.approx_dp = Some(Arc::from(
+                vec![ApproxDPPoint::build((0.0, 0.0))?].into_boxed_slice(),
+            ));
+            return Ok(out);
+        }
+
+        let mut composed_any_base_repr = false;
+
+        if let Some(points) = compose_singleton_approxDP(&curves)? {
+            out.approx_dp = Some(points);
+            composed_any_base_repr = true;
+        }
+
+        if !composed_any_base_repr && curves.iter().any(PrivacyCurve::has_base_repr) {
+            return fallible!(
+                FailedFunction,
+                "PrivacyCurve composition requires a common composition representation"
+            );
+        }
+
+        if !composed_any_base_repr {
+            out.approx_dp = Some(Arc::from(
+                vec![ApproxDPPoint::build((0.0, 0.0))?].into_boxed_slice(),
+            ));
+        }
+
+        Ok(out)
+    }
+
+    fn has_base_repr(&self) -> bool {
+        self.approx_dp.is_some() || self.profile.is_some() || self.tradeoff.is_some()
+    }
+}
+
+#[allow(dead_code)] // called by PrivacyCurve::compose later in the stack
+fn compose_singleton_approxDP(curves: &[PrivacyCurve]) -> Fallible<Option<Arc<[ApproxDPPoint]>>> {
+    let mut epsilon_sum = DInterval::point(0.0)?;
+    let mut delta_sum = DInterval::point(0.0)?;
+    let mut saw_non_identity = false;
+
+    for curve in curves {
+        match curve.approx_dp.as_deref() {
+            Some([point]) => {
+                epsilon_sum = epsilon_sum.add(DInterval::point(point.epsilon)?)?;
+                delta_sum = delta_sum.add(DInterval::point(point.delta)?)?;
+                saw_non_identity = true;
+            }
+            Some(_) => return Ok(None),
+            None if !curve.has_base_repr() => {}
+            None => return Ok(None),
+        }
+    }
+
+    if !saw_non_identity {
+        return Ok(None);
+    }
+
+    let epsilon_sum = epsilon_sum.upper_f64()?;
+    if !epsilon_sum.is_finite() {
+        return fallible!(Overflow, "composed epsilon is not finite");
+    }
+    let delta_sum = delta_sum.upper_f64()?.min(1.0);
+
+    Ok(Some(Arc::from(
+        vec![ApproxDPPoint::build((epsilon_sum, delta_sum))?].into_boxed_slice(),
+    )))
+}
+
+fn invert_delta_callback(delta: &DeltaFn, target_delta: f64) -> Fallible<f64> {
+    if checked_delta_output(delta(0.0)?)? <= target_delta {
+        return Ok(0.0);
+    }
+
+    match fallible_binary_search(
+        |epsilon| Ok(checked_delta_output(delta(*epsilon)?)? <= target_delta),
+        Above(0.0),
+    ) {
+        Ok(epsilon) => Ok(epsilon),
+        Err(err) if err.variant == ErrorVariant::Search => Ok(f64::INFINITY),
+        Err(err) => Err(err),
+    }
+}
+
+fn invert_log_profile(profile: &ProfileFn, target_delta: f64) -> Fallible<f64> {
+    if target_delta == 0.0 {
+        if profile(0.0)? == f64::NEG_INFINITY {
+            return Ok(0.0);
+        }
+
+        return match fallible_binary_search(
+            |epsilon| Ok(profile(*epsilon)? == f64::NEG_INFINITY),
+            Above(0.0),
+        ) {
+            Ok(epsilon) => Ok(epsilon),
+            Err(err) if err.variant == ErrorVariant::Search => Ok(f64::INFINITY),
+            Err(err) => Err(err),
+        };
+    }
+
+    let log_target_lower = delta_to_log_lower(target_delta)?;
+    if profile(0.0)? <= log_target_lower {
+        return Ok(0.0);
+    }
+
+    match fallible_binary_search(
+        |epsilon| Ok(profile(*epsilon)? <= log_target_lower),
+        Above(0.0),
+    ) {
+        Ok(epsilon) => Ok(epsilon),
+        Err(err) if err.variant == ErrorVariant::Search => Ok(f64::INFINITY),
+        Err(err) => Err(err),
+    }
+}
+
+fn checked_delta_output(delta: f64) -> Fallible<f64> {
+    check_delta(delta)?;
+    Ok(delta)
+}
+
+fn checked_log_delta_output(log_delta: f64) -> Fallible<f64> {
+    if log_delta.is_nan() || log_delta > 0.0 {
+        return fallible!(
+            FailedMap,
+            "log(delta) ({log_delta}) must be at most zero and not NaN"
+        );
+    }
+    Ok(log_delta)
+}
+
+fn check_epsilon(epsilon: f64) -> Fallible<()> {
+    if epsilon.is_nan() {
+        return fallible!(FailedMap, "epsilon must not be nan");
+    }
+    if epsilon.is_sign_negative() {
+        return fallible!(
+            FailedMap,
+            "epsilon ({epsilon}) must be a non-negative number"
+        );
+    }
+    Ok(())
+}
+fn check_alpha(alpha: f64) -> Fallible<()> {
+    check_01(alpha, "alpha")
+}
+fn check_beta(beta: f64) -> Fallible<()> {
+    check_01(beta, "beta")
+}
+fn check_delta(delta: f64) -> Fallible<()> {
+    check_01(delta, "delta")
+}
+
+fn check_01(value: f64, name: &str) -> Fallible<()> {
+    if !value.is_finite() {
+        return fallible!(FailedMap, "{name} ({value}) must be finite");
+    }
+    if value.is_sign_negative() || value > 1.0 {
+        return fallible!(FailedMap, "{name} ({value}) must be between zero and one");
+    }
+    Ok(())
+}

--- a/rust/src/measures/curves/profile.rs
+++ b/rust/src/measures/curves/profile.rs
@@ -1,0 +1,279 @@
+use crate::{
+    error::Fallible,
+    measures::curves::{ProfileFn, check_alpha, check_epsilon},
+    traits::{CInterval, DInterval},
+    utilities::search::{SearchMode, optimize_to_precision},
+};
+
+const F64_TRUE_MIN: f64 = f64::from_bits(1);
+const LOG_TRUE_MIN: f64 = -744.4400719213812;
+const EPS_TRUE_MIN: f64 = 744.4400719213812;
+
+// Finite sentinel for log-objectives where the actual value is -infinity.
+// Avoids depending on search helpers accepting non-finite objective values.
+const FAST_NEG_INF: f64 = -1.0e300;
+
+type Cert = DInterval;
+
+pub fn delta_via_profile(profile: &ProfileFn, epsilon: f64) -> Fallible<f64> {
+    profile_delta(profile, epsilon)?.upper_f64()
+}
+
+pub fn beta_via_profile(profile: &ProfileFn, alpha: f64) -> Fallible<f64> {
+    check_alpha(alpha)?;
+
+    if alpha == 0.0 {
+        return Ok(1.0);
+    }
+    if alpha == 1.0 {
+        return Ok(0.0);
+    }
+
+    // Tight conversion:
+    //
+    // beta(alpha) >= sup_eps max {
+    //     1 - delta(eps) - exp(eps) * alpha,
+    //     exp(-eps) * max(1 - delta(eps) - alpha, 0)
+    // }
+    //
+    // Fast objectives only choose candidate epsilons. The candidates are then
+    // recomputed with DInterval below.
+    let beta_t1 = maximize_t1_lower(profile, alpha)?;
+    let beta_t2 = maximize_t2_lower(profile, alpha)?;
+
+    Ok(beta_t1.max(beta_t2).clamp(0.0, 1.0))
+}
+
+/// Conservative enclosure of `delta(epsilon)`.
+///
+/// The profile contracts used here are one-sided: a delta profile returns a
+/// conservative upper value, and a log-delta profile returns a conservative
+/// upper log-delta. For the beta lower-bound formulas, the only information we
+/// need from this enclosure is its upper endpoint, via `1 - delta`.
+fn profile_delta(profile: &ProfileFn, epsilon: f64) -> Fallible<Cert> {
+    check_epsilon(epsilon)?;
+
+    let value = profile(epsilon)?;
+    if value.is_nan() || value > 0.0 {
+        return fallible!(FailedMap, "log-profile returned invalid log(delta)");
+    }
+    if value == f64::NEG_INFINITY {
+        return Cert::point(0.0);
+    }
+
+    let log_delta_hi = value.min(0.0);
+    let delta_hi = if log_delta_hi < LOG_TRUE_MIN {
+        F64_TRUE_MIN
+    } else {
+        Cert::point(log_delta_hi)?
+            .exp()?
+            .upper_f64()?
+            .clamp(0.0, 1.0)
+    };
+
+    Cert::between(0.0, delta_hi)
+}
+
+#[inline]
+fn one_minus_delta(delta: Cert) -> Fallible<Cert> {
+    Cert::point(1.0)?.sub(delta)?.clamp01()
+}
+
+/// Conservative enclosure of `1 - delta(epsilon)`.
+///
+/// For log-delta profiles, this uses:
+///
+/// `1 - exp(x) = -expm1(x)`
+///
+/// which avoids catastrophic cancellation when delta is close to one.
+fn profile_one_minus_delta(profile: &ProfileFn, epsilon: f64) -> Fallible<Cert> {
+    check_epsilon(epsilon)?;
+
+    let value = profile(epsilon)?;
+    if value.is_nan() || value > 0.0 {
+        return fallible!(FailedMap, "log-profile returned invalid log(delta)");
+    }
+    if value == f64::NEG_INFINITY {
+        return Cert::point(1.0);
+    }
+
+    // Widen upward because this value is used as an upper bound on log(delta),
+    // which gives a lower bound on 1 - delta.
+    let log_delta_hi = value.min(0.0);
+    if log_delta_hi < LOG_TRUE_MIN {
+        return one_minus_delta(Cert::between(0.0, F64_TRUE_MIN)?);
+    }
+
+    Cert::point(0.0)?
+        .sub(Cert::point(log_delta_hi)?.exp_m1()?)?
+        .clamp01()
+}
+
+#[inline]
+fn positive_part(x: Cert) -> Fallible<Cert> {
+    x.max(Cert::point(0.0)?)?.clamp01()
+}
+
+fn maximize_t1_lower(profile: &ProfileFn, alpha: f64) -> Fallible<f64> {
+    // For eps >= -ln(alpha), alpha * exp(eps) >= 1,
+    // so branch 1 cannot be positive.
+    let eps_hi = (-alpha.ln()).next_up().clamp(0.0, EPS_TRUE_MIN);
+
+    let mut best = beta_profile_candidate_t1_lower(profile, alpha, 0.0)?;
+
+    if eps_hi > 0.0 {
+        let eps = maximize_unimodal_epsilon(0.0, eps_hi, |eps| {
+            beta_profile_candidate_t1_fast(profile, alpha, eps)
+        });
+
+        best = best.max(beta_profile_candidate_t1_lower(profile, alpha, eps)?);
+        best = best.max(beta_profile_candidate_t1_lower(profile, alpha, eps_hi)?);
+    }
+
+    Ok(best.clamp(0.0, 1.0))
+}
+
+fn maximize_t2_lower(profile: &ProfileFn, alpha: f64) -> Fallible<f64> {
+    // branch 2 <= (1 - alpha) * exp(-eps).
+    // Beyond this range, no positive representable f64 lower bound is possible.
+    let one_minus_alpha_hi = CInterval::point(1.0)?
+        .sub(CInterval::point(alpha)?)?
+        .clamp01()?
+        .upper_f64()?;
+
+    if one_minus_alpha_hi == 0.0 {
+        return Ok(0.0);
+    }
+
+    let eps_hi = (one_minus_alpha_hi.ln() - LOG_TRUE_MIN)
+        .next_up()
+        .clamp(0.0, EPS_TRUE_MIN);
+
+    let mut best = beta_profile_candidate_t2_lower(profile, alpha, 0.0)?;
+
+    if eps_hi > 0.0 {
+        let eps = maximize_unimodal_epsilon(0.0, eps_hi, |eps| {
+            beta_profile_candidate_t2_fast(profile, alpha, eps)
+        });
+
+        best = best.max(beta_profile_candidate_t2_lower(profile, alpha, eps)?);
+        best = best.max(beta_profile_candidate_t2_lower(profile, alpha, eps_hi)?);
+    }
+
+    Ok(best.clamp(0.0, 1.0))
+}
+
+#[inline]
+fn maximize_unimodal_epsilon(lo: f64, hi: f64, objective: impl Fn(f64) -> Fallible<f64>) -> f64 {
+    if !(hi > lo) {
+        return lo;
+    }
+
+    optimize_to_precision(
+        SearchMode::Maximize,
+        lo,
+        hi,
+        None,
+        |epsilon| match objective(epsilon) {
+            Ok(value) => value,
+            Err(_) => SearchMode::Maximize.bad_value(),
+        },
+    )
+    .arg
+    .clamp(lo, hi)
+}
+
+// Fast, non-certified objective for branch 1:
+//
+//     t1(eps) = 1 - delta(eps) - alpha * exp(eps).
+//
+// This only chooses epsilon. Conservativeness comes from the final lower eval.
+#[inline]
+fn beta_profile_candidate_t1_fast(profile: &ProfileFn, alpha: f64, epsilon: f64) -> Fallible<f64> {
+    let one_minus_delta = one_minus_delta_fast(profile, epsilon)?;
+
+    let z = epsilon + alpha.ln();
+
+    if z >= 0.0 {
+        return Ok(0.0);
+    }
+
+    Ok((one_minus_delta - z.exp()).clamp(0.0, 1.0))
+}
+
+// Fast, non-certified objective for branch 2.
+//
+// Instead of returning beta-space directly, return log(branch 2):
+//
+//     log t2(eps) = -eps + log(1 - delta(eps) - alpha).
+//
+// This has the same maximizer wherever branch 2 is positive.
+#[inline]
+fn beta_profile_candidate_t2_fast(profile: &ProfileFn, alpha: f64, epsilon: f64) -> Fallible<f64> {
+    let one_minus_delta = one_minus_delta_fast(profile, epsilon)?;
+    let base = one_minus_delta - alpha;
+
+    if base <= 0.0 {
+        return Ok(FAST_NEG_INF);
+    }
+
+    Ok(-epsilon + base.ln())
+}
+
+#[inline]
+fn one_minus_delta_fast(profile: &ProfileFn, epsilon: f64) -> Fallible<f64> {
+    check_epsilon(epsilon)?;
+
+    let value = profile(epsilon)?;
+    if value.is_nan() || value > 0.0 {
+        return fallible!(FailedMap, "log-profile returned invalid log(delta)");
+    }
+    if value == f64::NEG_INFINITY {
+        return Ok(1.0);
+    }
+
+    // Fast path only: stable ordinary-f64 computation of 1 - exp(log_delta).
+    Ok((-value.exp_m1()).clamp(0.0, 1.0))
+}
+
+// Certified lower evaluation of branch 1:
+//
+//     1 - delta(eps) - alpha * exp(eps).
+#[inline]
+fn beta_profile_candidate_t1_lower(profile: &ProfileFn, alpha: f64, epsilon: f64) -> Fallible<f64> {
+    let one_minus_delta = profile_one_minus_delta(profile, epsilon)?;
+
+    // Compute alpha * exp(epsilon) as exp(epsilon + ln(alpha)).
+    // This avoids overflowing exp(epsilon) when alpha is tiny.
+    let z = Cert::point(epsilon)?.add(Cert::point(alpha)?.ln()?)?;
+
+    // If the upper endpoint is nonnegative, then alpha * exp(epsilon) may be
+    // at least one, and returning zero is a conservative lower bound.
+    if z.upper_f64()? >= 0.0 {
+        return Ok(0.0);
+    }
+
+    let alpha_exp_eps = z.exp()?;
+
+    positive_part(one_minus_delta.sub(alpha_exp_eps)?)?.lower_f64()
+}
+
+// Certified lower evaluation of branch 2:
+//
+//     exp(-eps) * max(1 - delta(eps) - alpha, 0).
+#[inline]
+fn beta_profile_candidate_t2_lower(profile: &ProfileFn, alpha: f64, epsilon: f64) -> Fallible<f64> {
+    let one_minus_delta = profile_one_minus_delta(profile, epsilon)?;
+
+    let base = positive_part(one_minus_delta.sub(Cert::point(alpha)?)?)?;
+
+    if base.upper_f64()? == 0.0 {
+        return Ok(0.0);
+    }
+
+    Cert::point(-epsilon)?
+        .exp()?
+        .mul(base)?
+        .clamp01()?
+        .lower_f64()
+}

--- a/rust/src/measures/curves/pseudocode/approxdp_point_beta.py
+++ b/rust/src/measures/curves/pseudocode/approxdp_point_beta.py
@@ -1,0 +1,18 @@
+# type: ignore
+def approxdp_point_beta(
+    epsilon: f64,
+    delta: f64,
+) -> Callable[[RBig], RBig]:
+    epsilon = DInterval.point(epsilon)
+    delta = RBig.try_from(delta)
+
+    exp_eps = epsilon.exp().upper.to_rbig()  # `\label{exp-eps}`
+    exp_neg_eps = (-epsilon).exp().lower.to_rbig()  # `\label{exp-neg-eps}`
+
+    def tradeoff(alpha: RBig) -> RBig:  # `\label{tradeoff}`
+        t1 = RBig(1) - delta - exp_eps * alpha
+        base = max(RBig(1) - delta - alpha, RBig(0))
+        t2 = exp_neg_eps * base
+        return max(max(t1, t2), RBig(0))
+
+    return tradeoff

--- a/rust/src/measures/curves/test.rs
+++ b/rust/src/measures/curves/test.rs
@@ -1,0 +1,211 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use crate::{
+    error::Fallible, measures::PrivacyCurve, measures::privacy_profile::log_to_delta_upper,
+};
+
+#[test]
+fn test_privacy_profile_from_approxdp_pairs() -> Fallible<()> {
+    let pairs = vec![(0.0, 1.0), (0.1, 1e-3), (0.5, 1e-7), (1.0, 0.0)];
+    let profile = PrivacyCurve::new().with_approxDP(pairs)?;
+
+    // Test exact points
+    assert_eq!(profile.delta(0.0)?, 1.0);
+    assert_eq!(profile.delta(1.0)?, 0.0);
+
+    // Test conservative stairstep behavior
+    let mid = profile.delta(0.05)?;
+    assert_eq!(mid, 1.0);
+    assert_eq!(profile.delta(0.3)?, 1e-3);
+
+    Ok(())
+}
+
+#[test]
+fn test_privacy_profile_from_single_approxdp_pair() -> Fallible<()> {
+    let profile = PrivacyCurve::new().with_approxDP(vec![(1.0, 1e-7)])?;
+
+    assert_eq!(profile.delta(0.5)?, 1.0);
+    assert_eq!(profile.delta(1.0)?, 1e-7);
+    assert_eq!(profile.delta(2.0)?, 1e-7);
+
+    let beta = profile.beta(0.25)?;
+    assert!(0.0 < beta && beta < 1.0);
+
+    Ok(())
+}
+
+#[test]
+fn test_tradeoff_curve_from_approxdp_satisfies_profile() -> Fallible<()> {
+    let epsilon = 0.5;
+    let delta = 1e-6;
+
+    let curve = PrivacyCurve::new().with_approxDP(vec![(epsilon, delta)])?;
+    assert!(curve.delta(epsilon)? <= delta);
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "honest-but-curious")]
+fn test_delta_slack_shifts_profile_and_inverse() -> Fallible<()> {
+    let curve = PrivacyCurve::new()
+        .with_log_profile(|eps| Ok(-eps))?
+        .with_delta_slack(1e-6)?;
+
+    assert_eq!(curve.delta(f64::INFINITY)?, 1e-6);
+    assert!(curve.epsilon(0.5e-6)?.is_infinite());
+
+    let epsilon = curve.epsilon((-2.0f64).exp() + 1e-6)?;
+    assert!((epsilon - 2.0).abs() < 1e-12);
+    Ok(())
+}
+
+#[test]
+fn test_delta_slack_matches_equivalent_approxdp_curve() -> Fallible<()> {
+    let epsilon = 1.0;
+    let delta_slack = 0.1;
+
+    let with_slack = PrivacyCurve::new()
+        .with_approxDP(vec![(epsilon, 0.0)])?
+        .with_delta_slack(delta_slack)?;
+    let direct = PrivacyCurve::new().with_approxDP(vec![(epsilon, delta_slack)])?;
+
+    for alpha in [0.0, 0.1, 0.25, 0.5, 0.9, 1.0] {
+        assert!((with_slack.beta(alpha)? - direct.beta(alpha)?).abs() < 1e-12);
+    }
+
+    assert_eq!(with_slack.delta(0.5)?, direct.delta(0.5)?);
+    assert!(
+        with_slack.delta(1.0)? >= direct.delta(1.0)?
+            && with_slack.delta(1.0)? <= direct.delta(1.0)?.next_up()
+    );
+    assert_eq!(
+        with_slack.epsilon(delta_slack)?,
+        direct.epsilon(delta_slack)?
+    );
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "honest-but-curious")]
+fn test_inversion_conservative_endpoints() -> Fallible<()> {
+    let cutoff = 1.0f64;
+    let profile = PrivacyCurve::new().with_log_profile(move |epsilon| {
+        Ok(if epsilon < cutoff {
+            0.5f64.ln()
+        } else {
+            0.25f64.ln()
+        })
+    })?;
+    let target_delta = profile.delta(cutoff)?;
+    assert_eq!(profile.epsilon(target_delta)?, cutoff);
+    assert!(profile.delta(cutoff.next_down())? > target_delta);
+
+    let tradeoff =
+        PrivacyCurve::new().with_tradeoff(|alpha| Ok(if alpha < 0.5 { 0.75 } else { 0.25 }))?;
+    let alpha = tradeoff.alpha(0.25)?;
+    assert_eq!(alpha, 0.5f64.next_down());
+    assert!(tradeoff.beta(alpha)? > 0.25);
+    Ok(())
+}
+
+#[test]
+fn test_input_validation() {
+    assert!(
+        PrivacyCurve::new()
+            .with_approxDP(vec![(-0.0, 0.0)])
+            .is_err()
+    );
+    assert!(
+        PrivacyCurve::new()
+            .with_approxDP(vec![(0.0, -0.0)])
+            .is_err()
+    );
+    assert!(PrivacyCurve::new().with_delta_slack(-0.0).is_err());
+
+    let curve = PrivacyCurve::new().with_approxDP(vec![(0.0, 0.0)]).unwrap();
+    assert!(curve.delta(-0.0).is_err());
+    assert!(curve.beta(-0.0).is_err());
+    assert!(curve.epsilon(-0.0).is_err());
+    assert!(curve.alpha(-0.0).is_err());
+
+    assert!(
+        PrivacyCurve::new()
+            .with_approxDP(vec![(0.0, 0.1), (1.0, 0.2)])
+            .is_err()
+    );
+}
+
+#[test]
+fn test_composition_identity_and_directed_sums() -> Fallible<()> {
+    let identity = PrivacyCurve::compose(vec![])?;
+    assert_eq!(identity.delta(0.0)?, 0.0);
+    assert_eq!(identity.beta(0.25)?, 0.75);
+
+    let first = PrivacyCurve::new().with_approxDP(vec![(0.1, 0.2)])?;
+    let second = PrivacyCurve::new().with_approxDP(vec![(0.2, 0.3)])?;
+    let composed = PrivacyCurve::compose(vec![first, second])?;
+
+    let epsilon = composed.epsilon(0.5)?;
+    assert!(epsilon >= 0.1 + 0.2);
+    assert!(composed.delta(epsilon)? >= 0.5);
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "honest-but-curious")]
+fn test_ordinary_profile_plateau_inversion() -> Fallible<()> {
+    let curve =
+        PrivacyCurve::new().with_profile(|epsilon| Ok(if epsilon >= 2.0 { 0.1 } else { 1.0 }))?;
+
+    assert_eq!(curve.epsilon(0.1)?, 2.0);
+    assert_eq!(curve.epsilon(0.1f64.next_down())?, f64::INFINITY);
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "honest-but-curious")]
+fn test_unreachable_ordinary_profile_delta_inverts_to_infinity() -> Fallible<()> {
+    let curve = PrivacyCurve::new().with_profile(|_| Ok(0.5))?;
+    assert_eq!(curve.epsilon(0.25)?, f64::INFINITY);
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "honest-but-curious")]
+fn test_log_profile_generic_inversion() -> Fallible<()> {
+    let curve = PrivacyCurve::new().with_log_profile(|epsilon| Ok(-epsilon))?;
+    assert!(curve.delta(2.0)? >= (-2.0f64).exp());
+    assert!(curve.epsilon((-2.0f64).exp())? >= 2.0);
+    assert_eq!(curve.epsilon(0.0)?, f64::INFINITY);
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "honest-but-curious")]
+fn test_certified_profile_inverse_bypasses_forward_search() -> Fallible<()> {
+    let forward_calls = Arc::new(AtomicUsize::new(0));
+    let forward_calls_ = forward_calls.clone();
+    let curve = PrivacyCurve::new().with_log_profile_with_epsilon(
+        move |epsilon| {
+            forward_calls_.fetch_add(1, Ordering::Relaxed);
+            Ok(-epsilon)
+        },
+        |_delta| Ok(3.0),
+    )?;
+
+    assert_eq!(curve.epsilon(1e-6)?, 3.0);
+    assert_eq!(forward_calls.load(Ordering::Relaxed), 0);
+    Ok(())
+}
+
+#[test]
+fn test_subnormal_log_to_delta_conversion() -> Fallible<()> {
+    let minimum = f64::from_bits(1);
+    assert_eq!(log_to_delta_upper(minimum.ln())?, f64::from_bits(2));
+    assert_eq!(log_to_delta_upper(minimum.ln().next_down())?, minimum);
+    Ok(())
+}

--- a/rust/src/measures/curves/tradeoff.rs
+++ b/rust/src/measures/curves/tradeoff.rs
@@ -1,0 +1,93 @@
+use crate::{
+    error::Fallible,
+    measures::curves::{TradeoffFn, check_beta, check_epsilon},
+    traits::{A, C, D, Interval, IntervalArithmeticBackend},
+    utilities::search::{SearchMode, optimize_to_precision_bracket},
+};
+
+pub fn delta_via_tradeoff(tradeoff: &TradeoffFn, symmetric: bool, epsilon: f64) -> Fallible<f64> {
+    check_epsilon(epsilon)?;
+
+    // Enclose r = exp(epsilon) with the soft backend once. The generic
+    // tradeoff formula below can then be evaluated over A for search and C for
+    // the final simple-arithmetic bound.
+    let r = Interval::<D>::point(epsilon)?.exp()?;
+    let r_lo = r.lower_f64()?;
+    let r_hi = r.upper_f64()?;
+
+    let c1 = delta_tradeoff_term(tradeoff, r_lo, r_hi, DeltaTradeoffTerm::EpsAlphaBeta)?;
+
+    if symmetric {
+        return Ok(c1.clamp(0.0, 1.0));
+    }
+
+    let c2 = delta_tradeoff_term(tradeoff, r_lo, r_hi, DeltaTradeoffTerm::EpsBetaAlpha)?;
+
+    Ok(c1.max(c2).clamp(0.0, 1.0))
+}
+
+#[derive(Clone, Copy, Debug)]
+enum DeltaTradeoffTerm {
+    // 1 - exp(epsilon) * alpha - beta(alpha)
+    EpsAlphaBeta,
+
+    // 1 - exp(epsilon) * beta(alpha) - alpha
+    EpsBetaAlpha,
+}
+
+#[inline]
+fn delta_tradeoff_term(
+    tradeoff: &TradeoffFn,
+    r_lo: f64,
+    r_hi: f64,
+    term: DeltaTradeoffTerm,
+) -> Fallible<f64> {
+    // Use the approximate interval backend only to choose the candidate alpha
+    // bracket. The final value is recomputed with C below on the returned
+    // bracket, not just at the optimizer's point.
+    let optimum =
+        optimize_to_precision_bracket(SearchMode::Maximize, 0.0, 1.0, None, |alpha: f64| {
+            delta_tradeoff_term_upper_on::<A>(tradeoff, r_lo, r_hi, alpha, alpha, term)
+                .unwrap_or_else(|_| SearchMode::Maximize.bad_value())
+        });
+
+    delta_tradeoff_term_upper_on::<C>(tradeoff, r_lo, r_hi, optimum.lo, optimum.hi, term)
+}
+
+#[inline]
+fn delta_tradeoff_term_upper_on<Bk>(
+    tradeoff: &TradeoffFn,
+    r_lo: f64,
+    r_hi: f64,
+    alpha_lo: f64,
+    alpha_hi: f64,
+    term: DeltaTradeoffTerm,
+) -> Fallible<f64>
+where
+    Bk: IntervalArithmeticBackend,
+{
+    debug_assert!(alpha_lo <= alpha_hi);
+
+    let alpha_lo = alpha_lo.max(0.0);
+    let alpha_hi = alpha_hi.min(1.0);
+
+    let beta_lo = tradeoff(alpha_hi)?;
+    check_beta(beta_lo)?;
+
+    let one = Interval::<Bk>::point(1.0)?;
+    let r = Interval::<Bk>::between(r_lo, r_hi)?;
+    let alpha = Interval::<Bk>::between(alpha_lo, alpha_hi)?;
+
+    // TradeoffFn is already conservative: beta_lo is a lower bound on beta at
+    // alpha_hi, and monotonicity makes it a lower bound over [alpha_lo, alpha_hi].
+    // Use a wide interval so subtraction can use the lower endpoint while the
+    // formula remains backend-generic.
+    let beta = Interval::<Bk>::between(beta_lo.max(0.0), 1.0)?;
+
+    let subtrahend = match term {
+        DeltaTradeoffTerm::EpsAlphaBeta => r.mul(alpha)?.add(beta)?,
+        DeltaTradeoffTerm::EpsBetaAlpha => r.mul(beta)?.add(alpha)?,
+    };
+
+    one.sub(subtrahend)?.clamp01()?.upper_f64()
+}

--- a/rust/src/measures/ffi.rs
+++ b/rust/src/measures/ffi.rs
@@ -18,7 +18,7 @@ use crate::{
     traits::ProductOrd,
 };
 
-use super::{PrivacyProfile, RenyiDivergence, SmoothedMaxDivergence};
+use super::{PrivacyCurve, RenyiDivergence, SmoothedMaxDivergence};
 
 #[bootstrap(
     name = "_measure_free",
@@ -444,7 +444,9 @@ pub extern "C" fn opendp_measures__new_privacy_profile(
     curve: *const CallbackFn,
 ) -> FfiResult<*mut AnyObject> {
     let curve = wrap_func(try_as_ref!(curve).clone());
-    FfiResult::Ok(AnyObject::new_raw(PrivacyProfile::new(
-        move |epsilon: f64| curve(&AnyObject::new(epsilon))?.downcast::<f64>(),
-    )))
+    let profile = try_!(
+        PrivacyCurve::new()
+            .with_profile(move |epsilon: f64| curve(&AnyObject::new(epsilon))?.downcast::<f64>(),)
+    );
+    FfiResult::Ok(AnyObject::new_raw(profile))
 }

--- a/rust/src/measures/mod.rs
+++ b/rust/src/measures/mod.rs
@@ -6,12 +6,15 @@
 #[cfg(feature = "ffi")]
 pub(crate) mod ffi;
 
-use std::{cmp::Ordering, fmt::Debug, sync::Arc};
+mod privacy_profile;
+pub(crate) use privacy_profile::{delta_to_log_lower, delta_to_log_upper, log_to_delta_upper};
 
-use crate::{
-    core::{Function, Measure},
-    error::Fallible,
-};
+pub(crate) mod curves;
+pub use curves::*;
+
+use std::fmt::Debug;
+
+use crate::core::{Function, Measure};
 
 /// Privacy measure used to define $\epsilon$-pure differential privacy.
 ///
@@ -48,7 +51,7 @@ impl Measure for MaxDivergence {
 /// The measurement's input metric defines the notion of adjacency,
 /// and the measurement's input domain defines the set of possible datasets.
 ///
-/// The distance $d$ is of type [`PrivacyProfile`], so it can be invoked with an $\epsilon$
+/// The distance $d$ is of type [`PrivacyCurve`], so it can be invoked with an $\epsilon$
 /// to retrieve the corresponding $\delta$.
 ///
 /// # Proof Definition
@@ -71,94 +74,7 @@ impl Measure for MaxDivergence {
 pub struct SmoothedMaxDivergence;
 
 impl Measure for SmoothedMaxDivergence {
-    type Distance = PrivacyProfile;
-}
-
-/// A function mapping from $\epsilon$ to $\delta$
-///
-/// This is the distance type for [`SmoothedMaxDivergence`].
-#[derive(Clone)]
-pub struct PrivacyProfile(Arc<dyn Fn(f64) -> Fallible<f64> + Send + Sync>);
-
-impl PrivacyProfile {
-    pub fn new(delta: impl Fn(f64) -> Fallible<f64> + 'static + Send + Sync) -> Self {
-        PrivacyProfile(Arc::new(delta))
-    }
-
-    pub fn epsilon(&self, delta: f64) -> Fallible<f64> {
-        // reject negative zero
-        if delta.is_sign_negative() {
-            return fallible!(FailedMap, "delta ({}) must not be negative", delta);
-        }
-
-        if !(0.0..=1.0).contains(&delta) {
-            return fallible!(FailedMap, "delta ({}) must be between zero and one", delta);
-        }
-
-        if delta == 1.0 {
-            return Ok(0.0);
-        }
-
-        self.epsilon_unchecked(delta)
-    }
-
-    pub(crate) fn epsilon_unchecked(&self, delta: f64) -> Fallible<f64> {
-        let mut e_min: f64 = 0.0;
-        let mut e_max: f64 = 2.0;
-        while self.delta(e_max)? > delta {
-            e_max *= e_max;
-            if e_max.is_infinite() {
-                // For mechanisms that are not pureDP, e_max will be infinity.
-                // This loop can be very long running.
-                return Ok(f64::INFINITY);
-            }
-        }
-
-        // delta(e_max) <= delta <= delta(e_min) -> always holds
-        // We always try to find the smallest e that minimizes |delta(e) - delta| and enforces delta(e) <= delta
-        //           -> if delta == delta(e_min), we can pick e_min, otherwise we have to take e_max
-        // same as   -> if e
-        // For delta == 1.0, we find the largest e that gives delta(e) == 1.0
-        // (so as not to create a discontinuity and go to zero.)
-        let mut e_mid = e_min;
-        loop {
-            let new_mid = e_min + ((e_max - e_min) / 2.0);
-
-            // converge when midpoint doesn't change
-            if new_mid == e_mid {
-                if delta == 1. {
-                    return Ok(e_max);
-                }
-
-                return Ok(if delta == self.delta(e_min)? {
-                    e_min
-                } else {
-                    e_max
-                });
-            }
-
-            e_mid = new_mid;
-
-            // get delta corresponding to e_mid
-            let d_mid: f64 = self.delta(e_mid)?;
-            match d_mid.partial_cmp(&delta) {
-                Some(Ordering::Greater) => e_min = e_mid,
-                Some(Ordering::Less) => e_max = e_mid,
-                Some(Ordering::Equal) => {
-                    if delta == 1. {
-                        e_min = e_mid
-                    } else {
-                        e_max = e_mid
-                    }
-                }
-                None => return fallible!(FailedMap, "not comparable"),
-            }
-        }
-    }
-
-    pub fn delta(&self, epsilon: f64) -> Fallible<f64> {
-        (self.0)(epsilon)
-    }
+    type Distance = PrivacyCurve;
 }
 
 /// Privacy measure used to define $\delta$-approximate PM-differential privacy.

--- a/rust/src/measures/privacy_profile.rs
+++ b/rust/src/measures/privacy_profile.rs
@@ -1,0 +1,54 @@
+use crate::{error::Fallible, traits::DInterval};
+
+/// Convert an ordinary delta upper bound to an upward-conservative log-delta
+/// upper bound.
+pub(crate) fn delta_to_log_upper(delta: f64) -> Fallible<f64> {
+    check_delta(delta)?;
+    if delta == 0.0 {
+        return Ok(f64::NEG_INFINITY);
+    }
+    if delta == 1.0 {
+        return Ok(0.0);
+    }
+
+    DInterval::point(delta)?.ln()?.upper_f64()
+}
+
+/// Convert an ordinary delta target to a downward-conservative log-delta
+/// target for certified profile inversion.
+pub(crate) fn delta_to_log_lower(delta: f64) -> Fallible<f64> {
+    check_delta(delta)?;
+    if delta == 0.0 {
+        return Ok(f64::NEG_INFINITY);
+    }
+    if delta == 1.0 {
+        return Ok(0.0);
+    }
+
+    DInterval::point(delta)?.ln()?.lower_f64()
+}
+
+/// Convert an upward-conservative log-delta bound to an ordinary delta bound.
+pub(crate) fn log_to_delta_upper(log_delta: f64) -> Fallible<f64> {
+    if log_delta.is_nan() || log_delta > 0.0 {
+        return fallible!(
+            FailedMap,
+            "log(delta) ({log_delta}) must be at most zero and not NaN"
+        );
+    }
+    if log_delta == f64::NEG_INFINITY {
+        return Ok(0.0);
+    }
+    if log_delta == 0.0 {
+        return Ok(1.0);
+    }
+
+    DInterval::point(log_delta)?.exp()?.upper_f64()
+}
+
+fn check_delta(delta: f64) -> Fallible<()> {
+    if delta.is_nan() || delta.is_sign_negative() || delta > 1.0 {
+        return fallible!(FailedMap, "delta ({delta}) must be between zero and one");
+    }
+    Ok(())
+}

--- a/rust/src/traits/directed/mod.rs
+++ b/rust/src/traits/directed/mod.rs
@@ -680,7 +680,21 @@ where
 
     #[inline]
     fn exp_to_<DOut: ODPRound>(self) -> Fallible<Self::Output<DOut>> {
-        Ok(DBig::raw(self.value.with_rounding::<DOut>().exp()))
+        let value = self
+            .value
+            .with_precision(64)
+            .value()
+            .with_rounding::<DOut>();
+        let min = FBig::<DOut>::try_from(f64::from_bits(1))?
+            .with_precision(64)
+            .value();
+        let min_log = min.clone().ln();
+
+        if value <= min_log {
+            return Ok(DBig::raw(if DOut::IS_UP { min } else { FBig::ZERO }));
+        }
+
+        Ok(DBig::raw(value.exp()))
     }
 }
 


### PR DESCRIPTION
Superseded by #2860, which uses the canonical fdp/05-privacy-curve-core head branch and the correct fdp/03-scalar-optimization base.