### PR TITLE
Fix typos and grammatical errors in essential-statistics

### DIFF
--- a/docs/source/getting-started/tabular-data/essential-statistics.rst
+++ b/docs/source/getting-started/tabular-data/essential-statistics.rst
@@ -76,7 +76,7 @@ introduction <index.rst>`__.
 Count
 -----
 
-The simplest query is a count of the number of records in a dataset.
+The simplest query is a count of records in a dataset.
 
 .. tab-set::
 
@@ -174,7 +174,7 @@ All the operations which follow require some information about
 the expected range of values: sum and mean need upper and lower bounds,
 while median and quantile take a set of candidate values.
 If you set bounds too wide, the additional noise will mean less accurate results;
-If you set bounds too narrow, clipping may produced biased results.
+If you set bounds too narrow, clipping may produce biased results.
 
 In some cases, for instance age in a demographic dataset, you will have prior
 knowledge that allows you to set bounds. In others, there may be a comparable
@@ -187,7 +187,7 @@ values to estimate the 5th and 95th percentiles (see :ref:`quantile`),
 or you could estimate a histogram using exponentially increasing bin widths.
 
 There are several good options;
-The only bad option is look at the data to determine bounds.
+The only bad option is to look at the data to determine bounds.
 
 
 Sum
@@ -253,7 +253,7 @@ about the data to a potential adversary, the library is able to ensure
 that overflow and/or numerical instability won’t undermine privacy
 guarantees.
 
-Now that you’ve become acquainted with margins, lets release some
+Now that you’ve become acquainted with margins, let's release some
 queries that make use of it. We start by releasing the total number of
 work hours across responses.
 
@@ -467,7 +467,7 @@ filtered data, as shown above.
 
 When ``invariant="lengths"`` is set, the number of records in the data
 is not protected (for those familiar with DP terminology, this is
-equivalent to bounded-DP). Therefore when computing the mean, a noisy
+equivalent to bounded-DP). Therefore, when computing the mean, a noisy
 sum is released and subsequently divided by the exact length. This
 behavior can be observed in the query summary:
 


### PR DESCRIPTION
Small grammar, clarity, and typos throughout. 

Supercedes #2871. Based on feedback, the previous PR's infer_schema changes were not warranted and were not merged; however, the grammar fixes were asked to be kept, re-forked, and worked from a feature branch off of main, per the advice I was given. I hope everything worked out and looks correct. Thank you so much for the advice and the help, @eddiestudies and @mccalluc. 