### PR TITLE
feat: compose privacy guarantees under MultiDP

### DIFF
--- a/rust/src/combinators/sequential_composition/CompositionMeasure_for_MultiDP.tex
+++ b/rust/src/combinators/sequential_composition/CompositionMeasure_for_MultiDP.tex
@@ -1,0 +1,50 @@
+\documentclass{article}
+\input{../../lib.sty}
+
+\title{\texttt{CompositionMeasure for MultiDP}}
+\author{\MichaelShoemateAuthor}
+\date{}
+
+\begin{document}
+\maketitle
+
+\contrib
+Proves soundness of the implementation of \rustdoc{combinators/sequential_composition/trait}{CompositionMeasure} for \texttt{MultiDP}.
+
+\section{Hoare Triple}
+\subsection*{Precondition}
+\subsubsection*{Compiler-verified}
+The output measure is derived from the common capabilities of all child measures.
+Only capabilities with a common composition theorem are retained.
+
+\subsubsection*{Caller-verified}
+None.
+
+\subsection*{Postcondition}
+\begin{theorem}
+\texttt{composability} returns \texttt{Ok(out)} if the composition of a vector of
+privacy guarantees is bounded above by \texttt{compose(d\_mids)} under the
+reported adaptivity and composability. Otherwise it returns an error.
+\end{theorem}
+
+\begin{proof}
+The composition implementation evaluates each representation only when every
+child supplies that representation. Native zCDP parameters are composed by
+adding $\rho_i$ and source deltas. Pure RDP parameters are composed pointwise
+by adding their curves; pure zCDP is embedded into RDP using the exact
+$\alpha\rho_i$ relation. Gaussian-DP parameters, when enabled, are composed by
+$\mu^2 = \sum_i \mu_i^2$.
+
+Each accumulator uses directed interval arithmetic, so its returned value is
+an upper bound on the corresponding exact composition. Approximate profiles
+and tradeoff functions are not composed without a representation-specific
+theorem. If no common supported capability exists, construction fails rather
+than advertising an unsupported composition. Therefore every representation
+retained in the resulting \texttt{PrivacyGuarantee} is a valid bound for the
+same composed privacy relation.
+\end{proof}
+
+\bibliographystyle{alpha}
+\bibliography{ref}
+
+\end{document}

--- a/rust/src/combinators/sequential_composition/ffi.rs
+++ b/rust/src/combinators/sequential_composition/ffi.rs
@@ -2,12 +2,36 @@ use crate::{
     combinators::Composability,
     error::Fallible,
     ffi::any::{AnyMeasure, AnyObject, Downcast},
-    measures::{Approximate, PureDP, RenyiDP, zCDP},
+    measures::{Approximate, MultiDP, PureDP, RenyiDP, zCDP},
 };
 
 use super::{Adaptivity, CompositionMeasure};
 
 impl CompositionMeasure for AnyMeasure {
+    fn compose_measure(measures: &[Self]) -> Fallible<Self> {
+        let Some(first) = measures.first() else {
+            return fallible!(MakeMeasurement, "Must have at least one measurement");
+        };
+
+        fn monomorphize<M: 'static + CompositionMeasure>(
+            _first: &AnyMeasure,
+            measures: &[AnyMeasure],
+        ) -> Fallible<AnyMeasure>
+        where
+            M::Distance: Clone,
+        {
+            let measures = measures
+                .iter()
+                .map(|measure| measure.downcast_ref::<M>().map(Clone::clone))
+                .collect::<Fallible<Vec<M>>>()?;
+            M::compose_measure(&measures).map(AnyMeasure::new)
+        }
+
+        dispatch!(monomorphize, [
+            (first.type_, [PureDP, Approximate<PureDP>, zCDP, Approximate<zCDP>, RenyiDP, MultiDP])
+        ], (first, measures))
+    }
+
     fn composability(&self, adaptivity: Adaptivity) -> Fallible<Composability> {
         fn monomorphize<M: 'static + CompositionMeasure>(
             self_: &AnyMeasure,
@@ -19,7 +43,7 @@ impl CompositionMeasure for AnyMeasure {
             self_.downcast_ref::<M>()?.composability(adaptivity)
         }
         dispatch!(monomorphize, [
-            (self.type_, [PureDP, Approximate<PureDP>, zCDP, Approximate<zCDP>, RenyiDP])
+            (self.type_, [PureDP, Approximate<PureDP>, zCDP, Approximate<zCDP>, RenyiDP, MultiDP])
         ], (self, adaptivity))
     }
     fn compose(&self, d_i: Vec<Self::Distance>) -> Fallible<Self::Distance> {
@@ -40,7 +64,7 @@ impl CompositionMeasure for AnyMeasure {
                 .map(AnyObject::new)
         }
         dispatch!(monomorphize, [
-            (self.type_, [PureDP, Approximate<PureDP>, zCDP, Approximate<zCDP>, RenyiDP])
+            (self.type_, [PureDP, Approximate<PureDP>, zCDP, Approximate<zCDP>, RenyiDP, MultiDP])
         ], (self, d_i))
     }
 }

--- a/rust/src/combinators/sequential_composition/mod.rs
+++ b/rust/src/combinators/sequential_composition/mod.rs
@@ -149,6 +149,7 @@ impl CompositionMeasure for RenyiDP {
     }
 }
 
