### PR TITLE
chore: ruff format src (excluding extras)

### DIFF
--- a/python/src/opendp/__init__.py
+++ b/python/src/opendp/__init__.py
@@ -1,1 +1,6 @@
-from opendp.mod import Transformation, Measurement, OpenDPException, UnknownTypeException
+from opendp.mod import (
+    Transformation,
+    Measurement,
+    OpenDPException,
+    UnknownTypeException,
+)

--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -29,25 +29,30 @@ from opendp.mod import (
 from opendp.typing import RuntimeType, RuntimeTypeDescriptor
 
 ATOM_MAP = {
-    'f32': ctypes.c_float,
-    'f64': ctypes.c_double,
-    'u8': ctypes.c_uint8,
-    'u16': ctypes.c_uint16,
-    'u32': ctypes.c_uint32,
-    'u64': ctypes.c_uint64,
-    'i8': ctypes.c_int8,
-    'i16': ctypes.c_int16,
-    'i32': ctypes.c_int32,
-    'i64': ctypes.c_int64,
-    'usize': ctypes.c_size_t,
-    'bool': ctypes.c_bool,
-    'AnyMeasurementPtr': Measurement,
-    'AnyTransformationPtr': Transformation,
+    "f32": ctypes.c_float,
+    "f64": ctypes.c_double,
+    "u8": ctypes.c_uint8,
+    "u16": ctypes.c_uint16,
+    "u32": ctypes.c_uint32,
+    "u64": ctypes.c_uint64,
+    "i8": ctypes.c_int8,
+    "i16": ctypes.c_int16,
+    "i32": ctypes.c_int32,
+    "i64": ctypes.c_int64,
+    "usize": ctypes.c_size_t,
+    "bool": ctypes.c_bool,
+    "AnyMeasurementPtr": Measurement,
+    "AnyTransformationPtr": Transformation,
 }
 
-_NUMPY_COMPATIBLE_ATOM_TYPES = frozenset(ATOM_MAP) - {'AnyMeasurementPtr', 'AnyTransformationPtr'}
+_NUMPY_COMPATIBLE_ATOM_TYPES = frozenset(ATOM_MAP) - {
+    "AnyMeasurementPtr",
+    "AnyTransformationPtr",
+}
+
+
 def _numpy_dtype_for_rust_type(type_name: str) -> Any:
-    np = import_optional_dependency('numpy')
+    np = import_optional_dependency("numpy")
     if type_name not in _NUMPY_COMPATIBLE_ATOM_TYPES:
         raise ValueError(f"unrecognized numpy dtype: {type_name}")
     return np.dtype(ATOM_MAP[type_name])
@@ -60,28 +65,44 @@ def c_int_limits(type_name):
     signed_limit = 2 ** (bit_size - 1)
     return (-signed_limit, signed_limit - 1) if signed else (0, 2 * signed_limit - 1)
 
+
 INT_SIZES = {
-    ty: c_int_limits(ty) for ty in (
-        'u8', 'u16', 'u32', 'u64', 'i8', 'i16', 'i32', 'i64', 'usize',
+    ty: c_int_limits(ty)
+    for ty in (
+        "u8",
+        "u16",
+        "u32",
+        "u64",
+        "i8",
+        "i16",
+        "i32",
+        "i64",
+        "usize",
     )
 }
 _ERROR_URL_298 = "https://github.com/opendp/opendp/discussions/298"
 
 
 def _check_and_cast_scalar(expected, value):
-    '''
+    """
     1. Converts integer value to float if expected value is float
     2. Checks that value is roughly a member of the same data type as expected
     3. Checks that integers are representable at the given data type
-    '''
+    """
     # relax checks in the case of an int
-    if isinstance(value, int) and expected in ["f32", "f64"] and not isinstance(value, bool):
+    if (
+        isinstance(value, int)
+        and expected in ["f32", "f64"]
+        and not isinstance(value, bool)
+    ):
         return float(value)
 
     inferred = str(RuntimeType.infer(value))
 
     if expected not in ATOM_EQUIVALENCE_CLASSES.get(inferred, [inferred]):
-        raise TypeError(f"inferred type is {inferred}, expected {expected}. See {_ERROR_URL_298}")
+        raise TypeError(
+            f"inferred type is {inferred}, expected {expected}. See {_ERROR_URL_298}"
+        )
 
     if expected in INT_SIZES:
         check_c_int_cast(value, expected)
@@ -116,8 +137,8 @@ def py_to_c(value: Any, c_type, type_name: RuntimeTypeDescriptor = None) -> Any:
         return _wrap_py_transition(value, type_name)
 
     if c_type == ExtrinsicObjectPtr:
-        # since the memory is allocated by python, 
-        #    don't actually return an ExtrinsicObjectPtr, 
+        # since the memory is allocated by python,
+        #    don't actually return an ExtrinsicObjectPtr,
         #    which would call rust to free the Python-allocated ExtrinsicObject
         return ctypes.pointer(ExtrinsicObject(ctypes.py_object(value)))
 
@@ -150,7 +171,8 @@ def py_to_c(value: Any, c_type, type_name: RuntimeTypeDescriptor = None) -> Any:
             return value
 
         from opendp._data import slice_as_object
-        return slice_as_object(value, type_name) # type: ignore[arg-type]
+
+        return slice_as_object(value, type_name)  # type: ignore[arg-type]
 
     if c_type == FfiSlicePtr:
         if type_name is None:
@@ -186,7 +208,7 @@ def c_to_py(value: Any) -> Any:
 
         if obj_type == PrivacyProfile.__name__:
             return PrivacyProfile(value)
-        
+
         if obj_type == "AnyOdometerQueryable":
             return OdometerQueryable(value)
 
@@ -210,6 +232,7 @@ def c_to_py(value: Any) -> Any:
 
     if isinstance(value, ctypes.c_char_p):
         from opendp._data import str_free
+
         assert value.value is not None
         value_contents = value.value.decode()
         str_free(value)
@@ -217,6 +240,7 @@ def c_to_py(value: Any) -> Any:
 
     if isinstance(value, BoolPtr):
         from opendp._data import bool_free
+
         value_contents = value.contents.value
         bool_free(value)
         return value_contents
@@ -226,6 +250,7 @@ def c_to_py(value: Any) -> Any:
 
     if isinstance(value, Domain):
         from opendp.domains import domain_type
+
         rt_type = RuntimeType.parse(domain_type(value))
 
         if isinstance(rt_type, RuntimeType):
@@ -426,7 +451,7 @@ def _py_to_slice(value: Any, type_name: Union[RuntimeType, str]) -> FfiSlicePtr:
 
 
 def _scalar_to_slice(val, type_name: str) -> FfiSlicePtr:
-    np = import_optional_dependency('numpy', raise_error=False)
+    np = import_optional_dependency("numpy", raise_error=False)
     if np is not None and isinstance(val, np.ndarray):
         val = val.item()
     val = _check_and_cast_scalar(type_name, val)
@@ -435,36 +460,45 @@ def _scalar_to_slice(val, type_name: str) -> FfiSlicePtr:
 
 
 def _slice_to_scalar(raw: FfiSlicePtr, type_name: str):
-    return ctypes.cast(raw.contents.ptr, ctypes.POINTER(ATOM_MAP[type_name])).contents.value # type: ignore[attr-defined]
+    return ctypes.cast(
+        raw.contents.ptr, ctypes.POINTER(ATOM_MAP[type_name])
+    ).contents.value  # type: ignore[attr-defined]
+
 
 def _extrinsic_to_slice(val) -> FfiSlicePtr:
     return _wrap_in_slice(ctypes.pointer(ExtrinsicObject(ctypes.py_object(val))), 1)
 
+
 def _slice_to_extrinsic(raw: FfiSlicePtr):
     return ctypes.cast(raw.contents.ptr, ctypes.POINTER(ExtrinsicObject)).contents.ptr
 
+
 def _string_to_slice(val: str) -> FfiSlicePtr:
-    np = import_optional_dependency('numpy', raise_error=False)
+    np = import_optional_dependency("numpy", raise_error=False)
     if np is not None and isinstance(val, np.ndarray):
         val = val.item()
     return _wrap_in_slice(ctypes.pointer(ctypes.c_char_p(val.encode())), 1)
 
 
 def _slice_to_string(raw: FfiSlicePtr) -> str:
-    value = ctypes.cast(raw.contents.ptr, ctypes.POINTER(ctypes.c_char_p)).contents.value
-    assert value is not None 
+    value = ctypes.cast(
+        raw.contents.ptr, ctypes.POINTER(ctypes.c_char_p)
+    ).contents.value
+    assert value is not None
     return value.decode()
 
 
 def _bitvector_to_slice(val: Sequence[Any]) -> FfiSlicePtr:
-    np = import_optional_dependency('numpy', raise_error=False)
+    np = import_optional_dependency("numpy", raise_error=False)
     if np is not None and isinstance(val, np.ndarray):
         val = val.tobytes()
-    
-    if not isinstance(val, (bytes, bytearray)):
-        raise TypeError("Expected type is BitVector but input data is not bytes or bytearray.")  # pragma: no cover
 
-    array = (ctypes.c_uint8 * len(val)).from_buffer_copy(val) # type: ignore[operator]
+    if not isinstance(val, (bytes, bytearray)):
+        raise TypeError(
+            "Expected type is BitVector but input data is not bytes or bytearray."
+        )  # pragma: no cover
+
+    array = (ctypes.c_uint8 * len(val)).from_buffer_copy(val)  # type: ignore[operator]
     return _wrap_in_slice(array, len(val) * 8)
 
 
@@ -472,12 +506,12 @@ def _slice_to_bitvector(raw: FfiSlicePtr) -> bytes:
     # raw.contents.len is the number of valid bits.
     # Division by -8 is ceiling rather than floor: the number of bytes in the buffer
     n_bytes = -(raw.contents.len // -8)
-    buffer = ctypes.cast(raw.contents.ptr, ctypes.POINTER(ctypes.c_uint8))[0:n_bytes] # type: ignore
+    buffer = ctypes.cast(raw.contents.ptr, ctypes.POINTER(ctypes.c_uint8))[0:n_bytes]  # type: ignore
     return bytes(buffer)
 
 
 def _vector_to_slice(val: Sequence[Any], type_name: RuntimeType) -> FfiSlicePtr:
-    if type_name.origin != 'Vec' or len(type_name.args) != 1:
+    if type_name.origin != "Vec" or len(type_name.args) != 1:
         raise ValueError("type_name must be Vec<_>")  # pragma: no cover
 
     inner_type_name = type_name.args[0]
@@ -496,11 +530,19 @@ def _vector_to_slice(val: Sequence[Any], type_name: RuntimeType) -> FfiSlicePtr:
         try:
             val = list(val)
         except TypeError:
-            raise TypeError(f"Expected type is {type_name} but input data is not a list.")
+            raise TypeError(
+                f"Expected type is {type_name} but input data is not a list."
+            )
 
-    if isinstance(inner_type_name, RuntimeType) or inner_type_name in {"Expr", "Bound", "BitVector"}:
-        c_repr = [py_to_c(v, c_type=AnyObjectPtr, type_name=inner_type_name) for v in val]
-        array = (AnyObjectPtr * len(val))(*c_repr) # type: ignore[operator]
+    if isinstance(inner_type_name, RuntimeType) or inner_type_name in {
+        "Expr",
+        "Bound",
+        "BitVector",
+    }:
+        c_repr = [
+            py_to_c(v, c_type=AnyObjectPtr, type_name=inner_type_name) for v in val
+        ]
+        array = (AnyObjectPtr * len(val))(*c_repr)  # type: ignore[operator]
         ffislice = _wrap_in_slice(array, len(val))
         ffislice.depends_on(*c_repr)
         return ffislice
@@ -514,37 +556,44 @@ def _vector_to_slice(val: Sequence[Any], type_name: RuntimeType) -> FfiSlicePtr:
 
     if inner_type_name == "SeriesDomain":
         # define the ctype of an array of domains
-        domain_array_type = (Domain * len(val)) # type: ignore[operator]
+        domain_array_type = Domain * len(val)  # type: ignore[operator]
         # create an instance of a ctype array of domains
-        array = domain_array_type(*val) # type: ignore[operator]
+        array = domain_array_type(*val)  # type: ignore[operator]
         return _wrap_in_slice(array, len(val))
-    
+
     # remaining inner types should be atomic
     val = [_check_and_cast_scalar(inner_type_name, v) for v in val]
 
     if inner_type_name == "String":
+
         def str_to_slice(val):
             return ctypes.c_char_p(val.encode())
+
         array = (ctypes.c_char_p * len(val))(*map(str_to_slice, val))
         return _wrap_in_slice(array, len(val))
 
     if inner_type_name not in ATOM_MAP:
-        raise TypeError(f"Members must be one of {tuple(ATOM_MAP.keys())}. Found {inner_type_name}.")  # pragma: no cover
+        raise TypeError(
+            f"Members must be one of {tuple(ATOM_MAP.keys())}. Found {inner_type_name}."
+        )  # pragma: no cover
 
     array = (ATOM_MAP[inner_type_name] * len(val))(*val)  # type: ignore[operator]
     return _wrap_in_slice(array, len(val))
 
 
 def _slice_to_vector(raw: FfiSlicePtr, type_name: RuntimeType) -> Sequence[Any]:
-    if type_name.origin != 'Vec' or len(type_name.args) != 1:
+    if type_name.origin != "Vec" or len(type_name.args) != 1:
         raise ValueError("type_name must be Vec<_>")  # pragma: no cover
 
     inner_type_name = type_name.args[0]
 
-    if inner_type_name in {'AnyObject', 'Expr', 'Bound'}:
+    if inner_type_name in {"AnyObject", "Expr", "Bound"}:
         from opendp._data import ffislice_of_anyobjectptrs
+
         raw = ffislice_of_anyobjectptrs(raw)
-        array = ctypes.cast(raw.contents.ptr, ctypes.POINTER(AnyObjectPtr))[0:raw.contents.len]
+        array = ctypes.cast(raw.contents.ptr, ctypes.POINTER(AnyObjectPtr))[
+            0 : raw.contents.len
+        ]
         res = list(map(c_to_py, array))
         # when the top-level AnyObject is freed, it recursively frees all anyobjects inside of it
         # adjust the type of constituent AnyObjects so that __delete__ is not called when they are dropped
@@ -552,28 +601,40 @@ def _slice_to_vector(raw: FfiSlicePtr, type_name: RuntimeType) -> Sequence[Any]:
             elem.__class__ = ctypes.POINTER(AnyObject)
         return res
 
-    if inner_type_name == 'ExtrinsicObject':
-        array = ctypes.cast(raw.contents.ptr, ctypes.POINTER(ExtrinsicObject))[0:raw.contents.len]
+    if inner_type_name == "ExtrinsicObject":
+        array = ctypes.cast(raw.contents.ptr, ctypes.POINTER(ExtrinsicObject))[
+            0 : raw.contents.len
+        ]
         return list(map(lambda v: v.ptr, array))
 
-    if inner_type_name == 'String':
-        array = ctypes.cast(raw.contents.ptr, ctypes.POINTER(ctypes.c_char_p))[0:raw.contents.len]
+    if inner_type_name == "String":
+        array = ctypes.cast(raw.contents.ptr, ctypes.POINTER(ctypes.c_char_p))[
+            0 : raw.contents.len
+        ]
         return list(map(lambda v: v.decode(), array))
 
     if not isinstance(inner_type_name, str):
-        raise ValueError(f"inner type must be atomic, found {inner_type_name}")  # pragma: no cover
-    
-    return ctypes.cast(raw.contents.ptr, ctypes.POINTER(ATOM_MAP[inner_type_name]))[0:raw.contents.len]
+        raise ValueError(
+            f"inner type must be atomic, found {inner_type_name}"
+        )  # pragma: no cover
+
+    return ctypes.cast(raw.contents.ptr, ctypes.POINTER(ATOM_MAP[inner_type_name]))[
+        0 : raw.contents.len
+    ]
 
 
 def _numpy_to_slice(val, type_name: RuntimeType) -> FfiSlicePtr:
     np = import_optional_dependency("numpy")
-    if type_name.origin != 'NDArray' or len(type_name.args) != 1:
-        raise ValueError(f"type_name must be NDArray<T> with one type argument, found {type_name}")  # pragma: no cover
+    if type_name.origin != "NDArray" or len(type_name.args) != 1:
+        raise ValueError(
+            f"type_name must be NDArray<T> with one type argument, found {type_name}"
+        )  # pragma: no cover
 
     inner_type_name = type_name.args[0]
     if not isinstance(inner_type_name, str):
-        raise ValueError(f"inner type must be atomic, found {inner_type_name}")  # pragma: no cover
+        raise ValueError(
+            f"inner type must be atomic, found {inner_type_name}"
+        )  # pragma: no cover
 
     np_dtype = _numpy_dtype_for_rust_type(inner_type_name)
     if not isinstance(val, np.ndarray):
@@ -593,42 +654,56 @@ def _numpy_to_slice(val, type_name: RuntimeType) -> FfiSlicePtr:
 
 def _slice_to_numpy(raw: FfiSlicePtr, type_name: RuntimeType):
     np = import_optional_dependency("numpy")
-    if type_name.origin != 'NDArray' or len(type_name.args) != 1:
-        raise ValueError(f"type_name must be NDArray<T> with one type argument, found {type_name}")  # pragma: no cover
+    if type_name.origin != "NDArray" or len(type_name.args) != 1:
+        raise ValueError(
+            f"type_name must be NDArray<T> with one type argument, found {type_name}"
+        )  # pragma: no cover
 
     inner_type_name = type_name.args[0]
     if not isinstance(inner_type_name, str):
-        raise ValueError(f"inner type must be atomic, found {inner_type_name}")  # pragma: no cover
-    
-    _numpy_dtype_for_rust_type(inner_type_name)  # validate numpy compatibility before casting
+        raise ValueError(
+            f"inner type must be atomic, found {inner_type_name}"
+        )  # pragma: no cover
 
-    array_ptr: Any = ctypes.cast(raw.contents.ptr, ctypes.POINTER(ATOM_MAP[inner_type_name]))
+    _numpy_dtype_for_rust_type(
+        inner_type_name
+    )  # validate numpy compatibility before casting
+
+    array_ptr: Any = ctypes.cast(
+        raw.contents.ptr, ctypes.POINTER(ATOM_MAP[inner_type_name])
+    )
     return np.ctypeslib.as_array(array_ptr, shape=(raw.contents.len,)).copy()
 
 
-def _tuple_to_slice(val: tuple[Any, ...], type_name: Union[RuntimeType, str]) -> FfiSlicePtr:
+def _tuple_to_slice(
+    val: tuple[Any, ...], type_name: Union[RuntimeType, str]
+) -> FfiSlicePtr:
     type_name = cast(RuntimeType, type_name)
     inner_type_names = type_name.args
     if not isinstance(val, tuple):
         raise TypeError("Cannot coerce a non-tuple type to a tuple")  # pragma: no cover
 
     if len(inner_type_names) != len(val):
-        raise TypeError("type_name members must have same length as tuple")  # pragma: no cover
+        raise TypeError(
+            "type_name members must have same length as tuple"
+        )  # pragma: no cover
 
-    if inner_type_names == ['f64', 'ExtrinsicObject']:
+    if inner_type_names == ["f64", "ExtrinsicObject"]:
         score_ptr = ctypes.pointer(ctypes.c_double(val[0]))
         ext_obj = ctypes.pointer(ExtrinsicObject(ctypes.py_object(val[1])))
 
         cand_ptr = py_to_c(ext_obj, c_type=AnyObjectPtr, type_name="ExtrinsicObject")
         array = (ctypes.c_void_p * 2)(
-            ctypes.cast(score_ptr, ctypes.c_void_p), 
-            ctypes.cast(cand_ptr, ctypes.c_void_p), 
+            ctypes.cast(score_ptr, ctypes.c_void_p),
+            ctypes.cast(cand_ptr, ctypes.c_void_p),
         )
         return _wrap_in_slice(ctypes.pointer(array), 2)
 
     for t in inner_type_names:
         if t not in ATOM_MAP:
-            raise TypeError(f"Tuple members must be one of {set(ATOM_MAP.keys())}. Got {t}")  # pragma: no cover
+            raise TypeError(
+                f"Tuple members must be one of {set(ATOM_MAP.keys())}. Got {t}"
+            )  # pragma: no cover
 
     # check that actual type can be represented by the inner_type_name
     val = tuple(
@@ -638,8 +713,9 @@ def _tuple_to_slice(val: tuple[Any, ...], type_name: Union[RuntimeType, str]) ->
 
     # ctypes.byref has edge-cases that cause use-after-free errors. ctypes.pointer fixes these edge-cases
     ptr_data = (
-        ctypes.cast(ctypes.pointer(ATOM_MAP[name](v)), ctypes.c_void_p) # type: ignore[index]
-        for v, name in zip(val, inner_type_names))
+        ctypes.cast(ctypes.pointer(ATOM_MAP[name](v)), ctypes.c_void_p)  # type: ignore[index]
+        for v, name in zip(val, inner_type_names)
+    )
 
     array = (ctypes.c_void_p * len(val))(*ptr_data)
     return _wrap_in_slice(ctypes.pointer(array), len(val))
@@ -648,23 +724,25 @@ def _tuple_to_slice(val: tuple[Any, ...], type_name: Union[RuntimeType, str]) ->
 def _slice_to_tuple(raw: FfiSlicePtr, type_name: RuntimeType) -> tuple[Any, ...]:
     inner_type_names = type_name.args
     void_array_ptr = ctypes.cast(raw.contents.ptr, ctypes.POINTER(ctypes.c_void_p))
-    ptr_data: list[ctypes.c_void_p] = void_array_ptr[0:raw.contents.len]
+    ptr_data: list[ctypes.c_void_p] = void_array_ptr[0 : raw.contents.len]
 
-    if inner_type_names == ['PrivacyProfile', 'f64']:
+    if inner_type_names == ["PrivacyProfile", "f64"]:
         curve = ctypes.cast(ptr_data[0], AnyObjectPtr)
         delta = ctypes.cast(ptr_data[1], ctypes.POINTER(ctypes.c_double))
         return PrivacyProfile(curve), delta.contents.value
-    
-    if inner_type_names == ['f64', 'AnyObject']:
+
+    if inner_type_names == ["f64", "AnyObject"]:
         score = ctypes.cast(ptr_data[0], ctypes.POINTER(ctypes.c_double))
         candidate_obj = ctypes.cast(ptr_data[1], AnyObjectPtr)
         candidate = c_to_py(c_to_py(candidate_obj))
-        candidate_obj.__class__ = ctypes.POINTER(AnyObject) # type: ignore[assignment]
+        candidate_obj.__class__ = ctypes.POINTER(AnyObject)  # type: ignore[assignment]
         return score.contents.value, candidate
 
     # tuple of instances of Python types
-    return tuple(ctypes.cast(void_p, ctypes.POINTER(ATOM_MAP[name])).contents.value # type: ignore[index,attr-defined]
-                 for void_p, name in zip(ptr_data, inner_type_names))
+    return tuple(
+        ctypes.cast(void_p, ctypes.POINTER(ATOM_MAP[name])).contents.value  # type: ignore[index,attr-defined]
+        for void_p, name in zip(ptr_data, inner_type_names)
+    )
 
 
 def _slice_to_option(raw: FfiSlicePtr, type_name: RuntimeType) -> Optional[Any]:
@@ -676,17 +754,24 @@ def _slice_to_option(raw: FfiSlicePtr, type_name: RuntimeType) -> Optional[Any]:
 def _hashmap_to_slice(val: MutableMapping, type_name: RuntimeType) -> FfiSlicePtr:
     key_type, val_type = type_name.args
     if not isinstance(val, MutableMapping):
-        raise TypeError(f"Expected type is {type_name} but input data is not a dict.")  # pragma: no cover
+        raise TypeError(
+            f"Expected type is {type_name} but input data is not a dict."
+        )  # pragma: no cover
 
     val = {
-        _check_and_cast_scalar(key_type, k):
-            _check_and_cast_scalar(val_type, v) if val_type != "ExtrinsicObject" else v
+        _check_and_cast_scalar(key_type, k): _check_and_cast_scalar(val_type, v)
+        if val_type != "ExtrinsicObject"
+        else v
         for k, v in val.items()
     }
-    
-    keys: AnyObjectPtr = py_to_c(list(val.keys()), type_name=f"Vec<{key_type}>", c_type=AnyObjectPtr)
-    vals: AnyObjectPtr = py_to_c(list(val.values()), type_name=f"Vec<{val_type}>", c_type=AnyObjectPtr)
-    ffislice = _wrap_in_slice(ctypes.pointer((AnyObjectPtr * 2)(keys, vals)), 2) # type: ignore[operator]
+
+    keys: AnyObjectPtr = py_to_c(
+        list(val.keys()), type_name=f"Vec<{key_type}>", c_type=AnyObjectPtr
+    )
+    vals: AnyObjectPtr = py_to_c(
+        list(val.values()), type_name=f"Vec<{val_type}>", c_type=AnyObjectPtr
+    )
+    ffislice = _wrap_in_slice(ctypes.pointer((AnyObjectPtr * 2)(keys, vals)), 2)  # type: ignore[operator]
 
     # The __del__ destructor on `keys` and `vals` is called and memory freed when their refcounts go to zero.
     # ffislice needs keys and vals to have a lifetime at least as long as itself,
@@ -705,6 +790,7 @@ def _slice_to_function(raw: FfiSlicePtr) -> Function:
 def _function_to_slice(raw: Function, type_name: RuntimeType) -> FfiSlicePtr:
     if not isinstance(raw, Function):
         from opendp.core import new_function
+
         raw = new_function(raw, TO=type_name.args[1])
     return _wrap_in_slice(raw, 1)
 
@@ -718,13 +804,13 @@ def _slice_to_hashmap(raw: FfiSlicePtr) -> MutableMapping:
     # AnyObjectPtr.__del__ would free the memory behind keys and vals when this stack frame is popped.
     # But that memory has a lifetime at least as long as raw, so it cannot be freed yet.
     # Adjust the class to avoid calling AnyObjectPtr.__del__, which would free the backing memory.
-    keys.__class__ = ctypes.POINTER(AnyObject) # type: ignore[assignment]
-    vals.__class__ = ctypes.POINTER(AnyObject) # type: ignore[assignment]
+    keys.__class__ = ctypes.POINTER(AnyObject)  # type: ignore[assignment]
+    vals.__class__ = ctypes.POINTER(AnyObject)  # type: ignore[assignment]
     return result
 
 
 def _lazyframe_to_slice(val) -> FfiSlicePtr:
-    pl = import_optional_dependency('polars')
+    pl = import_optional_dependency("polars")
     if not isinstance(val, pl.LazyFrame):
         raise ValueError("expected Polars LazyFrame")
 
@@ -735,15 +821,15 @@ def _lazyframe_to_slice(val) -> FfiSlicePtr:
 
 
 def _slice_to_lazyframe(raw: FfiSlicePtr):
-    pl = import_optional_dependency('polars')
+    pl = import_optional_dependency("polars")
     lf = pl.LazyFrame()
     slice_array = ctypes.cast(raw.contents.ptr, ctypes.POINTER(ctypes.c_uint8))
-    lf.__setstate__(bytes(slice_array[0:raw.contents.len]))
+    lf.__setstate__(bytes(slice_array[0 : raw.contents.len]))
     return lf
 
 
 def _expr_to_slice(val) -> FfiSlicePtr:
-    pl = import_optional_dependency('polars')
+    pl = import_optional_dependency("polars")
     if isinstance(val, str):
         val = pl.col(val)
 
@@ -757,25 +843,30 @@ def _expr_to_slice(val) -> FfiSlicePtr:
 
 
 def _slice_to_expr(raw: FfiSlicePtr):
-    pl = import_optional_dependency('polars')
+    pl = import_optional_dependency("polars")
     expr = pl.all()
     slice_array = ctypes.cast(raw.contents.ptr, ctypes.POINTER(ctypes.c_uint8))
-    expr.__setstate__(bytes(slice_array[0:raw.contents.len]))
+    expr.__setstate__(bytes(slice_array[0 : raw.contents.len]))
     return expr
 
 
 def _slice_to_exprplan(raw: FfiSlicePtr):
     void_array_ptr = ctypes.cast(raw.contents.ptr, ctypes.POINTER(ctypes.c_void_p))
-    ptr_data: list[ctypes.c_void_p] = void_array_ptr[0:raw.contents.len]
+    ptr_data: list[ctypes.c_void_p] = void_array_ptr[0 : raw.contents.len]
 
     plan = _slice_to_lazyframe(ctypes.cast(ptr_data[0], FfiSlicePtr))
     expr = _slice_to_expr(ctypes.cast(ptr_data[1], FfiSlicePtr))
-    fill = _slice_to_expr(ctypes.cast(ptr_data[2], FfiSlicePtr)) if raw.contents.len == 3 else None
+    fill = (
+        _slice_to_expr(ctypes.cast(ptr_data[2], FfiSlicePtr))
+        if raw.contents.len == 3
+        else None
+    )
 
     from collections import namedtuple
 
     ExprPlan = namedtuple("ExprPlan", ["plan", "expr", "fill"])
     return ExprPlan(plan, expr, fill)
+
 
 def _to_optional_u32_void_ptr(v):
     if v is None:
@@ -793,31 +884,35 @@ def _slice_to_margin(raw: FfiSlicePtr):
     from opendp.extras.polars import Margin
 
     void_array_ptr = ctypes.cast(raw.contents.ptr, ctypes.POINTER(ctypes.c_void_p))
-    ptr_data: list[ctypes.c_void_p] = void_array_ptr[0: raw.contents.len]
+    ptr_data: list[ctypes.c_void_p] = void_array_ptr[0 : raw.contents.len]
 
     invariant = ctypes.cast(ptr_data[3], ctypes.c_char_p)
     return Margin(
         by=c_to_py(ctypes.cast(ptr_data[0], AnyObjectPtr)),
         max_length=_from_optional_u32_void_ptr(ptr_data[1]),
         max_groups=_from_optional_u32_void_ptr(ptr_data[2]),
-        invariant=invariant.value.decode() if invariant.value else None, # type: ignore[arg-type]
+        invariant=invariant.value.decode() if invariant.value else None,  # type: ignore[arg-type]
     )
+
 
 def _check_polars_by(by):
     if isinstance(by, str):
-        raise ValueError(f"by ({by}) must be a sequence type; Did you mean [\"{by}\"]?")
-    
+        raise ValueError(f'by ({by}) must be a sequence type; Did you mean ["{by}"]?')
+
     if not isinstance(by, Sequence):
         raise ValueError(f"by ({by}) must be a sequence type")
 
 
 def _margin_to_slice(val) -> FfiSlicePtr:
     from opendp.extras.polars import Margin
+
     if not isinstance(val, Margin):
-        raise ValueError(f"expected Polars Margin, got {val}") # pragma: no cover
-    
+        raise ValueError(f"expected Polars Margin, got {val}")  # pragma: no cover
+
     _check_polars_by(val.by)
-    by = ctypes.cast(py_to_c(val.by, c_type=AnyObjectPtr, type_name="Vec<Expr>"), ctypes.c_void_p)
+    by = ctypes.cast(
+        py_to_c(val.by, c_type=AnyObjectPtr, type_name="Vec<Expr>"), ctypes.c_void_p
+    )
 
     max_length = _to_optional_u32_void_ptr(val.max_length)
     max_groups = _to_optional_u32_void_ptr(val.max_groups)
@@ -830,11 +925,12 @@ def _margin_to_slice(val) -> FfiSlicePtr:
     array = (ctypes.c_void_p * 4)(by, max_length, max_groups, invariant)
     return _wrap_in_slice(ctypes.pointer(array), 4)
 
+
 def _slice_to_group_bound(raw: FfiSlicePtr):
     from opendp.extras.polars import Bound
 
     void_array_ptr = ctypes.cast(raw.contents.ptr, ctypes.POINTER(ctypes.c_void_p))
-    ptr_data: list[ctypes.c_void_p] = void_array_ptr[0: raw.contents.len]
+    ptr_data: list[ctypes.c_void_p] = void_array_ptr[0 : raw.contents.len]
 
     return Bound(
         by=c_to_py(ctypes.cast(ptr_data[0], AnyObjectPtr)),
@@ -845,10 +941,13 @@ def _slice_to_group_bound(raw: FfiSlicePtr):
 
 def _bound_to_slice(val) -> FfiSlicePtr:
     from opendp.extras.polars import Bound
+
     assert isinstance(val, Bound)
 
     _check_polars_by(val.by)
-    by = ctypes.cast(py_to_c(val.by, c_type=AnyObjectPtr, type_name="Vec<Expr>"), ctypes.c_void_p)
+    by = ctypes.cast(
+        py_to_c(val.by, c_type=AnyObjectPtr, type_name="Vec<Expr>"), ctypes.c_void_p
+    )
 
     num_groups = _to_optional_u32_void_ptr(val.num_groups)
     per_group = _to_optional_u32_void_ptr(val.per_group)
@@ -857,9 +956,8 @@ def _bound_to_slice(val) -> FfiSlicePtr:
     return _wrap_in_slice(ctypes.pointer(array), 3)
 
 
-
 def _dataframe_to_slice(val) -> FfiSlicePtr:
-    pl = import_optional_dependency('polars')
+    pl = import_optional_dependency("polars")
     if not isinstance(val, pl.DataFrame):
         raise ValueError("expected Polars DataFrame")  # pragma: no cover
 
@@ -869,17 +967,21 @@ def _dataframe_to_slice(val) -> FfiSlicePtr:
     raw.depends_on(slices)
     return raw
 
+
 def _slice_to_dataframe(raw: FfiSlicePtr):
-    pl = import_optional_dependency('polars')
+    pl = import_optional_dependency("polars")
     slice_array = ctypes.cast(raw.contents.ptr, FfiSlicePtr)
-    series = [_slice_to_series(FfiSlicePtr(ffislice)) for ffislice in slice_array[0:raw.contents.len]]
+    series = [
+        _slice_to_series(FfiSlicePtr(ffislice))
+        for ffislice in slice_array[0 : raw.contents.len]
+    ]
     return pl.DataFrame(series)
 
 
 def _series_to_slice(val) -> FfiSlicePtr:
     from opendp._data import new_arrow_array, arrow_array_free
 
-    pl = import_optional_dependency('polars')
+    pl = import_optional_dependency("polars")
     if not isinstance(val, pl.Series):
         raise ValueError("expected Polars Series")
 
@@ -905,8 +1007,8 @@ def _series_to_slice(val) -> FfiSlicePtr:
 
 
 def _slice_to_series(raw: FfiSlicePtr):
-    pl = import_optional_dependency('polars')
-    pyarrow = import_optional_dependency('pyarrow')
+    pl = import_optional_dependency("polars")
+    pyarrow = import_optional_dependency("pyarrow")
     slice_array = ctypes.cast(raw.contents.ptr, ctypes.POINTER(ctypes.c_void_p))
     array_ptr, schema_ptr, name_ptr = slice_array[0:3]
 
@@ -929,8 +1031,8 @@ def _slice_to_anyobject(raw: FfiSlicePtr):
     ret = c_to_py(obj)
     # don't free obj, because it is owned by Rust
     # c_to_py cares that the type is AnyObject, so this needs to happen after c_to_py
-    obj.__class__ = ctypes.POINTER(AnyObject) # type: ignore[assignment]
-    
+    obj.__class__ = ctypes.POINTER(AnyObject)  # type: ignore[assignment]
+
     return ret
 
 
@@ -940,6 +1042,7 @@ def _wrap_in_slice(ptr, len_: int) -> FfiSlicePtr:
 
 def _invoke_py_callback(c_arg, userdata):
     from opendp._convert import c_to_py, py_to_c
+
     func, TO = userdata
 
     try:
@@ -963,10 +1066,13 @@ def _invoke_py_callback(c_arg, userdata):
 
     except Exception:
         import traceback
+
         lib.ffiresult_err.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
         lib.ffiresult_err.restype = ctypes.c_void_p
         return lib.ffiresult_err(
-            ctypes.c_char_p("Continued stack trace from Exception in user-defined function".encode()),
+            ctypes.c_char_p(
+                "Continued stack trace from Exception in user-defined function".encode()
+            ),
             ctypes.c_char_p(traceback.format_exc().encode()),
         )
 
@@ -985,20 +1091,22 @@ def _wrap_py_func(func, TO):
 # The output type cannot be an `ctypes.POINTER(FfiResult)` due to:
 #   https://bugs.python.org/issue5710#msg85731
 #                                   (answer         , query       , is_internal  , userdata        )
-TransitionFnValue = ctypes.CFUNCTYPE(ctypes.c_void_p, AnyObjectPtr, ctypes.c_bool, ctypes.py_object)
+TransitionFnValue = ctypes.CFUNCTYPE(
+    ctypes.c_void_p, AnyObjectPtr, ctypes.c_bool, ctypes.py_object
+)
+
 
 class TransitionFn(ctypes.Structure):
-    _fields_ = [
-        ("callback", TransitionFnValue),
-        ("userdata", ExtrinsicObject)
-    ]
+    _fields_ = [("callback", TransitionFnValue), ("userdata", ExtrinsicObject)]
 
-class TransitionFnPtr(ctypes.POINTER(TransitionFn)): # type: ignore[misc]
+
+class TransitionFnPtr(ctypes.POINTER(TransitionFn)):  # type: ignore[misc]
     _type_ = TransitionFn
 
 
 def _invoke_py_transition(c_query, c_is_internal: ctypes.c_bool, userdata):
     from opendp._convert import c_to_py, py_to_c
+
     py_transition, A = userdata
 
     try:
@@ -1023,10 +1131,13 @@ def _invoke_py_transition(c_query, c_is_internal: ctypes.c_bool, userdata):
 
     except Exception:
         import traceback
+
         lib.ffiresult_err.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
         lib.ffiresult_err.restype = ctypes.c_void_p
         return lib.ffiresult_err(
-            ctypes.c_char_p("Continued stack trace from Exception in user-defined function".encode()),
+            ctypes.c_char_p(
+                "Continued stack trace from Exception in user-defined function".encode()
+            ),
             ctypes.c_char_p(traceback.format_exc().encode()),
         )
 

--- a/python/src/opendp/_lib.py
+++ b/python/src/opendp/_lib.py
@@ -9,12 +9,12 @@ import importlib
 
 # list all acceptable alternative types for each default type
 ATOM_EQUIVALENCE_CLASSES: MutableMapping[str, Sequence[str]] = {
-    'i32': ['u8', 'u16', 'u32', 'u64', 'i8', 'i16', 'i32', 'i64', 'usize'],
-    'f64': ['f32', 'f64'],
-    'bool': ['bool'],
-    'AnyMeasurementPtr': ['AnyMeasurementPtr', 'AnyMeasurement'],
-    'AnyTransformationPtr': ['AnyTransformationPtr'],
-    'ExtrinsicObject': ['ExtrinsicObject']
+    "i32": ["u8", "u16", "u32", "u64", "i8", "i16", "i32", "i64", "usize"],
+    "f64": ["f32", "f64"],
+    "bool": ["bool"],
+    "AnyMeasurementPtr": ["AnyMeasurementPtr", "AnyMeasurement"],
+    "AnyTransformationPtr": ["AnyTransformationPtr"],
+    "ExtrinsicObject": ["ExtrinsicObject"],
 }
 
 
@@ -24,38 +24,48 @@ def _load_library():
     lib_dir = Path(os.environ.get(lib_envvar, default_lib_dir))
     if not lib_dir.exists():
         # fall back to default location of binaries in a developer install
-        build_dir = 'release' if os.environ.get('OPENDP_TEST_RELEASE') else 'debug'
-        lib_dir = Path(__file__).parent / ".." / ".." / ".." / 'rust' / 'target' / build_dir  # pragma: no cover
+        build_dir = "release" if os.environ.get("OPENDP_TEST_RELEASE") else "debug"
+        lib_dir = (
+            Path(__file__).parent / ".." / ".." / ".." / "rust" / "target" / build_dir
+        )  # pragma: no cover
 
     if lib_dir.exists():
         from importlib.machinery import EXTENSION_SUFFIXES
+
         suffixes = EXTENSION_SUFFIXES + [".dylib"]
 
         lib_dir_file_names = [
-            str(p.name) for p in lib_dir.iterdir() 
-            if "opendp" in p.name and "derive" not in p.name
+            str(p.name)
+            for p in lib_dir.iterdir()
+            if "opendp" in p.name
+            and "derive" not in p.name
             and any(p.name.endswith(suffix) for suffix in suffixes)
         ]
-        
+
         if len(lib_dir_file_names) != 1:  # pragma: no cover
             value = os.environ.get(lib_envvar)
             envvar_info = f" ({lib_envvar}='{value}')" if value is not None else ""
-            raise Exception(f"Expected exactly one binary to be present in '{lib_dir}'{envvar_info}. Got: {lib_dir_file_names}")
-        
+            raise Exception(
+                f"Expected exactly one binary to be present in '{lib_dir}'{envvar_info}. Got: {lib_dir_file_names}"
+            )
+
         lib_path = lib_dir / lib_dir_file_names[0]
         try:
             return ctypes.cdll.LoadLibrary(str(lib_path)), lib_path
-        except Exception as e: # pragma: no cover
+        except Exception as e:  # pragma: no cover
             raise Exception("Unable to load OpenDP shared library", lib_path, e)
 
-    elif os.environ.get('OPENDP_HEADLESS', "false") != "false":
+    elif os.environ.get("OPENDP_HEADLESS", "false") != "false":
         return None, None
 
     else:
-        raise ValueError("Unable to find lib directory. Consider setting OPENDP_LIB_DIR to a valid directory.")  # pragma: no cover
-    
+        raise ValueError(
+            "Unable to find lib directory. Consider setting OPENDP_LIB_DIR to a valid directory."
+        )  # pragma: no cover
+
 
 lib, lib_path = _load_library()
+
 
 def _total_cmp(left, right):
     try:
@@ -68,26 +78,34 @@ def _total_cmp(left, right):
             cmp = 1
         else:
             raise ValueError("left and right are not comparable")
-        
+
         lib.ffiresult_ok.argtypes = [ctypes.c_void_p]
         lib.ffiresult_ok.restype = ctypes.c_void_p
-        
+
         from opendp._convert import py_to_c
+
         c_out = py_to_c(cmp, c_type=AnyObjectPtr, type_name="i8")
         # don't free c_out, because we are giving ownership to Rust
         c_out.__class__ = ctypes.POINTER(AnyObject)
         return lib.ffiresult_ok(ctypes.addressof(c_out.contents))
-    
+
     except Exception:
         import traceback
+
         lib.ffiresult_err.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
         lib.ffiresult_err.restype = ctypes.c_void_p
         return lib.ffiresult_err(
-            ctypes.c_char_p("Continued stack trace from Exception in user-defined function".encode()),
+            ctypes.c_char_p(
+                "Continued stack trace from Exception in user-defined function".encode()
+            ),
             ctypes.c_char_p(traceback.format_exc().encode()),
         )
 
-_TOTAL_CMP = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.py_object, ctypes.py_object)(_total_cmp)
+
+_TOTAL_CMP = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.py_object, ctypes.py_object)(
+    _total_cmp
+)
+
 
 def _ref_count(ptr, increment):
     try:
@@ -95,11 +113,14 @@ def _ref_count(ptr, increment):
             ctypes.pythonapi.Py_IncRef(ctypes.py_object(ptr))
         else:
             ctypes.pythonapi.Py_DecRef(ctypes.py_object(ptr))
-    except Exception: # pragma: no cover
+    except Exception:  # pragma: no cover
         return False
     return True
 
-_REF_COUNT = ctypes.CFUNCTYPE(ctypes.c_bool, ctypes.py_object, ctypes.c_bool)(_ref_count)
+
+_REF_COUNT = ctypes.CFUNCTYPE(ctypes.c_bool, ctypes.py_object, ctypes.c_bool)(
+    _ref_count
+)
 
 
 if lib:
@@ -110,36 +131,40 @@ if lib:
 # Value: The opendp extra that provides this module,
 #        with the appropriate version pin, if needed
 install_names = {
-    'sklearn': 'scikit-learn',
-    'randomgen': 'numpy',
-    'scipy': 'scikit-learn',
+    "sklearn": "scikit-learn",
+    "randomgen": "numpy",
+    "scipy": "scikit-learn",
 }
 
 
 def import_optional_dependency(name, raise_error=True):
-    '''
+    """
     Imports optional dependency, or explains that it is required.
-    '''
+    """
     try:
         return importlib.import_module(name)
-    except ImportError: # pragma: no cover
+    except ImportError:  # pragma: no cover
         if raise_error:
             root_name = name.split(".")[0]
             install_name = install_names.get(root_name) or root_name
-            raise ImportError(f'The optional install {install_name} is required for this functionality')
+            raise ImportError(
+                f"The optional install {install_name} is required for this functionality"
+            )
         return None
 
 
 _np_csprng: Any = None
-_buffer_pos = 0 # TODO: Make this into a class rather than using ad-hoc globals.
+_buffer_pos = 0  # TODO: Make this into a class rather than using ad-hoc globals.
+
+
 def get_np_csprng():
     global _np_csprng
     global _buffer_pos
     if _np_csprng is not None:
         return _np_csprng
 
-    randomgen = import_optional_dependency('randomgen')
-    np = import_optional_dependency('numpy')
+    randomgen = import_optional_dependency("randomgen")
+    np = import_optional_dependency("numpy")
 
     buffer_len = 1024
     buffer = np.empty(buffer_len, dtype=np.uint64)
@@ -152,8 +177,9 @@ def get_np_csprng():
             from opendp._data import fill_bytes
 
             # there are 8x as many u8s as there are u64s
-            if not fill_bytes(buffer_ptr, buffer_len * 8): # pragma: no cover
+            if not fill_bytes(buffer_ptr, buffer_len * 8):  # pragma: no cover
                 from opendp.mod import OpenDPException
+
                 raise OpenDPException("FailedFunction", "Failed to sample from CSPRNG")
             _buffer_pos = 0
 
@@ -161,7 +187,7 @@ def get_np_csprng():
         _buffer_pos += 1
         return int(out)
 
-    _np_csprng = np.random.Generator(bit_generator=randomgen.UserBitGenerator(next_raw)) # type:ignore
+    _np_csprng = np.random.Generator(bit_generator=randomgen.UserBitGenerator(next_raw))  # type:ignore
     return _np_csprng
 
 
@@ -210,18 +236,19 @@ class AnyFunction(ctypes.Structure):
     pass  # Opaque struct
 
 
-class BoolPtr(ctypes.POINTER(ctypes.c_bool)): # type: ignore[misc]
+class BoolPtr(ctypes.POINTER(ctypes.c_bool)):  # type: ignore[misc]
     _type_ = ctypes.c_bool
 
 
-class AnyObjectPtr(ctypes.POINTER(AnyObject)): # type: ignore[misc]
+class AnyObjectPtr(ctypes.POINTER(AnyObject)):  # type: ignore[misc]
     _type_ = AnyObject
 
     def __del__(self):
         try:
             from opendp._data import object_free
+
             object_free(self)
-        except (ImportError, TypeError): # pragma: no cover
+        except (ImportError, TypeError):  # pragma: no cover
             # ImportError: sys.meta_path is None, Python is likely shutting down
             pass
 
@@ -230,7 +257,7 @@ class AnyQueryable(ctypes.Structure):
     pass  # Opaque struct
 
 
-class FfiSlicePtr(ctypes.POINTER(FfiSlice)): # type: ignore[misc]
+class FfiSlicePtr(ctypes.POINTER(FfiSlice)):  # type: ignore[misc]
     _type_ = FfiSlice
     _dependencies: MutableMapping = {}  # TODO: Tighten this
 
@@ -271,14 +298,15 @@ class ExtrinsicObject(ctypes.Structure):
     ]
 
 
-class ExtrinsicObjectPtr(ctypes.POINTER(ExtrinsicObject)): # type: ignore[misc]
+class ExtrinsicObjectPtr(ctypes.POINTER(ExtrinsicObject)):  # type: ignore[misc]
     _type_ = ExtrinsicObject
 
     def __del__(self):
         try:
             from opendp._data import extrinsic_object_free
+
             extrinsic_object_free(self)
-        except (ImportError, TypeError): # pragma: no cover
+        except (ImportError, TypeError):  # pragma: no cover
             # an example error that this catches:
             #   ImportError: sys.meta_path is None, Python is likely shutting down
             pass
@@ -289,23 +317,23 @@ class ExtrinsicObjectPtr(ctypes.POINTER(ExtrinsicObject)): # type: ignore[misc]
 #                                 (output         , input       , userdata        )
 CallbackFnValue = ctypes.CFUNCTYPE(ctypes.c_void_p, AnyObjectPtr, ctypes.py_object)
 
-class CallbackFn(ctypes.Structure):
-    _fields_ = [
-        ("callback", CallbackFnValue),
-        ("userdata", ExtrinsicObject)
-    ]
 
-class CallbackFnPtr(ctypes.POINTER(CallbackFn)): # type: ignore[misc]
+class CallbackFn(ctypes.Structure):
+    _fields_ = [("callback", CallbackFnValue), ("userdata", ExtrinsicObject)]
+
+
+class CallbackFnPtr(ctypes.POINTER(CallbackFn)):  # type: ignore[misc]
     _type_ = CallbackFn
+
 
 # def _str_to_c_char_p(s: Optional[str]) -> Optional[bytes]:
 #     return s and s.encode("utf-8")
 def _c_char_p_to_str(s: Optional[bytes]) -> Optional[str]:
-    ''''''
+    """"""
     if s is not None:
         return s.decode("utf-8")
     # TODO: Unused: would it indicate a problem if we did start hitting this?
-    return None # pragma: no cover
+    return None  # pragma: no cover
 
 
 def unwrap(result, type_) -> Any:
@@ -314,7 +342,7 @@ def unwrap(result, type_) -> Any:
 
     if not isinstance(result, FfiResult):
         # TODO: Unused: would it indicate a problem if we did start hitting this?
-        return result # pragma: no cover
+        return result  # pragma: no cover
 
     if result.tag == 0:
         return ctypes.cast(result.payload.Ok, type_)
@@ -329,11 +357,15 @@ def unwrap(result, type_) -> Any:
         raise OpenDPException("Failed to free error.")  # pragma: no cover
 
     # Rust stack traces follow from here:
-    pl = import_optional_dependency('polars', raise_error=False)
+    pl = import_optional_dependency("polars", raise_error=False)
     if pl is not None:
         from opendp.mod import _EXPECTED_POLARS_VERSION
-        if 'polars' in str(message).lower() and pl.__version__ != _EXPECTED_POLARS_VERSION:
-            message = f'Installed python polars version ({pl.__version__}) != expected version ({_EXPECTED_POLARS_VERSION}). {message}' # pragma: no cover
+
+        if (
+            "polars" in str(message).lower()
+            and pl.__version__ != _EXPECTED_POLARS_VERSION
+        ):
+            message = f"Installed python polars version ({pl.__version__}) != expected version ({_EXPECTED_POLARS_VERSION}). {message}"  # pragma: no cover
     raise OpenDPException(variant, message, backtrace)
 
 
@@ -388,7 +420,7 @@ def make_proof_link(
     # link from sphinx and rustdoc to latex
     sphinx_port = os.environ.get("OPENDP_SPHINX_PORT", None)
     if sphinx_port is not None:
-        proof_uri = f"http://localhost:{sphinx_port}" # pragma: no cover
+        proof_uri = f"http://localhost:{sphinx_port}"  # pragma: no cover
 
     else:
         # find the docs uri
@@ -408,16 +440,16 @@ def get_opendp_version():
 
     try:
         return unmangle_py_version(importlib.metadata.version("opendp"))
-    except importlib.metadata.PackageNotFoundError: # pragma: no cover
+    except importlib.metadata.PackageNotFoundError:  # pragma: no cover
         return get_opendp_version_from_file()
 
 
 def unmangle_py_version(py_version):
-    '''
+    """
     Python mangles pre-release versions like "X.Y.Z-nightly.NNN.M" into "X.Y.ZaNNN00M", but the docs use
     the original format, so we need to unmangle for links to work.
     There are more variations possible, but we only need to handle X.Y.Z-dev0, X.Y.Z-aNNN00M, X.Y.Z-bNNN00M, X.Y.Z
-    
+
     >>> unmangle_py_version('0.9.0')
     '0.9.0'
     >>> unmangle_py_version('0.9.0.dev0')
@@ -428,7 +460,7 @@ def unmangle_py_version(py_version):
     '0.9.0-beta.11111111.1'
     >>> unmangle_py_version('other')
     'other'
-    '''
+    """
     if py_version.endswith(".dev0"):
         return f"{py_version[:-5]}-dev"
     match = re.match(r"^(\d+\.\d+\.\d+)(?:([ab])(\d{8})(\d{3}))?$", py_version)
@@ -445,19 +477,19 @@ def unmangle_py_version(py_version):
 
 
 def get_opendp_version_from_file():
-    '''
+    """
     If the package isn't installed (eg when we're building docs), we can't get the version from metadata,
     so fall back to the version file.
 
     >>> import re
     >>> assert re.match(r'\\d+\\.\\d+\\.\\d+', get_opendp_version_from_file())
-    '''
-    version_path = Path(__file__).parent.parent.parent.parent / 'VERSION'
+    """
+    version_path = Path(__file__).parent.parent.parent.parent / "VERSION"
     return version_path.read_text().strip()
 
 
 def get_docs_ref(version):
-    '''
+    """
     >>> get_docs_ref('0.0.0')
     'v0.0.0'
     >>> get_docs_ref('0.0.0-dev')
@@ -466,7 +498,7 @@ def get_docs_ref(version):
     'nightly'
     >>> get_docs_ref('0.0.0-surprise')
     'unknown'
-    '''
+    """
     channel = get_channel(version)
     if channel == "stable":
         return f"v{version}"  # For stable, we have tags.
@@ -483,17 +515,18 @@ def get_channel(version):
         return channel or "stable"
     return "unknown"
 
+
 def indent(text):
-    '''
+    """
     Indents the lines after the first line of a multiline string.
     Used for nested reprs.
 
     >>> print(indent('object(\\nfield = 123)'))
     object(
         field = 123)
-    '''
-    lines = text.split('\n')
+    """
+    lines = text.split("\n")
     first, rest = lines[0], lines[1:]
-    spaces = ' ' * 4
-    indented_rest = [f'\n{spaces}{line}' for line in rest]
-    return first + ''.join(indented_rest)
+    spaces = " " * 4
+    indented_rest = [f"\n{spaces}{line}" for line in rest]
+    return first + "".join(indented_rest)

--- a/python/src/opendp/mod.py
+++ b/python/src/opendp/mod.py
@@ -1,66 +1,90 @@
-'''
+"""
 The ``mod`` module provides the classes which implement the
 `OpenDP Programming Framework <../../api/user-guide/programming-framework/index.html>`_,
 as well as utilities for enabling features and finding parameter values.
 
 The classes here correspond to other top-level modules: For example,
 instances of :py:class:`opendp.mod.Domain` are either inputs or outputs for functions in :py:mod:`opendp.domains`.
-'''
+"""
+
 from __future__ import annotations
 import ctypes
 from dataclasses import asdict
-from typing import Any, Literal, Sequence, Type, TypeVar, Union, Callable, Optional, overload, TYPE_CHECKING, cast
+from typing import (
+    Any,
+    Literal,
+    Sequence,
+    Type,
+    TypeVar,
+    Union,
+    Callable,
+    Optional,
+    overload,
+    TYPE_CHECKING,
+    cast,
+)
 import importlib
 import json
 import warnings
 
-from opendp._lib import AnyMeasurement, AnyTransformation, AnyDomain, AnyMetric, AnyMeasure, AnyFunction, AnyOdometer, import_optional_dependency, get_opendp_version
+from opendp._lib import (
+    AnyMeasurement,
+    AnyTransformation,
+    AnyDomain,
+    AnyMetric,
+    AnyMeasure,
+    AnyFunction,
+    AnyOdometer,
+    import_optional_dependency,
+    get_opendp_version,
+)
 
 
 # https://mypy.readthedocs.io/en/stable/runtime_troubles.html#import-cycles
 if TYPE_CHECKING:
-    from opendp.typing import RuntimeType # pragma: no cover
+    from opendp.typing import RuntimeType  # pragma: no cover
 
 
 __all__ = [
-    'Measurement',
-    'Transformation',
-    'Odometer',
-    'Queryable',
-    'OdometerQueryable',
-    'Function',
-    'Domain',
-    'AtomDomain',
-    'OptionDomain',
-    'VectorDomain',
-    'SeriesDomain',
-    'LazyFrameDomain',
-    'ExtrinsicDomain',
-    'Metric',
-    'SymmetricIdDistance',
-    'ChangeOneIdDistance',
-    'FrameDistance',
-    'Measure',
-    'ExtrinsicDivergence',
-    'ApproximateDivergence',
-    'PrivacyProfile',
-    '_PartialConstructor',
-    'UnknownTypeException',
-    'OpenDPException',
-    'GLOBAL_FEATURES',
-    'enable_features',
-    'disable_features',
-    'assert_features',
-    'binary_search_chain',
-    'binary_search_param',
-    'binary_search',
-    'exponential_bounds_search',
-    'serialize',
-    'deserialize',
-    '__version__',
+    "Measurement",
+    "Transformation",
+    "Odometer",
+    "Queryable",
+    "OdometerQueryable",
+    "Function",
+    "Domain",
+    "AtomDomain",
+    "OptionDomain",
+    "VectorDomain",
+    "SeriesDomain",
+    "LazyFrameDomain",
+    "ExtrinsicDomain",
+    "Metric",
+    "SymmetricIdDistance",
+    "ChangeOneIdDistance",
+    "FrameDistance",
+    "Measure",
+    "ExtrinsicDivergence",
+    "ApproximateDivergence",
+    "PrivacyProfile",
+    "_PartialConstructor",
+    "UnknownTypeException",
+    "OpenDPException",
+    "GLOBAL_FEATURES",
+    "enable_features",
+    "disable_features",
+    "assert_features",
+    "binary_search_chain",
+    "binary_search_param",
+    "binary_search",
+    "exponential_bounds_search",
+    "serialize",
+    "deserialize",
+    "__version__",
 ]
 
-class Measurement(ctypes.POINTER(AnyMeasurement)): # type: ignore[misc]
+
+class Measurement(ctypes.POINTER(AnyMeasurement)):  # type: ignore[misc]
     """A differentially private unit of computation.
     A measurement contains a function and a privacy relation.
     The function releases a differentially-private release.
@@ -110,37 +134,41 @@ class Measurement(ctypes.POINTER(AnyMeasurement)): # type: ignore[misc]
     >>> #     (1, 0.5): (SymmetricDistance, MaxDivergence)
     >>> assert chained.check(1, 0.5)
     """
+
     _type_ = AnyMeasurement
 
     def __call__(self, arg):
         from opendp.core import measurement_invoke
+
         return measurement_invoke(self, arg)
 
     def invoke(self, arg):
         """Create a differentially-private release with `arg`.
 
-        If `self` is (d_in, d_out)-close, then each invocation of this function is a d_out-DP release. 
-        
+        If `self` is (d_in, d_out)-close, then each invocation of this function is a d_out-DP release.
+
         :param arg: Input to the measurement.
         :return: differentially-private release
         :raises OpenDPException: packaged error from the core OpenDP library
         """
         from opendp.core import measurement_invoke
+
         return measurement_invoke(self, arg)
 
     def map(self, d_in):
         """Map an input distance `d_in` to an output distance.
-        
+
         :param d_in: Input distance
         """
         from opendp.core import measurement_map
+
         return measurement_map(self, d_in)
 
     def check(self, d_in, d_out, *, debug=False) -> bool:
         """Check if the measurement is (`d_in`, `d_out`)-close.
         If true, implies that if the distance between inputs is at most `d_in`, then the privacy usage is at most `d_out`.
         See also :func:`~Transformation.check`, a similar check for transformations.
-        
+
         :param d_in: Distance in terms of the input metric.
         :param d_out: Distance in terms of the output measure.
         :param debug: Enable to raise Exceptions to help identify why the privacy relation failed.
@@ -156,103 +184,117 @@ class Measurement(ctypes.POINTER(AnyMeasurement)): # type: ignore[misc]
             return measurement_check(self, d_in, d_out)
         except OpenDPException as err:
             if err.variant == "RelationDebug":
-                return False # pragma: no cover
+                return False  # pragma: no cover
             raise
 
-    def __rshift__(self, other: Union["Function", "Transformation", Callable]) -> "Measurement":
+    def __rshift__(
+        self, other: Union["Function", "Transformation", Callable]
+    ) -> "Measurement":
         if isinstance(other, Transformation):
             other = other.function
 
         if not isinstance(other, Function):
             if not callable(other):
-                raise ValueError(f'Expected a callable instead of {other}')  # pragma: no cover
+                raise ValueError(
+                    f"Expected a callable instead of {other}"
+                )  # pragma: no cover
             from opendp.core import new_function
+
             other = new_function(other, TO="ExtrinsicObject")
 
         from opendp.combinators import make_chain_pm
+
         return make_chain_pm(other, self)
 
     @property
     def input_domain(self) -> "Domain":
-        '''
+        """
         Input domain of measurement
-        '''
+        """
         from opendp.core import measurement_input_domain
+
         return measurement_input_domain(self)
-    
+
     @property
     def input_metric(self) -> "Metric":
-        '''
+        """
         Input metric of measurement
-        '''
+        """
         from opendp.core import measurement_input_metric
+
         return measurement_input_metric(self)
 
     @property
     def input_space(self) -> tuple["Domain", "Metric"]:
-        '''
+        """
         Input space of measurement
-        '''
+        """
         return self.input_domain, self.input_metric
-    
+
     @property
     def output_measure(self) -> "Measure":
-        '''
+        """
         Output measure of measurement
-        '''
+        """
         from opendp.core import measurement_output_measure
+
         return measurement_output_measure(self)
-    
+
     @property
     def function(self) -> "Function":
-        '''
+        """
         Function of measurement
-        '''
+        """
         from opendp.core import measurement_function
+
         return measurement_function(self)
-    
+
     @property
     def input_distance_type(self) -> Union["RuntimeType", str]:
         """Retrieve the distance type of the input metric.
         This may be any integral type for dataset metrics, or any numeric type for sensitivity metrics.
-        
+
         :return: distance type
         """
         from opendp.core import measurement_input_distance_type
         from opendp.typing import RuntimeType
+
         return RuntimeType.parse(measurement_input_distance_type(self))
 
     @property
     def output_distance_type(self) -> Union["RuntimeType", str]:
         """Retrieve the distance type of the output measure.
         This is the type that the budget is expressed in.
-        
+
         :return: distance type
         """
         from opendp.core import measurement_output_distance_type
         from opendp.typing import RuntimeType
+
         return RuntimeType.parse(measurement_output_distance_type(self))
 
     @property
     def input_carrier_type(self) -> Union["RuntimeType", str]:
         """Retrieve the carrier type of the input domain.
         Any member of the input domain is a member of the carrier type.
-        
+
         :return: carrier type
         """
         from opendp.core import measurement_input_carrier_type
         from opendp.typing import RuntimeType
+
         return RuntimeType.parse(measurement_input_carrier_type(self))
 
     def __del__(self):
         try:
             from opendp.core import _measurement_free
+
             _measurement_free(self)
-        except (ImportError, TypeError): # pragma: no cover
+        except (ImportError, TypeError):  # pragma: no cover
             # an example error that this catches:
             #   ImportError: sys.meta_path is None, Python is likely shutting down
             pass
-    
+
     def __repr__(self) -> str:
         return f"""Measurement(
     input_domain   = {self.input_domain},
@@ -260,12 +302,12 @@ class Measurement(ctypes.POINTER(AnyMeasurement)): # type: ignore[misc]
     output_measure = {self.output_measure})"""
 
     def __iter__(self):
-        # this overrides the implementation of __iter__ on POINTER, 
+        # this overrides the implementation of __iter__ on POINTER,
         # which yields infinitely on zero-sized types
         raise ValueError("Measurement does not support iteration")
-    
 
-class Odometer(ctypes.POINTER(AnyOdometer)): # type: ignore[misc]
+
+class Odometer(ctypes.POINTER(AnyOdometer)):  # type: ignore[misc]
     """A differentially private unit of computation with no privacy limit.
     An Odometer can be invoked with a dataset to return an OdometerQueryable.
 
@@ -302,60 +344,66 @@ class Odometer(ctypes.POINTER(AnyOdometer)): # type: ignore[misc]
     >>> qbl_comp.privacy_loss(1)
     0.8109302162163288
     """
+
     _type_ = AnyOdometer
 
     def __call__(self, arg):
         from opendp.core import odometer_invoke
+
         return odometer_invoke(self, arg)
 
     def invoke(self, arg):
         """Create a differentially-private release with `arg`.
 
-        If `self` is (d_in, d_out)-close, then each invocation of this function is a d_out-DP release. 
-        
+        If `self` is (d_in, d_out)-close, then each invocation of this function is a d_out-DP release.
+
         :param arg: Input to the measurement.
         :return: differentially-private release
         :raises OpenDPException: packaged error from the core OpenDP library
         """
         from opendp.core import odometer_invoke
+
         return odometer_invoke(self, arg)
 
     @property
     def input_domain(self) -> "Domain":
-        '''
+        """
         Input domain of odometer
-        '''
+        """
         from opendp.core import odometer_input_domain
+
         return odometer_input_domain(self)
-    
+
     @property
     def input_metric(self) -> "Metric":
-        '''
+        """
         Input metric of odometer
-        '''
+        """
         from opendp.core import odometer_input_metric
+
         return odometer_input_metric(self)
-    
+
     @property
     def input_space(self) -> tuple["Domain", "Metric"]:
-        '''
+        """
         Input domain and metric of odometer
-        '''
+        """
         return self.input_domain, self.input_metric
-    
+
     @property
     def output_measure(self) -> "Measure":
-        '''
+        """
         Output measure of odometer
-        '''
+        """
         from opendp.core import odometer_output_measure
+
         return odometer_output_measure(self)
-    
+
     @property
     def input_distance_type(self) -> Union["RuntimeType", str]:
         """Retrieve the distance type of the input metric.
         This may be any integral type for dataset metrics, or any numeric type for sensitivity metrics.
-        
+
         :return: distance type
         """
         return self.input_metric.distance_type
@@ -364,7 +412,7 @@ class Odometer(ctypes.POINTER(AnyOdometer)): # type: ignore[misc]
     def output_distance_type(self) -> Union["RuntimeType", str]:
         """Retrieve the distance type of the output measure.
         This is the type that the budget is expressed in.
-        
+
         :return: distance type
         """
         return self.output_measure.distance_type
@@ -373,7 +421,7 @@ class Odometer(ctypes.POINTER(AnyOdometer)): # type: ignore[misc]
     def input_carrier_type(self) -> Union["RuntimeType", str]:
         """Retrieve the carrier type of the input domain.
         Any member of the input domain is a member of the carrier type.
-        
+
         :return: carrier type
         """
         return self.input_domain.carrier_type
@@ -381,12 +429,13 @@ class Odometer(ctypes.POINTER(AnyOdometer)): # type: ignore[misc]
     def __del__(self):
         try:
             from opendp.core import _odometer_free
+
             _odometer_free(self)
-        except (ImportError, TypeError): # pragma: no cover
+        except (ImportError, TypeError):  # pragma: no cover
             # ImportError: sys.meta_path is None, Python is likely shutting down
             # TypeError: similar setting as above
             pass
-    
+
     def __repr__(self) -> str:
         return f"""Odometer(
     input_domain   = {self.input_domain},
@@ -394,12 +443,12 @@ class Odometer(ctypes.POINTER(AnyOdometer)): # type: ignore[misc]
     output_measure = {self.output_measure})"""
 
     def __iter__(self):
-        # this overrides the implementation of __iter__ on POINTER, 
+        # this overrides the implementation of __iter__ on POINTER,
         # which yields infinitely on zero-sized types
         raise ValueError("Odometer does not support iteration")
 
 
-class Transformation(ctypes.POINTER(AnyTransformation)): # type: ignore[misc]
+class Transformation(ctypes.POINTER(AnyTransformation)):  # type: ignore[misc]
     """A non-differentially private unit of computation.
     A transformation contains a function and a stability relation.
     The function maps from an input domain to an output domain.
@@ -427,7 +476,7 @@ class Transformation(ctypes.POINTER(AnyTransformation)): # type: ignore[misc]
 
     >>> count.input_space
     (VectorDomain(AtomDomain(T=i32)), SymmetricDistance())
-    
+
     >>> # invoke the transformation (invoke and __call__ are equivalent)
     >>> count.invoke([1, 2, 3])
     3
@@ -449,6 +498,7 @@ class Transformation(ctypes.POINTER(AnyTransformation)): # type: ignore[misc]
     3
     >>> assert chained.check(1, 1)  # both chained transformations were 1-stable
     """
+
     _type_ = AnyTransformation
 
     def invoke(self, arg):
@@ -459,18 +509,21 @@ class Transformation(ctypes.POINTER(AnyTransformation)): # type: ignore[misc]
         :raises OpenDPException: packaged error from the core OpenDP library
         """
         from opendp.core import transformation_invoke
-        return transformation_invoke(self, arg) 
+
+        return transformation_invoke(self, arg)
 
     def __call__(self, arg):
         from opendp.core import transformation_invoke
+
         return transformation_invoke(self, arg)
 
     def map(self, d_in):
         """Map an input distance `d_in` to an output distance.
-        
+
         :param d_in: Input distance. An upper bound on how far apart neighboring datasets can be with respect to the input metric
         """
         from opendp.core import transformation_map
+
         return transformation_map(self, d_in)
 
     def check(self, d_in, d_out, *, debug=False) -> bool:
@@ -492,100 +545,107 @@ class Transformation(ctypes.POINTER(AnyTransformation)): # type: ignore[misc]
 
         try:
             return transformation_check(self, d_in, d_out)
-        except OpenDPException as err: # pragma: no cover
+        except OpenDPException as err:  # pragma: no cover
             if err.variant == "RelationDebug":
                 return False
             raise
 
     @overload
-    def __rshift__(self, other: "Transformation") -> "Transformation":
-        ...
+    def __rshift__(self, other: "Transformation") -> "Transformation": ...
 
     @overload
-    def __rshift__(self, other: "Measurement") -> "Measurement":
-        ...
+    def __rshift__(self, other: "Measurement") -> "Measurement": ...
 
     @overload
-    def __rshift__(self, other: "Odometer") -> "Odometer":
-        ...
+    def __rshift__(self, other: "Odometer") -> "Odometer": ...
 
     @overload
-    def __rshift__(self, other: "_PartialConstructor") -> Union["Transformation", "Measurement", "Odometer"]:
-        ...
+    def __rshift__(
+        self, other: "_PartialConstructor"
+    ) -> Union["Transformation", "Measurement", "Odometer"]: ...
 
-    def __rshift__(self, other: Union["Measurement", "Transformation", "_PartialConstructor"]) -> Union["Measurement", "Transformation", "_PartialConstructor", "PartialChain"]:  # type: ignore[name-defined] # noqa F821
+    def __rshift__(
+        self, other: Union["Measurement", "Transformation", "_PartialConstructor"]
+    ) -> Union["Measurement", "Transformation", "_PartialConstructor", "PartialChain"]:  # type: ignore[name-defined] # noqa F821
         if isinstance(other, Measurement):
             from opendp.combinators import make_chain_mt
+
             return make_chain_mt(other, self)
 
         if isinstance(other, Transformation):
             from opendp.combinators import make_chain_tt
+
             return make_chain_tt(other, self)
-        
+
         if isinstance(other, _PartialConstructor):
-            return self >> other(self.output_domain, self.output_metric) # type: ignore[call-arg]
+            return self >> other(self.output_domain, self.output_metric)  # type: ignore[call-arg]
 
         from opendp.context import PartialChain
+
         if isinstance(other, PartialChain):
             return PartialChain(lambda x: self >> other.partial(x))
 
-        raise ValueError(f"rshift expected a measurement or transformation, got {other}")  # pragma: no cover
-
+        raise ValueError(
+            f"rshift expected a measurement or transformation, got {other}"
+        )  # pragma: no cover
 
     @property
     def input_domain(self) -> "Domain":
-        '''
+        """
         Input domain of transformation
-        '''
+        """
         from opendp.core import transformation_input_domain
+
         return transformation_input_domain(self)
-    
 
     @property
     def output_domain(self) -> "Domain":
-        '''
+        """
         Output domain of transformation
-        '''
+        """
         from opendp.core import transformation_output_domain
+
         return transformation_output_domain(self)
-    
 
     @property
     def input_metric(self) -> "Metric":
-        '''
+        """
         Input metric of transformation
-        '''
+        """
         from opendp.core import transformation_input_metric
+
         return transformation_input_metric(self)
-    
+
     @property
     def output_metric(self) -> "Metric":
-        '''
+        """
         Ouput metric of transformation
-        '''
+        """
         from opendp.core import transformation_output_metric
+
         return transformation_output_metric(self)
-    
+
     @property
     def input_space(self) -> tuple["Domain", "Metric"]:
-        '''
+        """
         Input space of transformation
-        '''
+        """
         return self.input_domain, self.input_metric
-    
+
     @property
     def output_space(self) -> tuple["Domain", "Metric"]:
-        '''
+        """
         Output space of transformation
-        '''
+        """
         return self.output_domain, self.output_metric
-    
+
     @property
     def function(self) -> "Function":
-        '''
+        """
         Function of transformation
-        '''
+        """
         from opendp.core import transformation_function
+
         return transformation_function(self)
 
     @property
@@ -597,6 +657,7 @@ class Transformation(ctypes.POINTER(AnyTransformation)): # type: ignore[misc]
         """
         from opendp.core import transformation_input_distance_type
         from opendp.typing import RuntimeType
+
         return RuntimeType.parse(transformation_input_distance_type(self))
 
     @property
@@ -608,8 +669,9 @@ class Transformation(ctypes.POINTER(AnyTransformation)): # type: ignore[misc]
         """
         from opendp.core import transformation_output_distance_type
         from opendp.typing import RuntimeType
+
         return RuntimeType.parse(transformation_output_distance_type(self))
-    
+
     @property
     def input_carrier_type(self) -> Union["RuntimeType", str]:
         """Retrieve the carrier type of the input domain.
@@ -619,13 +681,15 @@ class Transformation(ctypes.POINTER(AnyTransformation)): # type: ignore[misc]
         """
         from opendp.core import transformation_input_carrier_type
         from opendp.typing import RuntimeType
+
         return RuntimeType.parse(transformation_input_carrier_type(self))
 
     def __del__(self):
         try:
             from opendp.core import _transformation_free
+
             _transformation_free(self)
-        except (ImportError, TypeError): # pragma: no cover
+        except (ImportError, TypeError):  # pragma: no cover
             # an example error that this catches:
             #   ImportError: sys.meta_path is None, Python is likely shutting down
             pass
@@ -636,76 +700,91 @@ class Transformation(ctypes.POINTER(AnyTransformation)): # type: ignore[misc]
     output_domain  = {self.output_domain},
     input_metric   = {self.input_metric},
     output_metric  = {self.output_metric})"""
-    
+
     def __iter__(self):
         raise ValueError("Transformation does not support iteration")
 
 
-Transformation = cast(Type[Transformation], Transformation) # type: ignore[misc]
+Transformation = cast(Type[Transformation], Transformation)  # type: ignore[misc]
+
 
 class Queryable:
-    '''
+    """
     Queryables are used for interactive mechanisms like :ref:`adaptive composition <adaptive-composition>`.
 
     Queryables can be created with :py:func:`make_adaptive_composition <opendp.combinators.make_adaptive_composition>`
     or :py:func:`~opendp.core.new_queryable`.
-    '''
+    """
+
     def __init__(self, value, query_type):
         self.value = value
         self.query_type = query_type
 
     def __call__(self, query):
         from opendp.core import queryable_eval
+
         return queryable_eval(self.value, query)
-    
+
     def __repr__(self) -> str:
         return f"Queryable(Q={self.query_type})"
 
+
 class OdometerQueryable:
-    '''
+    """
     Odometer Queryables are used for instances of odometers like :ref:`fully adaptive composition <fully-adaptive-composition>`.
 
     Can be created via :py:func:`~opendp.combinators.make_fully_adaptive_composition`.
-    '''
+    """
+
     def __init__(self, value):
         self.value = value
 
     def __call__(self, query):
         from opendp.core import odometer_queryable_invoke
+
         return odometer_queryable_invoke(self.value, query)
-    
+
     def invoke(self, query):
         from opendp.core import odometer_queryable_invoke
+
         return odometer_queryable_invoke(self.value, query)
-    
+
     def privacy_loss(self, d_in):
         from opendp.core import odometer_queryable_privacy_loss
+
         return odometer_queryable_privacy_loss(self.value, d_in)
 
     def __repr__(self) -> str:
-        from opendp.core import odometer_queryable_invoke_type, odometer_queryable_privacy_loss_type
+        from opendp.core import (
+            odometer_queryable_invoke_type,
+            odometer_queryable_privacy_loss_type,
+        )
         from opendp.typing import RuntimeType
+
         Q = RuntimeType.parse(odometer_queryable_invoke_type(self.value))
         QB = RuntimeType.parse(odometer_queryable_privacy_loss_type(self.value))
         return f"OdometerQueryable(Q={Q}, QB={QB})"
 
 
-class Function(ctypes.POINTER(AnyFunction)): # type: ignore[misc]
-    '''
+class Function(ctypes.POINTER(AnyFunction)):  # type: ignore[misc]
+    """
     See the `Function <../../api/user-guide/programming-framework/supporting-elements.html#function>`_
     section in the Programming Framework docs for more context.
-    '''
+    """
+
     _type_ = AnyFunction
 
     def __call__(self, arg):
         from opendp.core import function_eval
+
         return function_eval(self, arg)
-    
+
     def __del__(self):
         try:
             from opendp.core import _function_free
+
             _function_free(self)
-        except (ImportError, TypeError): # pragma: no cover
+        except (ImportError, TypeError):  # pragma: no cover
             # an example error that this catches:
             #   ImportError: sys.meta_path is None, Python is likely shutting down
             pass
@@ -716,77 +795,85 @@ class Function(ctypes.POINTER(AnyFunction)): # type: ignore[misc]
 
 D = TypeVar("D")
 
-class Domain(ctypes.POINTER(AnyDomain)): # type: ignore[misc]
-    '''
+
+class Domain(ctypes.POINTER(AnyDomain)):  # type: ignore[misc]
+    """
     See the `Domain <../../api/user-guide/programming-framework/supporting-elements.html#domain>`_
     section in the Programming Framework docs for more context.
 
     Functions for creating domains are in :py:mod:`opendp.domains`.
-    '''
-    
+    """
+
     # for documentation see https://docs.python.org/3/library/ctypes.html#ctypes._Pointer._type_
     _type_ = AnyDomain
 
     def member(self, val) -> bool:
-        '''
+        """
         Check if ``val`` is a member of the domain.
-        
+
         :param val: a value to be checked for membership in `self`
-        '''
+        """
         try:
             from opendp.domains import _member
+
             return _member(self, val)
         except Exception as e:
             from warnings import warn
-            warn(f'Value ({val}) does not belong to carrier type of {self}. Details: {e}')
-            return False
 
+            warn(
+                f"Value ({val}) does not belong to carrier type of {self}. Details: {e}"
+            )
+            return False
 
     @property
     def type(self) -> Union["RuntimeType", str]:
-        '''
+        """
         Type of domain
-        '''
+        """
         from opendp.domains import domain_type
         from opendp.typing import RuntimeType
+
         return RuntimeType.parse(domain_type(self))
-    
+
     @property
     def carrier_type(self) -> Union["RuntimeType", str]:
-        '''
+        """
         Carrier type of domain
-        '''
+        """
         from opendp.domains import domain_carrier_type
         from opendp.typing import RuntimeType
+
         return RuntimeType.parse(domain_carrier_type(self))
-    
+
     def __repr__(self) -> str:
         from opendp.domains import domain_debug
+
         return domain_debug(self)
-    
+
     def __del__(self):
         try:
             from opendp.domains import _domain_free
+
             _domain_free(self)
-        except (ImportError, TypeError): # pragma: no cover
+        except (ImportError, TypeError):  # pragma: no cover
             # an example error that this catches:
             #   ImportError: sys.meta_path is None, Python is likely shutting down
             pass
-    
+
     def __eq__(self, other) -> bool:
         from opendp.domains import _domain_equal
 
         if not isinstance(other, Domain):
             return False
-        
+
         return _domain_equal(self, other)
-    
+
     def __hash__(self) -> int:
         return hash(str(self))
-    
+
     def __iter__(self):
         raise ValueError("Domain does not support iteration")
-    
+
     def cast(self, type_: Type[D]) -> D:
         """Retrieve the descriptor as the prescribed type, or error."""
         if not (
@@ -798,256 +885,285 @@ class Domain(ctypes.POINTER(AnyDomain)): # type: ignore[misc]
 
 
 class AtomDomain(Domain):
-    '''The domain of all values of a given atomic type.
+    """The domain of all values of a given atomic type.
 
     Create an instance of this domain with :py:func:`~opendp.domains.atom_domain`.
 
     If bounds are set, then the domain is restricted to the bounds.
     If nullable is set, then null value(s) are included in the domain.
-    '''
+    """
 
     _type_ = AnyDomain
-    
+
     @property
     def bounds(self) -> tuple[float, float]:
-        '''Bounds of the domain, if they exist'''
+        """Bounds of the domain, if they exist"""
         from opendp.domains import _atom_domain_get_bounds_closed
+
         return _atom_domain_get_bounds_closed(self)
-    
+
     @property
     def nan(self) -> bool:
         """Whether the domain includes NaN values
-        
+
         Only relevant when the carrier type is a floating point type.
         All other types will always return ``False``.
         """
         from opendp.domains import _atom_domain_nan
+
         return _atom_domain_nan(self)
-    
+
 
 class OptionDomain(Domain):
-    '''A domain whose members are either members of the ``element_domain``, or ``None``.
+    """A domain whose members are either members of the ``element_domain``, or ``None``.
 
     Create an instance of this domain with :py:func:`~opendp.domains.option_domain`.
 
     The element domain is the domain of non-null values.
-    '''
+    """
 
     _type_ = AnyDomain
 
     @property
     def element_domain(self) -> Domain:
-        '''Domain of non-null values'''
+        """Domain of non-null values"""
         from opendp.domains import _option_domain_get_element_domain
+
         return _option_domain_get_element_domain(self)
 
 
 class VectorDomain(Domain):
-    '''``VectorDomain`` describes the domain of all vectors whose elements are members of a given domain.
-    
+    """``VectorDomain`` describes the domain of all vectors whose elements are members of a given domain.
+
     Create an instance of this domain with :py:func:`~opendp.domains.vector_domain`.
-    '''
+    """
+
     _type_ = AnyDomain
-    
+
     @property
     def element_domain(self) -> Domain:
-        '''Domain of elements in the vector'''
+        """Domain of elements in the vector"""
         from opendp.domains import _vector_domain_get_element_domain
+
         return _vector_domain_get_element_domain(self)
-    
+
     @property
     def size(self) -> Optional[int]:
-        '''Size of vectors in the domain, if it is fixed'''
+        """Size of vectors in the domain, if it is fixed"""
         from opendp.domains import _vector_domain_get_size
+
         return _vector_domain_get_size(self)
 
 
 class SeriesDomain(Domain):
-    '''``SeriesDomain`` describes the domain of all polars Series.
-    
+    """``SeriesDomain`` describes the domain of all polars Series.
+
     Create an instance of this domain with :py:func:`~opendp.domains.series_domain`.
-    '''
+    """
+
     _type_ = AnyDomain
 
     @property
     def name(self) -> str:
-        '''Name of series in the domain'''
+        """Name of series in the domain"""
         from opendp.domains import _series_domain_get_name
+
         return _series_domain_get_name(self)
-    
+
     @property
     def element_domain(self) -> Domain:
-        '''Domain of non-null elements in the series'''
+        """Domain of non-null elements in the series"""
         from opendp.domains import _series_domain_get_element_domain
+
         return _series_domain_get_element_domain(self)
-    
+
     @property
     def nullable(self) -> bool:
-        '''Whether series in the domain may include null values'''
+        """Whether series in the domain may include null values"""
         from opendp.domains import _series_domain_get_nullable
+
         return _series_domain_get_nullable(self)
-    
+
+
 class LazyFrameDomain(Domain):
-    '''``LazyFrameDomain`` describes the domain of all polars LazyFrames.
-    
+    """``LazyFrameDomain`` describes the domain of all polars LazyFrames.
+
     Create an instance of this domain with :py:func:`~opendp.domains.lazyframe_domain`.
-    '''
+    """
+
     _type_ = AnyDomain
 
     @property
     def columns(self) -> list[str]:
-        '''List of column names in the frame'''
+        """List of column names in the frame"""
         from opendp.domains import _lazyframe_domain_get_columns
+
         return _lazyframe_domain_get_columns(self)
 
     def get_series_domain(self, name: str) -> SeriesDomain:
-        '''Retrieve the series domain with the given name'''
+        """Retrieve the series domain with the given name"""
         from opendp.domains import _lazyframe_domain_get_series_domain
+
         return _lazyframe_domain_get_series_domain(self, name)
-    
+
     def get_margin(self, by: Sequence[Any]):
-        '''Get the margin descriptor of the frame when grouped by the given columns'''
+        """Get the margin descriptor of the frame when grouped by the given columns"""
         from opendp.domains import _lazyframe_domain_get_margin
         from opendp._convert import _check_polars_by
+
         _check_polars_by(by)
 
         return _lazyframe_domain_get_margin(self, by)
 
 
 class ExtrinsicDomain(Domain):
-    '''A user-defined domain.'''
+    """A user-defined domain."""
 
     _type_ = AnyDomain
-        
+
     @property
     def descriptor(self) -> Any:
-        '''
-        Descriptor of domain. Used to retrieve the descriptor associated with domains defined in Python 
-        '''
+        """
+        Descriptor of domain. Used to retrieve the descriptor associated with domains defined in Python
+        """
         from opendp.domains import _extrinsic_domain_descriptor
+
         return _extrinsic_domain_descriptor(self)
 
 
-class Metric(ctypes.POINTER(AnyMetric)): # type: ignore[misc]
-    '''
+class Metric(ctypes.POINTER(AnyMetric)):  # type: ignore[misc]
+    """
     See the `Metric <../../api/user-guide/programming-framework/supporting-elements.html#metric>`_
     section in the Programming Framework docs for more context.
 
     Functions for creating metrics are in :py:mod:`opendp.metrics`.
-    '''
+    """
+
     _type_ = AnyMetric
 
     @property
     def type(self) -> Union["RuntimeType", str]:
-        '''
+        """
         Type of metric
-        '''
+        """
         from opendp.metrics import metric_type
         from opendp.typing import RuntimeType
+
         return RuntimeType.parse(metric_type(self))
-    
+
     @property
     def distance_type(self) -> Union["RuntimeType", str]:
-        '''
+        """
         Distance type of metric
-        '''
+        """
         from opendp.metrics import metric_distance_type
         from opendp.typing import RuntimeType
+
         return RuntimeType.parse(metric_distance_type(self))
 
     def __repr__(self) -> str:
         from opendp.metrics import metric_debug
+
         return metric_debug(self)
-    
+
     def __del__(self):
         try:
             from opendp.metrics import _metric_free
+
             _metric_free(self)
-        except (ImportError, TypeError): # pragma: no cover
+        except (ImportError, TypeError):  # pragma: no cover
             # an example error that this catches:
             #   ImportError: sys.meta_path is None, Python is likely shutting down
             pass
-    
+
     def __eq__(self, other) -> bool:
         from opendp.metrics import _metric_equal
 
         if not isinstance(other, Metric):
             return False
-        
+
         return _metric_equal(self, other)
-    
+
     def __hash__(self) -> int:
         return hash(str(self))
-    
+
     def __iter__(self):
         raise ValueError("Metric does not support iteration")
-    
+
     def cast(self, type_: Type[D]) -> D:
         """Retrieve the descriptor as the prescribed type, or error."""
         if not (
             isinstance(self, ExtrinsicDistance)
             and isinstance(descriptor := self.descriptor, type_)
         ):
-            raise ValueError(f"metric descriptor must be a {type_.__name__}, found {self}")
+            raise ValueError(
+                f"metric descriptor must be a {type_.__name__}, found {self}"
+            )
         return descriptor
 
 
 class ExtrinsicDistance(Metric):
-    '''A user-defined metric.'''
+    """A user-defined metric."""
 
     _type_ = AnyMetric
-        
+
     @property
     def descriptor(self) -> Any:
-        '''
-        Descriptor of domain. Used to retrieve the descriptor associated with domains defined in Python 
-        '''
+        """
+        Descriptor of domain. Used to retrieve the descriptor associated with domains defined in Python
+        """
         from opendp.metrics import _extrinsic_metric_descriptor
+
         return _extrinsic_metric_descriptor(self)
 
 
 class FrameDistance(Metric):
-    '''``FrameDistance`` is a higher-order metric that contains multiple distance bounds for different groupings of data.'''
+    """``FrameDistance`` is a higher-order metric that contains multiple distance bounds for different groupings of data."""
 
     _type_ = AnyMetric
-    
+
     @property
     def inner_metric(self) -> Metric:
-        '''Bounds of the domain, if they exist'''
+        """Bounds of the domain, if they exist"""
         from opendp.metrics import _frame_distance_get_inner_metric
+
         return _frame_distance_get_inner_metric(self)
-    
+
+
 class SymmetricIdDistance(Metric):
-    '''``SymmetricIdDistance`` is a metric for measuring the distance between the identifiers of two datasets.
-    
+    """``SymmetricIdDistance`` is a metric for measuring the distance between the identifiers of two datasets.
+
     The metric counts the number of identifiers that must be added or removed to make the two datasets equal.
-    '''
+    """
 
     _type_ = AnyMetric
-    
+
     @property
     def identifier(self):
-        '''The name of the column storing identifiers'''
+        """The name of the column storing identifiers"""
         from opendp.metrics import _symmetric_id_distance_get_identifier
+
         return _symmetric_id_distance_get_identifier(self)
-    
+
 
 class ChangeOneIdDistance(Metric):
-    '''``ChangeOneIdDistance`` is a metric for measuring the distance between the identifiers of two datasets.
-    
+    """``ChangeOneIdDistance`` is a metric for measuring the distance between the identifiers of two datasets.
+
     The metric counts the number of identifiers that must be changed to make the two datasets equal.
-    '''
+    """
 
     _type_ = AnyMetric
-    
+
     @property
     def identifier(self):
-        '''The name of the column storing identifiers'''
+        """The name of the column storing identifiers"""
         from opendp.metrics import _change_one_id_distance_get_identifier
+
         return _change_one_id_distance_get_identifier(self)
-    
-class Measure(ctypes.POINTER(AnyMeasure)): # type: ignore[misc]
-    '''
+
+
+class Measure(ctypes.POINTER(AnyMeasure)):  # type: ignore[misc]
+    """
     See the `Measure <../../api/user-guide/programming-framework/supporting-elements.html#measure>`_
     section in the Programming Framework docs for more context.
 
@@ -1059,36 +1175,41 @@ class Measure(ctypes.POINTER(AnyMeasure)): # type: ignore[misc]
     >>> measure, distance
     (MaxDivergence, 1.0)
 
-    '''
+    """
+
     _type_ = AnyMeasure
 
     @property
     def type(self) -> Union["RuntimeType", str]:
-        '''
+        """
         Type of measure
-        '''
+        """
         from opendp.measures import measure_type
         from opendp.typing import RuntimeType
+
         return RuntimeType.parse(measure_type(self))
-    
+
     @property
     def distance_type(self) -> Union["RuntimeType", str]:
-        '''
+        """
         Distance type of measure
-        '''
+        """
         from opendp.measures import measure_distance_type
         from opendp.typing import RuntimeType
+
         return RuntimeType.parse(measure_distance_type(self))
 
     def __repr__(self):
         from opendp.measures import measure_debug
+
         return measure_debug(self)
-    
+
     def __del__(self):
         try:
             from opendp.measures import _measure_free
+
             _measure_free(self)
-        except (ImportError, TypeError): # pragma: no cover
+        except (ImportError, TypeError):  # pragma: no cover
             # an example error that this catches:
             #   ImportError: sys.meta_path is None, Python is likely shutting down
             pass
@@ -1098,12 +1219,12 @@ class Measure(ctypes.POINTER(AnyMeasure)): # type: ignore[misc]
 
         if not isinstance(other, Measure):
             return False
-        
+
         return _measure_equal(self, other)
-    
+
     def __hash__(self) -> int:
         return hash(str(self))
-    
+
     def __iter__(self):
         raise ValueError("Measure does not support iteration")
 
@@ -1113,89 +1234,98 @@ class Measure(ctypes.POINTER(AnyMeasure)): # type: ignore[misc]
             isinstance(self, ExtrinsicDivergence)
             and isinstance(descriptor := self.descriptor, type_)
         ):
-            raise ValueError(f"measure descriptor must be a {type_.__name__}, found {self}")
+            raise ValueError(
+                f"measure descriptor must be a {type_.__name__}, found {self}"
+            )
         return descriptor
 
 
 class ExtrinsicDivergence(Measure):
-    '''A user-defined privacy measure.'''
+    """A user-defined privacy measure."""
 
     _type_ = AnyMeasure
 
     @property
     def descriptor(self) -> Any:
-        '''
+        """
         Descriptor of measure. Used to retrieve the descriptor associated with measures defined in Python
-        '''
+        """
         from opendp.measures import _extrinsic_measure_descriptor
+
         return _extrinsic_measure_descriptor(self)
 
 
-
 class ApproximateDivergence(Measure):
-    '''``ApproximateDivergence`` is a privacy measure representing the divergence between two distributions 
+    """``ApproximateDivergence`` is a privacy measure representing the divergence between two distributions
     with respect to some inner privacy measure, except for some subset of possible outputs with probability mass no greater than delta.
-    '''
+    """
 
     _type_ = AnyMeasure
-    
+
     @property
     def inner_measure(self) -> Measure:
         from opendp.measures import _approximate_divergence_get_inner_measure
+
         return _approximate_divergence_get_inner_measure(self)
-    
+
 
 class PrivacyProfile(object):
-    '''
+    """
     Given a profile function provided by the user,
     gives the epsilon corresponding to a given delta, and vice versa.
 
     :py:func:`~opendp.measures.new_privacy_profile`
     should be used to create new instances.
-    '''
+    """
+
     def __init__(self, curve):
         self.curve = curve
 
     def delta(self, epsilon):
-        '''
+        """
         Returns the delta that corresponds to this epsilon.
-        
+
         :param epsilon: Allowance for a multiplicative difference, or max divergence, in the distributions of releases on adjacent datasets
-        '''
+        """
         from opendp._data import privacy_profile_delta
+
         return privacy_profile_delta(self.curve, epsilon)
 
     def epsilon(self, delta):
-        '''
+        """
         Returns the epsilon that corresponds to this delta.
-        
+
         :param delta: Allowance for an additive difference between the distributions of releases on adjacent datasets
-        '''
+        """
         from opendp._data import privacy_profile_epsilon
+
         return privacy_profile_epsilon(self.curve, delta)
-    
+
 
 class _PartialConstructor(object):
-    '''
+    """ """
 
-    '''
     def __init__(self, constructor):
         self.constructor = constructor
         self.__opendp_dict__ = {}  # Not needed at runtime, but the definition prevents mypy errors.
-    
+
     def __call__(self, input_domain: Domain, input_metric: Metric):
         return self.constructor(input_domain, input_metric)
-    
+
     def __rshift__(self, other):
-        return _PartialConstructor(lambda input_domain, input_metric: self(input_domain, input_metric) >> other) # pragma: no cover
+        return _PartialConstructor(
+            lambda input_domain, input_metric: self(input_domain, input_metric) >> other
+        )  # pragma: no cover
 
     def __rrshift__(self, other):
-        if isinstance(other, tuple):  
+        if isinstance(other, tuple):
             domain, metric = other
-            if isinstance(domain, Domain) and isinstance(metric, Metric):  
-                return self(domain, metric)  
-            
-        raise TypeError(f"Cannot chain {type(self)} with {type(other)}")  # pragma: no cover
+            if isinstance(domain, Domain) and isinstance(metric, Metric):
+                return self(domain, metric)
+
+        raise TypeError(
+            f"Cannot chain {type(self)} with {type(other)}"
+        )  # pragma: no cover
 
 
 class UnknownTypeException(Exception):
@@ -1211,26 +1341,36 @@ class OpenDPException(Exception):
 
     Run ``dp.enable_features('rust-stack-trace')`` to see wrapped Rust stack traces.
     """
+
     raw_traceback: Optional[str]
 
-    def __init__(self, variant: str, message: Optional[str] = None, raw_traceback: Optional[str] = None):
+    def __init__(
+        self,
+        variant: str,
+        message: Optional[str] = None,
+        raw_traceback: Optional[str] = None,
+    ):
         self.variant = variant
         self.message = message
         self.raw_traceback = raw_traceback
 
     def _raw_frames(self):
         import re
+
         return re.split(r"\s*[0-9]+: ", self.raw_traceback or "")
-    
+
     def _frames(self):
         def _format_frame(frame):
             return "\n  ".join(line.strip() for line in frame.split("\n"))
+
         return [_format_frame(f) for f in self._raw_frames() if "opendp" in f]
 
     def _continued_stack_trace(self):
         # join and split by newlines because frames may be multi-line
-        lines = "\n".join(self._frames()[::-1]).split('\n')
-        return "Continued Rust stack trace:\n" + '\n'.join('    ' + line for line in lines)
+        lines = "\n".join(self._frames()[::-1]).split("\n")
+        return "Continued Rust stack trace:\n" + "\n".join(
+            "    " + line for line in lines
+        )
 
     def __str__(self) -> str:
         '''
@@ -1254,18 +1394,20 @@ class OpenDPException(Exception):
         <BLANKLINE>
           SomeVariant("my message")
         '''
-        response = ''
-        if self.raw_traceback and 'rust-stack-trace' in GLOBAL_FEATURES:
+        response = ""
+        if self.raw_traceback and "rust-stack-trace" in GLOBAL_FEATURES:
             response += self._continued_stack_trace()
-        response += '\n  ' + self.variant
+        response += "\n  " + self.variant
 
         if self.message:
             response += f'("{self.message}")'
-            
+
         return response
 
 
 GLOBAL_FEATURES: set[str] = set()
+
+
 def _normalize_features(features: Sequence[str], *, stacklevel: int) -> tuple[str, ...]:
     normalized = []
 
@@ -1285,39 +1427,44 @@ def _normalize_features(features: Sequence[str], *, stacklevel: int) -> tuple[st
 
 
 def enable_features(*features: str) -> None:
-    '''
+    """
     Allow the use of optional features. See :ref:`feature-listing` for details.
-    '''
+    """
     GLOBAL_FEATURES.update(set(_normalize_features(features, stacklevel=3)))
 
 
 def disable_features(*features: str) -> None:
-    '''
+    """
     Disallow the use of optional features. See :ref:`feature-listing` for details.
-    '''
+    """
     GLOBAL_FEATURES.difference_update(set(_normalize_features(features, stacklevel=3)))
 
 
 def assert_features(*features: str) -> None:
-    '''
+    """
     Check whether a given feature is enabled. See :ref:`feature-listing` for details.
-    '''
+    """
     features = _normalize_features(features, stacklevel=3)
     missing_features = [f for f in features if f not in GLOBAL_FEATURES]
     if missing_features:
-        features_string = ', '.join(f'"{f}"' for f in features)
-        raise OpenDPException(f"Attempted to use function that requires {features_string}, but not enabled. See https://docs.opendp.org/en/stable/api/user-guide/#feature-listing, then call enable_features({features_string})")
+        features_string = ", ".join(f'"{f}"' for f in features)
+        raise OpenDPException(
+            f"Attempted to use function that requires {features_string}, but not enabled. See https://docs.opendp.org/en/stable/api/user-guide/#feature-listing, then call enable_features({features_string})"
+        )
 
 
 M = TypeVar("M", Transformation, Measurement)
 
+
 def binary_search_chain(
-        make_chain: Callable[[float], M],
-        d_in: Any, d_out: Any,
-        bounds: tuple[float | None, float | None] | None = (None, None),
-        T=None) -> M:
+    make_chain: Callable[[float], M],
+    d_in: Any,
+    d_out: Any,
+    bounds: tuple[float | None, float | None] | None = (None, None),
+    T=None,
+) -> M:
     """Find the highest-utility (`d_in`, `d_out`)-close Transformation or Measurement.
-    
+
     Searches for the numeric parameter to `make_chain` that results in a computation
     that most tightly satisfies `d_out` when datasets differ by at most `d_in`,
     then returns the Transformation or Measurement corresponding to said parameter.
@@ -1354,7 +1501,7 @@ def binary_search_chain(
     >>> # Find a value in `bounds` that produces a (`d_in`, `d_out`)-chain nearest the decision boundary.
     >>> # The lambda function returns the complete computation chain when given a single numeric parameter.
     >>> chain = dp.binary_search_chain(
-    ...     lambda s: pre >> dp.m.then_laplace(scale=s), 
+    ...     lambda s: pre >> dp.m.then_laplace(scale=s),
     ...     d_in=1, d_out=1.)
     ...
     >>> # The resulting computation chain is always (`d_in`, `d_out`)-close, but we can still double-check:
@@ -1377,12 +1524,14 @@ def binary_search_chain(
 
 
 def binary_search_param(
-        make_chain: Callable[[float], Union[Transformation, Measurement]],
-        d_in: Any, d_out: Any,
-        bounds: tuple[float | None, float | None] | None = (None, None),
-        T=None) -> float:
+    make_chain: Callable[[float], Union[Transformation, Measurement]],
+    d_in: Any,
+    d_out: Any,
+    bounds: tuple[float | None, float | None] | None = (None, None),
+    T=None,
+) -> float:
     """Solve for the ideal constructor argument to `make_chain`.
-    
+
     Optimizes a parameterized chain `make_chain` within float or integer `bounds`,
     subject to the chained relation being (`d_in`, `d_out`)-close.
 
@@ -1412,10 +1561,10 @@ def binary_search_param(
     >>> # Constructing the same chain with the discovered parameter will always be (0.1, 1.)-close.
     >>> assert make_fixed_laplace(scale).check(0.1, 1.)
 
-    A policy research organization wants to know the smallest sample size necessary to release an "accurate" epsilon=1 DP mean income. 
-    Determine the smallest dataset size such that, with 95% confidence, 
-    the DP release differs from the clipped dataset's mean by no more than 1000. 
-    Assume that neighboring datasets have a symmetric distance at most 2. 
+    A policy research organization wants to know the smallest sample size necessary to release an "accurate" epsilon=1 DP mean income.
+    Determine the smallest dataset size such that, with 95% confidence,
+    the DP release differs from the clipped dataset's mean by no more than 1000.
+    Assume that neighboring datasets have a symmetric distance at most 2.
     Also assume a clipping bound of 500,000.
 
     >>> # we first work out the necessary noise scale to satisfy the above constraints.
@@ -1425,19 +1574,19 @@ def binary_search_param(
     >>> def make_mean(data_size):
     ...    return (
     ...        (dp.vector_domain(dp.atom_domain(bounds=(0., 500_000.)), data_size), dp.symmetric_distance()) >>
-    ...        dp.t.then_mean() >> 
+    ...        dp.t.then_mean() >>
     ...        dp.m.then_laplace(necessary_scale)
     ...    )
     ...
     >>> # solve for the smallest dataset size that admits a (2 neighboring, 1. epsilon)-close measurement
     >>> dp.binary_search_param(
-    ...     make_mean, 
+    ...     make_mean,
     ...     d_in=2, d_out=1.,
     ...     bounds=(1, 1000000))
     1498
     """
 
-    # one might think running scipy.optimize.brent* would be better, but 
+    # one might think running scipy.optimize.brent* would be better, but
     # 1. benchmarking showed no difference or minor regressions
     # 2. brentq is more complicated
 
@@ -1470,7 +1619,11 @@ def _call_rust_search(
     except OpenDPException as err:
         if first_exception is not None:
             exc = first_exception
-            if (bounds is None or bounds == (None, None)) and not had_success and hasattr(exc, "add_note"):
+            if (
+                (bounds is None or bounds == (None, None))
+                and not had_success
+                and hasattr(exc, "add_note")
+            ):
                 center = 0.0 if T in {"f32", "f64"} else 0
                 exc.add_note(
                     "Predicate in binary search always raises an exception. "
@@ -1487,43 +1640,45 @@ def _call_rust_search(
 # when return sign is false, only return float
 @overload
 def binary_search(
-        predicate: Callable[[float], bool],
-        bounds: tuple[float | None, float | None] | None = ...,
-        T: Type[float] | None = ...,
-        return_sign: Literal[False] = False) -> float:
-    ...
+    predicate: Callable[[float], bool],
+    bounds: tuple[float | None, float | None] | None = ...,
+    T: Type[float] | None = ...,
+    return_sign: Literal[False] = False,
+) -> float: ...
 
 
 # when setting return sign to true as a keyword argument, return both
 @overload
 def binary_search(
-        predicate: Callable[[float], bool],
-        bounds: tuple[float | None, float | None] | None = ...,
-        T: Type[float] | None = ...,
-        *, # see https://stackoverflow.com/questions/66435480/overload-following-optional-argument
-        return_sign: Literal[True]) -> tuple[float, int]:
-    ...
+    predicate: Callable[[float], bool],
+    bounds: tuple[float | None, float | None] | None = ...,
+    T: Type[float] | None = ...,
+    *,  # see https://stackoverflow.com/questions/66435480/overload-following-optional-argument
+    return_sign: Literal[True],
+) -> tuple[float, int]: ...
+
 
 # when setting return sign to true as a positional argument, return both
 @overload
 def binary_search(
-        predicate: Callable[[float], bool],
-        bounds: tuple[float | None, float | None] | None,
-        T: Type[float] | None,
-        return_sign: Literal[True]) -> tuple[float, int]:
-    ...
+    predicate: Callable[[float], bool],
+    bounds: tuple[float | None, float | None] | None,
+    T: Type[float] | None,
+    return_sign: Literal[True],
+) -> tuple[float, int]: ...
 
 
 def binary_search(
-        predicate: Callable[[float], bool],
-        bounds: tuple[float | None, float | None] | None = (None, None),
-        T: Type[float] | None = None,
-        return_sign: bool = False) -> float | tuple[float, int]:
+    predicate: Callable[[float], bool],
+    bounds: tuple[float | None, float | None] | None = (None, None),
+    T: Type[float] | None = None,
+    return_sign: bool = False,
+) -> float | tuple[float, int]:
     """Find the closest passing value to the decision boundary of `predicate`.
 
     Missing bounds are inferred. Pass `None` for either element of `bounds` to
     conduct a one-sided search, or omit `bounds` to conduct an exponential search.
-    
+
     :param predicate: a monotonic unary function from a number to a boolean
     :param bounds: a 2-tuple of optional lower and upper bounds to the input of `predicate`; use `None` for either bound to infer it
     :param T: type of argument to `predicate`, one of {float, int}
@@ -1552,12 +1707,12 @@ def binary_search(
     >>> # build a histogram that emits float counts
     >>> input_space = dp.vector_domain(dp.atom_domain(bounds=(0., 100.)), 1000), dp.symmetric_distance()
     >>> dp_mean = dp.c.make_fix_delta(dp.c.make_zCDP_to_approxDP(
-    ...     input_space >> dp.t.then_mean() >> dp.m.then_gaussian(1.)), 
+    ...     input_space >> dp.t.then_mean() >> dp.m.then_gaussian(1.)),
     ...     1e-8
     ... )
     ...
     >>> dp.binary_search(
-    ...     lambda d_out: dp_mean.check(3, (d_out, 1e-8)), 
+    ...     lambda d_out: dp_mean.check(3, (d_out, 1e-8)),
     ...     bounds = (0., 1.))
     0.5235561269546629
 
@@ -1568,7 +1723,7 @@ def binary_search(
     ...     categories=["a"], MO=dp.L2Distance[int])
     ...
     >>> dp.binary_search(
-    ...     lambda d_out: histogram.check(3, d_out), 
+    ...     lambda d_out: histogram.check(3, d_out),
     ...     bounds = (0, 100))
     3
     """
@@ -1599,18 +1754,21 @@ def binary_search(
     return _call_rust_search(
         predicate,
         runtime_T,
-        lambda wrapped: _binary_search(wrapped, lower=lower, upper=upper, return_sign=return_sign, T=runtime_T),
+        lambda wrapped: _binary_search(
+            wrapped, lower=lower, upper=upper, return_sign=return_sign, T=runtime_T
+        ),
         bounds=bounds,
     )
+
 
 def exponential_bounds_search(
     predicate: Callable[[float], bool], T: Optional[Union[Type[float], Type[int]]]
 ) -> Optional[tuple[float, float]]:
     """Determine bounds for a binary search via an exponential search,
     in large bands of [2^((k - 1)^2), 2^(k^2)] for k in [0, 8).
-    Will attempt to recover once if `predicate` throws an exception, 
+    Will attempt to recover once if `predicate` throws an exception,
     by searching bands on the ok side of the exception boundary.
-    
+
 
     :param predicate: a monotonic unary function from a number to a boolean
     :param T: type of argument to predicate, one of {float, int}
@@ -1637,14 +1795,14 @@ def _infer_type(predicate: Callable[[float], bool]) -> Union[Type[float], Type[i
         )
 
     try:
-        predicate(0.)
+        predicate(0.0)
         # predicate succeeded with a float, assume it wants floats
         return float
     except Exception as e:
         if not _is_type_error(e):
             # it didn't reject the type, but did fail with a different error
             return float
-    
+
     # Try again with the more forgiving type, an int.
     try:
         predicate(0)
@@ -1657,29 +1815,36 @@ def _infer_type(predicate: Callable[[float], bool]) -> Union[Type[float], Type[i
 
         # enrich the error message if in Python 3.11+.
         if hasattr(e, "add_note"):
-            e.add_note("Unable to infer type `T`; pass the type `T` or bounds. This exception is raised when the predicate is evaluated at 0")
+            e.add_note(
+                "Unable to infer type `T`; pass the type `T` or bounds. This exception is raised when the predicate is evaluated at 0"
+            )
         raise
 
 
-_TUPLE_FLAG = '__tuple__'
-_EXPR_FLAG = '__expr__'
-_LAZY_FLAG = '__lazyframe__'
-_MARGIN_FLAG = '__margin__'
-_FUNCTION_FLAG = '__function__'
-_MODULE_FLAG = '__module__'
-_KWARGS_FLAG = '__kwargs__'
+_TUPLE_FLAG = "__tuple__"
+_EXPR_FLAG = "__expr__"
+_LAZY_FLAG = "__lazyframe__"
+_MARGIN_FLAG = "__margin__"
+_FUNCTION_FLAG = "__function__"
+_MODULE_FLAG = "__module__"
+_KWARGS_FLAG = "__kwargs__"
+
 
 def _bytes_to_b64_str(serialized_polars):
     from base64 import b64encode
+
     b64_bytes = b64encode(serialized_polars)
     return b64_bytes.decode()
+
 
 def _b64_str_to_bytes(b64_str):
     from base64 import b64decode
     from io import BytesIO
+
     b64_bytes = b64_str.encode()
     serialized_polars = b64decode(b64_bytes)
     return BytesIO(serialized_polars)
+
 
 class _Encoder(json.JSONEncoder):
     def default(self, obj):
@@ -1698,46 +1863,65 @@ class _Encoder(json.JSONEncoder):
                 k: self.default(v)
                 for k, v in obj.items()
             }
-        
+
         from opendp.extras.polars import Margin
+
         if isinstance(obj, Margin):
             return {_MARGIN_FLAG: self.default(asdict(obj))}
 
         # OpenDP specific:
-        if hasattr(obj, '__opendp_dict__'):
-            return self.default({**obj.__opendp_dict__, '__version__': __version__})
+        if hasattr(obj, "__opendp_dict__"):
+            return self.default({**obj.__opendp_dict__, "__version__": __version__})
 
         stateful_error_msg = (
             f"OpenDP JSON Encoder does not handle instances of {type(obj)}: "
             f"It may have state which is not set by the constructor. Error on: {obj}"
         )
 
-        pl = import_optional_dependency('polars', raise_error=False)
+        pl = import_optional_dependency("polars", raise_error=False)
         if pl is not None:
             from opendp.extras.polars import LazyFrameQuery
+
             if isinstance(obj, LazyFrameQuery):
                 # Error out early, instead of falling through to pl.LazyFrame,
                 # which *could* be serialized!
                 raise Exception(stateful_error_msg)
             if isinstance(obj, pl.Expr):
-                return {_EXPR_FLAG: _bytes_to_b64_str(obj.meta.serialize()), '__version__': __version__}
+                return {
+                    _EXPR_FLAG: _bytes_to_b64_str(obj.meta.serialize()),
+                    "__version__": __version__,
+                }
             if isinstance(obj, pl.LazyFrame):
-                return {_LAZY_FLAG: _bytes_to_b64_str(obj.serialize()), '__version__': __version__}
+                return {
+                    _LAZY_FLAG: _bytes_to_b64_str(obj.serialize()),
+                    "__version__": __version__,
+                }
 
         # Exceptions:
         from opendp.context import Context
-        if isinstance(obj, (Context, Queryable,)):
+
+        if isinstance(
+            obj,
+            (
+                Context,
+                Queryable,
+            ),
+        ):
             raise Exception(stateful_error_msg)
 
-        raise Exception(f'OpenDP JSON Encoder does not handle {obj}')
+        raise Exception(f"OpenDP JSON Encoder does not handle {obj}")
+
 
 def _check_version(dp_dict):
     from warnings import warn
-    serialized_version = dp_dict['__version__']
+
+    serialized_version = dp_dict["__version__"]
     if serialized_version != __version__:
         warn(
-            f'OpenDP version in serialized object ({serialized_version}) '
-            f'!= this version ({__version__})')
+            f"OpenDP version in serialized object ({serialized_version}) "
+            f"!= this version ({__version__})"
+        )
+
 
 def _deserialization_hook(dp_dict):
     if _FUNCTION_FLAG in dp_dict:
@@ -1747,7 +1931,7 @@ def _deserialization_hook(dp_dict):
         return func(**dp_dict.get(_KWARGS_FLAG, {}))
     if _TUPLE_FLAG in dp_dict:
         return tuple(dp_dict[_TUPLE_FLAG])
-    pl = import_optional_dependency('polars', raise_error=False)
+    pl = import_optional_dependency("polars", raise_error=False)
     if pl is not None:
         if _EXPR_FLAG in dp_dict:
             _check_version(dp_dict)
@@ -1758,25 +1942,27 @@ def _deserialization_hook(dp_dict):
         if _MARGIN_FLAG in dp_dict:
             from opendp.extras.polars import Margin
 
-            by = [deserialize(v) for v in dp_dict[_MARGIN_FLAG].get('by', [])]
+            by = [deserialize(v) for v in dp_dict[_MARGIN_FLAG].get("by", [])]
             return Margin(**{**dp_dict[_MARGIN_FLAG], "by": by})
     return dp_dict
 
+
 def serialize(dp_obj):
     # The usual pattern would be
-    # 
+    #
     #   json.dumps(dp_obj, cls=_Encoder)
-    # 
+    #
     # but that only calls default() for objects which can't be handled otherwise.
     # In particular, it makes top-level tuples into lists,
     # even when special handling is specified in default().
     return json.dumps(_Encoder().default(dp_obj))
 
+
 def deserialize(dp_json):
     return json.loads(dp_json, object_hook=_deserialization_hook)
 
 
-_EXPECTED_POLARS_VERSION = '1.36.1' # Keep in sync with setup.cfg.
+_EXPECTED_POLARS_VERSION = "1.36.1"  # Keep in sync with setup.cfg.
 
 
 __version__ = get_opendp_version()

--- a/python/src/opendp/prelude.py
+++ b/python/src/opendp/prelude.py
@@ -1,4 +1,4 @@
-'''
+"""
 The ``prelude`` module provides shortcuts that reduce the number of ``import`` statements needed to get started.
 In most of our notebooks we begin with:
 
@@ -7,7 +7,7 @@ In most of our notebooks we begin with:
     >>> import opendp.prelude as dp
     >>> dp.enable_features("contrib")
 
-After that we can refer to members of 
+After that we can refer to members of
 :py:mod:`mod <opendp.mod>`,
 :py:mod:`domains <opendp.domains>`,
 :py:mod:`metrics <opendp.metrics>`,
@@ -33,7 +33,8 @@ For example:
     <class 'function'>
     >>> type(dp.c.make_composition)
     <class 'function'>
-'''
+"""
+
 from opendp.mod import *
 from opendp.extras import sklearn, numpy, polars, examples, mbi
 from opendp.extras.polars import dp_len as len

--- a/python/src/opendp/typing.py
+++ b/python/src/opendp/typing.py
@@ -1,4 +1,4 @@
-'''
+"""
 The ``typing`` module provides utilities that bridge between Python and Rust types.
 OpenDP relies on precise descriptions of data types to make its security guarantees:
 These are more natural in Rust with its fine-grained type system,
@@ -12,53 +12,75 @@ We suggest importing under the conventional name ``dp``:
 .. code:: pycon
 
     >>> import opendp.prelude as dp
-'''
+"""
+
 from __future__ import annotations
 import typing
 from collections.abc import Hashable
-from typing import Optional, TypeAlias, Union, Any, Type, Sequence, _GenericAlias # type: ignore[attr-defined]
+from typing import Optional, TypeAlias, Union, Any, Type, Sequence, _GenericAlias  # type: ignore[attr-defined]
 from types import GenericAlias
 import re
 
-from opendp.mod import UnknownTypeException, Measurement, Transformation, Domain, Metric, Measure
+from opendp.mod import (
+    UnknownTypeException,
+    Measurement,
+    Transformation,
+    Domain,
+    Metric,
+    Measure,
+)
 from opendp._lib import ATOM_EQUIVALENCE_CLASSES, import_optional_dependency
 
 
 _ELEMENTARY_TYPES: dict[Any, str] = {
-    int: 'i32',
-    float: 'f64',
-    str: 'String',
-    bool: 'bool',
-    Measurement: 'AnyMeasurementPtr',
-    Transformation: 'AnyTransformationPtr'
+    int: "i32",
+    float: "f64",
+    str: "String",
+    bool: "bool",
+    Measurement: "AnyMeasurementPtr",
+    Transformation: "AnyTransformationPtr",
 }
 try:
-    np = import_optional_dependency('numpy')
+    np = import_optional_dependency("numpy")
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#sized-aliases
-    _ELEMENTARY_TYPES.update({
-        # np.bytes_: '&[u8]',  # np.string_ # not used in OpenDP
-        np.str_: 'String',  # np.unicode_
-        np.bool_: 'bool',  # np.bool_
-        np.int8: 'i8',  # np.byte
-        np.int16: 'i16',  # np.short
-        np.int32: 'i32',  # np.intc
-        np.int64: 'i64',  # np.int_
-        np.longlong: 'i128',
-        np.uint8: 'u8',  # np.ubyte
-        np.uint16: 'u16',  # np.ushort
-        np.uint32: 'u32',  # np.uintc
-        np.uint64: 'u64',
-        np.ulonglong: 'u128',
-        # np.intp: 'isize',  # not used in OpenDP
-        # np.uintp: 'usize', # an alias for one of np.uint* that would overwrite the respective key
-        # np.float16: 'f16',  # not used in OpenDP
-        np.float32: 'f32',
-        np.float64: 'f64',  # np.double, np.float_
-    })
-except ImportError: # pragma: no cover
-    np = None # type: ignore[assignment]
+    _ELEMENTARY_TYPES.update(
+        {
+            # np.bytes_: '&[u8]',  # np.string_ # not used in OpenDP
+            np.str_: "String",  # np.unicode_
+            np.bool_: "bool",  # np.bool_
+            np.int8: "i8",  # np.byte
+            np.int16: "i16",  # np.short
+            np.int32: "i32",  # np.intc
+            np.int64: "i64",  # np.int_
+            np.longlong: "i128",
+            np.uint8: "u8",  # np.ubyte
+            np.uint16: "u16",  # np.ushort
+            np.uint32: "u32",  # np.uintc
+            np.uint64: "u64",
+            np.ulonglong: "u128",
+            # np.intp: 'isize',  # not used in OpenDP
+            # np.uintp: 'usize', # an alias for one of np.uint* that would overwrite the respective key
+            # np.float16: 'f16',  # not used in OpenDP
+            np.float32: "f32",
+            np.float64: "f64",  # np.double, np.float_
+        }
+    )
+except ImportError:  # pragma: no cover
+    np = None  # type: ignore[assignment]
 
-_INTEGER_TYPES = {"i8", "i16", "i32", "i64", "i128", "u8", "u16", "u32", "u64", "u128", "usize"}
+_INTEGER_TYPES = {
+    "i8",
+    "i16",
+    "i32",
+    "i64",
+    "i128",
+    "u8",
+    "u16",
+    "u32",
+    "u64",
+    "u128",
+    "usize",
+}
 _NUMERIC_TYPES = _INTEGER_TYPES | {"f32", "f64"}
 _HASHABLE_TYPES = _INTEGER_TYPES | {"bool", "String"}
 _PRIMITIVE_TYPES = _NUMERIC_TYPES | {"bool", "String"}
@@ -68,10 +90,14 @@ _PRIMITIVE_TYPES = _NUMERIC_TYPES | {"bool", "String"}
 RuntimeTypeDescriptor: TypeAlias = Union[
     "RuntimeType",  # as the normalized type -- ChangeOneDistance; RuntimeType.parse("i32")
     str,  # plaintext string in terms of Rust types -- "Vec<i32>"
-    Type[Union[Sequence[Any], tuple[Any, Any], float, str, bool]],  # using the Python type class itself -- int, float
-    tuple["RuntimeTypeDescriptor", ...],  # shorthand for tuples -- (float, "f64"); (ChangeOneDistance, Sequence[int])
-    _GenericAlias, # a Python type hint from the std typing module -- Sequence[int]
-    GenericAlias, # a Python type hint from the std types module -- Sequence[int]
+    Type[
+        Union[Sequence[Any], tuple[Any, Any], float, str, bool]
+    ],  # using the Python type class itself -- int, float
+    tuple[
+        "RuntimeTypeDescriptor", ...
+    ],  # shorthand for tuples -- (float, "f64"); (ChangeOneDistance, Sequence[int])
+    _GenericAlias,  # a Python type hint from the std typing module -- Sequence[int]
+    GenericAlias,  # a Python type hint from the std types module -- Sequence[int]
 ]
 
 
@@ -81,7 +107,7 @@ def set_default_int_type(T: RuntimeTypeDescriptor) -> None:
     When you build a computation chain, any unspecified integer types default to this int type.
 
     The default int type is i32.
-    
+
     :param T: must be one of [u8, u16, u32, u64, usize, i8, i16, i32, i64]
     :type T: :ref:`RuntimeTypeDescriptor`
     """
@@ -89,8 +115,8 @@ def set_default_int_type(T: RuntimeTypeDescriptor) -> None:
     T = RuntimeType.parse(T)
     assert T in equivalence_class, f"T must be one of {equivalence_class}"
 
-    ATOM_EQUIVALENCE_CLASSES[T] = ATOM_EQUIVALENCE_CLASSES.pop(_ELEMENTARY_TYPES[int]) # type: ignore[index]
-    _ELEMENTARY_TYPES[int] = T # type: ignore[assignment]
+    ATOM_EQUIVALENCE_CLASSES[T] = ATOM_EQUIVALENCE_CLASSES.pop(_ELEMENTARY_TYPES[int])  # type: ignore[index]
+    _ELEMENTARY_TYPES[int] = T  # type: ignore[assignment]
 
 
 def set_default_float_type(T: RuntimeTypeDescriptor) -> None:
@@ -108,13 +134,13 @@ def set_default_float_type(T: RuntimeTypeDescriptor) -> None:
     T = RuntimeType.parse(T)
     assert T in equivalence_class, f"T must be a float type in {equivalence_class}"
 
-    ATOM_EQUIVALENCE_CLASSES[T] = ATOM_EQUIVALENCE_CLASSES.pop(_ELEMENTARY_TYPES[float]) # type: ignore[index]
-    _ELEMENTARY_TYPES[float] = T # type: ignore[assignment]
+    ATOM_EQUIVALENCE_CLASSES[T] = ATOM_EQUIVALENCE_CLASSES.pop(_ELEMENTARY_TYPES[float])  # type: ignore[index]
+    _ELEMENTARY_TYPES[float] = T  # type: ignore[assignment]
 
 
 class RuntimeType(object):
-    """Utility for validating, manipulating, inferring and parsing/normalizing type information.
-    """
+    """Utility for validating, manipulating, inferring and parsing/normalizing type information."""
+
     origin: str
     args: Sequence[Union["RuntimeType", str]]
 
@@ -132,18 +158,20 @@ class RuntimeType(object):
         return self.origin == other.origin and self.args == other.args
 
     def __repr__(self):
-        result = self.origin or ''
-        if result == 'Tuple':
-            return f'({", ".join(map(str, self.args))})'
+        result = self.origin or ""
+        if result == "Tuple":
+            return f"({', '.join(map(str, self.args))})"
         if self.args:
-            result += f'<{", ".join(map(str, self.args))}>'
+            result += f"<{', '.join(map(str, self.args))}>"
         return result
-    
+
     def __hash__(self) -> int:
         return hash(str(self))
 
     @classmethod
-    def parse(cls, type_name: RuntimeTypeDescriptor, generics: Optional[Sequence[str]] = None) -> Union["RuntimeType", str]:
+    def parse(
+        cls, type_name: RuntimeTypeDescriptor, generics: Optional[Sequence[str]] = None
+    ) -> Union["RuntimeType", str]:
         """Parse type descriptor into a normalized Rust type.
 
         Type descriptor may be expressed as:
@@ -179,56 +207,67 @@ class RuntimeType(object):
         hinted_type = None
         if isinstance(type_name, _GenericAlias):
             hinted_type = typing.get_origin(type_name), typing.get_args(type_name)
-        if isinstance(type_name, GenericAlias): # type: ignore[attr-defined]
-            hinted_type = type_name.__origin__, type_name.__args__ # type: ignore[attr-defined]
-    
+        if isinstance(type_name, GenericAlias):  # type: ignore[attr-defined]
+            hinted_type = type_name.__origin__, type_name.__args__  # type: ignore[attr-defined]
+
         if hinted_type:
             origin, args = hinted_type
-            args = [RuntimeType.parse(v, generics=generics) for v in args] or None # type: ignore[assignment]
+            args = [RuntimeType.parse(v, generics=generics) for v in args] or None  # type: ignore[assignment]
             if origin == tuple:
-                origin = 'Tuple'
+                origin = "Tuple"
             elif origin == list:
-                origin = 'Vec'
+                origin = "Vec"
             elif origin == dict:
-                origin = 'HashMap'
-            
+                origin = "HashMap"
+
             return RuntimeType(RuntimeType.parse(origin, generics=generics), args)
 
         # parse a tuple of types-- (int, "f64"); (Sequence[int], (int, bool))
         if isinstance(type_name, tuple):
-            return RuntimeType('Tuple', list(cls.parse(v, generics=generics) for v in type_name))
+            return RuntimeType(
+                "Tuple", list(cls.parse(v, generics=generics) for v in type_name)
+            )
 
         # parse a string-- "Vec<f32>",
         if isinstance(type_name, str):
             type_name = type_name.strip()
             if type_name in generics:
                 return _GenericType(type_name)
-            if type_name.startswith('(') and type_name.endswith(')'):
-                return RuntimeType('Tuple', cls._parse_args(type_name[1:-1], generics=generics))
-            start, end = type_name.find('<'), type_name.rfind('>')
+            if type_name.startswith("(") and type_name.endswith(")"):
+                return RuntimeType(
+                    "Tuple", cls._parse_args(type_name[1:-1], generics=generics)
+                )
+            start, end = type_name.find("<"), type_name.rfind(">")
 
             # attempt to upgrade strings to the metric instance
             origin = type_name[:start] if 0 < start else type_name
-            closeness: RuntimeType = { # type: ignore[assignment]
-                'ChangeOneDistance': ChangeOneDistance,
-                'SymmetricDistance': SymmetricDistance,
-                'AbsoluteDistance': AbsoluteDistance,
-                'L1Distance': L1Distance,
-                'L2Distance': L2Distance,
+            closeness: RuntimeType = {  # type: ignore[assignment]
+                "ChangeOneDistance": ChangeOneDistance,
+                "SymmetricDistance": SymmetricDistance,
+                "AbsoluteDistance": AbsoluteDistance,
+                "L1Distance": L1Distance,
+                "L2Distance": L2Distance,
             }.get(origin)
             if closeness is not None:
                 if isinstance(closeness, SensitivityMetric):
-                    return closeness[cls._parse_args(type_name[start + 1: end], generics=generics)[0]]
+                    return closeness[
+                        cls._parse_args(type_name[start + 1 : end], generics=generics)[
+                            0
+                        ]
+                    ]
                 return closeness
 
             if 0 < start < end < len(type_name):
-                return RuntimeType(origin, args=cls._parse_args(type_name[start + 1: end], generics=generics))
+                return RuntimeType(
+                    origin,
+                    args=cls._parse_args(type_name[start + 1 : end], generics=generics),
+                )
             if start == end < 0:
                 if type_name == "int":
                     return _ELEMENTARY_TYPES[int]
                 if type_name == "float":
                     return _ELEMENTARY_TYPES[float]
-                if type_name == "str": # "str" translates to "String"
+                if type_name == "str":  # "str" translates to "String"
                     return _ELEMENTARY_TYPES[str]
                 return type_name
 
@@ -242,7 +281,10 @@ class RuntimeType(object):
 
     @classmethod
     def _parse_args(cls, args, generics: Optional[Sequence[str]] = None):
-        return [cls.parse(v, generics=generics) for v in re.split(r",\s*(?![^()<>]*\))", args)]
+        return [
+            cls.parse(v, generics=generics)
+            for v in re.split(r",\s*(?![^()<>]*\))", args)
+        ]
 
     @classmethod
     def infer(cls, public_example: Any, py_object=False) -> Union["RuntimeType", str]:
@@ -271,26 +313,28 @@ class RuntimeType(object):
         """
         if type(public_example) in _ELEMENTARY_TYPES:
             return _ELEMENTARY_TYPES[type(public_example)]
-        
+
         if isinstance(public_example, (Domain, Metric, Measure)):
             return RuntimeType.parse(public_example.type)
-        
+
         pl = import_optional_dependency("polars", raise_error=False)
         if pl is not None:
             if isinstance(public_example, pl.LazyFrame):
                 return LazyFrame
-            
+
             if isinstance(public_example, pl.DataFrame):
                 return DataFrame
-            
+
             if isinstance(public_example, pl.Series):
                 return Series
-            
+
             if isinstance(public_example, pl.Expr):
                 return Expr
 
         if isinstance(public_example, tuple):
-            return RuntimeType('Tuple', [cls.infer(e, py_object) for e in public_example])
+            return RuntimeType(
+                "Tuple", [cls.infer(e, py_object) for e in public_example]
+            )
 
         def _infer_homogeneous(value):
             types = {cls.infer(v, py_object=py_object) for v in value}
@@ -302,9 +346,9 @@ class RuntimeType(object):
             if py_object:
                 return "ExtrinsicObject"
             raise TypeError(f"elements must be homogeneously typed. Found {types}")
-        
+
         if isinstance(public_example, list):
-            return RuntimeType('Vec', [_infer_homogeneous(public_example)])
+            return RuntimeType("Vec", [_infer_homogeneous(public_example)])
 
         if np is not None and isinstance(public_example, np.ndarray):
             if public_example.ndim == 0:
@@ -313,20 +357,27 @@ class RuntimeType(object):
             if public_example.ndim == 1:
                 inner_type = _ELEMENTARY_TYPES.get(public_example.dtype.type)
                 if inner_type is None:
-                    raise UnknownTypeException(f"Unknown numpy array dtype: {public_example.dtype.type}")  # pragma: no cover
-                return RuntimeType('Vec', [inner_type])
+                    raise UnknownTypeException(
+                        f"Unknown numpy array dtype: {public_example.dtype.type}"
+                    )  # pragma: no cover
+                return RuntimeType("Vec", [inner_type])
 
-            raise UnknownTypeException("arrays with greater than one axis are not yet supported")  # pragma: no cover
+            raise UnknownTypeException(
+                "arrays with greater than one axis are not yet supported"
+            )  # pragma: no cover
 
         if isinstance(public_example, dict):
-            return RuntimeType('HashMap', [
-                _infer_homogeneous(public_example.keys()),
-                _infer_homogeneous(public_example.values())
-            ])
+            return RuntimeType(
+                "HashMap",
+                [
+                    _infer_homogeneous(public_example.keys()),
+                    _infer_homogeneous(public_example.values()),
+                ],
+            )
 
         if public_example is None:
             raise UnknownTypeException("Type of Option cannot be inferred from None")
-        
+
         if callable(public_example):
             return "CallbackFn"
 
@@ -336,10 +387,10 @@ class RuntimeType(object):
 
     @classmethod
     def parse_or_infer(
-            cls,
-            type_name: RuntimeTypeDescriptor | None = None,
-            public_example: Any = None,
-            generics: Optional[Sequence[str]] = None
+        cls,
+        type_name: RuntimeTypeDescriptor | None = None,
+        public_example: Any = None,
+        generics: Optional[Sequence[str]] = None,
     ) -> Union["RuntimeType", str]:
         """If type_name is supplied, normalize it. Otherwise, infer the normalized type from a public example.
 
@@ -356,92 +407,104 @@ class RuntimeType(object):
             return cls.parse(type_name, generics)
         if public_example is not None:
             return cls.infer(public_example)
-        raise UnknownTypeException("either type_name or public_example must be passed")  # pragma: no cover
+        raise UnknownTypeException(
+            "either type_name or public_example must be passed"
+        )  # pragma: no cover
+
 
 def _substitute(value: Union["RuntimeType", str], **kwargs):
-    '''
+    """
     Substitutes any generic type parameters according to the passed keyword arguments
-    
+
     :param value: The type to apply substitutions to
     :param kwargs: The substitutions to apply
-    '''
+    """
     if isinstance(value, _GenericType):
         return kwargs.get(value.origin, value)
     if isinstance(value, RuntimeType):
-        return RuntimeType(value.origin, value.args and [_substitute(arg, **kwargs) for arg in value.args])
+        return RuntimeType(
+            value.origin,
+            value.args and [_substitute(arg, **kwargs) for arg in value.args],
+        )
     return value
-    
+
 
 class _GenericType(RuntimeType):
     def __repr__(self):
-        raise UnknownTypeException(f"attempted to create a type_name with an unknown generic: {self.origin}")  # pragma: no cover
+        raise UnknownTypeException(
+            f"attempted to create a type_name with an unknown generic: {self.origin}"
+        )  # pragma: no cover
 
 
-SymmetricDistance = 'SymmetricDistance'
-InsertDeleteDistance = 'InsertDeleteDistance'
-ChangeOneDistance = 'ChangeOneDistance'
-HammingDistance = 'HammingDistance'
+SymmetricDistance = "SymmetricDistance"
+InsertDeleteDistance = "InsertDeleteDistance"
+ChangeOneDistance = "ChangeOneDistance"
+HammingDistance = "HammingDistance"
 
-DiscreteDistance = 'DiscreteDistance'
+DiscreteDistance = "DiscreteDistance"
 
 
 class SensitivityMetric(RuntimeType):
     """All sensitivity RuntimeTypes inherit from SensitivityMetric.
     Provides static type checking in user-code for sensitivity metrics and a getitem interface like stdlib typing.
     """
+
     def __getitem__(self, associated_type):
         return SensitivityMetric(self.origin, [self.parse(type_name=associated_type)])
 
 
-AbsoluteDistance: SensitivityMetric = SensitivityMetric('AbsoluteDistance')
-L1Distance: SensitivityMetric = SensitivityMetric('L1Distance')
-L2Distance: SensitivityMetric = SensitivityMetric('L2Distance')
+AbsoluteDistance: SensitivityMetric = SensitivityMetric("AbsoluteDistance")
+L1Distance: SensitivityMetric = SensitivityMetric("L1Distance")
+L2Distance: SensitivityMetric = SensitivityMetric("L2Distance")
 
 
-MaxDivergence = 'MaxDivergence'
-SmoothedMaxDivergence = 'SmoothedMaxDivergence'
-FixedSmoothedMaxDivergence = 'FixedSmoothedMaxDivergence'
-ZeroConcentratedDivergence = 'ZeroConcentratedDivergence'
+MaxDivergence = "MaxDivergence"
+SmoothedMaxDivergence = "SmoothedMaxDivergence"
+FixedSmoothedMaxDivergence = "FixedSmoothedMaxDivergence"
+ZeroConcentratedDivergence = "ZeroConcentratedDivergence"
+
 
 class Carrier(RuntimeType):
     def __getitem__(self, subdomains):
         if not isinstance(subdomains, tuple):
             subdomains = (subdomains,)
-        return Carrier(self.origin, [self.parse(type_name=subdomain) for subdomain in subdomains])
+        return Carrier(
+            self.origin, [self.parse(type_name=subdomain) for subdomain in subdomains]
+        )
 
 
-Vec: Carrier = Carrier('Vec')
-NDArray: Carrier = Carrier('NDArray')
-HashMap: Carrier = Carrier('HashMap')
-i8: str = 'i8'
-i16: str = 'i16'
-i32: str = 'i32'
-i64: str = 'i64'
-i128: str = 'i128'
-isize: str = 'isize'
-u8: str = 'u8'
-u16: str = 'u16'
-u32: str = 'u32'
-u64: str = 'u64'
-u128: str = 'u128'
-usize: str = 'usize'
-f32: str = 'f32'
-f64: str = 'f64'
-String: str = 'String'
-BitVector: str = 'BitVector'
-LazyFrame: str = 'LazyFrame'
-DataFrame: str = 'DataFrame'
-Series: str = 'Series'
-Expr: str = 'Expr'
-AnyMeasurementPtr: str = 'AnyMeasurementPtr'
-AnyTransformationPtr: str = 'AnyTransformationPtr'
+Vec: Carrier = Carrier("Vec")
+NDArray: Carrier = Carrier("NDArray")
+HashMap: Carrier = Carrier("HashMap")
+i8: str = "i8"
+i16: str = "i16"
+i32: str = "i32"
+i64: str = "i64"
+i128: str = "i128"
+isize: str = "isize"
+u8: str = "u8"
+u16: str = "u16"
+u32: str = "u32"
+u64: str = "u64"
+u128: str = "u128"
+usize: str = "usize"
+f32: str = "f32"
+f64: str = "f64"
+String: str = "String"
+BitVector: str = "BitVector"
+LazyFrame: str = "LazyFrame"
+DataFrame: str = "DataFrame"
+Series: str = "Series"
+Expr: str = "Expr"
+AnyMeasurementPtr: str = "AnyMeasurementPtr"
+AnyTransformationPtr: str = "AnyTransformationPtr"
 
 
 def get_atom(type_name):
-    '''Parse type name and return the contained atomic type.
-    
+    """Parse type name and return the contained atomic type.
+
     :param type_name: Rust type name
-    '''
+    """
     type_name = RuntimeType.parse(type_name)
     while isinstance(type_name, RuntimeType):
         if isinstance(type_name, _GenericType):
@@ -451,21 +514,21 @@ def get_atom(type_name):
 
 
 def get_atom_or_infer(type_name: Union[RuntimeType, str], example):
-    '''Parse type name and return the contained atomic type,
+    """Parse type name and return the contained atomic type,
     or infer from example.
-    
+
     :param type_name: Rust type name
     :param example: Public example whose type will be inferred
-    '''
+    """
     return get_atom(type_name) or RuntimeType.infer(example)
 
 
 def get_first(value):
-    '''
+    """
     Get first value from iterable.
-    
+
     :param value: An iterable
-    '''
+    """
     if value is None or not len(value):
         return None
     return next(iter(value))
@@ -479,51 +542,58 @@ def get_first_non_null(*values):
     return None
 
 
-def parse_or_infer(type_name: RuntimeTypeDescriptor | None, example) -> Union[RuntimeType, str]:
-    '''
+def parse_or_infer(
+    type_name: RuntimeTypeDescriptor | None, example
+) -> Union[RuntimeType, str]:
+    """
     Given a ``RuntimeTypeDescriptor``, returns a ``RuntimeType`` or ``str``.
 
     :param type_name: Rust type name
     :param example: Public example whose type will be inferred
-    '''
+    """
     return RuntimeType.parse_or_infer(type_name, example)
 
+
 def pass_through(value: Any) -> Any:
-    '''
+    """
     No-op
 
     :param value: Value to pass through
-    '''
+    """
     return value
 
+
 def get_carrier_type(domain: Domain) -> Union[RuntimeType, str]:
-    '''
+    """
     Returns the carrier type for a domain.
 
     :param domain: A domain
-    '''
+    """
     return domain.carrier_type
 
+
 def get_type(element: Union[Domain, Metric, Measure]):
-    '''
+    """
     Returns the type for a supporting element.
 
     :param element: A supporting element
-    '''
+    """
     return element.type
 
+
 def get_value_type(type_descriptor: RuntimeTypeDescriptor):
-    '''
+    """
     Returns the value type for a dict type descriptor.
 
     :param type_descriptor: runtime type
-    '''
-    return RuntimeType.parse(type_descriptor).args[1] # type: ignore[union-attr]
+    """
+    return RuntimeType.parse(type_descriptor).args[1]  # type: ignore[union-attr]
+
 
 def get_distance_type(value: Union[Metric, Measure]) -> Union[RuntimeType, str]:
-    '''
+    """
     Returns the distance type for a metric or measure.
 
     :param value: Metric or measure
-    '''
+    """
     return value.distance_type


### PR DESCRIPTION
- Towards #2787
- Just the effect of running `ruff format ./src/opendp/*.py`
- replaces #2818. Rerunning will be easier than resolving conflicts.

Locally, `pytest -k test_feature_fails` passes. (Failed in CI for earlier PR.)