### PR TITLE
docs: add a link to cookbook

### DIFF
--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -4,6 +4,7 @@ Getting Started
 This is an overview of OpenDP's Python and R APIs.
 
 * To interactively build OpenDP examples, try `DP Wizard <https://mccalluc-dp-wizard.share.connect.posit.cloud/>`_.
+* For a collection of OpenDP recipes see the `OpenDP Cookbook <https://opendp.github.io/opendp-cookbook/>`_.
 * For a more conceptual overview of differential privacy see the :doc:`../theory/index` section.
 * For Python, R, and Rust library references see the :doc:`../api/index` documentation.
 


### PR DESCRIPTION
This PR is really a placeholder. What do we think the cookbook needs before it can be official?
- Better web design?
  - or maybe, instead of having a separate site, the examples should be pulled into the docs here?
  - or maybe we have a separate sphinx site there?
- If it is a separate site, a CNAME?
- More examples?
- Better examples?
- More tooling? (More description on the homepage, and not just the filename?) 