+#[proven(proof_path = "combinators/sequential_composition/CompositionMeasure_for_MultiDP.tex")]
 impl CompositionMeasure for MultiDP {
     fn composability(&self, _adaptivity: Adaptivity) -> Fallible<Composability> {
         // Representation-specific approximate-RDP and approximate-zCDP deltas

--- a/rust/src/combinators/sequential_composition/mod.rs
+++ b/rust/src/combinators/sequential_composition/mod.rs
@@ -152,7 +152,8 @@ impl CompositionMeasure for RenyiDP {
 impl CompositionMeasure for MultiDP {
     fn composability(&self, _adaptivity: Adaptivity) -> Fallible<Composability> {
         // Representation-specific approximate-RDP and approximate-zCDP deltas
-        // currently have sequential composition theorems.
+        // currently have sequential composition theorems. Privacy profiles and
+        // tradeoff functions are intentionally not composition capabilities.
         Ok(Composability::Sequential)
     }
 

--- a/rust/src/combinators/sequential_composition/mod.rs
+++ b/rust/src/combinators/sequential_composition/mod.rs
@@ -20,7 +20,7 @@ mod ffi;
 use crate::{
     core::{Function, Measure},
     error::Fallible,
-    measures::{Approximate, PureDP, RenyiDP, zCDP},
+    measures::{Approximate, MultiDP, PrivacyGuarantee, PureDP, RenyiDP, zCDP},
     traits::InfAdd,
 };
 
@@ -50,6 +50,23 @@ pub enum Composability {
 /// Otherwise returns an error.
 pub trait CompositionMeasure: Measure {
     fn composability(&self, adaptivity: Adaptivity) -> Fallible<Composability>;
+
+    /// Derive the output measure from the measures of all child measurements.
+    ///
+    /// Most measures are only composable when all children use the same
+    /// measure, so the default implementation preserves that behavior.
+    /// Measures whose equality intentionally ignores construction metadata can
+    /// override this hook to derive a sound output descriptor instead.
+    fn compose_measure(measures: &[Self]) -> Fallible<Self> {
+        let Some(first) = measures.first() else {
+            return fallible!(MakeMeasurement, "Must have at least one measurement");
+        };
+        if !measures.iter().all(|measure| measure == first) {
+            return fallible!(MetricMismatch, "All output measures must be the same");
+        }
+        Ok(first.clone())
+    }
+
     fn compose(&self, d_mids: Vec<Self::Distance>) -> Fallible<Self::Distance>;
 }
 
@@ -129,5 +146,69 @@ impl CompositionMeasure for RenyiDP {
                 .map(|f| f.eval(alpha))
                 .try_fold(0.0, |sum, eps| privacy_loss_add(sum, eps?))
         }))
+    }
+}
+
+impl CompositionMeasure for MultiDP {
+    fn composability(&self, _adaptivity: Adaptivity) -> Fallible<Composability> {
+        // Representation-specific approximate-RDP and approximate-zCDP deltas
+        // currently have sequential composition theorems.
+        Ok(Composability::Sequential)
+    }
+
+    fn compose_measure(measures: &[Self]) -> Fallible<Self> {
+        if measures.is_empty() {
+            return fallible!(MakeMeasurement, "Must have at least one measurement");
+        }
+
+        let capabilities = measures.iter().map(|measure| measure.capabilities());
+        let capabilities = capabilities.collect::<Vec<_>>();
+
+        // Native zCDP composition is available whenever every child
+        // guarantees zCDP. Purity is the meet of the child guarantees.
+        let zcdp = capabilities.iter().all(|caps| caps.zcdp().is_some());
+
+        // Pure zCDP embeds into pure RDP. Native pure RDP is the other
+        // supported RDP path. Approximate representations are deliberately
+        // excluded from this exact-RDP capability.
+        let renyi = capabilities.iter().all(|caps| {
+            caps.renyi() == Some(crate::measures::Purity::Pure)
+                || caps.zcdp() == Some(crate::measures::Purity::Pure)
+        });
+
+        let gaussian = capabilities.iter().all(|caps| caps.gaussian());
+        if !zcdp && !renyi && !gaussian {
+            return fallible!(
+                FailedFunction,
+                "MultiDP composition has no supported common capability path"
+            );
+        }
+
+        let mut derived = crate::measures::PrivacyCapabilities::default();
+        if zcdp {
+            let purity = if capabilities
+                .iter()
+                .all(|caps| caps.zcdp() == Some(crate::measures::Purity::Pure))
+            {
+                crate::measures::Purity::Pure
+            } else {
+                crate::measures::Purity::Approximate
+            };
+            derived = derived.with_zcdp(purity);
+        }
+        if renyi {
+            derived = derived.with_renyi(crate::measures::Purity::Pure);
+        }
+        if gaussian {
+            derived = derived.with_gaussian();
+        }
+
+        // Keep this independent of the first child's descriptor. MultiDP
+        // equality intentionally ignores capability richness.
+        Ok(MultiDP::new(derived))
+    }
+
+    fn compose(&self, d_mids: Vec<Self::Distance>) -> Fallible<Self::Distance> {
+        PrivacyGuarantee::compose(d_mids)
     }
 }

--- a/rust/src/combinators/sequential_composition/non_adaptive/mod.rs
+++ b/rust/src/combinators/sequential_composition/non_adaptive/mod.rs
@@ -50,7 +50,12 @@ where
     }
     let input_domain = measurements[0].input_domain.clone();
     let input_metric = measurements[0].input_metric.clone();
