### PR TITLE
docs: Add troubleshooting page

### DIFF
--- a/R/opendp/R/typing.R
+++ b/R/opendp/R/typing.R
@@ -209,7 +209,7 @@ print.runtime_type <- function(x, ...) print(rt_to_string(x), ...)
 
 # nolint start: cyclocomp_linter
 rt_assert_is_similar <- function(expected, inferred) {
-  ERROR_URL_298 <- "https://github.com/opendp/opendp/discussions/298"
+  INFERRED_TYPE_ERROR_URL <- "https://docs.opendp.org/en/stable/getting-started/trouble-shooting.html#inferred-type-is-xxx-expected-yyy"
 
   if (!inherits(expected, "runtime_type")) {
     expected <- rt_parse(expected)
@@ -243,12 +243,12 @@ rt_assert_is_similar <- function(expected, inferred) {
 
     if (inferred$origin %in% names(ATOM_EQUIVALENCE_CLASSES)) {
       if (!(expected$origin %in% ATOM_EQUIVALENCE_CLASSES[[inferred$origin]])) {
-        stop(paste0("inferred type is ", rt_to_string(inferred), ", expected ", rt_to_string(expected), ". See ", ERROR_URL_298), call. = FALSE)
+        stop(paste0("inferred type is ", rt_to_string(inferred), ", expected ", rt_to_string(expected), ". See ", INFERRED_TYPE_ERROR_URL), call. = FALSE)
       }
     } else if (expected$origin == inferred$origin) {
       return()
     } else {
-      stop(paste0("inferred type is ", rt_to_string(inferred), ", expected ", rt_to_string(expected), ". See ", ERROR_URL_298), call. = FALSE)
+      stop(paste0("inferred type is ", rt_to_string(inferred), ", expected ", rt_to_string(expected), ". See ", INFERRED_TYPE_ERROR_URL), call. = FALSE)
     }
   } else if (!is.null(expected$args) && !is.null(inferred$args)) {
     if (expected$origin == "Vec" && inferred$origin == "Tuple") {
@@ -264,10 +264,10 @@ rt_assert_is_similar <- function(expected, inferred) {
       }
     }
     if (expected$origin != inferred$origin) {
-      stop(paste0("inferred type is ", inferred$origin, ", expected ", expected$origin, ". See ", ERROR_URL_298), call. = FALSE)
+      stop(paste0("inferred type is ", inferred$origin, ", expected ", expected$origin, ". See ", INFERRED_TYPE_ERROR_URL), call. = FALSE)
     }
     if (length(expected$args) != length(inferred$args)) {
-      stop(paste0("inferred type has ", length(inferred$args), " arg(s), expected ", length(expected$args), " arg(s). See ", ERROR_URL_298), call. = FALSE)
+      stop(paste0("inferred type has ", length(inferred$args), " arg(s), expected ", length(expected$args), " arg(s). See ", INFERRED_TYPE_ERROR_URL), call. = FALSE)
     }
 
     for (pair in mapply(list, expected$args, inferred$args, SIMPLIFY = FALSE)) {
@@ -275,7 +275,7 @@ rt_assert_is_similar <- function(expected, inferred) {
     }
   } else {
     # inferred type differs in structure
-    stop(paste0("inferred type is ", rt_to_string(inferred), ", expected ", rt_to_string(expected), ". See ", ERROR_URL_298), call. = FALSE)
+    stop(paste0("inferred type is ", rt_to_string(inferred), ", expected ", rt_to_string(expected), ". See ", INFERRED_TYPE_ERROR_URL), call. = FALSE)
   }
 }
 # nolint end

--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -15,4 +15,5 @@ This is an overview of OpenDP's Python and R APIs.
   tabular-data/index
   statistical-modeling/index
   utility
+  trouble-shooting
   next-steps

--- a/docs/source/getting-started/trouble-shooting.rst
+++ b/docs/source/getting-started/trouble-shooting.rst
@@ -1,0 +1,13 @@
+Troubleshooting
+===============
+
+If you've hit an error and this information doesn't help, feel free to reach out on Slack, or at contact@opendp.org.
+
+Inferred type is XXX, expected YYY
+----------------------------------
+
+By the time you invoke a function or call a relation, OpenDP has already determined the type of the data you are supposed to pass.
+To ensure type safety, OpenDP checks that the types of the arguments you pass are similar to the type the function is expecting.
+
+Fixing this may be as simple as passing integers instead of floats, or it may require additional preprocessing.
+One common cause of this error is passing a scalar ``epsilon`` to a relation that expects an ``(epsilon, delta)`` tuple.

--- a/python/src/opendp/_convert.py
+++ b/python/src/opendp/_convert.py
@@ -80,7 +80,9 @@ INT_SIZES = {
         "usize",
     )
 }
-_ERROR_URL_298 = "https://github.com/opendp/opendp/discussions/298"
+
+
+_INFERRED_TYPE_ERROR_URL = "https://docs.opendp.org/en/stable/getting-started/trouble-shooting.html#inferred-type-is-xxx-expected-yyy"
 
 
 def _check_and_cast_scalar(expected, value):
@@ -101,7 +103,7 @@ def _check_and_cast_scalar(expected, value):
 
     if expected not in ATOM_EQUIVALENCE_CLASSES.get(inferred, [inferred]):
         raise TypeError(
-            f"inferred type is {inferred}, expected {expected}. See {_ERROR_URL_298}"
+            f"inferred type is {inferred}, expected {expected}. See {_INFERRED_TYPE_ERROR_URL}"
         )
 
     if expected in INT_SIZES:


### PR DESCRIPTION
- Fix #1139 (Not adding a scan, just fixing problem identified by scan)

This new page could grow over time, but I don't think we should wait until it's encyclopedic.

The page referenced won't exist until after the release, but since we're close to the release I think that makes more sense than referencing nightly.

Could also imagine putting this in the API User Guide: I don't have a strong preference.