-    let output_measure = measurements[0].output_measure.clone();
+    let output_measure = MO::compose_measure(
+        &measurements
+            .iter()
+            .map(|measurement| measurement.output_measure.clone())
+            .collect::<Vec<_>>(),
+    )?;
 
     if !measurements.iter().all(|v| input_domain == v.input_domain) {
         return fallible!(DomainMismatch, "All input domains must be the same");
@@ -58,13 +63,6 @@ where
     if !measurements.iter().all(|v| input_metric == v.input_metric) {
         return fallible!(MetricMismatch, "All input metrics must be the same");
     }
-    if !measurements
-        .iter()
-        .all(|v| output_measure == v.output_measure)
-    {
-        return fallible!(MetricMismatch, "All output measures must be the same");
-    }
-
     let functions = measurements
         .iter()
         .map(|m| m.function.clone())

--- a/rust/src/combinators/sequential_composition/non_adaptive/test.rs
+++ b/rust/src/combinators/sequential_composition/non_adaptive/test.rs
@@ -2,7 +2,7 @@ use crate::core::*;
 use crate::domains::AtomDomain;
 use crate::interactive::Queryable;
 use crate::measurements::make_laplace;
-use crate::measures::{Approximate, PureDP, RenyiDP, zCDP};
+use crate::measures::{Approximate, MultiDP, PrivacyGuarantee, PureDP, Purity, RenyiDP, zCDP};
 use crate::metrics::{AbsoluteDistance, DiscreteDistance};
 
 use super::*;
@@ -65,6 +65,158 @@ fn test_rdp_composition() -> Fallible<()> {
     // then we are composing two queries, so the total loss is 6. * 2. = 12.
     let rdp_curve = composition.map(&2.)?;
     assert_eq!(rdp_curve.eval(&3.0)?, 12.0);
+    Ok(())
+}
+
+#[test]
+fn test_multidp_composition_derives_capabilities_from_all_children() -> Fallible<()> {
+    let domain = AtomDomain::<i32>::default();
+    let metric = AbsoluteDistance::<i32>::default();
+    let rdp_child = Measurement::new(
+        domain.clone(),
+        metric.clone(),
+        MultiDP::with_renyi(Purity::Pure),
+        Function::new(|arg: &i32| *arg),
+        PrivacyMap::new_fallible(|_| {
+            PrivacyGuarantee::new().with_renyiDP_trusted(|alpha| Ok(alpha), 0.0)
+        }),
+    )?;
+    let zcdp_child = Measurement::new(
+        domain,
+        metric,
+        MultiDP::with_zcdp(Purity::Pure),
+        Function::new(|arg: &i32| *arg),
+        PrivacyMap::new_fallible(|_| PrivacyGuarantee::new().with_zCDP(0.1, 0.0)),
+    )?;
+
+    let composition = make_composition(vec![rdp_child, zcdp_child])?;
+    assert_eq!(
+        composition.output_measure.capabilities().renyi(),
+        Some(Purity::Pure)
+    );
+    assert_eq!(composition.output_measure.capabilities().zcdp(), None);
+    assert!(composition.map(&1)?.epsilon(1e-3)?.is_finite());
+    Ok(())
+}
+
+#[test]
+fn test_multidp_composition_meets_zcdp_purity() -> Fallible<()> {
+    let pure = Measurement::new(
+        AtomDomain::<i32>::default(),
+        AbsoluteDistance::<i32>::default(),
+        MultiDP::with_zcdp(Purity::Pure),
+        Function::new(|arg: &i32| *arg),
+        PrivacyMap::new_fallible(|_| PrivacyGuarantee::new().with_zCDP(0.1, 0.0)),
+    )?;
+    let approximate = Measurement::new(
+        AtomDomain::<i32>::default(),
+        AbsoluteDistance::<i32>::default(),
+        MultiDP::with_zcdp(Purity::Approximate),
+        Function::new(|arg: &i32| *arg),
+        PrivacyMap::new_fallible(|_| PrivacyGuarantee::new().with_zCDP(0.2, 0.01)),
+    )?;
+
+    let composition = make_composition(vec![pure, approximate])?;
+    assert_eq!(
+        composition.output_measure.capabilities().zcdp(),
+        Some(Purity::Approximate)
+    );
+    assert_eq!(composition.output_measure.capabilities().renyi(), None);
+    Ok(())
+}
+
+#[test]
+fn test_multidp_composition_requires_a_common_capability_path() -> Fallible<()> {
+    let make_measurement = |measure| {
+        Measurement::new(
+            AtomDomain::<i32>::default(),
+            AbsoluteDistance::<i32>::default(),
+            measure,
+            Function::new(|arg: &i32| *arg),
+            PrivacyMap::new(|_| PrivacyGuarantee::new()),
+        )
+    };
+    let profile = make_measurement(MultiDP::with_profile(Purity::Pure))?;
+    let tradeoff = make_measurement(MultiDP::with_tradeoff())?;
+
+    let error = make_composition(vec![profile, tradeoff]).unwrap_err();
+    assert_eq!(
+        error.message.as_deref(),
+        Some("MultiDP composition has no supported common capability path")
+    );
+    Ok(())
+}
+
+#[cfg(feature = "idealized-numerics")]
+#[test]
+fn test_multidp_composes_native_gaussian_dp() -> Fallible<()> {
+    let make_measurement = |mu| {
+        Measurement::new(
+            AtomDomain::<i32>::default(),
+            AbsoluteDistance::<i32>::default(),
+            MultiDP::with_gaussian(),
+            Function::new(|arg: &i32| *arg),
+            PrivacyMap::new_fallible(move |_| PrivacyGuarantee::new().with_gaussianDP(mu)),
+        )
+    };
+    let composition = make_composition(vec![make_measurement(0.3)?, make_measurement(0.4)?])?;
+    assert!(composition.output_measure.capabilities().gaussian());
+    assert!(composition.map(&1)?.delta(1.0)?.is_finite());
+    Ok(())
+}
+
+#[cfg(feature = "idealized-numerics")]
+#[test]
+fn test_multidp_runtime_extras_do_not_enlarge_capabilities() -> Fallible<()> {
+    let make_measurement = |mu| {
+        Measurement::new(
+            AtomDomain::<i32>::default(),
+            AbsoluteDistance::<i32>::default(),
+            MultiDP::with_zcdp(Purity::Pure),
+            Function::new(|arg: &i32| *arg),
+            PrivacyMap::new_fallible(move |_| {
+                PrivacyGuarantee::new()
+                    .with_zCDP(0.1, 0.0)
+                    .and_then(|guarantee| guarantee.with_gaussianDP(mu))
+            }),
+        )
+    };
+    let composition = make_composition(vec![make_measurement(0.3)?, make_measurement(0.4)?])?;
+    assert_eq!(
+        composition.output_measure.capabilities().zcdp(),
+        Some(Purity::Pure)
+    );
+    assert!(!composition.output_measure.capabilities().gaussian());
+    assert!(composition.map(&1)?.delta(1.0)?.is_finite());
+    Ok(())
+}
+
+#[cfg(feature = "idealized-numerics")]
+#[test]
+fn test_multidp_composition_ignores_optional_path_failure() -> Fallible<()> {
+    let domain = AtomDomain::<i32>::default();
+    let metric = AbsoluteDistance::<i32>::default();
+    let first = Measurement::new(
+        domain.clone(),
+        metric.clone(),
+        MultiDP::with_zcdp(Purity::Pure),
+        Function::new(|arg: &i32| *arg),
+        PrivacyMap::new_fallible(|_| {
+            PrivacyGuarantee::new()
+                .with_zCDP(0.1, 0.0)
+                .and_then(|guarantee| guarantee.with_gaussianDP(f64::MAX))
+        }),
+    )?;
+    let second = Measurement::new(
+        domain,
+        metric,
+        MultiDP::with_zcdp(Purity::Pure),
+        Function::new(|arg: &i32| *arg),
+        PrivacyMap::new_fallible(|_| PrivacyGuarantee::new().with_zCDP(0.2, 0.0)),
+    )?;
+
+    let composition = make_composition(vec![first, second])?;
+    assert!(composition.map(&1)?.epsilon(1e-3)?.is_finite());
     Ok(())
 }
 

--- a/rust/src/measures/curves/composition.rs
+++ b/rust/src/measures/curves/composition.rs
@@ -10,7 +10,9 @@ impl PrivacyGuarantee {
     /// Compose privacy guarantees while retaining every supported runtime
     /// representation. Static capability selection is performed by
     /// `CompositionMeasure::compose_measure`; this method only evaluates
-    /// representations that happen to be present at runtime.
+    /// representations that happen to be present at runtime. Privacy profiles
+    /// and tradeoff functions have no generic composition rule here: they are
+    /// omitted, even when another supported representation is also present.
     pub(crate) fn compose(curves: Vec<Self>) -> Fallible<Self> {
         if curves.is_empty() {
             let mut identity = PrivacyGuarantee::new();

--- a/rust/src/measures/curves/composition.rs
+++ b/rust/src/measures/curves/composition.rs
@@ -1,0 +1,312 @@
+use std::sync::Arc;
+
+use super::{PrivacyGuarantee, RenyiFn, RenyiRepresentation, ZCDPRepresentation, check_rho};
+use crate::{
+    error::Fallible,
+    traits::{SInterval, backend::Dashu},
+};
+
+impl PrivacyGuarantee {
+    /// Compose privacy guarantees while retaining every supported runtime
+    /// representation. Static capability selection is performed by
+    /// `CompositionMeasure::compose_measure`; this method only evaluates
+    /// representations that happen to be present at runtime.
+    pub(crate) fn compose(curves: Vec<Self>) -> Fallible<Self> {
+        if curves.is_empty() {
+            let mut identity = PrivacyGuarantee::new();
+            identity.renyi = Some(RenyiRepresentation {
+                curve: Arc::new(|_| Ok(0.0)),
+                source_delta: 0.0,
+            });
+            identity.zcdp = Some(ZCDPRepresentation {
+                rho: 0.0,
+                source_delta: 0.0,
+            });
+            #[cfg(feature = "idealized-numerics")]
+            {
+                identity.gaussian = Some(super::GaussianDPRepresentation { mu: 0.0 });
+            }
+            return Ok(identity);
+        }
+
+        let mut out = PrivacyGuarantee::new();
+        let mut path_errors = Vec::new();
+
+        #[cfg(feature = "idealized-numerics")]
+        match compose_gaussianDP(&curves) {
+            Ok(gaussian) => out.gaussian = gaussian,
+            Err(error) => path_errors.push(error),
+        }
+        match compose_renyiDP(&curves) {
+            Ok(renyi) => out.renyi = renyi,
+            Err(error) => path_errors.push(error),
+        }
+        match compose_zCDP(&curves) {
+            Ok(zcdp) => out.zcdp = zcdp,
+            Err(error) => path_errors.push(error),
+        }
+
+        let has_representation = out.renyi.is_some() || out.zcdp.is_some() || {
+            #[cfg(feature = "idealized-numerics")]
+            {
+                out.gaussian.is_some()
+            }
+            #[cfg(not(feature = "idealized-numerics"))]
+            {
+                false
+            }
+        };
+        if !has_representation {
+            if let Some(error) = path_errors.into_iter().next() {
+                return Err(error);
+            }
+            return fallible!(
+                FailedFunction,
+                "PrivacyGuarantee composition has no supported common representation"
+            );
+        }
+
+        Ok(out)
+    }
+}
+
+/// Gaussian-DP composition is analytic: mu_total² = sum_i mu_i².
+#[cfg(feature = "idealized-numerics")]
+#[allow(non_snake_case)]
+fn compose_gaussianDP(
+    curves: &[PrivacyGuarantee],
+) -> Fallible<Option<super::GaussianDPRepresentation>> {
+    if curves.iter().any(|curve| curve.gaussian.is_none()) {
+        return Ok(None);
+    }
+
+    let mut sum_mu2 = SInterval::<Dashu>::point(0.0)?;
+    for curve in curves {
+        let mu = curve.gaussian.unwrap().mu;
+        let mu = SInterval::<Dashu>::point(mu)?;
+        sum_mu2 = (sum_mu2 + (mu.clone() * mu)?)?;
+    }
+
+    let mu = sum_mu2.sqrt()?.upper_f64()?;
+    if !mu.is_finite() {
+        return fallible!(Overflow, "composed Gaussian DP parameter is not finite");
+    }
+    Ok(Some(super::GaussianDPRepresentation { mu }))
+}
+
+/// Native approximate-zCDP representations compose by adding rho and source
+/// delta. No RDP-to-zCDP conversion is attempted.
+#[allow(non_snake_case)]
+fn compose_zCDP(curves: &[PrivacyGuarantee]) -> Fallible<Option<ZCDPRepresentation>> {
+    if curves.iter().any(|curve| curve.zcdp.is_none()) {
+        return Ok(None);
+    }
+
+    let mut rho_sum = SInterval::<Dashu>::point(0.0)?;
+    let mut delta_sum = SInterval::<Dashu>::point(0.0)?;
+    let mut rho_is_infinite = false;
+
+    for curve in curves {
+        let ZCDPRepresentation { rho, source_delta } = curve.zcdp.unwrap();
+        check_rho(rho)?;
+        super::check_delta(source_delta)?;
+
+        if rho.is_infinite() {
+            rho_is_infinite = true;
+        } else {
+            rho_sum = (rho_sum + SInterval::<Dashu>::point(rho)?)?;
+        }
+        delta_sum = (delta_sum + SInterval::<Dashu>::point(source_delta)?)?;
+    }
+
+    Ok(Some(ZCDPRepresentation {
+        rho: if rho_is_infinite {
+            f64::INFINITY
+        } else {
+            rho_sum.upper_f64()?
+        },
+        source_delta: delta_sum.upper_f64()?.min(1.0),
+    }))
+}
+
+#[derive(Clone)]
+enum RdpComponent {
+    Native(Arc<RenyiFn>),
+    ZCDP(f64),
+    Minimum { native: Arc<RenyiFn>, zcdp_rho: f64 },
+}
+
+/// Compose RDP using native pure RDP and the approved pure-zCDP embedding.
+/// Approximate zCDP is never embedded into exact RDP.
+#[allow(non_snake_case)]
+fn compose_renyiDP(curves: &[PrivacyGuarantee]) -> Fallible<Option<RenyiRepresentation>> {
+    let mut components = Vec::with_capacity(curves.len());
+    let mut source_delta = 0.0;
+
+    // If an all-exact path exists, use it independently of any approximate
+    // native RDP representation. This prevents an invalid pointwise minimum
+    // between approximate RDP and exact zCDP.
+    let has_exact_path = curves.iter().all(|guarantee| {
+        matches!(
+            guarantee.renyi,
+            Some(RenyiRepresentation {
+                source_delta: 0.0,
+                ..
+            })
+        ) || matches!(
+            guarantee.zcdp,
+            Some(ZCDPRepresentation {
+                source_delta: 0.0,
+                ..
+            })
+        )
+    });
+
+    for guarantee in curves {
+        let component = if has_exact_path {
+            match (&guarantee.renyi, guarantee.zcdp) {
+                (
+                    Some(RenyiRepresentation {
+                        curve,
+                        source_delta: 0.0,
+                    }),
+                    Some(ZCDPRepresentation {
+                        rho,
+                        source_delta: 0.0,
+                    }),
+                ) => {
+                    check_rho(rho)?;
+                    RdpComponent::Minimum {
+                        native: curve.clone(),
+                        zcdp_rho: rho,
+                    }
+                }
+                (
+                    Some(RenyiRepresentation {
+                        curve,
+                        source_delta: 0.0,
+                    }),
+                    _,
+                ) => RdpComponent::Native(curve.clone()),
+                (
+                    _,
+                    Some(ZCDPRepresentation {
+                        rho,
+                        source_delta: 0.0,
+                    }),
+                ) => {
+                    check_rho(rho)?;
+                    RdpComponent::ZCDP(rho)
+                }
+                _ => unreachable!("exact RDP path was checked above"),
+            }
+        } else {
+            match (&guarantee.renyi, guarantee.zcdp) {
+                (
+                    Some(RenyiRepresentation {
+                        curve,
+                        source_delta,
+                    }),
+                    _,
+                ) if *source_delta == 0.0 => RdpComponent::Native(curve.clone()),
+                (
+                    Some(RenyiRepresentation {
+                        curve,
+                        source_delta: native_delta,
+                    }),
+                    Some(ZCDPRepresentation {
+                        source_delta: 0.0, ..
+                    }),
+                ) => {
+                    // Approximate native RDP cannot be intersected with exact
+                    // zCDP. It is retained only as an approximate path when
+                    // no all-exact composition path exists.
+                    super::check_delta(*native_delta)?;
+                    source_delta = *native_delta;
+                    RdpComponent::Native(curve.clone())
+                }
+                (Some(RenyiRepresentation { .. }), _) => return Ok(None),
+                (
+                    None,
+                    Some(ZCDPRepresentation {
+                        rho,
+                        source_delta: 0.0,
+                    }),
+                ) => {
+                    check_rho(rho)?;
+                    RdpComponent::ZCDP(rho)
+                }
+                // An approximate zCDP source delta is local to zCDP and is
+                // not silently reinterpreted as approximate-RDP source delta.
+                (None, Some(ZCDPRepresentation { .. })) | (None, None) => return Ok(None),
+            }
+        };
+        components.push(component);
+    }
+
+    if source_delta != 0.0 && curves.len() != 1 {
+        return Ok(None);
+    }
+
+    let curve = Arc::new(move |alpha: f64| -> Fallible<f64> {
+        check_renyi_order(alpha)?;
+        let mut sum = SInterval::<Dashu>::point(0.0)?;
+        for component in &components {
+            let epsilon = match component {
+                RdpComponent::Native(native) => eval_native_rdp(native.as_ref(), alpha)?,
+                RdpComponent::ZCDP(rho) => eval_zcdp_rdp(*rho, alpha)?,
+                RdpComponent::Minimum { native, zcdp_rho } => {
+                    let native = eval_native_rdp(native.as_ref(), alpha);
+                    let zcdp = eval_zcdp_rdp(*zcdp_rho, alpha);
+                    match (native, zcdp) {
+                        (Ok(native), Ok(zcdp)) => native.min(zcdp),
+                        (Ok(native), Err(_)) => native,
+                        (Err(_), Ok(zcdp)) => zcdp,
+                        (Err(error), Err(_)) => return Err(error),
+                    }
+                }
+            };
+            if epsilon.is_infinite() {
+                return Ok(f64::INFINITY);
+            }
+            sum = (sum + SInterval::<Dashu>::point(epsilon)?)?;
+        }
+        sum.upper_f64()
+    });
+
+    Ok(Some(RenyiRepresentation {
+        curve,
+        source_delta,
+    }))
+}
+
+fn eval_native_rdp(curve: &RenyiFn, alpha: f64) -> Fallible<f64> {
+    let epsilon = curve(alpha)?;
+    if epsilon.is_nan() || epsilon.is_sign_negative() {
+        return fallible!(
+            FailedMap,
+            "RDP epsilon ({epsilon}) must be non-negative and not NaN"
+        );
+    }
+    Ok(epsilon)
+}
+
+fn eval_zcdp_rdp(rho: f64, alpha: f64) -> Fallible<f64> {
+    if rho.is_infinite() {
+        return Ok(f64::INFINITY);
+    }
+    (SInterval::<Dashu>::point(alpha)? * SInterval::<Dashu>::point(rho)?)?.upper_f64()
+}
+
+fn check_renyi_order(alpha: f64) -> Fallible<()> {
+    if !alpha.is_finite() || alpha <= 1.0 {
+        return fallible!(
+            FailedMap,
+            "Rényi order alpha ({alpha}) must be finite and greater than one"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod test;

--- a/rust/src/measures/curves/composition/test.rs
+++ b/rust/src/measures/curves/composition/test.rs
@@ -1,0 +1,165 @@
+use super::*;
+#[cfg(feature = "contrib")]
+use crate::{
+    combinators::CompositionMeasure,
+    measures::{MultiDP, PrivacyProfile},
+};
+
+fn rdp_epsilon(curve: &PrivacyGuarantee, alpha: f64) -> Fallible<f64> {
+    (curve.renyi.as_ref().unwrap().curve)(alpha)
+}
+
+#[test]
+fn test_composition_retains_supported_approximate_zcdp() -> Fallible<()> {
+    let first = PrivacyGuarantee::new().with_zCDP(0.1, 0.1)?;
+    let second = PrivacyGuarantee::new().with_zCDP(0.2, 0.2)?;
+    let composed = PrivacyGuarantee::compose(vec![first, second])?;
+
+    assert!(composed.renyi.is_none());
+    let zcdp = composed.zcdp.unwrap();
+    assert!(zcdp.rho >= 0.3);
+    assert!((0.3..0.4).contains(&zcdp.source_delta));
+    Ok(())
+}
+
+#[test]
+fn test_zcdp_and_rdp_compose_via_rdp() -> Fallible<()> {
+    let zcdp = PrivacyGuarantee::new().with_zCDP(0.2, 0.0)?;
+    let rdp = PrivacyGuarantee::new().with_renyiDP_trusted(|_| Ok(0.1), 0.0)?;
+    let composed = PrivacyGuarantee::compose(vec![zcdp, rdp])?;
+
+    assert!(composed.renyi.is_some());
+    assert!(composed.zcdp.is_none());
+    assert!(rdp_epsilon(&composed, 2.0)? >= 0.5);
+    Ok(())
+}
+
+#[cfg(feature = "contrib")]
+#[test]
+fn test_sequential_composition_uses_guarantee_composition() -> Fallible<()> {
+    let zcdp = PrivacyGuarantee::new().with_zCDP(0.2, 0.0)?;
+    let rdp = PrivacyGuarantee::new().with_renyiDP_trusted(|_| Ok(0.1), 0.0)?;
+    let composed = MultiDP::default().compose(vec![zcdp, rdp])?;
+
+    assert!(composed.renyi.is_some());
+    assert!(composed.zcdp.is_none());
+    Ok(())
+}
+
+#[test]
+fn test_rdp_uses_tighter_native_or_zcdp_bound_pointwise() -> Fallible<()> {
+    let curve = PrivacyGuarantee::new()
+        .with_renyiDP_trusted(|alpha| Ok(if alpha < 3.0 { alpha * 2.0 } else { 1.0 }), 0.0)?
+        .with_zCDP(1.0, 0.0)?;
+    let composed = PrivacyGuarantee::compose(vec![curve])?;
+
+    assert_eq!(rdp_epsilon(&composed, 2.0)?, 2.0);
+    assert_eq!(rdp_epsilon(&composed, 4.0)?, 1.0);
+    Ok(())
+}
+
+#[test]
+fn test_approximate_rdp_does_not_intersect_exact_zcdp() -> Fallible<()> {
+    let curve = PrivacyGuarantee::new()
+        .with_renyiDP_trusted(|_| Ok(0.5), 0.1)?
+        .with_zCDP(10.0, 0.0)?;
+    let composed = PrivacyGuarantee::compose(vec![curve])?;
+
+    // The approximate native RDP fact is not pointwise-minimized with exact
+    // zCDP. The independent exact zCDP path is used instead.
+    assert_eq!(rdp_epsilon(&composed, 2.0)?, 20.0);
+    assert_eq!(composed.renyi.unwrap().source_delta, 0.0);
+    Ok(())
+}
+
+#[test]
+fn test_rdp_zcdp_and_zcdp_retain_both() -> Fallible<()> {
+    let both = PrivacyGuarantee::new()
+        .with_renyiDP_trusted(|_| Ok(0.5), 0.0)?
+        .with_zCDP(0.1, 0.0)?;
+    let zcdp = PrivacyGuarantee::new().with_zCDP(0.2, 0.0)?;
+    let composed = PrivacyGuarantee::compose(vec![both, zcdp])?;
+
+    assert!(composed.renyi.is_some());
+    assert!(composed.zcdp.is_some());
+    assert!(rdp_epsilon(&composed, 2.0)? >= 0.6);
+    assert!(composed.zcdp.unwrap().rho >= 0.3);
+    Ok(())
+}
+
+#[test]
+fn test_profile_only_composition_has_no_supported_path() -> Fallible<()> {
+    let first = PrivacyGuarantee::from_profile(PrivacyProfile::new(|_| Ok(0.1)));
+    let second = PrivacyGuarantee::from_profile(PrivacyProfile::new(|_| Ok(0.2)));
+    let error = PrivacyGuarantee::compose(vec![first, second]).unwrap_err();
+    assert_eq!(
+        error.message.as_deref(),
+        Some("PrivacyGuarantee composition has no supported common representation")
+    );
+    Ok(())
+}
+
+#[test]
+fn test_nary_composition() -> Fallible<()> {
+    let curves = [0.1, 0.2, 0.3, 0.4]
+        .into_iter()
+        .map(|rho| PrivacyGuarantee::new().with_zCDP(rho, 0.0))
+        .collect::<Fallible<Vec<_>>>()?;
+    let composed = PrivacyGuarantee::compose(curves)?;
+    assert!(composed.zcdp.unwrap().rho >= 1.0);
+    Ok(())
+}
+
+#[test]
+fn test_rdp_optional_callback_error_uses_independent_zcdp_path() -> Fallible<()> {
+    let failing = PrivacyGuarantee::new()
+        .with_renyiDP_trusted(
+            |_| fallible!(FailedFunction, "optional RDP path failed"),
+            0.0,
+        )?
+        .with_zCDP(0.1, 0.0)?;
+    let composed = PrivacyGuarantee::compose(vec![failing])?;
+    assert_eq!(rdp_epsilon(&composed, 2.0)?, 0.2);
+    Ok(())
+}
+
+#[test]
+fn test_approximate_zcdp_delta_is_not_embedded_into_rdp() -> Fallible<()> {
+    let first = PrivacyGuarantee::new().with_zCDP(0.1, 0.01)?;
+    let second = PrivacyGuarantee::new().with_zCDP(0.2, 0.02)?;
+    let composed = PrivacyGuarantee::compose(vec![first, second])?;
+
+    assert!(composed.renyi.is_none());
+    assert!(composed.zcdp.unwrap().source_delta >= 0.03);
+    Ok(())
+}
+
+#[test]
+fn test_approximate_rdp_composition_requires_a_theorem() -> Fallible<()> {
+    let first = PrivacyGuarantee::new()
+        .with_renyiDP_trusted(|_| Ok(0.1), 0.03)?
+        .with_zCDP(0.2, 0.4)?;
+    let second = PrivacyGuarantee::new().with_renyiDP_trusted(|_| Ok(0.2), 0.05)?;
+    let error = PrivacyGuarantee::compose(vec![first, second]).unwrap_err();
+    assert_eq!(
+        error.message.as_deref(),
+        Some("PrivacyGuarantee composition has no supported common representation")
+    );
+    Ok(())
+}
+
+#[test]
+fn test_composition_identity() -> Fallible<()> {
+    let identity = PrivacyGuarantee::compose(vec![])?;
+    assert_eq!(identity.delta(0.0)?, 0.0);
+    Ok(())
+}
+
+#[cfg(feature = "idealized-numerics")]
+#[test]
+fn test_gaussian_composition_rejects_overflow() -> Fallible<()> {
+    let first = PrivacyGuarantee::new().with_gaussianDP(f64::MAX)?;
+    let second = PrivacyGuarantee::new().with_gaussianDP(f64::MAX)?;
+    assert!(PrivacyGuarantee::compose(vec![first, second]).is_err());
+    Ok(())
+}

--- a/rust/src/measures/curves/composition/test.rs
+++ b/rust/src/measures/curves/composition/test.rs
@@ -1,9 +1,7 @@
 use super::*;
+use crate::measures::PrivacyProfile;
 #[cfg(feature = "contrib")]
-use crate::{
-    combinators::CompositionMeasure,
-    measures::{MultiDP, PrivacyProfile},
-};
+use crate::{combinators::CompositionMeasure, measures::MultiDP};
 
 fn rdp_epsilon(curve: &PrivacyGuarantee, alpha: f64) -> Fallible<f64> {
     (curve.renyi.as_ref().unwrap().curve)(alpha)
@@ -100,6 +98,41 @@ fn test_profile_only_composition_has_no_supported_path() -> Fallible<()> {
 }
 
 #[test]
+fn test_point_backed_profile_is_not_composed_as_approximate_dp() -> Fallible<()> {
+    let profile = PrivacyProfile::new(|_| Ok(1.0)).with_approxDP(vec![(0.1, 0.2)])?;
+    assert!(
+        PrivacyGuarantee::compose(vec![PrivacyGuarantee::from_profile(profile.clone(),)]).is_err()
+    );
+    let first = PrivacyGuarantee::from_profile(profile.clone());
+    let second = PrivacyGuarantee::from_profile(profile);
+    assert!(PrivacyGuarantee::compose(vec![first, second]).is_err());
+
+    let first = PrivacyGuarantee::from_profile(
+        PrivacyProfile::new(|_| Ok(1.0)).with_approxDP(vec![(0.1, 0.2)])?,
+    )
+    .with_zCDP(0.1, 0.0)?;
+    let second = PrivacyGuarantee::new().with_zCDP(0.2, 0.0)?;
+    let composed = PrivacyGuarantee::compose(vec![first, second])?;
+
+    assert!(composed.profile.is_none());
+    assert!((0.3..0.31).contains(&composed.zcdp.unwrap().rho));
+    Ok(())
+}
+
+#[cfg(feature = "honest-but-curious")]
+#[test]
+fn test_tradeoff_only_composition_has_no_supported_path() -> Fallible<()> {
+    let first = PrivacyGuarantee::new().with_tradeoff(|_| Ok(0.5))?;
+    let second = PrivacyGuarantee::new().with_tradeoff(|_| Ok(0.4))?;
+    let error = PrivacyGuarantee::compose(vec![first, second]).unwrap_err();
+    assert_eq!(
+        error.message.as_deref(),
+        Some("PrivacyGuarantee composition has no supported common representation")
+    );
+    Ok(())
+}
+
+#[test]
 fn test_nary_composition() -> Fallible<()> {
     let curves = [0.1, 0.2, 0.3, 0.4]
         .into_iter()
@@ -151,6 +184,12 @@ fn test_approximate_rdp_composition_requires_a_theorem() -> Fallible<()> {
 #[test]
 fn test_composition_identity() -> Fallible<()> {
     let identity = PrivacyGuarantee::compose(vec![])?;
+    assert!(identity.profile.is_none());
+    assert!(identity.tradeoff.is_none());
+    assert!(identity.renyi.is_some());
+    assert!(identity.zcdp.is_some());
+    #[cfg(feature = "idealized-numerics")]
+    assert!(identity.gaussian.is_some());
     assert_eq!(identity.delta(0.0)?, 0.0);
     Ok(())
 }

--- a/rust/src/measures/curves/mod.rs
+++ b/rust/src/measures/curves/mod.rs
@@ -20,6 +20,7 @@ mod tradeoff;
 #[cfg(feature = "ffi")]
 mod zcdp_ffi;
 
+mod composition;
 #[cfg(feature = "ffi")]
 mod renyidp_ffi;
 #[cfg(feature = "ffi")]


### PR DESCRIPTION
## Summary

- compose each supported `PrivacyGuarantee` representation independently
- support Gaussian-DP (when enabled), RDP, and zCDP composition
- use native RDP plus the exact zCDP embedding, taking the tighter bound pointwise when both are available
- reject compositions with no supported common representation
- keep privacy profiles and f-DP tradeoff functions out of generic composition
- do not special-case point-backed profiles as approximate-DP compositions
- keep approximate-zCDP source delta local rather than embedding it into RDP
- retain the normal empty-composition identity for supported representations

ApproxDP composition is intentionally not inferred from the internal shape of a `PrivacyProfile`; if supported in the future, it should be modeled as an explicit composable representation or capability.

## Tests

- focused composition tests with default and contrib/idealized features
- `cargo check --tests --features honest-but-curious,idealized-numerics`
- Rust formatting and `git diff --check`